### PR TITLE
fan-in-sutabu5-wopekko-no-ni-m

### DIFF
--- a/modules/streams/src/core/graph/stream_graph.rs
+++ b/modules/streams/src/core/graph/stream_graph.rs
@@ -193,6 +193,9 @@ impl StreamGraph {
             | StageKind::FlowBroadcast
             | StageKind::FlowBalance
             | StageKind::FlowMerge
+            | StageKind::FlowMergePreferred
+            | StageKind::FlowMergePrioritized
+            | StageKind::FlowMergeSorted
             | StageKind::FlowInterleave
             | StageKind::FlowPrepend
             | StageKind::FlowZip

--- a/modules/streams/src/core/stage/flow.rs
+++ b/modules/streams/src/core/stage/flow.rs
@@ -1674,28 +1674,62 @@ where
     self.merge(fan_in)
   }
 
-  /// Adds a merge-preferred compatibility stage.
+  /// Adds a merge-preferred stage that prioritizes slot 0 (preferred) input.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `fan_in` is zero.
   #[must_use]
-  pub fn merge_preferred(self, fan_in: usize) -> Flow<In, Out, Mat> {
-    self.merge(fan_in)
+  pub fn merge_preferred(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
+    assert!(fan_in > 0, "fan_in must be greater than zero");
+    let definition = merge_preferred_definition::<Out>(fan_in);
+    let inlet_id = definition.inlet;
+    let from = self.graph.tail_outlet();
+    self.graph.push_stage(StageDefinition::Flow(definition));
+    if let Some(from) = from {
+      let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
+    }
+    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
   }
 
-  /// Adds a merge-prioritized compatibility stage.
+  /// Adds a merge-prioritized stage with equal weights across all input ports.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `fan_in` is zero.
   #[must_use]
-  pub fn merge_prioritized(self, fan_in: usize) -> Flow<In, Out, Mat> {
-    self.merge(fan_in)
+  pub fn merge_prioritized(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
+    assert!(fan_in > 0, "fan_in must be greater than zero");
+    let equal_priorities: Vec<usize> = vec![1; fan_in];
+    let definition = merge_prioritized_definition::<Out>(fan_in, &equal_priorities);
+    let inlet_id = definition.inlet;
+    let from = self.graph.tail_outlet();
+    self.graph.push_stage(StageDefinition::Flow(definition));
+    if let Some(from) = from {
+      let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
+    }
+    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
   }
 
-  /// Adds a merge-prioritized-n compatibility stage.
+  /// Adds a merge-prioritized stage with custom weight priorities per input port.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `fan_in` is zero, when `priorities.len() != fan_in`,
+  /// or when any priority is zero.
   #[must_use]
-  pub fn merge_prioritized_n(self, fan_in: usize, _priorities: &[usize]) -> Flow<In, Out, Mat> {
-    self.merge(fan_in)
-  }
-
-  /// Adds a merge-sorted compatibility stage.
-  #[must_use]
-  pub fn merge_sorted(self, fan_in: usize) -> Flow<In, Out, Mat> {
-    self.merge(fan_in)
+  pub fn merge_prioritized_n(mut self, fan_in: usize, priorities: &[usize]) -> Flow<In, Out, Mat> {
+    assert!(fan_in > 0, "fan_in must be greater than zero");
+    assert_eq!(priorities.len(), fan_in, "priorities length must match fan_in");
+    assert!(priorities.iter().all(|&p| p > 0), "priorities must be positive");
+    let definition = merge_prioritized_definition::<Out>(fan_in, priorities);
+    let inlet_id = definition.inlet;
+    let from = self.graph.tail_outlet();
+    self.graph.push_stage(StageDefinition::Flow(definition));
+    if let Some(from) = from {
+      let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
+    }
+    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
   }
 
   /// Adds an or-else compatibility stage.
@@ -1933,6 +1967,30 @@ where
         }
       })
       .flatten_optional()
+  }
+}
+
+impl<In, Out, Mat> Flow<In, Out, Mat>
+where
+  In: Send + Sync + 'static,
+  Out: Ord + Send + Sync + 'static,
+{
+  /// Adds a merge-sorted stage that merges pre-sorted inputs into a single sorted output.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `fan_in` is zero.
+  #[must_use]
+  pub fn merge_sorted(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
+    assert!(fan_in > 0, "fan_in must be greater than zero");
+    let definition = merge_sorted_definition::<Out>(fan_in);
+    let inlet_id = definition.inlet;
+    let from = self.graph.tail_outlet();
+    self.graph.push_stage(StageDefinition::Flow(definition));
+    if let Some(from) = from {
+      let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
+    }
+    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
   }
 }
 
@@ -2810,6 +2868,81 @@ where
   let logic = MergeLogic::<In> { fan_in, _pd: PhantomData };
   FlowDefinition {
     kind:        StageKind::FlowMerge,
+    inlet:       inlet.id(),
+    outlet:      outlet.id(),
+    input_type:  TypeId::of::<In>(),
+    output_type: TypeId::of::<In>(),
+    mat_combine: MatCombine::KeepLeft,
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    logic:       Box::new(logic),
+  }
+}
+
+pub(in crate::core) fn merge_preferred_definition<In>(fan_in: usize) -> FlowDefinition
+where
+  In: Send + Sync + 'static, {
+  let inlet: Inlet<In> = Inlet::new();
+  let outlet: Outlet<In> = Outlet::new();
+  let logic = MergePreferredLogic::<In> {
+    fan_in,
+    edge_slots: Vec::with_capacity(fan_in),
+    pending: Vec::with_capacity(fan_in),
+    source_done: false,
+  };
+  FlowDefinition {
+    kind:        StageKind::FlowMergePreferred,
+    inlet:       inlet.id(),
+    outlet:      outlet.id(),
+    input_type:  TypeId::of::<In>(),
+    output_type: TypeId::of::<In>(),
+    mat_combine: MatCombine::KeepLeft,
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    logic:       Box::new(logic),
+  }
+}
+
+pub(in crate::core) fn merge_prioritized_definition<In>(fan_in: usize, priorities: &[usize]) -> FlowDefinition
+where
+  In: Send + Sync + 'static, {
+  let inlet: Inlet<In> = Inlet::new();
+  let outlet: Outlet<In> = Outlet::new();
+  let logic = MergePrioritizedLogic::<In> {
+    fan_in,
+    priorities: priorities.to_vec(),
+    edge_slots: Vec::with_capacity(fan_in),
+    pending: Vec::with_capacity(fan_in),
+    credits: Vec::with_capacity(fan_in),
+    current: 0,
+    source_done: false,
+  };
+  FlowDefinition {
+    kind:        StageKind::FlowMergePrioritized,
+    inlet:       inlet.id(),
+    outlet:      outlet.id(),
+    input_type:  TypeId::of::<In>(),
+    output_type: TypeId::of::<In>(),
+    mat_combine: MatCombine::KeepLeft,
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    logic:       Box::new(logic),
+  }
+}
+
+pub(in crate::core) fn merge_sorted_definition<In>(fan_in: usize) -> FlowDefinition
+where
+  In: Ord + Send + Sync + 'static, {
+  let inlet: Inlet<In> = Inlet::new();
+  let outlet: Outlet<In> = Outlet::new();
+  let logic = MergeSortedLogic::<In> {
+    fan_in,
+    edge_slots: Vec::with_capacity(fan_in),
+    pending: Vec::with_capacity(fan_in),
+    source_done: false,
+  };
+  FlowDefinition {
+    kind:        StageKind::FlowMergeSorted,
     inlet:       inlet.id(),
     outlet:      outlet.id(),
     input_type:  TypeId::of::<In>(),
@@ -4525,6 +4658,328 @@ where
 
   fn expected_fan_in(&self) -> Option<usize> {
     Some(self.fan_in)
+  }
+}
+
+struct MergePreferredLogic<In> {
+  fan_in:      usize,
+  edge_slots:  Vec<usize>,
+  pending:     Vec<VecDeque<In>>,
+  source_done: bool,
+}
+
+impl<In> MergePreferredLogic<In>
+where
+  In: Send + Sync + 'static,
+{
+  fn slot_for_edge(&mut self, edge_index: usize) -> Result<usize, StreamError> {
+    if let Some(position) = self.edge_slots.iter().position(|index| *index == edge_index) {
+      return Ok(position);
+    }
+    if self.edge_slots.len() >= self.fan_in {
+      return Err(StreamError::InvalidConnection);
+    }
+    let insert_at = self.edge_slots.partition_point(|index| *index < edge_index);
+    self.edge_slots.insert(insert_at, edge_index);
+    self.pending.insert(insert_at, VecDeque::new());
+    Ok(insert_at)
+  }
+
+  fn pop_preferred(&mut self) -> Option<In> {
+    if self.pending.is_empty() {
+      return None;
+    }
+    // slot 0 はpreferred入力。常に最初にチェックする。
+    if let Some(value) = self.pending[0].pop_front() {
+      return Some(value);
+    }
+    // preferred が空の場合のみ他のスロットから取得
+    for slot in 1..self.pending.len() {
+      if let Some(value) = self.pending[slot].pop_front() {
+        return Some(value);
+      }
+    }
+    None
+  }
+}
+
+impl<In> FlowLogic for MergePreferredLogic<In>
+where
+  In: Send + Sync + 'static,
+{
+  fn apply(&mut self, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+    self.apply_with_edge(0, input)
+  }
+
+  fn apply_with_edge(&mut self, edge_index: usize, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+    if self.fan_in == 0 {
+      return Err(StreamError::InvalidConnection);
+    }
+    let value = downcast_value::<In>(input)?;
+    let slot = self.slot_for_edge(edge_index)?;
+    self.pending[slot].push_back(value);
+    if let Some(next) = self.pop_preferred() {
+      return Ok(vec![Box::new(next) as DynValue]);
+    }
+    Ok(Vec::new())
+  }
+
+  fn expected_fan_in(&self) -> Option<usize> {
+    Some(self.fan_in)
+  }
+
+  fn on_source_done(&mut self) -> Result<(), StreamError> {
+    self.source_done = true;
+    Ok(())
+  }
+
+  fn drain_pending(&mut self) -> Result<Vec<DynValue>, StreamError> {
+    if !self.source_done {
+      return Ok(Vec::new());
+    }
+    let Some(next) = self.pop_preferred() else {
+      return Ok(Vec::new());
+    };
+    Ok(vec![Box::new(next) as DynValue])
+  }
+
+  fn on_restart(&mut self) -> Result<(), StreamError> {
+    self.edge_slots.clear();
+    self.pending.clear();
+    self.source_done = false;
+    Ok(())
+  }
+}
+
+struct MergePrioritizedLogic<In> {
+  fan_in:      usize,
+  priorities:  Vec<usize>,
+  edge_slots:  Vec<usize>,
+  pending:     Vec<VecDeque<In>>,
+  credits:     Vec<usize>,
+  current:     usize,
+  source_done: bool,
+}
+
+impl<In> MergePrioritizedLogic<In>
+where
+  In: Send + Sync + 'static,
+{
+  fn slot_for_edge(&mut self, edge_index: usize) -> Result<usize, StreamError> {
+    if let Some(position) = self.edge_slots.iter().position(|index| *index == edge_index) {
+      return Ok(position);
+    }
+    if self.edge_slots.len() >= self.fan_in {
+      return Err(StreamError::InvalidConnection);
+    }
+    let insert_at = self.edge_slots.partition_point(|index| *index < edge_index);
+    self.edge_slots.insert(insert_at, edge_index);
+    self.pending.insert(insert_at, VecDeque::new());
+    // 仮クレジットを挿入後、全スロットのクレジットを再計算する。
+    // 挿入によりスロットがシフトするため、個別設定だとpriorities[slot]との不整合が発生する。
+    self.credits.insert(insert_at, 0);
+    self.refill_credits();
+    if insert_at <= self.current && self.edge_slots.len() > 1 {
+      self.current = self.current.saturating_add(1) % self.edge_slots.len();
+    }
+    Ok(insert_at)
+  }
+
+  fn refill_credits(&mut self) {
+    for (slot, credit) in self.credits.iter_mut().enumerate() {
+      *credit = self.priorities[slot];
+    }
+  }
+
+  fn pop_prioritized(&mut self) -> Option<In> {
+    if self.pending.is_empty() {
+      return None;
+    }
+    let len = self.pending.len();
+    // 加重ラウンドロビン: 現在のスロットからクレジットに基づいて要素を取得
+    for _ in 0..len {
+      let slot = self.current % len;
+      if self.credits[slot] > 0 {
+        if let Some(value) = self.pending[slot].pop_front() {
+          self.credits[slot] = self.credits[slot].saturating_sub(1);
+          if self.credits[slot] == 0 {
+            self.current = (slot + 1) % len;
+          }
+          return Some(value);
+        }
+      }
+      self.current = (slot + 1) % len;
+    }
+    // 全クレジット消費済み → 再充填して再試行
+    self.refill_credits();
+    for _ in 0..len {
+      let slot = self.current % len;
+      if let Some(value) = self.pending[slot].pop_front() {
+        self.credits[slot] = self.credits[slot].saturating_sub(1);
+        if self.credits[slot] == 0 {
+          self.current = (slot + 1) % len;
+        }
+        return Some(value);
+      }
+      self.current = (slot + 1) % len;
+    }
+    None
+  }
+}
+
+impl<In> FlowLogic for MergePrioritizedLogic<In>
+where
+  In: Send + Sync + 'static,
+{
+  fn apply(&mut self, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+    self.apply_with_edge(0, input)
+  }
+
+  fn apply_with_edge(&mut self, edge_index: usize, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+    if self.fan_in == 0 {
+      return Err(StreamError::InvalidConnection);
+    }
+    let value = downcast_value::<In>(input)?;
+    let slot = self.slot_for_edge(edge_index)?;
+    self.pending[slot].push_back(value);
+    if let Some(next) = self.pop_prioritized() {
+      return Ok(vec![Box::new(next) as DynValue]);
+    }
+    Ok(Vec::new())
+  }
+
+  fn expected_fan_in(&self) -> Option<usize> {
+    Some(self.fan_in)
+  }
+
+  fn on_source_done(&mut self) -> Result<(), StreamError> {
+    self.source_done = true;
+    Ok(())
+  }
+
+  fn drain_pending(&mut self) -> Result<Vec<DynValue>, StreamError> {
+    if !self.source_done {
+      return Ok(Vec::new());
+    }
+    let Some(next) = self.pop_prioritized() else {
+      return Ok(Vec::new());
+    };
+    Ok(vec![Box::new(next) as DynValue])
+  }
+
+  fn on_restart(&mut self) -> Result<(), StreamError> {
+    self.edge_slots.clear();
+    self.pending.clear();
+    self.credits.clear();
+    self.current = 0;
+    self.source_done = false;
+    Ok(())
+  }
+}
+
+struct MergeSortedLogic<In> {
+  fan_in:      usize,
+  edge_slots:  Vec<usize>,
+  pending:     Vec<VecDeque<In>>,
+  source_done: bool,
+}
+
+impl<In> MergeSortedLogic<In>
+where
+  In: Ord + Send + Sync + 'static,
+{
+  fn slot_for_edge(&mut self, edge_index: usize) -> Result<usize, StreamError> {
+    if let Some(position) = self.edge_slots.iter().position(|index| *index == edge_index) {
+      return Ok(position);
+    }
+    if self.edge_slots.len() >= self.fan_in {
+      return Err(StreamError::InvalidConnection);
+    }
+    let insert_at = self.edge_slots.partition_point(|index| *index < edge_index);
+    self.edge_slots.insert(insert_at, edge_index);
+    self.pending.insert(insert_at, VecDeque::new());
+    Ok(insert_at)
+  }
+
+  fn pop_sorted(&mut self) -> Option<In> {
+    if self.pending.is_empty() {
+      return None;
+    }
+    // source_done前は全fan_inスロットが登録され、かつ全てに要素が揃うのを待つ
+    if !self.source_done {
+      if self.pending.len() < self.fan_in {
+        return None;
+      }
+      let all_have_data = self.pending.iter().all(|queue| !queue.is_empty());
+      if !all_have_data {
+        return None;
+      }
+    }
+    // 全スロットの先頭要素を比較して最小値のスロットを選択
+    let mut min_slot: Option<usize> = None;
+    for (slot, queue) in self.pending.iter().enumerate() {
+      if let Some(front) = queue.front() {
+        match min_slot {
+          | None => min_slot = Some(slot),
+          | Some(current_min) => {
+            if let Some(current_front) = self.pending[current_min].front() {
+              if front < current_front {
+                min_slot = Some(slot);
+              }
+            }
+          },
+        }
+      }
+    }
+    min_slot.and_then(|slot| self.pending[slot].pop_front())
+  }
+}
+
+impl<In> FlowLogic for MergeSortedLogic<In>
+where
+  In: Ord + Send + Sync + 'static,
+{
+  fn apply(&mut self, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+    self.apply_with_edge(0, input)
+  }
+
+  fn apply_with_edge(&mut self, edge_index: usize, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+    if self.fan_in == 0 {
+      return Err(StreamError::InvalidConnection);
+    }
+    let value = downcast_value::<In>(input)?;
+    let slot = self.slot_for_edge(edge_index)?;
+    self.pending[slot].push_back(value);
+    if let Some(next) = self.pop_sorted() {
+      return Ok(vec![Box::new(next) as DynValue]);
+    }
+    Ok(Vec::new())
+  }
+
+  fn expected_fan_in(&self) -> Option<usize> {
+    Some(self.fan_in)
+  }
+
+  fn on_source_done(&mut self) -> Result<(), StreamError> {
+    self.source_done = true;
+    Ok(())
+  }
+
+  fn drain_pending(&mut self) -> Result<Vec<DynValue>, StreamError> {
+    if !self.source_done {
+      return Ok(Vec::new());
+    }
+    let Some(next) = self.pop_sorted() else {
+      return Ok(Vec::new());
+    };
+    Ok(vec![Box::new(next) as DynValue])
+  }
+
+  fn on_restart(&mut self) -> Result<(), StreamError> {
+    self.edge_slots.clear();
+    self.pending.clear();
+    self.source_done = false;
+    Ok(())
   }
 }
 

--- a/modules/streams/src/core/stage/flow/tests.rs
+++ b/modules/streams/src/core/stage/flow/tests.rs
@@ -1568,3 +1568,364 @@ fn flow_map_materialized_value_transforms_materialized_value_and_keeps_data_path
     .expect("collect_values");
   assert_eq!(values, vec![5_u32]);
 }
+
+// --- MergePreferredLogic テスト ---
+
+#[test]
+fn merge_preferred_keeps_single_path_behavior() {
+  let values = Source::single(7_u32).via(Flow::new().merge_preferred(1)).collect_values().expect("collect_values");
+  assert_eq!(values, vec![7_u32]);
+}
+
+#[test]
+#[should_panic(expected = "fan_in must be greater than zero")]
+fn merge_preferred_rejects_zero_fan_in() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new();
+  let _ = flow.merge_preferred(0);
+}
+
+#[test]
+fn merge_preferred_logic_prefers_slot_zero() {
+  let mut logic = super::MergePreferredLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    source_done: false,
+  };
+
+  // edge 1 が最初に接続 → partition_point により slot 0 に配置される
+  let result = logic.apply_with_edge(1, Box::new(100_u32)).expect("edge 1");
+  assert_eq!(result.len(), 1); // slot 0 から即座に取得
+
+  // edge 1 に再度データ投入 → 即座に消費される
+  let _ = logic.apply_with_edge(1, Box::new(200_u32)).expect("edge 1 second");
+  // edge 0 が接続 → partition_point により slot 0 に挿入、edge 1 は slot 1 にシフト
+  let result = logic.apply_with_edge(0, Box::new(10_u32)).expect("edge 0");
+  // edge 0 のデータが slot 0（preferred）にあるため出力される
+  assert_eq!(result.len(), 1);
+  let value = result[0].downcast_ref::<u32>().expect("downcast");
+  assert_eq!(*value, 10_u32);
+}
+
+#[test]
+fn merge_preferred_logic_always_prefers_slot_zero_in_sequence() {
+  let mut logic = super::MergePreferredLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    source_done: false,
+  };
+
+  // 各apply_with_edgeで投入されたデータは即座に消費される（同時データなし）
+  // このテストはシーケンシャルな投入・消費の基本動作を確認する
+  let r1 = logic.apply_with_edge(0, Box::new(10_u32)).expect("edge 0 first");
+  assert_eq!(r1.len(), 1);
+  assert_eq!(*r1[0].downcast_ref::<u32>().expect("downcast"), 10_u32);
+
+  let r2 = logic.apply_with_edge(1, Box::new(99_u32)).expect("edge 1");
+  assert_eq!(r2.len(), 1);
+  assert_eq!(*r2[0].downcast_ref::<u32>().expect("downcast"), 99_u32);
+
+  let r3 = logic.apply_with_edge(0, Box::new(20_u32)).expect("edge 0 second");
+  assert_eq!(r3.len(), 1);
+  assert_eq!(*r3[0].downcast_ref::<u32>().expect("downcast"), 20_u32);
+}
+
+#[test]
+fn merge_preferred_logic_prefers_slot_zero_with_simultaneous_data() {
+  // 両スロットに同時にデータが存在する状態で、slot 0（preferred）が優先されることを検証
+  let mut logic = super::MergePreferredLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  vec![0, 1],
+    pending:     vec![VecDeque::from([10, 20, 30]), VecDeque::from([100, 200, 300])],
+    source_done: false,
+  };
+
+  // pop_preferred は常に slot 0 を優先する。
+  // slot 0 のデータが全て消費されてから slot 1 のデータを取得する。
+  let v1 = logic.pop_preferred().expect("pop 1");
+  assert_eq!(v1, 10_u32);
+  let v2 = logic.pop_preferred().expect("pop 2");
+  assert_eq!(v2, 20_u32);
+  let v3 = logic.pop_preferred().expect("pop 3");
+  assert_eq!(v3, 30_u32);
+
+  // slot 0 が空になったので slot 1 から取得
+  let v4 = logic.pop_preferred().expect("pop 4");
+  assert_eq!(v4, 100_u32);
+  let v5 = logic.pop_preferred().expect("pop 5");
+  assert_eq!(v5, 200_u32);
+  let v6 = logic.pop_preferred().expect("pop 6");
+  assert_eq!(v6, 300_u32);
+
+  // 全消費後は None
+  assert!(logic.pop_preferred().is_none());
+}
+
+#[test]
+fn merge_preferred_logic_falls_back_to_secondary() {
+  // slot 0（preferred）が空の場合、slot 1（secondary）から取得されることを検証
+  let mut logic = super::MergePreferredLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  vec![0, 1],
+    pending:     vec![VecDeque::new(), VecDeque::from([100, 200])],
+    source_done: false,
+  };
+
+  // slot 0 は空なので slot 1 にフォールバック
+  let v1 = logic.pop_preferred().expect("pop 1");
+  assert_eq!(v1, 100_u32);
+  let v2 = logic.pop_preferred().expect("pop 2");
+  assert_eq!(v2, 200_u32);
+
+  assert!(logic.pop_preferred().is_none());
+}
+
+#[test]
+fn merge_preferred_logic_on_restart_clears_state() {
+  let mut logic = super::MergePreferredLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    source_done: false,
+  };
+
+  let _ = logic.apply_with_edge(0, Box::new(1_u32)).expect("apply");
+  logic.on_source_done().expect("source done");
+
+  logic.on_restart().expect("restart");
+
+  let drained = logic.drain_pending().expect("drain");
+  assert!(drained.is_empty());
+}
+
+// --- MergePrioritizedLogic テスト ---
+
+#[test]
+fn merge_prioritized_keeps_single_path_behavior() {
+  let values = Source::single(7_u32).via(Flow::new().merge_prioritized(1)).collect_values().expect("collect_values");
+  assert_eq!(values, vec![7_u32]);
+}
+
+#[test]
+#[should_panic(expected = "fan_in must be greater than zero")]
+fn merge_prioritized_rejects_zero_fan_in() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new();
+  let _ = flow.merge_prioritized(0);
+}
+
+#[test]
+fn merge_prioritized_n_keeps_single_path_behavior() {
+  let values =
+    Source::single(7_u32).via(Flow::new().merge_prioritized_n(1, &[1])).collect_values().expect("collect_values");
+  assert_eq!(values, vec![7_u32]);
+}
+
+#[test]
+#[should_panic(expected = "priorities must be positive")]
+fn merge_prioritized_n_rejects_zero_priority() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new();
+  let _ = flow.merge_prioritized_n(2, &[3, 0]);
+}
+
+#[test]
+#[should_panic(expected = "fan_in must be greater than zero")]
+fn merge_prioritized_n_rejects_zero_fan_in() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new();
+  let _ = flow.merge_prioritized_n(0, &[]);
+}
+
+#[test]
+#[should_panic(expected = "priorities length must match fan_in")]
+fn merge_prioritized_n_rejects_length_mismatch() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new();
+  let _ = flow.merge_prioritized_n(3, &[3, 1]);
+}
+
+#[test]
+fn merge_prioritized_logic_outputs_on_each_apply() {
+  // シーケンシャルな投入・消費の基本動作を確認
+  let mut logic = super::MergePrioritizedLogic::<u32> {
+    fan_in:      2,
+    priorities:  vec![3, 1],
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    credits:     Vec::new(),
+    current:     0,
+    source_done: false,
+  };
+
+  // 各apply_with_edgeで投入されたデータは即座に消費される
+  let r1 = logic.apply_with_edge(0, Box::new(10_u32)).expect("edge 0 first");
+  assert_eq!(r1.len(), 1);
+  assert_eq!(*r1[0].downcast_ref::<u32>().expect("downcast"), 10_u32);
+
+  let r2 = logic.apply_with_edge(1, Box::new(99_u32)).expect("edge 1 first");
+  assert_eq!(r2.len(), 1);
+  assert_eq!(*r2[0].downcast_ref::<u32>().expect("downcast"), 99_u32);
+
+  let r3 = logic.apply_with_edge(0, Box::new(20_u32)).expect("edge 0 second");
+  assert_eq!(r3.len(), 1);
+  assert_eq!(*r3[0].downcast_ref::<u32>().expect("downcast"), 20_u32);
+
+  // source_done後のdrain: 全要素は即座に出力されたため、drainは空
+  logic.on_source_done().expect("source done");
+  let drained = logic.drain_pending().expect("drain");
+  assert!(drained.is_empty());
+}
+
+#[test]
+fn merge_prioritized_logic_respects_weight_ratio() {
+  // 重み [3, 1] で両スロットにデータが同時に存在する場合、
+  // slot 0 から3つ → slot 1 から1つ のサイクルで取得されることを検証
+  let mut logic = super::MergePrioritizedLogic::<u32> {
+    fan_in:      2,
+    priorities:  vec![3, 1],
+    edge_slots:  vec![0, 1],
+    pending:     vec![VecDeque::from([10, 20, 30, 40, 50, 60]), VecDeque::from([100, 200, 300, 400, 500, 600])],
+    credits:     vec![3, 1],
+    current:     0,
+    source_done: false,
+  };
+
+  let mut results = Vec::new();
+  for _ in 0..8 {
+    if let Some(v) = logic.pop_prioritized() {
+      results.push(v);
+    }
+  }
+
+  // クレジットベースラウンドロビン:
+  // サイクル1: slot 0 × 3 (credit=3) → slot 1 × 1 (credit=1)
+  // サイクル2: refill → slot 0 × 3 → slot 1 × 1
+  assert_eq!(results, vec![10, 20, 30, 100, 40, 50, 60, 200]);
+}
+
+#[test]
+fn merge_prioritized_logic_equal_weights_alternates() {
+  // 等重み [1, 1] で両スロットにデータがある場合、交互に取得されることを検証
+  let mut logic = super::MergePrioritizedLogic::<u32> {
+    fan_in:      2,
+    priorities:  vec![1, 1],
+    edge_slots:  vec![0, 1],
+    pending:     vec![VecDeque::from([10, 20, 30]), VecDeque::from([100, 200, 300])],
+    credits:     vec![1, 1],
+    current:     0,
+    source_done: false,
+  };
+
+  let mut results = Vec::new();
+  for _ in 0..6 {
+    if let Some(v) = logic.pop_prioritized() {
+      results.push(v);
+    }
+  }
+
+  // 等重み: slot 0 × 1 → slot 1 × 1 → refill → 繰り返し
+  assert_eq!(results, vec![10, 100, 20, 200, 30, 300]);
+}
+
+#[test]
+fn merge_prioritized_logic_on_restart_clears_state() {
+  let mut logic = super::MergePrioritizedLogic::<u32> {
+    fan_in:      2,
+    priorities:  vec![1, 1],
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    credits:     Vec::new(),
+    current:     0,
+    source_done: false,
+  };
+
+  let _ = logic.apply_with_edge(0, Box::new(1_u32)).expect("apply");
+  logic.on_source_done().expect("source done");
+
+  logic.on_restart().expect("restart");
+
+  let drained = logic.drain_pending().expect("drain");
+  assert!(drained.is_empty());
+}
+
+// --- MergeSortedLogic テスト ---
+
+#[test]
+fn merge_sorted_keeps_single_path_behavior() {
+  let values = Source::single(7_u32).via(Flow::new().merge_sorted(1)).collect_values().expect("collect_values");
+  assert_eq!(values, vec![7_u32]);
+}
+
+#[test]
+#[should_panic(expected = "fan_in must be greater than zero")]
+fn merge_sorted_rejects_zero_fan_in() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new();
+  let _ = flow.merge_sorted(0);
+}
+
+#[test]
+fn merge_sorted_logic_emits_minimum_value() {
+  let mut logic = super::MergeSortedLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    source_done: false,
+  };
+
+  // edge 0 に大きい値
+  let result = logic.apply_with_edge(0, Box::new(10_u32)).expect("edge 0");
+  assert!(result.is_empty()); // もう1つのスロットが空なので待機
+
+  // edge 1 に小さい値 → 全スロットに要素があるので最小値を出力
+  let result = logic.apply_with_edge(1, Box::new(3_u32)).expect("edge 1");
+  assert_eq!(result.len(), 1);
+  let value = result[0].downcast_ref::<u32>().expect("downcast");
+  assert_eq!(*value, 3_u32);
+}
+
+#[test]
+fn merge_sorted_logic_drain_emits_sorted_order() {
+  let mut logic = super::MergeSortedLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    source_done: false,
+  };
+
+  // 各edgeにソート済みデータを蓄積
+  let _ = logic.apply_with_edge(0, Box::new(1_u32)).expect("edge 0 a");
+  let _ = logic.apply_with_edge(0, Box::new(3_u32)).expect("edge 0 b");
+  let _ = logic.apply_with_edge(1, Box::new(2_u32)).expect("edge 1 a");
+  let _ = logic.apply_with_edge(1, Box::new(4_u32)).expect("edge 1 b");
+
+  logic.on_source_done().expect("source done");
+
+  let mut results = Vec::new();
+  loop {
+    let drained = logic.drain_pending().expect("drain");
+    if drained.is_empty() {
+      break;
+    }
+    for value in drained {
+      results.push(*value.downcast::<u32>().expect("downcast"));
+    }
+  }
+  // drain時のソート済み順序: apply_with_edgeで1と2が既に出力済み、残りの3, 4がドレインされる
+  assert_eq!(results, vec![3_u32, 4_u32]);
+}
+
+#[test]
+fn merge_sorted_logic_on_restart_clears_state() {
+  let mut logic = super::MergeSortedLogic::<u32> {
+    fan_in:      2,
+    edge_slots:  Vec::new(),
+    pending:     Vec::new(),
+    source_done: false,
+  };
+
+  let _ = logic.apply_with_edge(0, Box::new(1_u32)).expect("apply");
+  logic.on_source_done().expect("source done");
+
+  logic.on_restart().expect("restart");
+
+  let drained = logic.drain_pending().expect("drain");
+  assert!(drained.is_empty());
+}

--- a/modules/streams/src/core/stage/stage_kind.rs
+++ b/modules/streams/src/core/stage/stage_kind.rs
@@ -81,6 +81,12 @@ pub enum StageKind {
   FlowBalance,
   /// Flow stage that merges elements from multiple inputs.
   FlowMerge,
+  /// Flow stage that merges elements with a preferred input port checked first.
+  FlowMergePreferred,
+  /// Flow stage that merges elements with weighted priority across input ports.
+  FlowMergePrioritized,
+  /// Flow stage that merges pre-sorted inputs into a single sorted output.
+  FlowMergeSorted,
   /// Flow stage that interleaves elements from multiple inputs in round-robin order.
   FlowInterleave,
   /// Flow stage that prepends higher-priority input lanes before others.


### PR DESCRIPTION
## Summary

## Execution Report

Piece `stub-elimination` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core stream fan-in semantics by adding new scheduling/ordering logic, which can affect correctness and performance under concurrent multi-input workloads despite added tests.
> 
> **Overview**
> Adds first-class fan-in merge variants to the streams DSL: `merge_preferred` (always checks preferred input first), `merge_prioritized`/`merge_prioritized_n` (weighted round-robin across inputs), and `merge_sorted` (k-way merge of pre-sorted inputs).
> 
> This introduces new `StageKind`s and corresponding `FlowDefinition` + `FlowLogic` implementations, updates `StreamGraph::ensure_stage_metadata` to accept them, and replaces prior compatibility stubs that delegated to plain `merge`. Extensive unit tests were added to validate prioritization, weight handling, sorted emission/draining, panic conditions, and restart behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd53cd4a929204371f5cdd3071003fa3d6789c3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フロー ステージに3つの新しいマージ機能を追加：
    * マージ優先：最初の入力ポートを優先的に処理
    * マージ優先度付き：重み付けされた優先度に基づくマージ
    * マージソート済み：事前にソートされた入力をマージ

* **テスト**
  * 新しいマージロジックの包括的なテストカバレッジを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->