### PR TITLE
issue-138-output-contract-30line

### DIFF
--- a/.takt/facets/output-contracts/pekko-compat-review.md
+++ b/.takt/facets/output-contracts/pekko-compat-review.md
@@ -11,36 +11,20 @@
 |-----------|----------------|------|
 | `ClassName.method` | `type_name::method` | OK / 未実装 / 不正確 |
 
-## 確認した観点
-- [x] Pekko参照実装との対応関係
-- [x] Scala→Rust変換パターン
-- [x] 型パラメータ（TB: RuntimeToolbox）
-- [x] no_std/std分離
-- [x] CQS原則
-- [x] 命名規約
-- [x] テストカバレッジ
-- [x] YAGNI
-
 ## 今回の指摘（new）
 | # | finding_id | 場所 | 問題 | 修正案 |
 |---|------------|------|------|--------|
-| 1 | PEKKO-NEW-src-file-L42 | `src/file.rs:42` | 問題の説明 | 修正方法 |
+| 1 | PEKKO-NEW-{file}-L{line} | `{file}:{line}` | {問題} | {修正案} |
 
 ## 継続指摘（persists）
 | # | finding_id | 前回根拠 | 今回根拠 | 問題 | 修正案 |
 |---|------------|----------|----------|------|--------|
-| 1 | PEKKO-PERSIST-src-file-L77 | `src/file.rs:77` | `src/file.rs:77` | 未解消 | 既存修正方針を適用 |
 
 ## 解消済み（resolved）
 | finding_id | 解消根拠 |
 |------------|----------|
-| PEKKO-RESOLVED-src-file-L10 | 修正済み |
 
-## REJECT判定条件
-- `new` または `persists` が1件以上ある場合のみ REJECT 可
-- `finding_id` なしの指摘は無効
+## 出力ルール
+- APPROVE → サマリーとPekko API対応状況のみ。REJECT → 該当指摘テーブルのみ
+- `new`/`persists` が1件以上 → REJECT。`finding_id` なしの指摘は無効
 ```
-
-**認知負荷軽減ルール:**
-- APPROVE → サマリーとPekko API対応状況のみ
-- REJECT → 該当指摘のみ表で記載


### PR DESCRIPTION
## Summary

> **CodeRabbit が PR #134 で検出した問題** (🟡 Minor)
> https://github.com/j5ik2o/fraktor-rs/pull/134

---

_⚠️ Potential issue_ | _🟡 Minor_

**Output Contract の30行制限を超過（46行 vs 上限30行）**

Learnings によると Output Contract ファセットは30行以内が基準。現状46行あり、テンプレートを簡潔にする必要がある。

また、認知負荷軽減ルール（Lines 44-46）が ` ```markdown ` コードブロックの外に配置されている。テンプレートとして一貫性を保つなら、コードブロック内に含めるか、テンプレート本体を削減して30行以内に収めるべき。

削減案:
- 「継続指摘」「解消済み」テーブルのサンプル行を削除し、ヘッダのみにする
- 「REJECT判定条件」を認知負荷軽減ルールに統合する

Based on learnings: "TAKT Output Contractファセットは以下の品質基準に準拠すること: ファイルサイズは30行以内とする"

<details>
<summary>🤖 Prompt for AI Agents</summary>

````
Verify each finding against the current code and only fix it if needed.

In @.takt/facets/output-contracts/pekko-compat-review.md around lines 1 - 46,
The template exceeds the 30-line Output Contract limit and places "認知負荷軽減ルール"
outside the markdown code block; fix by trimming the template to <=30 lines and
keeping rules inside the code block: remove sample rows under "##
継続指摘（persists）" and "## 解消済み（resolved）" leaving only headers, merge "REJECT判定条件"
into the "認知負荷軽減ルール" section, and ensure the "```markdown" opening and closing
fence encloses all template content including "認知負荷軽減ルール" so that the final
markdown (including headings like "## サマリー", "## Pekko API対応状況", "## 確認した観点",
"## 今回の指摘（new）", "## 継続指摘（persists）", "## 解消済み（resolved）" and the merged rules)
fits within 30 lines.
````

</details>

<!-- fingerprinting:phantom:medusa:phoenix -->

<!-- This is an auto-generated comment by CodeRabbit -->

---

**元コメント**: https://github.com/j5ik2o/fraktor-rs/pull/134#discussion_r2841656928


## Execution Report

Piece `default` completed successfully.

Closes #138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> テンプレート文言の整理のみで、実行コードやデータ処理・セキュリティ面への影響はありません。
> 
> **Overview**
> Pekko互換性レビューのOutput Contract（`.takt/facets/output-contracts/pekko-compat-review.md`）を**30行以内に収まるよう簡素化**し、テンプレート内の冗長なチェックリストやサンプル行を削除しました。
> 
> あわせて、APPROVE/REJECT時に出力すべき内容とREJECT条件を`## 出力ルール`に集約し、`finding_id`付きの指摘のみを有効とするルールを明記しました。
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e2cb60cee992fc3e50a1cec7de94a8450d81152e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->