### PR TITLE
issue-135-reject-table-to-policy

### DIFF
--- a/.takt/facets/personas/pekko-compat-reviewer.md
+++ b/.takt/facets/personas/pekko-compat-reviewer.md
@@ -40,15 +40,6 @@
 | Scala trait 階層 | Rust trait + 合成 | 継承→合成への変換 |
 | `Future[T]` | `async` / `Pin<Box<dyn Future>>` | 非同期変換の正確性 |
 
-### REJECT判定基準
+### REJECT判定
 
-| 問題 | 判定 |
-|------|------|
-| Pekko APIに対応するメソッドが欠落 | タスク指示に含まれるならREJECT |
-| 型パラメータの対応が不正確 | REJECT |
-| no_std互換でない実装がcoreに配置 | REJECT |
-| `&self`/`&mut self` の使い分けがCQS原則に違反 | REJECT |
-| 禁止サフィックス（Manager, Service等）の使用 | REJECT |
-| テストが欠落 | REJECT |
-| 参照実装を読まずに「互換」と主張 | REJECT |
-| YAGNI違反（タスク範囲外の機能追加） | REJECT |
+REJECT判定はポリシー（pekko-compat）に従う。

--- a/.takt/facets/policies/pekko-compat.md
+++ b/.takt/facets/policies/pekko-compat.md
@@ -1,0 +1,14 @@
+# Pekko互換性レビューポリシー
+
+## REJECT判定基準
+
+| 問題 | 判定 |
+|------|------|
+| Pekko APIに対応するメソッドが欠落 | タスク指示に含まれるならREJECT |
+| 型パラメータの対応が不正確 | REJECT |
+| no_std互換でない実装がcoreに配置 | REJECT |
+| `&self`/`&mut self` の使い分けがCQS原則に違反 | REJECT |
+| 禁止サフィックス（Manager, Service等）の使用 | REJECT |
+| テストが欠落 | REJECT |
+| 参照実装を読まずに「互換」と主張 | REJECT |
+| YAGNI違反（タスク範囲外の機能追加） | REJECT |

--- a/.takt/pieces/pekko-porting.yaml
+++ b/.takt/pieces/pekko-porting.yaml
@@ -17,6 +17,7 @@ knowledge:
 
 policies:
   fraktor-coding: ../facets/policies/fraktor-coding.md
+  pekko-compat: ../facets/policies/pekko-compat.md
 
 instructions:
   plan-pekko-impl: ../facets/instructions/plan-pekko-impl.md
@@ -196,7 +197,9 @@ movements:
       - name: pekko-compat-review
         edit: false
         persona: pekko-compat-reviewer
-        policy: review
+        policy:
+          - review
+          - pekko-compat
         knowledge:
           - pekko-porting
           - architecture


### PR DESCRIPTION
## Summary

> **CodeRabbit が PR #134 で検出した問題** (⚪ Unknown)
> https://github.com/j5ik2o/fraktor-rs/pull/134

---

_🛠️ Refactor suggestion_ | _🟠 Major_

**REJECT判定基準テーブルは Policy ファセットに移動すべき**

Persona ファセットにはポリシーの詳細ルール（決定テーブル）を混入させないのが原則。この REJECT判定基準テーブルは `fraktor-coding.md` ポリシーまたは専用の Pekko 互換性ポリシーファセットに配置するのが適切。

Persona にはせいぜい「REJECT判定はポリシーに従う」程度の参照にとどめる。

Based on learnings: "TAKT Personaファセットは以下の品質基準に準拠すること: ポリシーの詳細ルール（コード例・テーブル）を混入させない"

<details>
<summary>🤖 Prompt for AI Agents</summary>

```
Verify each finding against the current code and only fix it if needed.

In @.takt/facets/personas/pekko-compat-reviewer.md around lines 43 - 54, Move
the "REJECT判定基準" decision table out of the persona facet file and into the
policy facet (e.g., fraktor-coding.md or a dedicated Pekko-compatibility policy
file); in the persona file replace the table with a short statement like
"REJECT判定はポリシーに従う" and add a reference/link to the policy document; ensure the
original table header "REJECT判定基準" and entries are preserved verbatim in the
target policy file so rules like "Pekko APIに対応するメソッドが欠落" and "型パラメータの対応が不正確"
remain intact and discoverable.
```

</details>

<!-- fingerprinting:phantom:medusa:phoenix -->

<!-- This is an auto-generated comment by CodeRabbit -->

---

**元コメント**: https://github.com/j5ik2o/fraktor-rs/pull/134#discussion_r2841656936


## Execution Report

Piece `default` completed successfully.

Closes #135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ドキュメント/TAKT設定の整理のみで、プロダクトコードや実行ロジックは変更しません。ポリシー参照の追加によりレビュー判定がより厳格になる可能性はあります。
> 
> **Overview**
> Pekko互換性レビューの *REJECT判定基準* を `pekko-compat-reviewer` persona から分離し、専用ポリシー `pekko-compat` として新規追加しました（persona 側は「REJECT判定はポリシーに従う」へ簡略化）。
> 
> `pekko-porting.yaml` を更新し、レビュー工程 `pekko-compat-review` に `pekko-compat` ポリシーを追加適用するように変更しました。
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7ef3e312acf1f0c4a109414915f7e7e4eb29327. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->