### PR TITLE
timeout-sutabu4-wopekko-no-ni

### DIFF
--- a/modules/streams/src/core/graph/stream_graph.rs
+++ b/modules/streams/src/core/graph/stream_graph.rs
@@ -178,6 +178,10 @@ impl StreamGraph {
             | StageKind::FlowDelay
             | StageKind::FlowInitialDelay
             | StageKind::FlowTakeWithin
+            | StageKind::FlowBackpressureTimeout
+            | StageKind::FlowCompletionTimeout
+            | StageKind::FlowIdleTimeout
+            | StageKind::FlowInitialTimeout
             | StageKind::FlowBatch
             | StageKind::FlowGroupBy
             | StageKind::FlowRecover

--- a/modules/streams/src/core/stage/stage_kind.rs
+++ b/modules/streams/src/core/stage/stage_kind.rs
@@ -49,6 +49,14 @@ pub enum StageKind {
   FlowInitialDelay,
   /// Flow stage that forwards elements only within configured tick window.
   FlowTakeWithin,
+  /// Flow stage that fails when downstream backpressure exceeds tick threshold.
+  FlowBackpressureTimeout,
+  /// Flow stage that fails when stream does not complete within tick threshold.
+  FlowCompletionTimeout,
+  /// Flow stage that fails when no elements arrive within tick threshold.
+  FlowIdleTimeout,
+  /// Flow stage that fails when the first element does not arrive within tick threshold.
+  FlowInitialTimeout,
   /// Flow stage that represents an asynchronous execution boundary.
   FlowAsyncBoundary,
   /// Flow stage that groups elements into fixed-size batches.

--- a/modules/streams/src/core/stream_error.rs
+++ b/modules/streams/src/core/stream_error.rs
@@ -45,6 +45,13 @@ pub enum StreamError {
     /// Maximum allowed substream count.
     max_substreams: usize,
   },
+  /// Indicates that a timeout condition was reached.
+  Timeout {
+    /// Timeout kind identifier.
+    kind:  &'static str,
+    /// Configured tick threshold.
+    ticks: u64,
+  },
 }
 
 impl fmt::Display for StreamError {
@@ -68,6 +75,9 @@ impl fmt::Display for StreamError {
       },
       | Self::SubstreamLimitExceeded { max_substreams } => {
         write!(f, "substream limit exceeded: max_substreams={max_substreams}")
+      },
+      | Self::Timeout { kind, ticks } => {
+        write!(f, "{kind} timeout after {ticks} ticks")
       },
     }
   }


### PR DESCRIPTION
## Summary

## Execution Report

Piece `stub-elimination` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new failure paths and timing/state logic inside core stream execution, which could cause unexpected stream termination if tick accounting differs from prior behavior.
> 
> **Overview**
> Replaces the previous timeout *compatibility aliases* (which delegated to `take_within`) with real `Flow` stages: `backpressure_timeout`, `completion_timeout`, `idle_timeout`, and `initial_timeout`, each tracking ticks and failing with a new `StreamError::Timeout` when their specific condition is met.
> 
> Adds new stage kinds (`FlowBackpressureTimeout`, `FlowCompletionTimeout`, `FlowIdleTimeout`, `FlowInitialTimeout`) to the stage enum and graph validation, plus comprehensive unit tests for success, timeout failure, and zero-tick argument validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a2a2edcf4a755e730bb61cbf90ed69aebb1f41c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 4つの新しいタイムアウト制御を追加：バックプレッシャータイムアウト、完了タイムアウト、アイドルタイムアウト、初期タイムアウト。ストリーム処理の異なるタイミングシナリオに対応し、より柔軟なフロー制御が可能になりました。

* **テスト**
  * 新機能の動作を検証する包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->