### PR TITLE
issue-140-missing-loop-monitors

### DIFF
--- a/.takt/pieces/pekko-porting.yaml
+++ b/.takt/pieces/pekko-porting.yaml
@@ -51,6 +51,83 @@ loop_monitors:
         - condition: 非生産的（改善なし）
           next: reviewers
 
+  - cycle:
+      - reviewers
+      - fix
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction_template: |
+        reviewers と fix のレビュー・修正サイクルが {cycle_count} 回繰り返されました。
+
+        各サイクルのレポートを確認し、このループが健全（進捗がある）か、
+        非生産的（同じ問題を繰り返している）かを判断してください。
+
+        **参照するレポート:**
+        - Pekko互換性レビュー: {report:05-pekko-compat-review.md}
+        - QAレビュー: {report:06-qa-review.md}
+
+        **判断基準:**
+        - 各サイクルで新しい問題が発見・修正されているか
+        - 同じ指摘が繰り返されていないか
+        - 修正が実際に反映されているか
+      rules:
+        - condition: 健全（進捗あり）
+          next: fix
+        - condition: 非生産的（改善なし）
+          next: supervise
+
+  - cycle:
+      - supervise
+      - plan
+    threshold: 2
+    judge:
+      persona: supervisor
+      instruction_template: |
+        supervise と plan のサイクルが {cycle_count} 回繰り返されました。
+
+        各サイクルのレポートを確認し、このループが健全（進捗がある）か、
+        非生産的（同じ問題を繰り返している）かを判断してください。
+
+        **参照するレポート:**
+        - スーパーバイザー検証: {report:supervisor-validation.md}
+        - 計画: {report:00-plan.md}
+
+        **判断基準:**
+        - 前回のsuperviseで指摘された問題が解決に向かっているか
+        - 計画が前回と実質的に異なる改善を含んでいるか
+        - 同じテスト失敗やビルドエラーが繰り返されていないか
+      rules:
+        - condition: 健全（進捗あり）
+          next: plan
+        - condition: 非生産的（改善なし）
+          next: ABORT
+
+  - cycle:
+      - ai_fix
+      - ai_no_fix
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction_template: |
+        ai_fix と ai_no_fix のループが {cycle_count} 回繰り返されました。
+
+        ai_fix が修正不要と判断し、ai_no_fix が修正必要と差し戻すサイクルが
+        繰り返されています。このループが健全か判断してください。
+
+        **参照するレポート:**
+        - AIレビュー結果: {report:04-ai-review.md}
+
+        **判断基準:**
+        - ai_fix と ai_no_fix の間で同じ指摘について意見が分かれ続けていないか
+        - 新しい観点や情報が各サイクルで追加されているか
+        - 合意に向かう進捗があるか
+      rules:
+        - condition: 健全（進捗あり）
+          next: ai_fix
+        - condition: 非生産的（改善なし）
+          next: reviewers
+
 movements:
   - name: plan
     edit: false


### PR DESCRIPTION
## Summary

> **CodeRabbit が PR #134 で検出した問題** (🟠 Major)
> https://github.com/j5ik2o/fraktor-rs/pull/134

---

_⚠️ Potential issue_ | _🟠 Major_

**`reviewers → fix` サイクルの `loop_monitors` が欠落**

`ai_review → ai_fix` サイクルには loop_monitor が定義されているが、`reviewers → fix → reviewers` の循環にはない。Learnings によると review→fix サイクルにも threshold: 3 の loop_monitor と ABORT 条件が必要。

<details>
<summary>追加案</summary>

```diff
 loop_monitors:
   - cycle:
       - ai_review
       - ai_fix
     threshold: 3
     judge:
       persona: supervisor
       instruction_template: |
         ai_review と ai_fix のループが {cycle_count} 回繰り返されました。
         ...
       rules:
         - condition: 健全（進捗あり）
           next: ai_review
         - condition: 非生産的（改善なし）
           next: reviewers
+  - cycle:
+      - reviewers
+      - fix
+    threshold: 3
+    judge:
+      persona: supervisor
+      instruction_template: |
+        reviewers と fix のループが {cycle_count} 回繰り返されました。
+
+        各サイクルのレビュー結果を確認し、このループが健全（進捗がある）か、
+        非生産的（同じ問題を繰り返している）かを判断してください。
+
+        **判断基準:**
+        - 各サイクルで指摘が減少しているか
+        - 同じ指摘が繰り返されていないか
+      rules:
+        - condition: 健全（進捗あり）
+          next: reviewers
+        - condition: 非生産的（改善なし）
+          next: ABORT
```
</details>

Based on learnings: "review→fix サイクルには `loop_monitors` を追加し、`threshold` を3回に設定し、ABORT条件を追加する"

<details>
<summary>🤖 Prompt for AI Agents</summary>

```
Verify each finding against the current code and only fix it if needed.

In @.takt/pieces/pekko-porting.yaml around lines 28 - 52, Add a loop_monitors
entry for the reviewers→fix cycle: define loop_monitors with cycle: [reviewers,
fix], threshold: 3, judge persona supervisor and an instruction_template similar
to the existing ai_review/ai_fix one (referencing the per-cycle report), and
include rules that map a healthy outcome back to reviewers and an explicit ABORT
condition (e.g., condition: ABORT or 非生産的 with next: abort) to stop the loop
after 3 non‑productive iterations; reference the existing loop_monitors, cycle,
threshold, judge, instruction_template and rules symbols when inserting.
```

</details>

<!-- fingerprinting:phantom:medusa:phoenix -->

<!-- This is an auto-generated comment by CodeRabbit -->

---

**元コメント**: https://github.com/j5ik2o/fraktor-rs/pull/134#discussion_r2841656950


## Execution Report

Piece `default` completed successfully.

Closes #140

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML workflow/config-only change; main risk is misrouting or prematurely aborting automation loops if the new `next` transitions or thresholds are incorrect.
> 
> **Overview**
> Adds missing `loop_monitors` to `.takt/pieces/pekko-porting.yaml` to detect and break non-productive review/repair loops.
> 
> Specifically introduces supervision for the `reviewers`↔`fix` cycle (threshold 3; references `05-pekko-compat-review.md` and `06-qa-review.md`) and adds new monitors for `supervise`↔`plan` (threshold 2, can `ABORT`) and `ai_fix`↔`ai_no_fix` (threshold 3) to escalate when progress stalls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0144970e1ff43a4248942bce2a0a501db40485b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->