### PR TITLE
lazy-sutabu3-wopekko-no-ni-laz

### DIFF
--- a/modules/streams/src/core/graph/stream_graph.rs
+++ b/modules/streams/src/core/graph/stream_graph.rs
@@ -227,6 +227,10 @@ impl StreamGraph {
     self.nodes.last().and_then(|node| node.stage.outlet())
   }
 
+  pub(in crate::core) fn into_stages(self) -> Vec<StageDefinition> {
+    self.nodes.into_iter().map(|node| node.stage).collect()
+  }
+
   pub(in crate::core) fn expected_fan_out_for_outlet(&self, outlet: PortId) -> Option<usize> {
     for node in &self.nodes {
       if let StageDefinition::Flow(definition) = &node.stage

--- a/modules/streams/src/core/stage/sink.rs
+++ b/modules/streams/src/core/stage/sink.rs
@@ -123,27 +123,41 @@ where
   }
 
   /// Lazily creates a completion-stage sink.
+  ///
+  /// Alias of [`Sink::lazy_sink`].
   #[must_use]
   pub fn lazy_completion_stage_sink<F>(factory: F) -> Self
   where
-    F: FnOnce() -> Self, {
-    factory()
+    F: FnOnce() -> Self + Send + 'static, {
+    Self::lazy_sink(factory)
   }
 
   /// Lazily creates a future sink.
+  ///
+  /// Alias of [`Sink::lazy_sink`].
   #[must_use]
   pub fn lazy_future_sink<F>(factory: F) -> Self
   where
-    F: FnOnce() -> Self, {
-    factory()
+    F: FnOnce() -> Self + Send + 'static, {
+    Self::lazy_sink(factory)
   }
 
   /// Lazily creates a sink.
+  ///
+  /// The factory is not called until the first element arrives.
+  /// The sink logic from the created sink is extracted and used for processing.
   #[must_use]
   pub fn lazy_sink<F>(factory: F) -> Self
   where
-    F: FnOnce() -> Self, {
-    factory()
+    F: FnOnce() -> Self + Send + 'static, {
+    let completion = StreamCompletion::new();
+    let logic = LazySinkLogic::<In, F> {
+      factory:    Some(factory),
+      inner:      None,
+      completion: completion.clone(),
+      _pd:        PhantomData,
+    };
+    Self::from_definition(StageKind::Custom, logic, completion)
   }
 
   /// Converts this sink into a pre-materialized form.
@@ -421,6 +435,67 @@ impl<In, Mat> StreamStage for Sink<In, Mat> {
   fn shape(&self) -> StreamShape<Self::In, Self::Out> {
     let inlet = self.graph.head_inlet().map(Inlet::from_id).unwrap_or_default();
     StreamShape::new(inlet, Outlet::new())
+  }
+}
+
+struct LazySinkLogic<In, F> {
+  factory:    Option<F>,
+  inner:      Option<Box<dyn SinkLogic>>,
+  completion: StreamCompletion<StreamDone>,
+  _pd:        PhantomData<fn(In)>,
+}
+
+impl<In, F> SinkLogic for LazySinkLogic<In, F>
+where
+  In: Send + Sync + 'static,
+  F: FnOnce() -> Sink<In, StreamCompletion<StreamDone>> + Send + 'static,
+{
+  fn on_start(&mut self, demand: &mut super::DemandTracker) -> Result<(), StreamError> {
+    demand.request(1)
+  }
+
+  fn on_push(&mut self, input: DynValue, demand: &mut super::DemandTracker) -> Result<SinkDecision, StreamError> {
+    if let Some(factory) = self.factory.take() {
+      let sink = factory();
+      let (graph, _inner_completion) = sink.into_parts();
+      let stages = graph.into_stages();
+      for stage in stages {
+        if let StageDefinition::Sink(def) = stage {
+          self.inner = Some(def.logic);
+          break;
+        }
+      }
+    }
+
+    match &mut self.inner {
+      | Some(inner) => inner.on_push(input, demand),
+      | None => {
+        self.completion.complete(Err(StreamError::Failed));
+        Ok(SinkDecision::Complete)
+      },
+    }
+  }
+
+  fn on_complete(&mut self) -> Result<(), StreamError> {
+    if let Some(inner) = &mut self.inner {
+      let _ = inner.on_complete();
+    }
+    self.completion.complete(Ok(StreamDone::new()));
+    Ok(())
+  }
+
+  fn on_error(&mut self, error: StreamError) {
+    if let Some(inner) = &mut self.inner {
+      inner.on_error(error.clone());
+    }
+    self.completion.complete(Err(error));
+  }
+
+  fn on_restart(&mut self) -> Result<(), StreamError> {
+    if let Some(inner) = &mut self.inner {
+      inner.on_restart()?;
+    }
+    Ok(())
   }
 }
 

--- a/modules/streams/src/core/stage/sink/tests.rs
+++ b/modules/streams/src/core/stage/sink/tests.rs
@@ -269,6 +269,55 @@ fn sink_lazy_sink_alias_completes_with_done() {
 }
 
 #[test]
+fn sink_lazy_sink_defers_factory_call() {
+  let called = ArcShared::new(SpinSyncMutex::new(false));
+  let called_clone = called.clone();
+  let sink = Sink::lazy_sink(move || {
+    *called_clone.lock() = true;
+    Sink::ignore()
+  });
+  // ファクトリはまだ呼ばれていない
+  assert!(!*called.lock());
+  let completion = run_source_with_sink(Source::from_array([1_u32, 2, 3]), sink);
+  // ファクトリが呼ばれ、完了する
+  assert!(*called.lock());
+  assert_eq!(completion, Completion::Ready(Ok(StreamDone::new())));
+}
+
+#[test]
+fn sink_lazy_sink_with_foreach_processes_elements() {
+  let collected = ArcShared::new(SpinSyncMutex::new(Vec::<u32>::new()));
+  let collected_clone = collected.clone();
+  let sink = Sink::lazy_sink(move || {
+    Sink::foreach(move |value: u32| {
+      collected_clone.lock().push(value);
+    })
+  });
+  let completion = run_source_with_sink(Source::from_array([1_u32, 2, 3]), sink);
+  assert_eq!(completion, Completion::Ready(Ok(StreamDone::new())));
+  assert_eq!(*collected.lock(), vec![1_u32, 2, 3]);
+}
+
+#[test]
+fn sink_lazy_completion_stage_sink_delegates_to_lazy_sink() {
+  let completion =
+    run_source_with_sink(Source::from_array([1_u32, 2, 3]), Sink::lazy_completion_stage_sink(Sink::ignore));
+  assert_eq!(completion, Completion::Ready(Ok(StreamDone::new())));
+}
+
+#[test]
+fn sink_lazy_future_sink_delegates_to_lazy_sink() {
+  let completion = run_source_with_sink(Source::from_array([1_u32, 2, 3]), Sink::lazy_future_sink(Sink::ignore));
+  assert_eq!(completion, Completion::Ready(Ok(StreamDone::new())));
+}
+
+#[test]
+fn sink_lazy_sink_with_empty_source_completes() {
+  let completion = run_source_with_sink(Source::<u32, _>::empty(), Sink::lazy_sink(Sink::ignore));
+  assert_eq!(completion, Completion::Ready(Ok(StreamDone::new())));
+}
+
+#[test]
 fn sink_pre_materialize_returns_pending_completion_handle() {
   let (_sink, completion) = Sink::<u32, StreamCompletion<StreamDone>>::ignore().pre_materialize();
   assert_eq!(completion.poll(), Completion::Pending);


### PR DESCRIPTION
## Summary

## Execution Report

Piece `stub-elimination` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new custom runtime logic for core `Source`/`Flow`/`Sink` execution and buffering, which could affect stream semantics and completion/backpressure edge cases despite good test coverage.
> 
> **Overview**
> Adds real lazy-stage support for streams: `Source::lazy_source`, `Flow::lazy_flow` (and the `lazy_*_flow` aliases), and `Sink::lazy_sink` (and `lazy_*_sink` aliases) now defer calling their factories until demand/first element, rather than eagerly constructing the inner stages.
> 
> Implements custom `Lazy*Logic` wrappers that extract inner stage logic from a factory-created graph (`StreamGraph::into_stages`) and then forward elements/ticks/completion through the extracted logic chain, with new tests covering deferral, passthrough behavior, chaining, and empty-source cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b96038a63ff9d8769fb97039c10370a3802feed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 遅延初期化メカニズムが導入されました。ストリーミング処理のファクトリー関数の呼び出しが、実際に使用されるまで遅延されるようになります。この改善により、リソース効率が向上し、より柔軟なストリーム処理が可能になります。

* **テスト**
  * 新機能の包括的なテストカバレッジが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->