### PR TITLE
fix(actor): prioritize system messages over mailbox pressure hook

### DIFF
--- a/modules/actor/src/core/dispatch/dispatcher/dispatcher_core.rs
+++ b/modules/actor/src/core/dispatch/dispatcher/dispatcher_core.rs
@@ -160,7 +160,7 @@ impl<TB: RuntimeToolbox + 'static> DispatcherCoreGeneric<TB> {
         break;
       }
 
-      if self.process_mailbox_pressure() {
+      if self.mailbox.system_len() == 0 && self.process_mailbox_pressure() {
         self.record_progress();
         processed += 1;
         continue;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized scheduling-order change in the dispatcher loop with a clear unit test; main risk is subtle behavior change in backpressure timing.
> 
> **Overview**
> Updates `DispatcherCoreGeneric::process_batch` so the mailbox-pressure hook only runs when there are **no pending system messages**, preventing backpressure handling from delaying system control messages.
> 
> Adds a unit test (`dispatcher_core_prioritizes_system_messages_over_mailbox_pressure`) that enqueues a system message plus a pressure event and asserts dispatch order is *system first, then pressure* (even with throughput limited to 1).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5aa4b7b79ae0795351964c847e5a7950d3994ebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->