### PR TITLE
risutabu3-wopekko-no-ni-merge

### DIFF
--- a/modules/streams/src/core/shape.rs
+++ b/modules/streams/src/core/shape.rs
@@ -11,6 +11,7 @@ mod shape;
 mod sink_shape;
 mod source_shape;
 mod stream_shape;
+mod uniform_fan_in_shape;
 
 pub use bidi_shape::BidiShape;
 pub use closed_shape::ClosedShape;
@@ -22,3 +23,4 @@ pub use shape::Shape;
 pub use sink_shape::SinkShape;
 pub use source_shape::SourceShape;
 pub use stream_shape::StreamShape;
+pub use uniform_fan_in_shape::UniformFanInShape;

--- a/modules/streams/src/core/shape/uniform_fan_in_shape.rs
+++ b/modules/streams/src/core/shape/uniform_fan_in_shape.rs
@@ -1,0 +1,52 @@
+use alloc::vec::Vec;
+
+use super::{Inlet, Outlet, Shape};
+
+/// Shape with multiple uniform input ports and one output port.
+///
+/// Corresponds to Pekko `UniformFanInShape[T, O]` which has N inlets of the
+/// same type `In` and a single outlet of type `Out`.
+#[derive(Debug, Clone)]
+pub struct UniformFanInShape<In, Out> {
+  inlets: Vec<Inlet<In>>,
+  outlet: Outlet<Out>,
+}
+
+impl<In, Out> UniformFanInShape<In, Out> {
+  /// Creates a new fan-in shape from the given inlets and outlet.
+  #[must_use]
+  pub fn new(inlets: Vec<Inlet<In>>, outlet: Outlet<Out>) -> Self {
+    Self { inlets, outlet }
+  }
+
+  /// Creates a fan-in shape with `port_count` inlets and a fresh outlet.
+  #[must_use]
+  pub fn with_port_count(port_count: usize) -> Self {
+    let inlets = (0..port_count).map(|_| Inlet::new()).collect();
+    let outlet = Outlet::new();
+    Self { inlets, outlet }
+  }
+
+  /// Returns the input ports.
+  #[must_use]
+  pub fn inlets(&self) -> &[Inlet<In>] {
+    &self.inlets
+  }
+
+  /// Returns the output port.
+  #[must_use]
+  pub fn outlet(&self) -> &Outlet<Out> {
+    &self.outlet
+  }
+
+  /// Returns the number of input ports.
+  #[must_use]
+  pub fn port_count(&self) -> usize {
+    self.inlets.len()
+  }
+}
+
+impl<In, Out> Shape for UniformFanInShape<In, Out> {
+  type In = In;
+  type Out = Out;
+}

--- a/modules/streams/src/core/stage.rs
+++ b/modules/streams/src/core/stage.rs
@@ -40,9 +40,9 @@ pub use flow::Flow;
 #[allow(unused_imports)]
 pub(in crate::core) use flow::{
   async_boundary_definition, balance_definition, broadcast_definition, buffer_definition, concat_definition,
-  flat_map_merge_definition, interleave_definition, merge_definition, merge_substreams_with_parallelism_definition,
-  partition_definition, prepend_definition, split_after_definition, split_when_definition, unzip_definition,
-  unzip_with_definition, zip_all_definition, zip_definition,
+  flat_map_merge_definition, interleave_definition, merge_definition, merge_latest_definition,
+  merge_substreams_with_parallelism_definition, partition_definition, prepend_definition, split_after_definition,
+  split_when_definition, unzip_definition, unzip_with_definition, zip_all_definition, zip_definition,
 };
 pub use flow_monitor::FlowMonitor;
 pub use flow_sub_flow::FlowSubFlow;

--- a/modules/streams/src/core/stage/flow/tests.rs
+++ b/modules/streams/src/core/stage/flow/tests.rs
@@ -5,9 +5,10 @@ use fraktor_utils_rs::core::collections::queue::OverflowPolicy;
 
 use crate::core::{
   Completion, DynValue, FlowLogic, KeepBoth, KeepLeft, KeepRight, RestartSettings, SourceLogic, StreamBufferConfig,
-  StreamDone, StreamDslError, StreamError, StreamNotUsed,
+  StreamCompletion, StreamDone, StreamDslError, StreamError, StreamNotUsed,
   lifecycle::{DriveOutcome, Stream},
   operator::{DefaultOperatorCatalog, OperatorCatalog, OperatorKey},
+  shape::UniformFanInShape,
   stage::{Flow, FlowMonitor, Sink, Source, StageKind},
 };
 
@@ -1567,4 +1568,107 @@ fn flow_map_materialized_value_transforms_materialized_value_and_keeps_data_path
     .collect_values()
     .expect("collect_values");
   assert_eq!(values, vec![5_u32]);
+}
+
+// --- merge_latest tests ---
+
+#[test]
+fn merge_latest_wraps_single_path_value_into_vec() {
+  let values = Source::single(7_u32)
+    .via(Flow::new().merge_latest(1))
+    .collect_values()
+    .expect("collect_values");
+  assert_eq!(values, vec![vec![7_u32]]);
+}
+
+#[test]
+#[should_panic(expected = "fan_in must be greater than zero")]
+fn merge_latest_rejects_zero_fan_in() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new();
+  let _ = flow.merge_latest(0);
+}
+
+#[test]
+fn merge_latest_emits_latest_snapshot_on_each_update() {
+  use alloc::vec;
+  use crate::core::{DynValue, FlowLogic, StreamError, downcast_value};
+  use super::merge_latest_definition;
+
+  let def = merge_latest_definition::<u32>(2);
+  let mut logic = def.logic;
+
+  // edge 0: 値10 → 全スロット未充填のためemitなし
+  let result = logic.apply_with_edge(0, Box::new(10_u32) as DynValue).expect("apply edge 0");
+  assert!(result.is_empty());
+
+  // edge 1: 値20 → 全スロット充填。Vec[10, 20]をemit
+  let result = logic.apply_with_edge(1, Box::new(20_u32) as DynValue).expect("apply edge 1");
+  assert_eq!(result.len(), 1);
+  let snapshot = downcast_value::<Vec<u32>>(result.into_iter().next().unwrap()).expect("downcast");
+  assert_eq!(snapshot, vec![10, 20]);
+
+  // edge 0: 値30 → latestが[30, 20]に更新
+  let result = logic.apply_with_edge(0, Box::new(30_u32) as DynValue).expect("apply edge 0 again");
+  assert_eq!(result.len(), 1);
+  let snapshot = downcast_value::<Vec<u32>>(result.into_iter().next().unwrap()).expect("downcast");
+  assert_eq!(snapshot, vec![30, 20]);
+}
+
+// --- watch_termination tests ---
+
+#[test]
+fn watch_termination_passes_through_elements() {
+  let values = Source::single(42_u32)
+    .via(Flow::new().watch_termination_mat(KeepLeft))
+    .collect_values()
+    .expect("collect_values");
+  assert_eq!(values, vec![42_u32]);
+}
+
+#[test]
+fn watch_termination_completes_stream_completion_handle() {
+  let (graph, completion) = Flow::<u32, u32, StreamNotUsed>::new().watch_termination_mat(KeepRight).into_parts();
+  // 実行前はPending
+  assert_eq!(completion.poll(), Completion::Pending);
+
+  let source_flow: Flow<u32, u32, StreamCompletion<()>> = Flow::from_graph(graph, completion.clone());
+  let values = Source::single(1_u32).via(source_flow).collect_values().expect("collect_values");
+  assert_eq!(values, vec![1_u32]);
+
+  // 実行後はReady
+  assert_eq!(completion.poll(), Completion::Ready(Ok(())));
+}
+
+#[test]
+fn watch_termination_mat_keeps_both() {
+  let (_graph, (left, right)) =
+    Flow::<u32, u32, StreamNotUsed>::new().watch_termination_mat(KeepBoth).into_parts();
+  assert_eq!(left, StreamNotUsed::new());
+  assert_eq!(right.poll(), Completion::Pending);
+}
+
+// --- UniformFanInShape tests ---
+
+#[test]
+fn uniform_fan_in_shape_creates_with_port_count() {
+  let shape = UniformFanInShape::<u32, u32>::with_port_count(3);
+  assert_eq!(shape.port_count(), 3);
+  assert_eq!(shape.inlets().len(), 3);
+}
+
+#[test]
+fn uniform_fan_in_shape_creates_from_parts() {
+  use crate::core::shape::{Inlet, Outlet};
+  let inlets = alloc::vec![Inlet::<u32>::new(), Inlet::<u32>::new()];
+  let outlet = Outlet::<u64>::new();
+  let shape = UniformFanInShape::new(inlets, outlet);
+  assert_eq!(shape.port_count(), 2);
+  assert_eq!(shape.inlets().len(), 2);
+}
+
+#[test]
+fn uniform_fan_in_shape_zero_ports() {
+  let shape = UniformFanInShape::<u32, u32>::with_port_count(0);
+  assert_eq!(shape.port_count(), 0);
+  assert!(shape.inlets().is_empty());
 }

--- a/modules/streams/src/core/stage/stage_kind.rs
+++ b/modules/streams/src/core/stage/stage_kind.rs
@@ -81,6 +81,8 @@ pub enum StageKind {
   FlowBalance,
   /// Flow stage that merges elements from multiple inputs.
   FlowMerge,
+  /// Flow stage that keeps the latest value from each input and emits all latest on every update.
+  FlowMergeLatest,
   /// Flow stage that interleaves elements from multiple inputs in round-robin order.
   FlowInterleave,
   /// Flow stage that prepends higher-priority input lanes before others.
@@ -93,6 +95,8 @@ pub enum StageKind {
   FlowZipWithIndex,
   /// Flow stage that concatenates inputs in port order.
   FlowConcat,
+  /// Flow stage that watches stream termination and completes a handle.
+  FlowWatchTermination,
   /// Sink that ignores elements.
   SinkIgnore,
   /// Sink that folds elements.


### PR DESCRIPTION
## Summary

## Execution Report

Piece `stub-elimination` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new flow-stage kinds and non-trivial runtime logic (edge-slot bookkeeping, snapshot emission, termination completion) that can affect stream semantics and graph wiring; covered by targeted unit tests but still touches core streaming behavior.
> 
> **Overview**
> Adds a new `UniformFanInShape` (N inlets, 1 outlet) and exposes it from `core::shape`.
> 
> Implements a real `Flow::merge_latest(fan_in)` stage (now outputs `Vec<Out>` snapshots once all inputs have emitted, then on every update) backed by a new `StageKind::FlowMergeLatest` and `MergeLatestLogic`, and wires `merge_latest_definition` into core stage re-exports.
> 
> Replaces the previous no-op `watch_termination` stub with `watch_termination_mat`, introducing `StageKind::FlowWatchTermination` and logic that passes elements through while completing a materialized `StreamCompletion<()>` on upstream completion; adds unit tests for merge-latest behavior, termination completion, and the new shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66d4eda4d358103e3a87084c6ef3bcab999bde60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数入力を単一出力に統合するための新しい形状機能を追加しました
  * マージ機能を改善し、複数の値を同時に処理できるようになりました
  * ストリーム完了の追跡機能を追加しました

* **テスト**
  * 新しい形状機能と完了追跡機能の包括的なテストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->