### PR TITLE
fix: update toolchain to nightly-2025-12-01 and remove stabilized fea…

### DIFF
--- a/modules/actor/examples/death_watch_std/main.rs
+++ b/modules/actor/examples/death_watch_std/main.rs
@@ -1,5 +1,3 @@
-#![feature(let_chains)]
-
 use std::{thread, time::Duration};
 
 #[path = "../std_tick_driver_support.rs"]

--- a/modules/actor/examples/scheduler_diagnostics_no_std/main.rs
+++ b/modules/actor/examples/scheduler_diagnostics_no_std/main.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(all(not(test), target_os = "none"), no_std)]
-#![feature(let_chains)]
 
 extern crate alloc;
 

--- a/modules/actor/src/lib.rs
+++ b/modules/actor/src/lib.rs
@@ -21,7 +21,7 @@
 #![deny(clippy::unused_self)]
 #![deny(clippy::unnecessary_wraps)]
 #![deny(clippy::unreachable)]
-#![deny(clippy::empty_enum)]
+#![deny(clippy::empty_enums)]
 #![deny(clippy::no_effect)]
 #![deny(dropping_copy_types)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
@@ -49,7 +49,6 @@
 #![allow(unknown_lints)]
 #![deny(cfg_std_forbid)]
 #![cfg_attr(not(test), no_std)]
-#![feature(let_chains)]
 
 //! Actor runtime for Rust
 

--- a/modules/cluster/src/lib.rs
+++ b/modules/cluster/src/lib.rs
@@ -21,7 +21,7 @@
 #![deny(clippy::unused_self)]
 #![deny(clippy::unnecessary_wraps)]
 #![deny(clippy::unreachable)]
-#![deny(clippy::empty_enum)]
+#![deny(clippy::empty_enums)]
 #![deny(clippy::no_effect)]
 #![deny(dropping_copy_types)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
@@ -48,8 +48,6 @@
 #![deny(unreachable_pub)]
 #![allow(unknown_lints)]
 #![deny(cfg_std_forbid)]
-#![feature(let_chains)]
-#![feature(const_vec_string_slice)]
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 
 //! Cluster runtime components compatible with Proto.Actor/Pekko semantics.

--- a/modules/remote/src/lib.rs
+++ b/modules/remote/src/lib.rs
@@ -5,7 +5,6 @@
 #![deny(unreachable_pub)]
 #![allow(unknown_lints)]
 #![deny(cfg_std_forbid)]
-#![feature(let_chains)]
 //! Remoting facilities for the fraktor actor runtime.
 
 extern crate alloc;

--- a/modules/utils/src/lib.rs
+++ b/modules/utils/src/lib.rs
@@ -21,7 +21,7 @@
 #![deny(clippy::unused_self)]
 #![deny(clippy::unnecessary_wraps)]
 #![deny(clippy::unreachable)]
-#![deny(clippy::empty_enum)]
+#![deny(clippy::empty_enums)]
 #![deny(clippy::no_effect)]
 #![deny(dropping_copy_types)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-02-15"
+channel = "nightly-2025-12-01"
 components = ["rustfmt", "clippy"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 #![deny(clippy::unused_self)]
 #![deny(clippy::unnecessary_wraps)]
 #![deny(clippy::unreachable)]
-#![deny(clippy::empty_enum)]
+#![deny(clippy::empty_enums)]
 #![deny(clippy::no_effect)]
 #![deny(dropping_copy_types)]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]


### PR DESCRIPTION
…tures

- Update rust-toolchain.toml from nightly-2025-02-15 to nightly-2025-12-01
- Rename clippy::empty_enum to clippy::empty_enums (renamed in newer clippy)
- Remove #![feature(let_chains)] - stabilized in Rust 1.88
- Remove #![feature(const_vec_string_slice)] - stabilized in Rust 1.87