### PR TITLE
coderabbit-13-major-lazy-flow

### DIFF
--- a/modules/streams/src/core/graph/graph_interpreter/tests.rs
+++ b/modules/streams/src/core/graph/graph_interpreter/tests.rs
@@ -247,7 +247,7 @@ fn flat_map_concat_uses_inner_source() {
 #[test]
 fn flat_map_concat_respects_backpressure_when_inner_emits_multiple_elements() {
   let graph = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic { next: 1, end: 2 })
-    .flat_map_concat(|value| Source::single(value).broadcast(2))
+    .flat_map_concat(|value| Source::single(value).broadcast(2).expect("broadcast"))
     .to_mat(
       Sink::fold(Vec::new(), |mut acc: Vec<u32>, value| {
         acc.push(value);
@@ -270,7 +270,7 @@ fn flat_map_merge_uses_configured_breadth() {
 
   let source = source_sequence_u32(source_outlet, 3);
   let flat_map_merge =
-    flat_map_merge_definition::<u32, u32, StreamNotUsed, _>(2, |value| Source::single(value).broadcast(2));
+    flat_map_merge_definition::<u32, u32, StreamNotUsed, _>(2, |value| Source::single(value).broadcast(2).expect("broadcast"));
   let flat_map_merge_inlet = flat_map_merge.inlet;
   let flat_map_merge_outlet = flat_map_merge.outlet;
   let sink = collect_u32_sequence_sink(sink_inlet, completion.clone());
@@ -298,7 +298,7 @@ fn flat_map_merge_delays_new_inner_creation_until_breadth_slot_is_released() {
       move |value| {
         let mut guard = created.lock();
         *guard = guard.saturating_add(1);
-        Source::single(value).broadcast(2)
+        Source::single(value).broadcast(2).expect("broadcast")
       }
     })
     .expect("flat_map_merge")
@@ -1326,7 +1326,7 @@ fn cross_operator_backpressure_propagates_through_substream_and_async_boundary()
     restart:     None,
   };
   let flat_map_merge =
-    flat_map_merge_definition::<u32, u32, StreamNotUsed, _>(1, |value| Source::single(value).broadcast(2));
+    flat_map_merge_definition::<u32, u32, StreamNotUsed, _>(1, |value| Source::single(value).broadcast(2).expect("broadcast"));
   let flat_map_merge_inlet = flat_map_merge.inlet;
   let flat_map_merge_outlet = flat_map_merge.outlet;
   let split_after = split_after_definition::<u32, _>(|_| true);

--- a/modules/streams/src/core/stage/flow.rs
+++ b/modules/streams/src/core/stage/flow.rs
@@ -684,14 +684,13 @@ where
 
   /// Adds a broadcast stage that duplicates each element `fan_out` times.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_out` is zero.
-  #[must_use]
-  pub fn broadcast(mut self, fan_out: usize) -> Flow<In, Out, Mat>
+  /// Returns [`StreamDslError`] when `fan_out` is zero.
+  pub fn broadcast(mut self, fan_out: usize) -> Result<Flow<In, Out, Mat>, StreamDslError>
   where
     Out: Clone, {
-    assert!(fan_out > 0, "fan_out must be greater than zero");
+    let _ = validate_positive_argument("fan_out", fan_out)?;
     let definition = broadcast_definition::<Out>(fan_out);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -699,17 +698,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a balance stage that distributes elements across `fan_out` outputs.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_out` is zero.
-  #[must_use]
-  pub fn balance(mut self, fan_out: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_out > 0, "fan_out must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_out` is zero.
+  pub fn balance(mut self, fan_out: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_out", fan_out)?;
     let definition = balance_definition::<Out>(fan_out);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -717,17 +715,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a merge stage that merges `fan_in` upstream paths.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn merge(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge(mut self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = merge_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -735,17 +732,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds an interleave stage that consumes `fan_in` inputs in round-robin order.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn interleave(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn interleave(mut self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = interleave_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -753,17 +749,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a prepend stage that prioritizes lower-index input lanes.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn prepend(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn prepend(mut self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = prepend_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -771,17 +766,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a zip stage that emits one vector after receiving one element from each input.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn zip(mut self, fan_in: usize) -> Flow<In, Vec<Out>, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn zip(mut self, fan_in: usize) -> Result<Flow<In, Vec<Out>, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = zip_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -789,19 +783,18 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a zip-all stage that fills missing lanes with `fill_value` after completion.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn zip_all(mut self, fan_in: usize, fill_value: Out) -> Flow<In, Vec<Out>, Mat>
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn zip_all(mut self, fan_in: usize, fill_value: Out) -> Result<Flow<In, Vec<Out>, Mat>, StreamDslError>
   where
     Out: Clone, {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = zip_all_definition::<Out>(fan_in, fill_value);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -809,7 +802,7 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a zip-with-index stage that pairs each element with an incrementing index.
@@ -827,12 +820,11 @@ where
 
   /// Adds a concat stage that emits all elements from each input in port order.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn concat(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn concat(mut self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = concat_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -840,7 +832,7 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   pub(crate) fn from_graph(graph: StreamGraph, mat: Mat) -> Self {
@@ -1247,6 +1239,10 @@ where
   ///
   /// The factory is not called until the first element arrives.
   /// Flow stages from the created flow are extracted and chained for processing.
+  ///
+  /// The outer `Flow`'s Mat value uses `Mat::default()`. The factory-produced Mat
+  /// is captured internally by `LazyFlowLogic` but is not propagated as the
+  /// outer Mat.
   #[must_use]
   pub fn lazy_flow<F>(factory: F) -> Flow<In, Out, Mat>
   where
@@ -1257,6 +1253,7 @@ where
     let logic = LazyFlowLogic::<In, Out, Mat, F> {
       factory:      Some(factory),
       inner_logics: Vec::new(),
+      mat:          None,
       _pd:          PhantomData,
     };
     let definition = FlowDefinition {
@@ -1354,12 +1351,10 @@ where
     F: FnMut(Acc, Out) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Acc> + Send + 'static, {
     self.scan(initial, move |acc, value| {
-      let mut future = (func)(acc.clone(), value);
-      // SAFETY: future はローカル変数でこのクロージャを超えて移動しない
-      let mut pinned = unsafe { Pin::new_unchecked(&mut future) };
+      let mut future = Box::pin((func)(acc.clone(), value));
       let waker = noop_waker();
       let mut cx = Context::from_waker(&waker);
-      match pinned.as_mut().poll(&mut cx) {
+      match future.as_mut().poll(&mut cx) {
         | Poll::Ready(result) => result,
         | Poll::Pending => acc,
       }
@@ -1724,32 +1719,47 @@ where
   }
 
   /// Adds a merge-sequence compatibility stage.
-  #[must_use]
-  pub fn merge_sequence(self, fan_in: usize) -> Flow<In, Out, Mat> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge_sequence(self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
     self.merge(fan_in)
   }
 
   /// Adds a concat-all-lazy compatibility stage.
-  #[must_use]
-  pub fn concat_all_lazy(self, fan_in: usize) -> Flow<In, Out, Mat> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn concat_all_lazy(self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
     self.concat(fan_in)
   }
 
   /// Adds a concat-lazy compatibility stage.
-  #[must_use]
-  pub fn concat_lazy(self, fan_in: usize) -> Flow<In, Out, Mat> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn concat_lazy(self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
     self.concat(fan_in)
   }
 
   /// Adds an interleave-all compatibility stage.
-  #[must_use]
-  pub fn interleave_all(self, fan_in: usize) -> Flow<In, Out, Mat> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn interleave_all(self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
     self.interleave(fan_in)
   }
 
   /// Adds a merge-all compatibility stage.
-  #[must_use]
-  pub fn merge_all(self, fan_in: usize) -> Flow<In, Out, Mat> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge_all(self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
     self.merge(fan_in)
   }
 
@@ -1759,14 +1769,13 @@ where
   /// No output is produced until every input has delivered at least one
   /// element.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics if `fan_in` is zero.
-  #[must_use]
-  pub fn merge_latest(mut self, fan_in: usize) -> Flow<In, Vec<Out>, Mat>
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge_latest(mut self, fan_in: usize) -> Result<Flow<In, Vec<Out>, Mat>, StreamDslError>
   where
     Out: Clone, {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = merge_latest_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1774,17 +1783,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a merge-preferred stage that prioritizes slot 0 (preferred) input.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn merge_preferred(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge_preferred(mut self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = merge_preferred_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1792,17 +1800,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a merge-prioritized stage with equal weights across all input ports.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn merge_prioritized(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge_prioritized(mut self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let equal_priorities: Vec<usize> = vec![1; fan_in];
     let definition = merge_prioritized_definition::<Out>(fan_in, &equal_priorities);
     let inlet_id = definition.inlet;
@@ -1811,20 +1818,33 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a merge-prioritized stage with custom weight priorities per input port.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero, when `priorities.len() != fan_in`,
-  /// or when any priority is zero.
-  #[must_use]
-  pub fn merge_prioritized_n(mut self, fan_in: usize, priorities: &[usize]) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
-    assert_eq!(priorities.len(), fan_in, "priorities length must match fan_in");
-    assert!(priorities.iter().all(|&p| p > 0), "priorities must be positive");
+  /// Returns [`StreamDslError`] when `fan_in` is zero, when
+  /// `priorities.len() != fan_in`, or when any priority is zero.
+  pub fn merge_prioritized_n(mut self, fan_in: usize, priorities: &[usize]) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
+    if priorities.len() != fan_in {
+      return Err(StreamDslError::InvalidArgument {
+        name:   "priorities",
+        value:  priorities.len(),
+        reason: "length must match fan_in",
+      });
+    }
+    for (i, &p) in priorities.iter().enumerate() {
+      if p == 0 {
+        return Err(StreamDslError::InvalidArgument {
+          name:   "priorities",
+          value:  i,
+          reason: "all priorities must be positive",
+        });
+      }
+    }
     let definition = merge_prioritized_definition::<Out>(fan_in, priorities);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1832,46 +1852,61 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds an or-else compatibility stage.
-  #[must_use]
-  pub fn or_else(self, fan_in: usize) -> Flow<In, Out, Mat> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn or_else(self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
     self.prepend(fan_in)
   }
 
   /// Adds a prepend-lazy compatibility stage.
-  #[must_use]
-  pub fn prepend_lazy(self, fan_in: usize) -> Flow<In, Out, Mat> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn prepend_lazy(self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
     self.prepend(fan_in)
   }
 
   /// Adds a zip-latest compatibility stage.
-  #[must_use]
-  pub fn zip_latest(self, fan_in: usize, fill_value: Out) -> Flow<In, Vec<Out>, Mat>
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn zip_latest(self, fan_in: usize, fill_value: Out) -> Result<Flow<In, Vec<Out>, Mat>, StreamDslError>
   where
     Out: Clone, {
     self.zip_all(fan_in, fill_value)
   }
 
   /// Adds a zip-latest-with compatibility stage.
-  #[must_use]
-  pub fn zip_latest_with<T, F>(self, fan_in: usize, fill_value: Out, func: F) -> Flow<In, T, Mat>
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn zip_latest_with<T, F>(self, fan_in: usize, fill_value: Out, func: F) -> Result<Flow<In, T, Mat>, StreamDslError>
   where
     Out: Clone,
     T: Send + Sync + 'static,
     F: FnMut(Vec<Out>) -> T + Send + Sync + 'static, {
-    self.zip_latest(fan_in, fill_value).map(func)
+    Ok(self.zip_latest(fan_in, fill_value)?.map(func))
   }
 
   /// Adds a zip-with compatibility stage.
-  #[must_use]
-  pub fn zip_with<T, F>(self, fan_in: usize, func: F) -> Flow<In, T, Mat>
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn zip_with<T, F>(self, fan_in: usize, func: F) -> Result<Flow<In, T, Mat>, StreamDslError>
   where
     T: Send + Sync + 'static,
     F: FnMut(Vec<Out>) -> T + Send + Sync + 'static, {
-    self.zip(fan_in).map(func)
+    Ok(self.zip(fan_in)?.map(func))
   }
 
   /// Adds an also-to compatibility stage.
@@ -2095,12 +2130,11 @@ where
 {
   /// Adds a merge-sorted stage that merges pre-sorted inputs into a single sorted output.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn merge_sorted(mut self, fan_in: usize) -> Flow<In, Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge_sorted(mut self, fan_in: usize) -> Result<Flow<In, Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = merge_sorted_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -2108,7 +2142,7 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Flow { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Flow { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 }
 
@@ -3379,7 +3413,9 @@ where
 struct LazyFlowLogic<In, Out, Mat, F> {
   factory:      Option<F>,
   inner_logics: Vec<Box<dyn FlowLogic>>,
-  _pd:          PhantomData<fn(In, Out, Mat)>,
+  // factory 生成 Flow の Mat 値を保持
+  mat:          Option<Mat>,
+  _pd:          PhantomData<fn(In, Out)>,
 }
 
 impl<In, Out, Mat, F> FlowLogic for LazyFlowLogic<In, Out, Mat, F>
@@ -3392,7 +3428,8 @@ where
   fn apply(&mut self, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
     if let Some(factory) = self.factory.take() {
       let flow = factory();
-      let (graph, _mat) = flow.into_parts();
+      let (graph, mat) = flow.into_parts();
+      self.mat = Some(mat);
       let stages = graph.into_stages();
       for stage in stages {
         if let StageDefinition::Flow(def) = stage {
@@ -3456,7 +3493,8 @@ where
   }
 
   fn take_shutdown_request(&mut self) -> bool {
-    self.inner_logics.iter_mut().any(|l| l.take_shutdown_request())
+    // any() の短絡評価を避け、全 inner logic のフラグを一括クリアする
+    self.inner_logics.iter_mut().fold(false, |acc, l| l.take_shutdown_request() || acc)
   }
 
   fn on_restart(&mut self) -> Result<(), StreamError> {

--- a/modules/streams/src/core/stage/flow/tests.rs
+++ b/modules/streams/src/core/stage/flow/tests.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, collections::VecDeque};
-use core::{future::Future, pin::Pin, task::Poll};
+use core::{future::Future, marker::PhantomData, pin::Pin, task::Poll};
 
 use fraktor_utils_rs::core::collections::queue::OverflowPolicy;
 
@@ -56,67 +56,62 @@ impl SourceLogic for PulsedSourceLogic {
 
 #[test]
 fn broadcast_duplicates_each_element() {
-  let values = Source::single(7_u32).via(Flow::new().broadcast(2)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().broadcast(2).expect("broadcast")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32, 7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_out must be greater than zero")]
 fn broadcast_rejects_zero_fan_out() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.broadcast(0);
+  assert!(flow.broadcast(0).is_err());
 }
 
 #[test]
 fn balance_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().balance(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().balance(1).expect("balance")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_out must be greater than zero")]
 fn balance_rejects_zero_fan_out() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.balance(0);
+  assert!(flow.balance(0).is_err());
 }
 
 #[test]
 fn merge_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().merge(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().merge(1).expect("merge")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn merge_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge(0);
+  assert!(flow.merge(0).is_err());
 }
 
 #[test]
 fn zip_wraps_value_when_single_path() {
-  let values = Source::single(7_u32).via(Flow::new().zip(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().zip(1).expect("zip")).collect_values().expect("collect_values");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn zip_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.zip(0);
+  assert!(flow.zip(0).is_err());
 }
 
 #[test]
 fn concat_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().concat(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().concat(1).expect("concat")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn concat_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.concat(0);
+  assert!(flow.concat(0).is_err());
 }
 
 #[test]
@@ -145,41 +140,38 @@ fn unzip_with_emits_mapped_tuple_components() {
 
 #[test]
 fn interleave_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().interleave(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().interleave(1).expect("interleave")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn interleave_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.interleave(0);
+  assert!(flow.interleave(0).is_err());
 }
 
 #[test]
 fn prepend_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().prepend(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().prepend(1).expect("prepend")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn prepend_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.prepend(0);
+  assert!(flow.prepend(0).is_err());
 }
 
 #[test]
 fn zip_all_wraps_value_when_single_path() {
-  let values = Source::single(7_u32).via(Flow::new().zip_all(1, 0_u32)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().zip_all(1, 0_u32).expect("zip_all")).collect_values().expect("collect_values");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn zip_all_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.zip_all(0, 0_u32);
+  assert!(flow.zip_all(0, 0_u32).is_err());
 }
 
 #[test]
@@ -1754,15 +1746,14 @@ fn initial_timeout_rejects_zero_ticks() {
 
 #[test]
 fn merge_preferred_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().merge_preferred(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().merge_preferred(1).expect("merge_preferred")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn merge_preferred_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge_preferred(0);
+  assert!(flow.merge_preferred(0).is_err());
 }
 
 #[test]
@@ -1884,43 +1875,39 @@ fn merge_preferred_logic_on_restart_clears_state() {
 
 #[test]
 fn merge_prioritized_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().merge_prioritized(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().merge_prioritized(1).expect("merge_prioritized")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn merge_prioritized_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge_prioritized(0);
+  assert!(flow.merge_prioritized(0).is_err());
 }
 
 #[test]
 fn merge_prioritized_n_keeps_single_path_behavior() {
   let values =
-    Source::single(7_u32).via(Flow::new().merge_prioritized_n(1, &[1])).collect_values().expect("collect_values");
+    Source::single(7_u32).via(Flow::new().merge_prioritized_n(1, &[1]).expect("merge_prioritized_n")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "priorities must be positive")]
 fn merge_prioritized_n_rejects_zero_priority() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge_prioritized_n(2, &[3, 0]);
+  assert!(flow.merge_prioritized_n(2, &[3, 0]).is_err());
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn merge_prioritized_n_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge_prioritized_n(0, &[]);
+  assert!(flow.merge_prioritized_n(0, &[]).is_err());
 }
 
 #[test]
-#[should_panic(expected = "priorities length must match fan_in")]
 fn merge_prioritized_n_rejects_length_mismatch() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge_prioritized_n(3, &[3, 1]);
+  assert!(flow.merge_prioritized_n(3, &[3, 1]).is_err());
 }
 
 #[test]
@@ -2031,15 +2018,14 @@ fn merge_prioritized_logic_on_restart_clears_state() {
 
 #[test]
 fn merge_sorted_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().merge_sorted(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().merge_sorted(1).expect("merge_sorted")).collect_values().expect("collect_values");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn merge_sorted_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge_sorted(0);
+  assert!(flow.merge_sorted(0).is_err());
 }
 
 #[test]
@@ -2115,15 +2101,14 @@ fn merge_sorted_logic_on_restart_clears_state() {
 
 #[test]
 fn merge_latest_wraps_single_path_value_into_vec() {
-  let values = Source::single(7_u32).via(Flow::new().merge_latest(1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().merge_latest(1).expect("merge_latest")).collect_values().expect("collect_values");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn merge_latest_rejects_zero_fan_in() {
   let flow = Flow::<u32, u32, StreamNotUsed>::new();
-  let _ = flow.merge_latest(0);
+  assert!(flow.merge_latest(0).is_err());
 }
 
 #[test]
@@ -2207,4 +2192,49 @@ fn uniform_fan_in_shape_zero_ports() {
   let shape = UniformFanInShape::<u32, u32>::with_port_count(0);
   assert_eq!(shape.port_count(), 0);
   assert!(shape.inlets().is_empty());
+}
+
+// take_shutdown_request の全フラグクリアを検証するためのカスタム FlowLogic
+struct ShutdownFlagFlowLogic {
+  shutdown_requested: bool,
+}
+
+impl FlowLogic for ShutdownFlagFlowLogic {
+  fn apply(&mut self, input: DynValue) -> Result<alloc::vec::Vec<DynValue>, StreamError> {
+    Ok(alloc::vec![input])
+  }
+
+  fn take_shutdown_request(&mut self) -> bool {
+    let was_requested = self.shutdown_requested;
+    self.shutdown_requested = false;
+    was_requested
+  }
+}
+
+#[test]
+fn flow_lazy_flow_take_shutdown_request_clears_all_inner_flags() {
+  // Given: 3つの inner logic すべてにシャットダウンフラグが設定された LazyFlowLogic
+  let mut logic = super::LazyFlowLogic::<u32, u32, StreamNotUsed, fn() -> Flow<u32, u32, StreamNotUsed>> {
+    factory:      None,
+    inner_logics: alloc::vec![
+      Box::new(ShutdownFlagFlowLogic { shutdown_requested: true }),
+      Box::new(ShutdownFlagFlowLogic { shutdown_requested: true }),
+      Box::new(ShutdownFlagFlowLogic { shutdown_requested: true }),
+    ],
+    mat:          None,
+    _pd:          PhantomData,
+  };
+
+  // When: take_shutdown_request を呼ぶ
+  let first_call = logic.take_shutdown_request();
+
+  // Then: true が返る（いずれかのフラグが設定されていたため）
+  assert!(first_call);
+
+  // When: 再度呼ぶ（fold で全フラグがクリア済みであれば false になる）
+  let second_call = logic.take_shutdown_request();
+
+  // Then: 全フラグがクリアされているため false
+  // any() 短絡評価の場合、2番目以降のフラグが未クリアで true になりテスト失敗
+  assert!(!second_call);
 }

--- a/modules/streams/src/core/stage/source.rs
+++ b/modules/streams/src/core/stage/source.rs
@@ -307,11 +307,13 @@ where
   }
 
   /// Lazily creates a single-element source.
+  ///
+  /// The factory is deferred until the first element is demanded.
   #[must_use]
   pub fn lazy_single<F>(factory: F) -> Self
   where
-    F: FnOnce() -> Out, {
-    Self::single(factory())
+    F: FnOnce() -> Out + Send + 'static, {
+    Self::lazy_source(move || Self::single(factory()))
   }
 
   /// Lazily creates a source from a source factory.
@@ -325,6 +327,7 @@ where
     Self::from_logic(StageKind::Custom, LazySourceLogic::<Out, F> {
       factory: Some(factory),
       buffer:  VecDeque::new(),
+      error:   None,
       _pd:     PhantomData,
     })
   }
@@ -415,18 +418,24 @@ where
   }
 
   /// Alias of [`Source::zip`].
-  #[must_use]
-  pub fn zip_n(self, n: usize) -> Source<Vec<Out>, StreamNotUsed> {
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `n` is zero.
+  pub fn zip_n(self, n: usize) -> Result<Source<Vec<Out>, StreamNotUsed>, StreamDslError> {
     self.zip(n)
   }
 
   /// Alias of [`Source::zip_n`] followed by mapping.
-  #[must_use]
-  pub fn zip_with_n<T, F>(self, n: usize, func: F) -> Source<T, StreamNotUsed>
+  ///
+  /// # Errors
+  ///
+  /// Returns [`StreamDslError`] when `n` is zero.
+  pub fn zip_with_n<T, F>(self, n: usize, func: F) -> Result<Source<T, StreamNotUsed>, StreamDslError>
   where
     T: Send + Sync + 'static,
     F: FnMut(Vec<Out>) -> T + Send + Sync + 'static, {
-    self.zip_n(n).map(func)
+    Ok(self.zip_n(n)?.map(func))
   }
 
   pub(in crate::core) fn from_logic<L>(kind: StageKind, logic: L) -> Self
@@ -1151,14 +1160,13 @@ where
 
   /// Adds a broadcast stage that duplicates each element `fan_out` times.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_out` is zero.
-  #[must_use]
-  pub fn broadcast(mut self, fan_out: usize) -> Source<Out, Mat>
+  /// Returns [`StreamDslError`] when `fan_out` is zero.
+  pub fn broadcast(mut self, fan_out: usize) -> Result<Source<Out, Mat>, StreamDslError>
   where
     Out: Clone, {
-    assert!(fan_out > 0, "fan_out must be greater than zero");
+    let _ = validate_positive_argument("fan_out", fan_out)?;
     let definition = broadcast_definition::<Out>(fan_out);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1166,17 +1174,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a balance stage that distributes elements across `fan_out` outputs.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_out` is zero.
-  #[must_use]
-  pub fn balance(mut self, fan_out: usize) -> Source<Out, Mat> {
-    assert!(fan_out > 0, "fan_out must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_out` is zero.
+  pub fn balance(mut self, fan_out: usize) -> Result<Source<Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_out", fan_out)?;
     let definition = balance_definition::<Out>(fan_out);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1184,17 +1191,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a merge stage that merges `fan_in` upstream paths.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn merge(mut self, fan_in: usize) -> Source<Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn merge(mut self, fan_in: usize) -> Result<Source<Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = merge_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1202,17 +1208,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds an interleave stage that consumes `fan_in` inputs in round-robin order.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn interleave(mut self, fan_in: usize) -> Source<Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn interleave(mut self, fan_in: usize) -> Result<Source<Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = interleave_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1220,17 +1225,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a prepend stage that prioritizes lower-index input lanes.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn prepend(mut self, fan_in: usize) -> Source<Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn prepend(mut self, fan_in: usize) -> Result<Source<Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = prepend_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1238,17 +1242,16 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a zip stage that emits one vector after receiving one element from each input.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn zip(mut self, fan_in: usize) -> Source<Vec<Out>, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn zip(mut self, fan_in: usize) -> Result<Source<Vec<Out>, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = zip_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1256,19 +1259,18 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a zip-all stage that fills missing lanes with `fill_value` after completion.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn zip_all(mut self, fan_in: usize, fill_value: Out) -> Source<Vec<Out>, Mat>
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn zip_all(mut self, fan_in: usize, fill_value: Out) -> Result<Source<Vec<Out>, Mat>, StreamDslError>
   where
     Out: Clone, {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = zip_all_definition::<Out>(fan_in, fill_value);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1276,7 +1278,7 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Adds a zip-with-index stage that pairs each element with an incrementing index.
@@ -1294,12 +1296,11 @@ where
 
   /// Adds a concat stage that emits all elements from each input in port order.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when `fan_in` is zero.
-  #[must_use]
-  pub fn concat(mut self, fan_in: usize) -> Source<Out, Mat> {
-    assert!(fan_in > 0, "fan_in must be greater than zero");
+  /// Returns [`StreamDslError`] when `fan_in` is zero.
+  pub fn concat(mut self, fan_in: usize) -> Result<Source<Out, Mat>, StreamDslError> {
+    let _ = validate_positive_argument("fan_in", fan_in)?;
     let definition = concat_definition::<Out>(fan_in);
     let inlet_id = definition.inlet;
     let from = self.graph.tail_outlet();
@@ -1307,7 +1308,7 @@ where
     if let Some(from) = from {
       let _ = self.graph.connect(&Outlet::<Out>::from_id(from), &Inlet::<Out>::from_id(inlet_id), MatCombine::KeepLeft);
     }
-    Source { graph: self.graph, mat: self.mat, _pd: PhantomData }
+    Ok(Source { graph: self.graph, mat: self.mat, _pd: PhantomData })
   }
 
   /// Runs this source to completion and collects emitted elements.
@@ -1771,6 +1772,8 @@ where
 struct LazySourceLogic<Out, F> {
   factory: Option<F>,
   buffer:  VecDeque<DynValue>,
+  // factory 消費後に collect_values が失敗した場合のエラー状態
+  error:   Option<StreamError>,
   _pd:     PhantomData<fn() -> Out>,
 }
 
@@ -1780,12 +1783,29 @@ where
   F: FnOnce() -> Source<Out, StreamNotUsed> + Send + 'static,
 {
   fn pull(&mut self) -> Result<Option<DynValue>, StreamError> {
+    if let Some(error) = &self.error {
+      return Err(error.clone());
+    }
     if let Some(factory) = self.factory.take() {
       let source = factory();
-      let values = source.collect_values()?;
-      self.buffer = values.into_iter().map(|v| Box::new(v) as DynValue).collect();
+      match source.collect_values() {
+        | Ok(values) => {
+          self.buffer = values.into_iter().map(|v| Box::new(v) as DynValue).collect();
+        },
+        | Err(e) => {
+          self.error = Some(e.clone());
+          return Err(e);
+        },
+      }
     }
     Ok(self.buffer.pop_front())
+  }
+
+  fn on_restart(&mut self) -> Result<(), StreamError> {
+    if let Some(error) = &self.error {
+      return Err(error.clone());
+    }
+    Ok(())
   }
 }
 

--- a/modules/streams/src/core/stage/source/tests.rs
+++ b/modules/streams/src/core/stage/source/tests.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, collections::VecDeque};
-use core::future::ready;
+use core::{future::ready, marker::PhantomData};
 
 use fraktor_utils_rs::core::{
   collections::queue::OverflowPolicy,
@@ -9,7 +9,7 @@ use fraktor_utils_rs::core::{
 
 use crate::core::{
   DynValue, KeepLeft, KeepRight, RestartSettings, SourceLogic, StreamBufferConfig, StreamCompletion, StreamDone,
-  StreamDslError, StreamError,
+  StreamDslError, StreamError, StreamNotUsed,
   lifecycle::{
     DriveOutcome, SharedKillSwitch, Stream, StreamHandleGeneric, StreamHandleId, StreamSharedGeneric, StreamState,
   },
@@ -286,7 +286,7 @@ fn shared_kill_switch_created_before_materialization_controls_multiple_streams()
 
 #[test]
 fn source_broadcast_duplicates_each_element() {
-  let values = Source::single(5_u32).broadcast(2).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).broadcast(2).expect("broadcast").collect_values().expect("collect_values");
   assert_eq!(values, vec![5_u32, 5_u32]);
 }
 
@@ -565,7 +565,7 @@ fn source_unfold_async_emits_state_progression() {
 
 #[test]
 fn source_zip_n_alias_wraps_values_by_fan_in() {
-  let values = Source::single(15_u32).zip_n(1).collect_values().expect("collect_values");
+  let values = Source::single(15_u32).zip_n(1).expect("zip_n").collect_values().expect("collect_values");
   assert_eq!(values, vec![vec![15_u32]]);
 }
 
@@ -573,6 +573,7 @@ fn source_zip_n_alias_wraps_values_by_fan_in() {
 fn source_zip_with_n_alias_maps_zipped_values() {
   let values = Source::single(16_u32)
     .zip_with_n(1, |items: Vec<u32>| items.into_iter().sum::<u32>())
+    .expect("zip_with_n")
     .collect_values()
     .expect("collect_values");
   assert_eq!(values, vec![16_u32]);
@@ -615,57 +616,52 @@ fn source_from_path_emits_path_bytes() {
 }
 
 #[test]
-#[should_panic(expected = "fan_out must be greater than zero")]
 fn source_broadcast_rejects_zero_fan_out() {
-  let _ = Source::single(1_u32).broadcast(0);
+  assert!(Source::single(1_u32).broadcast(0).is_err());
 }
 
 #[test]
 fn source_balance_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).balance(1).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).balance(1).expect("balance").collect_values().expect("collect_values");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_out must be greater than zero")]
 fn source_balance_rejects_zero_fan_out() {
-  let _ = Source::single(1_u32).balance(0);
+  assert!(Source::single(1_u32).balance(0).is_err());
 }
 
 #[test]
 fn source_merge_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).merge(1).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).merge(1).expect("merge").collect_values().expect("collect_values");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn source_merge_rejects_zero_fan_in() {
-  let _ = Source::single(1_u32).merge(0);
+  assert!(Source::single(1_u32).merge(0).is_err());
 }
 
 #[test]
 fn source_zip_wraps_value_when_single_path() {
-  let values = Source::single(5_u32).zip(1).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).zip(1).expect("zip").collect_values().expect("collect_values");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn source_zip_rejects_zero_fan_in() {
-  let _ = Source::single(1_u32).zip(0);
+  assert!(Source::single(1_u32).zip(0).is_err());
 }
 
 #[test]
 fn source_concat_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).concat(1).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).concat(1).expect("concat").collect_values().expect("collect_values");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn source_concat_rejects_zero_fan_in() {
-  let _ = Source::single(1_u32).concat(0);
+  assert!(Source::single(1_u32).concat(0).is_err());
 }
 
 #[test]
@@ -694,38 +690,35 @@ fn source_unzip_with_emits_mapped_tuple_components() {
 
 #[test]
 fn source_interleave_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).interleave(1).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).interleave(1).expect("interleave").collect_values().expect("collect_values");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn source_interleave_rejects_zero_fan_in() {
-  let _ = Source::single(1_u32).interleave(0);
+  assert!(Source::single(1_u32).interleave(0).is_err());
 }
 
 #[test]
 fn source_prepend_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).prepend(1).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).prepend(1).expect("prepend").collect_values().expect("collect_values");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn source_prepend_rejects_zero_fan_in() {
-  let _ = Source::single(1_u32).prepend(0);
+  assert!(Source::single(1_u32).prepend(0).is_err());
 }
 
 #[test]
 fn source_zip_all_wraps_value_when_single_path() {
-  let values = Source::single(5_u32).zip_all(1, 0_u32).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).zip_all(1, 0_u32).expect("zip_all").collect_values().expect("collect_values");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
 #[test]
-#[should_panic(expected = "fan_in must be greater than zero")]
 fn source_zip_all_rejects_zero_fan_in() {
-  let _ = Source::single(1_u32).zip_all(0, 0_u32);
+  assert!(Source::single(1_u32).zip_all(0, 0_u32).is_err());
 }
 
 #[test]
@@ -1207,6 +1200,7 @@ fn source_p2_regression_group_by_merge_substreams_with_delay_and_zip_all() {
     .delay(1)
     .expect("delay")
     .zip_all(1, 0_u32)
+    .expect("zip_all")
     .collect_values()
     .expect("collect_values");
   assert_eq!(values, vec![vec![1_u32], vec![2_u32], vec![3_u32]]);
@@ -1219,6 +1213,7 @@ fn source_p2_regression_concat_substreams_with_take_within_and_prepend() {
     .take_within(2)
     .expect("take_within")
     .prepend(1)
+    .expect("prepend")
     .collect_values()
     .expect("collect_values");
   assert_eq!(values, vec![4_u32, 5_u32]);
@@ -1402,4 +1397,28 @@ fn source_reduce_folds_with_first_element_as_seed() {
     .collect_values()
     .expect("collect_values");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
+}
+
+#[test]
+fn source_lazy_source_persists_error_on_collect_values_failure() {
+  let mut logic = super::LazySourceLogic::<u32, _> {
+    factory: Some(|| Source::<u32, StreamNotUsed>::failed(StreamError::Failed)),
+    buffer:  VecDeque::new(),
+    error:   None,
+    _pd:     PhantomData,
+  };
+
+  // Given: 初回 pull で factory が消費され collect_values が失敗する
+  let first = logic.pull();
+  assert!(matches!(first, Err(StreamError::Failed)));
+
+  // When: 後続 pull を呼ぶ（factory は既に消費済み）
+  let second = logic.pull();
+  // Then: 偽の正常完了（Ok(None)）ではなくエラーを返す
+  assert!(matches!(second, Err(StreamError::Failed)));
+
+  // When: on_restart を呼ぶ
+  let restart = logic.on_restart();
+  // Then: エラー状態が永続化されリスタートも失敗する
+  assert!(matches!(restart, Err(StreamError::Failed)));
 }

--- a/modules/streams/src/core/stream_completion.rs
+++ b/modules/streams/src/core/stream_completion.rs
@@ -54,7 +54,10 @@ impl<T> StreamCompletion<T> {
 
   pub(crate) fn complete(&self, result: Result<T, StreamError>) {
     let mut guard = self.inner.lock();
-    guard.result = Some(result);
+    // 既存結果の上書きを防止
+    if guard.result.is_none() {
+      guard.result = Some(result);
+    }
   }
 }
 

--- a/modules/streams/src/core/stream_completion/tests.rs
+++ b/modules/streams/src/core/stream_completion/tests.rs
@@ -21,3 +21,19 @@ fn completion_try_take_consumes_result() {
   assert_eq!(completion.try_take(), Some(Err(StreamError::Failed)));
   assert_eq!(completion.poll(), Completion::Pending);
 }
+
+#[test]
+fn completion_preserves_first_result_on_duplicate_complete() {
+  let completion: StreamCompletion<u32> = StreamCompletion::new();
+  completion.complete(Ok(42));
+  completion.complete(Err(StreamError::Failed));
+  assert_eq!(completion.poll(), Completion::Ready(Ok(42)));
+}
+
+#[test]
+fn completion_preserves_first_error_on_duplicate_complete() {
+  let completion: StreamCompletion<u32> = StreamCompletion::new();
+  completion.complete(Err(StreamError::Failed));
+  completion.complete(Ok(99));
+  assert_eq!(completion.poll(), Completion::Ready(Err(StreamError::Failed)));
+}


### PR DESCRIPTION
## Summary

## Execution Report

Piece `critical-bug-fix` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public DSL method signatures (many `Source`/`Flow` combinators now return `Result`) and adjusts completion/error propagation semantics, which can break callers and alter runtime behavior.
> 
> **Overview**
> **Makes stream graph construction fallible instead of panicking**: `Source`/`Flow` fan-in/fan-out operators (e.g. `broadcast`, `merge`, `zip`, `concat`, plus related compatibility aliases) now validate arguments via `StreamDslError` and return `Result`, with tests updated to use `.expect(...)`/`is_err()`.
> 
> **Hardens lazy and completion semantics**: `Source::lazy_single` is now truly demand-deferred; `LazySourceLogic` persists failures from inner `collect_values` across subsequent pulls/restarts; lazy sinks now call `on_start` on the inner sink when instantiated and propagate inner `on_complete` errors; `LazyFlowLogic` clears all inner shutdown flags (no `any()` short-circuit) and avoids unsafe pinning in `scan_async`; `StreamCompletion::complete` no longer overwrites an existing result.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71dd4943e6a19efecf1df45f5cde10b6edd8edce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 不正な入力パラメータに対するエラーハンドリングが改善されました。

* **新機能**
  * ストリーム操作の入力検証が強化されました。

* **改善**
  * 完了処理で重複呼び出しの際に最初の結果を保持するように改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->