### PR TITLE
ci(github): add workflow to convert BugBot comments to GitHub Issues

### DIFF
--- a/.github/workflows/bugbot-to-issue.yml
+++ b/.github/workflows/bugbot-to-issue.yml
@@ -1,0 +1,87 @@
+name: BugBot → GitHub Issue
+
+on:
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  create-issue:
+    # BugBot のコメントのみ対象
+    # issue_comment は PR 上のコメントのみ（通常 Issue は除外）
+    if: |
+      github.event.comment.user.login == 'cursor[bot]' &&
+      (
+        github.event_name == 'pull_request_review_comment' ||
+        github.event.issue.pull_request != null
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve PR URL and number
+        id: pr
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_review_comment" ]]; then
+            echo "url=${{ github.event.pull_request.html_url }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.pull_request.number }}"  >> "$GITHUB_OUTPUT"
+          else
+            echo "url=${{ github.event.issue.html_url }}"  >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract issue title from BugBot comment
+        id: title
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          # 空行をスキップして最初の行を取得（最大80文字）
+          title=$(printf '%s' "$BODY" | grep -m1 -v '^[[:space:]]*$' | sed 's/^#*[[:space:]]*//' | cut -c1-80)
+          # タイトルが空の場合はデフォルト値
+          echo "title=${title:-BugBot detected an issue}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure "bug" label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create bug \
+            --repo "${{ github.repository }}" \
+            --color d73a4a \
+            --description "Something isn't working" \
+            2>/dev/null || true
+
+      - name: Build issue body
+        env:
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+        run: |
+          # --body-file を使いコマンドインジェクションを防ぐ
+          {
+            echo "> **BugBot が PR #${PR_NUMBER} で検出したバグ**"
+            echo "> ${PR_URL}"
+            echo ""
+            echo "---"
+            echo ""
+            printf '%s\n' "${COMMENT_BODY}"
+            echo ""
+            echo "---"
+            echo ""
+            echo "**元コメント**: ${COMMENT_URL}"
+          } > /tmp/issue-body.md
+
+      - name: Create GitHub Issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUG_TITLE: ${{ steps.title.outputs.title }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "🐛 [BugBot] ${BUG_TITLE}" \
+            --body-file /tmp/issue-body.md \
+            --label "bug"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Limited to a new automation workflow using `GITHUB_TOKEN` to create labeled issues; main risk is noisy/duplicate issue creation if the trigger conditions are too broad.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/bugbot-to-issue.yml`) that listens for newly created PR review comments and PR issue comments from `cursor[bot]` and automatically opens a GitHub Issue.
> 
> The workflow derives the issue title from the first non-empty line of the bot comment, ensures a `bug` label exists, and creates an issue whose body links back to the originating PR and comment (using `--body-file` to avoid shell injection).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca2ff96bdc02638431f92c66ea5843974215a3f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * BugBotのコメントから自動的にGitHubのissueを作成するワークフローを追加しました。バグレポートの管理がより効率化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->