### PR TITLE
coderabbit-pr117-review-feedback

### DIFF
--- a/modules/persistence/examples/persistent_counter_no_std/main.rs
+++ b/modules/persistence/examples/persistent_counter_no_std/main.rs
@@ -78,7 +78,7 @@ impl Eventsourced<TB> for CounterActor {
   ) -> Result<(), ActorError> {
     if let Some(Command::Add(delta)) = message.downcast_ref::<Command>() {
       self.persist(ctx, Event::Incremented(*delta), |actor, event| actor.apply_event(event));
-      self.flush_batch(ctx);
+      self.flush_batch(ctx)?;
     }
     Ok(())
   }

--- a/modules/persistence/src/core/journal_actor.rs
+++ b/modules/persistence/src/core/journal_actor.rs
@@ -90,7 +90,10 @@ where
       return;
     }
     self.poll_scheduled = true;
-    let _ = ctx.self_ref().tell(AnyMessageGeneric::new(JournalPoll));
+    if ctx.self_ref().tell(AnyMessageGeneric::new(JournalPoll)).is_err() {
+      // tell失敗時にフラグをリセットし、ポーリング停止を防ぐ
+      self.poll_scheduled = false;
+    }
   }
 
   fn poll_in_flight(&mut self, ctx: &mut ActorContextGeneric<'_, TB>) {

--- a/modules/persistence/src/core/persistence_context/tests.rs
+++ b/modules/persistence/src/core/persistence_context/tests.rs
@@ -95,7 +95,7 @@ fn start_recovery_none_requests_highest_sequence_nr() {
   let mut context = DummyContext::new("pid-1".to_string());
   context.bind_actor_refs(journal_ref, snapshot_ref).expect("bind actor refs");
 
-  context.start_recovery(crate::core::Recovery::none(), ActorRefGeneric::null());
+  context.start_recovery(crate::core::Recovery::none(), ActorRefGeneric::null()).expect("start recovery");
 
   let journal_messages = journal_store.lock();
   assert_eq!(journal_messages.len(), 1);

--- a/modules/persistence/src/core/persistent_actor.rs
+++ b/modules/persistence/src/core/persistent_actor.rs
@@ -3,7 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-use alloc::{boxed::Box, string::ToString, vec::Vec};
+use alloc::{boxed::Box, format, string::ToString, vec::Vec};
 use core::any::Any;
 
 use fraktor_actor_rs::core::{actor::ActorContextGeneric, error::ActorError, messaging::AnyMessageViewGeneric};
@@ -83,9 +83,13 @@ where
   }
 
   /// Flushes the pending batch to the journal.
-  fn flush_batch(&mut self, ctx: &mut ActorContextGeneric<'_, TB>) {
+  ///
+  /// # Errors
+  ///
+  /// Returns `ActorError` when the batch send fails.
+  fn flush_batch(&mut self, ctx: &mut ActorContextGeneric<'_, TB>) -> Result<(), ActorError> {
     let sender = ctx.self_ref();
-    self.persistence_context().flush_batch(sender);
+    self.persistence_context().flush_batch(sender).map_err(|error| ActorError::fatal(format!("{error:?}")))
   }
 
   /// Saves a snapshot.
@@ -116,10 +120,14 @@ where
   }
 
   /// Starts recovery by delegating to the base.
-  fn start_recovery(&mut self, ctx: &mut ActorContextGeneric<'_, TB>) {
+  ///
+  /// # Errors
+  ///
+  /// Returns `ActorError` when recovery initiation fails.
+  fn start_recovery(&mut self, ctx: &mut ActorContextGeneric<'_, TB>) -> Result<(), ActorError> {
     let sender = ctx.self_ref();
     let recovery = self.recovery();
-    self.persistence_context().start_recovery(recovery, sender);
+    self.persistence_context().start_recovery(recovery, sender).map_err(|error| ActorError::fatal(format!("{error:?}")))
   }
 
   /// Handles journal responses by delegating to the base.

--- a/modules/persistence/src/core/persistent_actor_adapter.rs
+++ b/modules/persistence/src/core/persistent_actor_adapter.rs
@@ -56,7 +56,9 @@ where
     persistence_context
       .bind_actor_refs(journal_actor_ref, snapshot_actor_ref)
       .map_err(|error| ActorError::fatal(format!("{error:?}")))?;
-    persistence_context.start_recovery(recovery, ctx.self_ref());
+    persistence_context
+      .start_recovery(recovery, ctx.self_ref())
+      .map_err(|error| ActorError::fatal(format!("{error:?}")))?;
     Ok(())
   }
 

--- a/modules/persistence/src/core/snapshot_actor.rs
+++ b/modules/persistence/src/core/snapshot_actor.rs
@@ -89,7 +89,10 @@ where
       return;
     }
     self.poll_scheduled = true;
-    let _ = ctx.self_ref().tell(AnyMessageGeneric::new(SnapshotPoll));
+    if ctx.self_ref().tell(AnyMessageGeneric::new(SnapshotPoll)).is_err() {
+      // tell失敗時にフラグをリセットし、ポーリング停止を防ぐ
+      self.poll_scheduled = false;
+    }
   }
 
   fn poll_in_flight(&mut self, ctx: &mut ActorContextGeneric<'_, TB>) {

--- a/modules/persistence/tests/persistence_flow.rs
+++ b/modules/persistence/tests/persistence_flow.rs
@@ -85,7 +85,7 @@ impl Eventsourced<TB> for CounterActor {
   ) -> Result<(), ActorError> {
     if let Some(Command::Add(delta)) = message.downcast_ref::<Command>() {
       self.persist(ctx, Event::Incremented(*delta), |actor, event| actor.apply_event(event));
-      self.flush_batch(ctx);
+      self.flush_batch(ctx)?;
     }
     Ok(())
   }

--- a/modules/persistence/tests/persistent_actor_example.rs
+++ b/modules/persistence/tests/persistent_actor_example.rs
@@ -76,7 +76,7 @@ impl Eventsourced<TB> for BatchActor {
     if let Some(Command::AddAll(events)) = message.downcast_ref::<Command>() {
       let mapped: Vec<Event> = events.iter().map(|value| Event::Added(*value)).collect();
       self.persist_all(ctx, mapped, |actor, event| actor.apply_event(event));
-      self.flush_batch(ctx);
+      self.flush_batch(ctx)?;
     }
     Ok(())
   }

--- a/modules/streams/src/core/hub/partition_hub/tests.rs
+++ b/modules/streams/src/core/hub/partition_hub/tests.rs
@@ -135,7 +135,7 @@ fn partition_hub_route_with_partitioner_assigns_to_active_consumer() {
   hub
     .route_with(99_u32, |consumer_count| {
       assert_eq!(consumer_count, 2);
-      2
+      1 // Nth-active-consumer index: 0 → partition 0, 1 → partition 2
     })
     .expect("route_with");
 


### PR DESCRIPTION
## Summary

## Execution Report

Piece `critical-bug-fix` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lock-free queueing, actor lifecycle concurrency, and persistence state-machine/error paths; while changes are targeted bug fixes, subtle ordering/rollback mistakes could impact message delivery or recovery behavior under load.
> 
> **Overview**
> Improves correctness under concurrency by closing several TOCTOU/race windows: re-checks actor termination after taking locks in `ActorCell` (`handle_watch`, `spawn_pipe_task`), hardens `SystemQueue::pop` with a CAS-based `pending` install and a rollback path to avoid losing FIFO chains, and changes `PartitionHub::route_with` to interpret the partitioner’s return as an *Nth active consumer* index rather than a raw partition index.
> 
> Tightens persistence error handling by making `PersistenceContext::flush_batch`/`start_recovery` return `Result` and adding explicit rollback/cleanup when state transitions or message sends fail; updates `PersistentActor`/adapter + examples/tests accordingly, and prevents journal/snapshot poll loops from stalling by resetting `poll_scheduled` when self-`tell` fails.
> 
> Avoids potential deadlocks in waiter notification by changing `WaitNode` completion APIs to return a `Waker` for callers to `wake()` *after* releasing locks, and updates `WaitQueue` to follow that pattern; also adds small stream safety fixes (heap-pin in `scan_async`, `saturating_sub` in timeout checks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e1bffffab213242554c337f4dcdc8cfe7cd6f73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->