### PR TITLE
github-issue-126-bugbot-system

### DIFF
--- a/modules/actor/src/core/dispatch/mailbox/system_queue.rs
+++ b/modules/actor/src/core/dispatch/mailbox/system_queue.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use core::{
   ptr,
-  sync::atomic::{AtomicPtr, AtomicUsize, Ordering},
+  sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering},
 };
 
 use crate::core::messaging::system_message::SystemMessage;
@@ -23,9 +23,12 @@ impl Node {
 /// Lock-free system queue that guarantees FIFO processing order by using
 /// a Treiber stack for writers and a pending FIFO list for readers.
 pub(crate) struct SystemQueue {
-  head:    AtomicPtr<Node>,
-  pending: AtomicPtr<Node>,
-  len:     AtomicUsize,
+  head:     AtomicPtr<Node>,
+  pending:  AtomicPtr<Node>,
+  len:      AtomicUsize,
+  // Serializes the slow path (head → pending transfer) to prevent
+  // FIFO-breaking interleave during concurrent head → pending transfer.
+  draining: AtomicBool,
 }
 
 impl Default for SystemQueue {
@@ -39,9 +42,10 @@ impl SystemQueue {
   #[must_use]
   pub(crate) const fn new() -> Self {
     Self {
-      head:    AtomicPtr::new(ptr::null_mut()),
-      pending: AtomicPtr::new(ptr::null_mut()),
-      len:     AtomicUsize::new(0),
+      head:     AtomicPtr::new(ptr::null_mut()),
+      pending:  AtomicPtr::new(ptr::null_mut()),
+      len:      AtomicUsize::new(0),
+      draining: AtomicBool::new(false),
     }
   }
 
@@ -63,6 +67,7 @@ impl SystemQueue {
   /// Pops the next message in FIFO order.
   pub(crate) fn pop(&self) -> Option<SystemMessage> {
     loop {
+      // Fast path: pop from the existing FIFO pending list (lock-free).
       let pending = self.pending.load(Ordering::Acquire);
       if !pending.is_null() {
         if let Some(message) = self.pop_from_pending(pending) {
@@ -71,36 +76,30 @@ impl SystemQueue {
         continue;
       }
 
+      // Slow path: transfer head → pending. Only one thread may do this
+      // at a time to avoid FIFO-breaking interleave during concurrent transfer.
+      if self.draining.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed).is_err() {
+        core::hint::spin_loop();
+        continue;
+      }
+
+      // Re-check: pending may have been filled by a prior drainer between
+      // our null-check above and acquiring the flag.
+      if !self.pending.load(Ordering::Acquire).is_null() {
+        self.draining.store(false, Ordering::Release);
+        continue;
+      }
+
       let head = self.head.swap(ptr::null_mut(), Ordering::AcqRel);
       if head.is_null() {
+        self.draining.store(false, Ordering::Release);
         return None;
       }
-      let fifo_head = Self::reverse_list(head);
-      // CAS: pendingがまだnullの場合のみ書き込み。競合時はheadに戻す
-      if self.pending.compare_exchange(ptr::null_mut(), fifo_head, Ordering::AcqRel, Ordering::Acquire).is_err() {
-        self.return_to_head(fifo_head);
-      }
-    }
-  }
 
-  /// Re-pushes a FIFO chain back to the head stack without modifying len.
-  ///
-  /// # Safety
-  ///
-  /// The chain must consist of valid nodes originally taken from head.
-  fn return_to_head(&self, mut node: *mut Node) {
-    while !node.is_null() {
-      let next = unsafe { (*node).next };
-      loop {
-        let current_head = self.head.load(Ordering::Acquire);
-        unsafe {
-          (*node).next = current_head;
-        }
-        if self.head.compare_exchange(current_head, node, Ordering::AcqRel, Ordering::Acquire).is_ok() {
-          break;
-        }
-      }
-      node = next;
+      let fifo_head = Self::reverse_list(head);
+      // Safe: pending is guaranteed null while we hold draining.
+      self.pending.store(fifo_head, Ordering::Release);
+      self.draining.store(false, Ordering::Release);
     }
   }
 

--- a/modules/actor/src/core/dispatch/mailbox/system_queue/tests.rs
+++ b/modules/actor/src/core/dispatch/mailbox/system_queue/tests.rs
@@ -28,3 +28,158 @@ fn len_tracks_push_and_pop_operations() {
   queue.pop();
   assert_eq!(queue.len(), 0);
 }
+
+/// Regression test for GitHub issue #126: concurrent pushers + poppers must
+/// preserve per-producer FIFO order. The old `return_to_head()` broke this by
+/// reinserting the reversed chain one node at a time, interleaving with new pushes.
+#[test]
+fn concurrent_push_pop_preserves_per_producer_fifo() {
+  use core::sync::atomic::{AtomicBool, Ordering};
+  use std::{
+    sync::{Arc, Barrier},
+    thread,
+  };
+
+  const PRODUCERS: u64 = 4;
+  const ITEMS_PER_PRODUCER: u64 = 200;
+  const TOTAL: usize = (PRODUCERS * ITEMS_PER_PRODUCER) as usize;
+  const CONSUMERS: usize = 2;
+  const ROUNDS: usize = 50;
+
+  for _ in 0..ROUNDS {
+    let queue = Arc::new(SystemQueue::new());
+    let done = Arc::new(AtomicBool::new(false));
+    let barrier = Arc::new(Barrier::new((PRODUCERS as usize) + CONSUMERS));
+
+    let mut producer_handles = Vec::new();
+    for producer in 0..PRODUCERS {
+      let q = Arc::clone(&queue);
+      let b = Arc::clone(&barrier);
+      producer_handles.push(thread::spawn(move || {
+        b.wait();
+        let base = producer * ITEMS_PER_PRODUCER;
+        for seq in 0..ITEMS_PER_PRODUCER {
+          q.push(SystemMessage::Watch(Pid::new(base + seq, 0)));
+        }
+      }));
+    }
+
+    let mut consumer_handles = Vec::new();
+    for _ in 0..CONSUMERS {
+      let q = Arc::clone(&queue);
+      let b = Arc::clone(&barrier);
+      let d = Arc::clone(&done);
+      consumer_handles.push(thread::spawn(move || {
+        b.wait();
+        let mut collected = Vec::new();
+        loop {
+          match q.pop() {
+            | Some(SystemMessage::Watch(pid)) => collected.push(pid.value()),
+            | Some(_) => panic!("unexpected message variant"),
+            | None if d.load(Ordering::Acquire) => break,
+            | None => thread::yield_now(),
+          }
+        }
+        collected
+      }));
+    }
+
+    for h in producer_handles {
+      h.join().unwrap();
+    }
+    done.store(true, Ordering::Release);
+
+    let consumer_results: Vec<Vec<u64>> = consumer_handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // Verify per-producer FIFO: within each consumer's output,
+    // items from the same producer must appear in push order.
+    for (cidx, seq) in consumer_results.iter().enumerate() {
+      for producer in 0..PRODUCERS {
+        let base = producer * ITEMS_PER_PRODUCER;
+        let end = base + ITEMS_PER_PRODUCER;
+        let producer_items: Vec<u64> = seq.iter().copied().filter(|&v| v >= base && v < end).collect();
+        for w in producer_items.windows(2) {
+          assert!(
+            w[0] < w[1],
+            "FIFO violated: consumer {cidx}, producer {producer}: {v0} before {v1}",
+            v0 = w[0],
+            v1 = w[1],
+          );
+        }
+      }
+    }
+
+    let mut all_values: Vec<u64> = consumer_results.into_iter().flatten().collect();
+    while let Some(msg) = queue.pop() {
+      if let SystemMessage::Watch(pid) = msg {
+        all_values.push(pid.value());
+      }
+    }
+
+    all_values.sort();
+    let mut expected: Vec<u64> = Vec::with_capacity(TOTAL);
+    for producer in 0..PRODUCERS {
+      let base = producer * ITEMS_PER_PRODUCER;
+      for seq in 0..ITEMS_PER_PRODUCER {
+        expected.push(base + seq);
+      }
+    }
+    expected.sort();
+    assert_eq!(all_values, expected, "all messages must be delivered exactly once");
+  }
+}
+
+/// Verify per-producer FIFO: items from each producer appear in the
+/// order they were pushed, even with concurrent consumers.
+#[test]
+fn concurrent_consumers_see_monotonic_per_producer_sequence() {
+  use std::{
+    sync::{Arc, Barrier},
+    thread,
+  };
+
+  const ITEMS: u64 = 500;
+  const CONSUMERS: usize = 4;
+  const ROUNDS: usize = 50;
+
+  for _ in 0..ROUNDS {
+    let queue = Arc::new(SystemQueue::new());
+
+    // Single producer pushes a sequential batch.
+    for i in 0..ITEMS {
+      queue.push(SystemMessage::Watch(Pid::new(i, 0)));
+    }
+
+    let barrier = Arc::new(Barrier::new(CONSUMERS));
+    let mut handles = Vec::new();
+    for _ in 0..CONSUMERS {
+      let q = Arc::clone(&queue);
+      let b = Arc::clone(&barrier);
+      handles.push(thread::spawn(move || {
+        b.wait();
+        let mut collected = Vec::new();
+        while let Some(msg) = q.pop() {
+          if let SystemMessage::Watch(pid) = msg {
+            collected.push(pid.value());
+          }
+        }
+        collected
+      }));
+    }
+
+    let per_consumer: Vec<Vec<u64>> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // Each consumer's local sequence must be strictly increasing (FIFO).
+    for (idx, seq) in per_consumer.iter().enumerate() {
+      for w in seq.windows(2) {
+        assert!(w[0] < w[1], "FIFO violated for consumer {idx}: {v0} appeared before {v1}", v0 = w[0], v1 = w[1],);
+      }
+    }
+
+    // All items delivered exactly once.
+    let mut all: Vec<u64> = per_consumer.into_iter().flatten().collect();
+    all.sort();
+    let expected: Vec<u64> = (0..ITEMS).collect();
+    assert_eq!(all, expected);
+  }
+}


### PR DESCRIPTION
## Summary

> **BugBot が PR #117 で検出したバグ**
> https://github.com/j5ik2o/fraktor-rs/pull/117

---

### SystemQueue CAS fallback can reorder messages

**Medium Severity**

<!-- DESCRIPTION START -->
On `pending.compare_exchange` failure, `return_to_head()` pushes the FIFO chain back onto the LIFO `head` one node at a time. This likely reverses relative ordering for that batch, so subsequent pops can deliver system messages out of FIFO order under contention.
<!-- DESCRIPTION END -->

<!-- BUGBOT_BUG_ID: 29287ae6-71bd-4881-8505-d68c45f7c0c6 -->

<!-- LOCATIONS START
modules/actor/src/core/dispatch/mailbox/system_queue.rs#L73-L104
LOCATIONS END -->
<p><a href="https://cursor.com/open?data=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImJ1Z2JvdC12MiJ9.eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiQlVHQk9UX0ZJWF9JTl9DVVJTT1IiLCJkYXRhIjp7InJlZGlzS2V5IjoiYnVnYm90OmU0ZWFmNjJmLTdjYjktNGE0NC1hNzdjLWMzMzc2ZTk3YTRiYiIsImVuY3J5cHRpb25LZXkiOiI1cTZIQ0pUX1NPam1oRzJremZmVEN3NENYeDRwZ1BDdDVxTThMZXh4amhvIiwiYnJhbmNoIjoicmVmYWN0b3ItMDItMjIiLCJyZXBvT3duZXIiOiJqNWlrMm8iLCJyZXBvTmFtZSI6ImZyYWt0b3ItcnMifSwiaWF0IjoxNzcxODQ1ODI0LCJleHAiOjE3NzQ0Mzc4MjR9.TjUueCvzz1_bmNDJ5wA1kbC0dW6KQupI9MQUBpInjG-MvEsrdVVfb_4btxHSJ245e1k1ZJaceJlw-Q7GXC3yb4qNB41OV8VknwPbqMUx5xVk-EQxHQ0B1oReHlgsQnRAmgtsr4JLt-p0Qc-taHaM1QWQ96LUXAjXnZ-BI6wL7atAyjvBwlC-9Wnw2_XAq110SL1iFnyNOeio1iFCXnLTgmRJ-NM4eJwCDbSd5h67LKPb2Miv5NaFgQdovoOuOGTapEyo58UBEX5CtcBYnvYveSOb3jrTxLf3BaHZCR5uXnuMUdf29tSWanBItzL64_u_LUjkjGbK3utRv0LZm1YHDQ" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-cursor-light.png"><img alt="Fix in Cursor" width="115" height="28" src="https://cursor.com/assets/images/fix-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?data=eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImJ1Z2JvdC12MiJ9.eyJ2ZXJzaW9uIjoxLCJ0eXBlIjoiQlVHQk9UX0ZJWF9JTl9XRUIiLCJkYXRhIjp7InJlZGlzS2V5IjoiYnVnYm90OmU0ZWFmNjJmLTdjYjktNGE0NC1hNzdjLWMzMzc2ZTk3YTRiYiIsImVuY3J5cHRpb25LZXkiOiI1cTZIQ0pUX1NPam1oRzJremZmVEN3NENYeDRwZ1BDdDVxTThMZXh4amhvIiwiYnJhbmNoIjoicmVmYWN0b3ItMDItMjIiLCJyZXBvT3duZXIiOiJqNWlrMm8iLCJyZXBvTmFtZSI6ImZyYWt0b3ItcnMiLCJwck51bWJlciI6MTE3LCJjb21taXRTaGEiOiI2MmI1OWUzOTQ0ODQzODM5ZmI2YzVjMGUzODAzYzkyOTdhOGYyODA1IiwicHJvdmlkZXIiOiJnaXRodWIifSwiaWF0IjoxNzcxODQ1ODI0LCJleHAiOjE3NzQ0Mzc4MjR9.yzReeM7f06B0cS3Py3mU8Writrt03xRP5Oq_SHu__N7wYVNCtfLl5HJBGYTzEoacEH-WmbLNdReVlmHW3KfFIAHu6mx2jyO8EjBp44BsS6aw_rFf1rJq12iYUiIap72RLdvT6EiDmLOhshXjOg2j8YJFyw5xcsl-ICjdqGRhp2RTH_bALvAdEPrKWfLb7sI_y0PFc1DMo-965a2cHTwmZmP6_2swgJHbF0Pl2NE1ZFqC0U68bF7UQONbGCCY35lnjzgo3hBS0tmquEMPbfsH3BnODSNLvWM8Z8zgwu0rYAo4IXpbjUF4UvJMVddW3G6TI_SmGPNO3M7RrDPIBxGNfQ" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/fix-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/fix-in-web-light.png"><img alt="Fix in Web" width="99" height="28" src="https://cursor.com/assets/images/fix-in-web-dark.png"></picture></a></p>



---

**元コメント**: https://github.com/j5ik2o/fraktor-rs/pull/117#discussion_r2840335413


## Execution Report

Piece `default` completed successfully.

Closes #126

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches lock-free concurrency logic in `SystemQueue::pop`, where subtle ordering/atomic mistakes could cause deadlocks or message loss under contention; added stress tests reduce this risk but it remains non-trivial.
> 
> **Overview**
> Fixes a FIFO-ordering bug in the mailbox `SystemQueue` slow path by serializing the `head`→`pending` drain with a new `draining` `AtomicBool`, eliminating the prior CAS-fallback that could reinsert nodes and interleave with concurrent pushes.
> 
> Adds concurrency regression/stress tests (multiple producers/consumers, repeated rounds) to assert **per-producer FIFO** and **exactly-once delivery** under contention (GitHub issue #126).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 057934e2db3d7ab87a6a69a5c3e14cc1c50ad9e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

本リリースでは、内部メッセージキュー処理の信頼性と安定性を向上させるための改善を実施しました。

* **バグ修正**
  * メッセージキューの並行処理時における順序の一貫性を確保する同期メカニズムを改善
  * 複数のプロデューサー・コンシューマー間でのメッセージ配信の正確性を強化

* **テスト**
  * 並行処理時のメッセージキュー動作に関する回帰テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->