### PR TITLE
github-issue-124-bugbot-title

### DIFF
--- a/.github/workflows/bugbot-to-issue.yml
+++ b/.github/workflows/bugbot-to-issue.yml
@@ -40,7 +40,7 @@ jobs:
           BODY: ${{ github.event.comment.body }}
         run: |
           # 空行をスキップして最初の行を取得（最大80文字）
-          title=$(printf '%s' "$BODY" | grep -m1 -v '^[[:space:]]*$' | sed 's/^#*[[:space:]]*//' | cut -c1-80)
+          title=$(printf '%s' "$BODY" | grep -m1 -v '^[[:space:]]*$' | sed 's/^#*[[:space:]]*//' | cut -c1-80) || true
           # タイトルが空の場合はデフォルト値
           echo "title=${title:-BugBot detected an issue}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/tests/test_extract_title.sh
+++ b/.github/workflows/tests/test_extract_title.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Tests for the "Extract issue title" logic in bugbot-to-issue.yml
+#
+# This script exercises the same pipeline used in the workflow:
+#   title=$(printf '%s' "$BODY" | grep -m1 -v '^[[:space:]]*$' \
+#           | sed 's/^#*[[:space:]]*//' | cut -c1-80) || true
+#   echo "title=${title:-BugBot detected an issue}"
+#
+# Usage: bash .github/workflows/tests/test_extract_title.sh
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+assert_title() {
+  local test_name="$1"
+  local body="$2"
+  local expected="$3"
+
+  # Replicate the exact pipeline from the workflow (with || true fix)
+  local title
+  title=$(printf '%s' "$body" | grep -m1 -v '^[[:space:]]*$' | sed 's/^#*[[:space:]]*//' | cut -c1-80) || true
+  local result="${title:-BugBot detected an issue}"
+
+  if [[ "$result" == "$expected" ]]; then
+    echo "PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $test_name"
+    echo "  expected: '$expected'"
+    echo "  got:      '$result'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Normal cases ---
+
+assert_title \
+  "Normal single-line body" \
+  "Title extraction fails on empty comment" \
+  "Title extraction fails on empty comment"
+
+assert_title \
+  "Body with leading blank line" \
+  "
+Actual title here" \
+  "Actual title here"
+
+assert_title \
+  "Body with markdown heading prefix" \
+  "### Title extraction fails on empty comment" \
+  "Title extraction fails on empty comment"
+
+assert_title \
+  "Body with multiple heading hashes" \
+  "## Some heading" \
+  "Some heading"
+
+# --- Edge cases (the bug scenario) ---
+
+assert_title \
+  "Empty body" \
+  "" \
+  "BugBot detected an issue"
+
+assert_title \
+  "Whitespace-only body (spaces)" \
+  "   " \
+  "BugBot detected an issue"
+
+assert_title \
+  "Whitespace-only body (tabs)" \
+  "		" \
+  "BugBot detected an issue"
+
+assert_title \
+  "Body with only blank lines" \
+  "
+
+" \
+  "BugBot detected an issue"
+
+# --- Truncation ---
+
+long_title="$(printf 'A%.0s' {1..120})"
+expected_truncated="$(printf 'A%.0s' {1..80})"
+assert_title \
+  "Long title truncated to 80 chars" \
+  "$long_title" \
+  "$expected_truncated"
+
+# --- Summary ---
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

> **BugBot が PR #123 で検出したバグ**
> https://github.com/j5ik2o/fraktor-rs/pull/123

---

### Title extraction fails on empty comment

**Medium Severity**

<!-- DESCRIPTION START -->
The “Extract issue title” step can fail when `github.event.comment.body` is empty or only whitespace because `grep -m1 -v` returns exit code `1` and GitHub Actions runs bash with `-e`/`pipefail`. That aborts the job before the default title fallback (`${title:-...}`) is written to `GITHUB_OUTPUT`.
<!-- DESCRIPTION END -->

<!-- BUGBOT_BUG_ID: fa1eb744-7253-45eb-a9c8-81d603b741d3 -->

<!-- LOCATIONS START
.github/workflows/bugbot-to-issue.yml#L36-L45
LOCATIONS END -->
<p><a href="https://cursor.com/open?data=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImJ1Z2JvdC12MiJ9.eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiQlVHQk9UX0ZJWF9JTl9DVVJTT1IiLCJkYXRhIjp7InJlZGlzS2V5IjoiYnVnYm90OmVkZTM3NmI2LTA3ZTgtNDhiMS05MjE4LTM3Yzk5MGFmODY0MyIsImVuY3J5cHRpb25LZXkiOiJmWmU3XzY0aFN6Wkg1Z2Z5V3pjLWluNVBNRk45V2pEMXcxWnhwLWo2cWpBIiwiYnJhbmNoIjoidG8taXNzdWUteWFtbCIsInJlcG9Pd25lciI6Imo1aWsybyIsInJlcG9OYW1lIjoiZnJha3Rvci1ycyJ9LCJpYXQiOjE3NzE4NDUzNDgsImV4cCI6MTc3NDQzNzM0OH0.lNjbryo9pr9ct_SZkptxjYUgkDjC3OrV20hR_yTYQay7iP0o8NK2mJ2Sy_OoHqSG9iUN8Xh_4WbelmGAlJZeihkORG_2De2Dh1VAGagIHE0im4uli5KiyBQx0cdC8wo-SH1uhf4f7w2HRCEY80txjg8s2rSzv9M_kf7IcRpwDejkVsKHzoD1OmhEZA9uJsRETGme7J6EykWbtyNDvHH9YQZmGDyK-AmCJgx-luO7NDmuBJxEO8Hpq21sgYcl-EZjfihMBeQYOR5UIEySFCtmx1esYtxylRMcR_PosfeAtIQIdHtzf4jwLWq1GHIzUUE65e_csDksEAGJ8lhDr8s-nw" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-cursor-light.png"><img alt="Fix in Cursor" width="115" height="28" src="https://cursor.com/assets/images/fix-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?data=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImJ1Z2JvdC12MiJ9.eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiQlVHQk9UX0ZJWF9JTl9XRUIiLCJkYXRhIjp7InJlZGlzS2V5IjoiYnVnYm90OmVkZTM3NmI2LTA3ZTgtNDhiMS05MjE4LTM3Yzk5MGFmODY0MyIsImVuY3J5cHRpb25LZXkiOiJmWmU3XzY0aFN6Wkg1Z2Z5V3pjLWluNVBNRk45V2pEMXcxWnhwLWo2cWpBIiwiYnJhbmNoIjoidG8taXNzdWUteWFtbCIsInJlcG9Pd25lciI6Imo1aWsybyIsInJlcG9OYW1lIjoiZnJha3Rvci1ycyIsInByTnVtYmVyIjoxMjMsImNvbW1pdFNoYSI6ImNhMmZmOTZiZGMwMjYzODQzMWY5MmM2NmVhNTg0Mzk3NDIxNWEzZjAiLCJwcm92aWRlciI6ImdpdGh1YiJ9LCJpYXQiOjE3NzE4NDUzNDgsImV4cCI6MTc3NDQzNzM0OH0.n6iQ--3xqIts7byYxFSaRUYAOCHwOGfRGZUhXl9J6kQf5z8jvoIIPcLJopjZ5KkdCaq1-vVGu1rEgeNL6kF_PqrhDTvZCloAUYEVyZVdZzpYunI-rMDBai3o4-F9MBDocpExw049mzuYLHqStJPtWkFND4KIRRLal-HSMXVVGYZ6B3oxn3MPWN3Q6YH6F7M0wfWySapNSl4I0KKX0jAGqsJUZT8RHwMiK44Y4lxcb_ZXUxxUm21GUBkT-B7Mik1Kniiq6qrbBa5L6uf62K-sPpnc3fo5jT6TITnI01YNJtWhCECb1iU39Lopgc7v2z1A4OnvaKoSpTnE59NdHCcb7w" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-web-light.png"><img alt="Fix in Web" width="99" height="28" src="https://cursor.com/assets/images/fix-in-web-dark.png"></picture></a></p>



---

**元コメント**: https://github.com/j5ik2o/fraktor-rs/pull/123#discussion_r2840300120


## Execution Report

Piece `default` completed successfully.

Closes #124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small GitHub Actions shell change plus a standalone test script; risk is limited to slightly masking unexpected `grep` failures in that workflow step.
> 
> **Overview**
> Fixes the `BugBot → GitHub Issue` workflow so the “Extract issue title” step no longer fails when the BugBot comment body is empty/whitespace by tolerating the `grep` no-match exit (`|| true`) and allowing the default title fallback to be emitted.
> 
> Adds a lightweight bash test script (`.github/workflows/tests/test_extract_title.sh`) that exercises the exact title-extraction pipeline across normal, empty/whitespace, and truncation scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffeac7e9cbdee654dd09d42896629625dda5c050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->