### PR TITLE
streams-factories-and-operators

### DIFF
--- a/modules/streams/src/core.rs
+++ b/modules/streams/src/core.rs
@@ -48,6 +48,8 @@ mod stream_error;
 mod stream_not_used;
 /// Test utilities for stream verification.
 pub mod testing;
+/// Throttle behavior mode.
+mod throttle_mode;
 /// Positive argument validator.
 mod validate_positive_argument;
 
@@ -73,6 +75,7 @@ pub use stream_done::StreamDone;
 pub use stream_dsl_error::StreamDslError;
 pub use stream_error::StreamError;
 pub use stream_not_used::StreamNotUsed;
+pub use throttle_mode::ThrottleMode;
 pub use validate_positive_argument::validate_positive_argument;
 type DynValue = Box<dyn Any + Send + Sync + 'static>;
 

--- a/modules/streams/src/core/lifecycle/kill_switches.rs
+++ b/modules/streams/src/core/lifecycle/kill_switches.rs
@@ -18,4 +18,17 @@ impl KillSwitches {
   pub fn single() -> UniqueKillSwitch {
     UniqueKillSwitch::new()
   }
+
+  /// Creates a bidirectional kill switch backed by identity flows.
+  #[must_use]
+  pub fn single_bidi<T1, T2>() -> crate::core::stage::BidiFlow<T1, T1, T2, T2, UniqueKillSwitch>
+  where
+    T1: Send + Sync + 'static,
+    T2: Send + Sync + 'static, {
+    crate::core::stage::BidiFlow::from_flows_mat(
+      crate::core::stage::Flow::new(),
+      crate::core::stage::Flow::new(),
+      UniqueKillSwitch::new(),
+    )
+  }
 }

--- a/modules/streams/src/core/lifecycle/kill_switches/tests.rs
+++ b/modules/streams/src/core/lifecycle/kill_switches/tests.rs
@@ -13,3 +13,19 @@ fn kill_switches_single_returns_unique_kill_switch() {
   assert!(!switch.is_shutdown());
   assert!(!switch.is_aborted());
 }
+
+#[test]
+fn kill_switches_single_bidi_returns_bidi_flow_with_kill_switch() {
+  let bidi = KillSwitches::single_bidi::<u32, u32>();
+  let (_, _, switch) = bidi.split();
+  assert!(!switch.is_shutdown());
+  assert!(!switch.is_aborted());
+}
+
+#[test]
+fn kill_switches_single_bidi_shutdown_propagates_to_switch() {
+  let bidi = KillSwitches::single_bidi::<u32, u32>();
+  let (_top, _bottom, switch) = bidi.split();
+  switch.shutdown();
+  assert!(switch.is_shutdown());
+}

--- a/modules/streams/src/core/stage.rs
+++ b/modules/streams/src/core/stage.rs
@@ -5,7 +5,8 @@
 use super::{
   DemandTracker, DynValue, FlowDefinition, FlowLogic, MatCombine, MatCombineRule, RestartBackoff, RestartSettings,
   SinkDecision, SinkDefinition, SinkLogic, SourceDefinition, SourceLogic, StageDefinition, StreamBufferConfig,
-  StreamCompletion, StreamDone, StreamDslError, StreamError, StreamNotUsed, SupervisionStrategy, downcast_value, graph,
+  StreamCompletion, StreamDone, StreamDslError, StreamError, StreamNotUsed, SupervisionStrategy, ThrottleMode,
+  downcast_value, graph,
   graph::StreamGraph,
   keep_left, keep_right,
   lifecycle::{self, DriveOutcome},

--- a/modules/streams/src/core/throttle_mode.rs
+++ b/modules/streams/src/core/throttle_mode.rs
@@ -1,0 +1,11 @@
+#[cfg(test)]
+mod tests;
+
+/// Throttle behavior mode controlling how excess upstream demand is handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThrottleMode {
+  /// Makes pauses before emitting messages to meet the throttle rate.
+  Shaping,
+  /// Fails with an error when upstream is faster than the throttle rate.
+  Enforcing,
+}

--- a/modules/streams/src/core/throttle_mode/tests.rs
+++ b/modules/streams/src/core/throttle_mode/tests.rs
@@ -1,0 +1,21 @@
+use crate::core::ThrottleMode;
+
+#[test]
+fn shaping_and_enforcing_are_distinct_variants() {
+  assert_ne!(ThrottleMode::Shaping, ThrottleMode::Enforcing);
+}
+
+#[test]
+fn throttle_mode_is_clone_and_copy() {
+  let mode = ThrottleMode::Shaping;
+  let cloned = mode;
+  assert_eq!(mode, cloned);
+}
+
+#[test]
+fn throttle_mode_debug_output_contains_variant_name() {
+  let shaping = alloc::format!("{:?}", ThrottleMode::Shaping);
+  let enforcing = alloc::format!("{:?}", ThrottleMode::Enforcing);
+  assert!(shaping.contains("Shaping"));
+  assert!(enforcing.contains("Enforcing"));
+}


### PR DESCRIPTION
## Summary

## Execution Report

Piece `pekko-porting` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces public API changes and alters throttle/backpressure semantics, which can affect runtime behavior and error handling under load. Scope is contained to stream operators and covered by new/updated tests.
> 
> **Overview**
> Adds new stream-construction helpers and operators across `Source`/`Flow`/`Sink`, including `distinct`/`distinct_by`, `Sink::contramap`, `Source::pre_materialize`, and public `from_graph` constructors to rebuild stages from existing `StreamGraph` parts.
> 
> Refactors throttling to accept a new `ThrottleMode` (`Shaping` vs `Enforcing`), changing the throttle/async-boundary buffering logic so *enforcing* mode does not backpressure and instead fails with `StreamError::BufferOverflow` on overflow; call sites/tests are updated accordingly.
> 
> Extends lifecycle utilities with `KillSwitches::single_bidi()` to create a bidirectional kill switch via identity `BidiFlow`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d9306c425d082d90e07875e785882fbba75dc91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スロットルモードの設定可能化（シェーピング/エンフォーシング）により、バックプレッシャーの動作をカスタマイズ可能に
  * 重複排除フィルタリング機能を追加
  * 既存のグラフから新規にステージを作成する機能を追加
  * シンク入力型の変換機能を追加
  * ソースの事前マテリアライゼーション機能を追加
  * 双方向キルスイッチ作成機能を追加

* **テスト**
  * 新機能に関する包括的なテストカバレッジを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->