### PR TITLE
feat(streams): add pekko-stream compatibility spec and improve transp…

### DIFF
--- a/.kiro/specs/ai-agent-workflow-streams-foundation/requirements.md
+++ b/.kiro/specs/ai-agent-workflow-streams-foundation/requirements.md
@@ -1,0 +1,86 @@
+# 要件ドキュメント
+
+## 導入
+本仕様は、AIエージェントのワークフローを安全かつ継続的に実行するためのストリーム基盤要件を定義する。対象は `fraktor-streams-rs` を中心としたワークフロー実行面であり、no_std/std の両環境で一貫した挙動を提供する。
+
+## 要件
+
+### 要件1: ワークフロー入力取り込みと実行開始
+**目的:** ワークフロー開発者として AIエージェントの入力イベントを確実に実行へ載せ、処理漏れを防ぎたい。
+
+#### 受け入れ条件
+1. 新しいワークフロー入力イベントが到着したとき、Agent Workflow Streams Service は実行可能な処理単位として受理しなければならない。
+2. 必須メタデータが欠落した入力ならば、Agent Workflow Streams Service は当該入力を拒否し、識別可能な失敗理由を返さなければならない。
+3. ワークフロー実行が有効な間、Agent Workflow Streams Service は受理済み入力を重複なく実行系へ引き渡し続けなければならない。
+4. 優先実行オプションを含む場合、Agent Workflow Streams Service は通常入力と区別して優先順序を適用しなければならない。
+5. Agent Workflow Streams Service は常に入力単位に追跡可能な識別子を関連付けなければならない。
+
+### 要件2: 容量制御とバックプレッシャ
+**目的:** 運用担当者として 負荷急増時でもメモリ枯渇や暴走を避け、安定運用を維持したい。
+
+#### 受け入れ条件
+1. 入力速度が処理速度を上回ったとき、Agent Workflow Streams Service は受理側へバックプレッシャまたは等価の抑制信号を返さなければならない。
+2. 構成済み容量上限を超過する条件ならば、Agent Workflow Streams Service は無制限にキューを拡張してはならず、定義済み方針で応答しなければならない。
+3. 下流処理が停滞している間、Agent Workflow Streams Service は上流受理の抑制状態を維持し続けなければならない。
+4. 容量監視オプションを含む場合、Agent Workflow Streams Service は現在負荷を観測可能な形で報告しなければならない。
+5. Agent Workflow Streams Service は常に容量制御の結果を判定可能な状態で返さなければならない。
+
+### 要件3: 非同期タスク実行と順序契約
+**目的:** ワークフロー設計者として 外部LLM/ツール呼び出しを並列化しつつ、必要な順序保証を維持したい。
+
+#### 受け入れ条件
+1. 非同期処理ステージに要素が到着したとき、Agent Workflow Streams Service は設定された並行度上限の範囲で処理を開始しなければならない。
+2. 並行度上限が0または無効値ならば、Agent Workflow Streams Service は実行開始前に当該設定を拒否しなければならない。
+3. 順序保持モードの間、Agent Workflow Streams Service は同一ストリーム内の完了順に依存せず入力順序を保持し続けなければならない。
+4. 非順序モードを含む場合、Agent Workflow Streams Service は順序制約よりスループットを優先する挙動を許可しなければならない。
+5. Agent Workflow Streams Service は常に各処理モードの順序契約を利用者が識別できる形で提示しなければならない。
+
+### 要件4: 分岐・合流とセッション分離
+**目的:** エージェント開発者として 会話やタスク単位で処理を分離し、必要な地点で安全に再合流したい。
+
+#### 受け入れ条件
+1. 分岐条件が成立したとき、Agent Workflow Streams Service は要素を該当分岐へ振り分けなければならない。
+2. 分岐上限を超える条件ならば、Agent Workflow Streams Service は過剰分岐を黙認せず失敗として扱わなければならない。
+3. セッション分離が有効な間、Agent Workflow Streams Service は異なるセッションの要素を同一処理系列へ混在させてはならない。
+4. 再合流オプションを含む場合、Agent Workflow Streams Service は選択された合流規則に従って要素を再構成しなければならない。
+5. Agent Workflow Streams Service は常に分岐/合流時の整合性を検証可能な結果として提供しなければならない。
+
+### 要件5: 障害回復と監督
+**目的:** 運用担当者として 一時障害は自動回復し、回復不能障害は制御可能に終端させたい。
+
+#### 受け入れ条件
+1. 処理失敗が発生したとき、Agent Workflow Streams Service は設定された回復方針に従って再試行または停止を実行しなければならない。
+2. 再試行上限を超過する条件ならば、Agent Workflow Streams Service は定義済み終端方針で処理を完了または失敗させなければならない。
+3. 再試行待機中の間、Agent Workflow Streams Service は追加処理を無制限に進行させず制御された状態を維持し続けなければならない。
+4. 監督方針オプションを含む場合、Agent Workflow Streams Service は `resume`・`restart`・`stop` 相当の挙動を区別して適用しなければならない。
+5. Agent Workflow Streams Service は常に失敗種別と回復結果を観測可能な形で記録しなければならない。
+
+### 要件6: 停止制御とタイムアウト
+**目的:** プラットフォーム運用者として 暴走・長時間停滞を即時停止し、安全に収束させたい。
+
+#### 受け入れ条件
+1. 停止指示が発行されたとき、Agent Workflow Streams Service は該当実行系列への新規入力を停止しなければならない。
+2. 強制中断条件ならば、Agent Workflow Streams Service は当該実行系列を失敗として終端しなければならない。
+3. 停止処理中の間、Agent Workflow Streams Service は停止前に受理済みの要素について定義済み終端規則を守り続けなければならない。
+4. タイムアウト制御を含む場合、Agent Workflow Streams Service は期限超過を検知して定義済み応答を返さなければならない。
+5. Agent Workflow Streams Service は常に最初に確定した停止シグナルを優先しなければならない。
+
+### 要件7: 動的接続と可観測性
+**目的:** ワークフロー管理者として 実行中に入力元/出力先を切り替えつつ、状態を継続監視したい。
+
+#### 受け入れ条件
+1. 動的な接続要求が行われたとき、Agent Workflow Streams Service は接続条件を検証したうえで受理または拒否しなければならない。
+2. 有効な受信先が存在しない条件ならば、Agent Workflow Streams Service は要素を黙って破棄してはならない。
+3. 実行中の間、Agent Workflow Streams Service は進行状態・滞留状態・終端状態を観測可能な形で公開し続けなければならない。
+4. 監査オプションを含む場合、Agent Workflow Streams Service は入力から終端までの主要イベントを追跡可能に記録しなければならない。
+5. Agent Workflow Streams Service は常に障害解析に必要な最小限の診断情報を提供しなければならない。
+
+### 要件8: 実行環境互換と品質ゲート
+**目的:** プロダクト開発者として no_std/std の両環境で同等契約を維持し、回帰を継続的に防止したい。
+
+#### 受け入れ条件
+1. 対応対象環境でビルドと検証が実行されたとき、Agent Workflow Streams Service は同一要件に対する互換結果を提示しなければならない。
+2. 要件に紐づく検証が欠落した条件ならば、Agent Workflow Streams Service はリリース可能と判定してはならない。
+3. 継続的検証の間、Agent Workflow Streams Service は要件ID単位で合否を追跡し続けなければならない。
+4. 互換レポート出力を含む場合、Agent Workflow Streams Service は対応範囲と未対応範囲を識別可能に示さなければならない。
+5. Agent Workflow Streams Service は常に要件トレーサビリティを更新可能な形式で保持しなければならない。

--- a/.kiro/specs/ai-agent-workflow-streams-foundation/spec.json
+++ b/.kiro/specs/ai-agent-workflow-streams-foundation/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "ai-agent-workflow-streams-foundation",
+  "created_at": "2026-02-10T07:41:43Z",
+  "updated_at": "2026-02-10T07:43:17Z",
+  "language": "ja",
+  "phase": "requirements-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": false
+    },
+    "design": {
+      "generated": false,
+      "approved": false
+    },
+    "tasks": {
+      "generated": false,
+      "approved": false
+    }
+  },
+  "ready_for_implementation": false
+}


### PR DESCRIPTION
…ort bridge tests

Add AI agent workflow streams foundation requirements and spec. Enhance endpoint transport bridge with improved test coverage for message ordering and edge cases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is limited to emitting an additional error log on a timeout/discard path; the rest is new specification docs and test coverage.
> 
> **Overview**
> Adds a new Kiro spec (`.kiro/specs/ai-agent-workflow-streams-foundation`) with Japanese *requirements* and a `spec.json` tracking generation/approval state for the AI agent workflow streams foundation.
> 
> Updates the `EndpointTransportBridge` handshake-timeout watchdog to explicitly emit an **error log** when it discards deferred envelopes, and extends `endpoint_transport_bridge` tests with an event-stream recorder plus a new test that asserts the discard-on-timeout log is produced (including utilities to build a deferred envelope).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b8c853d37d2e1909e442d4b1a53668ecbc23219. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->