### PR TITLE
issue-137-codeblock-lang-spec

### DIFF
--- a/.takt/facets/knowledge/pekko-porting.md
+++ b/.takt/facets/knowledge/pekko-porting.md
@@ -13,7 +13,7 @@
 
 ## fraktor-rs モジュール構造
 
-```
+```text
 modules/
 ├── utils/       # fraktor-utils-rs: 共有ユーティリティ
 ├── actor/       # fraktor-actor-rs: アクターシステムコア
@@ -23,7 +23,8 @@ modules/
 ```
 
 各モジュールの内部構造:
-```
+
+```text
 modules/{name}/src/
 ├── core/     # no_std 実装（ヒープのみ、OS非依存）
 └── std/      # std 依存の拡張（Tokio等）


### PR DESCRIPTION
## Summary

> **CodeRabbit が PR #134 で検出した問題** (🟡 Minor)
> https://github.com/j5ik2o/fraktor-rs/pull/134

---

_⚠️ Potential issue_ | _🟡 Minor_

**コードブロックに言語指定が欠落 & 空行不足**

静的解析の指摘どおり、ディレクトリ構造のコードブロック（Lines 15, 25）に言語指定がない。また Line 25 の前に空行がない。

<details>
<summary>修正案</summary>

```diff
-```
+```text
 modules/
 ├── utils/       # fraktor-utils-rs: 共有ユーティリティ
 ├── actor/       # fraktor-actor-rs: アクターシステムコア
 ├── remote/      # fraktor-remote-rs: リモーティング
 ├── cluster/     # fraktor-cluster-rs: クラスタリング
 └── streams/     # fraktor-streams-rs: ストリーム処理
 ```
 
 各モジュールの内部構造:
-```
+
+```text
 modules/{name}/src/
 ├── core/     # no_std 実装（ヒープのみ、OS非依存）
 └── std/      # std 依存の拡張（Tokio等）
 ```
```
</details>

<!-- suggestion_start -->

<details>
<summary>📝 Committable suggestion</summary>

> ‼️ **IMPORTANT**
> Carefully review the code before committing. Ensure that it accurately replaces the highlighted code, contains no missing lines, and has no issues with indentation. Thoroughly test & benchmark the code to ensure it meets the requirements.

```suggestion

```

</details>

<!-- suggestion_end -->

<details>
<summary>🧰 Tools</summary>

<details>
<summary>🪛 markdownlint-cli2 (0.21.0)</summary>

[warning] 15-15: Fenced code blocks should have a language specified

(MD040, fenced-code-language)

---

[warning] 25-25: Fenced code blocks should be surrounded by blank lines

(MD031, blanks-around-fences)

---

[warning] 25-25: Fenced code blocks should have a language specified

(MD040, fenced-code-language)

</details>

</details>

<details>
<summary>🤖 Prompt for AI Agents</summary>

````
Verify each finding against the current code and only fix it if needed.

In @.takt/facets/knowledge/pekko-porting.md around lines 15 - 29, The markdown
has two fenced code blocks showing directory trees that lack a language tag and
are missing a separating blank line before the second block; update both fences
to use a language identifier (e.g., ```text) and insert a single blank line
between the first tree block and the "各モジュールの内部構造:" heading so the second fence
is preceded by an empty line; target the directory-tree fenced blocks (the
modules/ tree block and the modules/{name}/src/ tree block) and change their
opening backticks to ```text and add the blank line before the second fence.
````

</details>

<!-- fingerprinting:phantom:medusa:phoenix -->

<!-- This is an auto-generated comment by CodeRabbit -->

---

**元コメント**: https://github.com/j5ik2o/fraktor-rs/pull/134#discussion_r2841656902


## Execution Report

Piece `default` completed successfully.

Closes #137

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markdown formatting changes with no impact on runtime behavior.
> 
> **Overview**
> Updates `.takt/facets/knowledge/pekko-porting.md` to satisfy markdownlint by adding `text` language identifiers to the two directory-tree fenced code blocks and inserting the missing blank line before the second block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd12d59ac200caecf4ef035fe67bebc5818ea9a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->