### PR TITLE
actor-signals-and-watch

### DIFF
--- a/modules/actor/examples/behaviors_receive_signal_no_std/main.rs
+++ b/modules/actor/examples/behaviors_receive_signal_no_std/main.rs
@@ -31,7 +31,9 @@ fn guardian_behavior() -> Behavior<GuardianCommand> {
       | BehaviorSignal::Started => println!("guardian: Started signal"),
       | BehaviorSignal::Stopped => println!("guardian: Stopped signal"),
       | BehaviorSignal::Terminated(pid) => println!("guardian: Terminated({pid:?})"),
-      | BehaviorSignal::AdapterFailed(_) => println!("guardian: AdapterFailed signal"),
+      | BehaviorSignal::MessageAdaptionFailure(_) => println!("guardian: MessageAdaptionFailure signal"),
+      | BehaviorSignal::ChildFailed { pid, error } => println!("guardian: ChildFailed({pid:?}, {error:?})"),
+      | BehaviorSignal::PreRestart => println!("guardian: PreRestart signal"),
     }
     Ok(Behaviors::same())
   })

--- a/modules/actor/examples/behaviors_receive_signal_std/main.rs
+++ b/modules/actor/examples/behaviors_receive_signal_std/main.rs
@@ -30,7 +30,11 @@ fn guardian_behavior() -> Behavior<GuardianCommand> {
       | BehaviorSignal::Started => println!("guardian: Started signal"),
       | BehaviorSignal::Stopped => println!("guardian: Stopped signal"),
       | BehaviorSignal::Terminated(pid) => println!("guardian: Terminated({pid:?})"),
-      | BehaviorSignal::AdapterFailed(reason) => println!("guardian: AdapterFailed({reason:?})"),
+      | BehaviorSignal::MessageAdaptionFailure(reason) => {
+        println!("guardian: MessageAdaptionFailure({reason:?})")
+      },
+      | BehaviorSignal::ChildFailed { pid, error } => println!("guardian: ChildFailed({pid:?}, {error:?})"),
+      | BehaviorSignal::PreRestart => println!("guardian: PreRestart signal"),
     }
     Ok(Behaviors::same())
   })

--- a/modules/actor/src/core/typed/actor/actor_context.rs
+++ b/modules/actor/src/core/typed/actor/actor_context.rs
@@ -112,6 +112,20 @@ where
     self.inner().watch(target.as_untyped())
   }
 
+  /// Watches the provided typed target with a custom message.
+  ///
+  /// When the target terminates, the provided `message` is delivered as a user message
+  /// instead of a `Terminated` signal.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the watch operation cannot be performed.
+  pub fn watch_with<C>(&self, target: &TypedActorRefGeneric<C, TB>, message: M) -> Result<(), SendError<TB>>
+  where
+    C: Send + Sync + 'static, {
+    self.inner().watch_with(target.as_untyped(), AnyMessageGeneric::new(message))
+  }
+
   /// Stops watching the provided typed target.
   ///
   /// # Errors

--- a/modules/actor/src/core/typed/actor/typed_actor.rs
+++ b/modules/actor/src/core/typed/actor/typed_actor.rs
@@ -88,4 +88,30 @@ where
   ) -> Result<(), ActorError> {
     Err(ActorError::recoverable(ActorErrorReason::new("message adapter failure")))
   }
+
+  /// Called before the actor is restarted by its supervisor.
+  ///
+  /// The default implementation delegates to [`post_stop`](TypedActor::post_stop).
+  ///
+  /// # Errors
+  ///
+  /// Returns an error when pre-restart cleanup fails.
+  fn pre_restart(&mut self, ctx: &mut TypedActorContextGeneric<'_, M, TB>) -> Result<(), ActorError> {
+    self.post_stop(ctx)
+  }
+
+  /// Called when a supervised child actor fails.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error when the notification cannot be processed.
+  #[allow(unused_variables)]
+  fn on_child_failed(
+    &mut self,
+    ctx: &mut TypedActorContextGeneric<'_, M, TB>,
+    child: Pid,
+    error: ActorError,
+  ) -> Result<(), ActorError> {
+    Ok(())
+  }
 }

--- a/modules/actor/src/core/typed/behavior_runner/tests.rs
+++ b/modules/actor/src/core/typed/behavior_runner/tests.rs
@@ -6,10 +6,12 @@ use fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox;
 use super::BehaviorRunner;
 use crate::core::{
   actor::ActorContextGeneric,
+  error::ActorError,
   system::ActorSystemGeneric,
   typed::{
     Behaviors,
     actor::{TypedActor, TypedActorContextGeneric},
+    behavior::Behavior,
     behavior_signal::BehaviorSignal,
     message_adapter::{AdapterError, MessageAdapterRegistry},
   },
@@ -22,6 +24,24 @@ fn build_context() -> (ActorContextGeneric<'static, NoStdToolbox>, MessageAdapte
   let pid = system.allocate_pid();
   let ctx = ActorContextGeneric::new(&system, pid);
   (ctx, MessageAdapterRegistry::new())
+}
+
+fn build_context_with_pids(count: usize) -> (ActorSystemGeneric<NoStdToolbox>, Vec<crate::core::actor::Pid>) {
+  let system = ActorSystemGeneric::<NoStdToolbox>::new_empty();
+  let pids: Vec<_> = (0..count).map(|_| system.allocate_pid()).collect();
+  (system, pids)
+}
+
+fn signal_probe_behavior(
+  target_signal: fn(&BehaviorSignal) -> bool,
+  witness: Arc<AtomicBool>,
+) -> Behavior<ProbeMessage, NoStdToolbox> {
+  Behaviors::receive_signal(move |_, signal| {
+    if target_signal(signal) {
+      witness.store(true, Ordering::SeqCst);
+    }
+    Ok(Behaviors::same())
+  })
 }
 
 #[test]
@@ -37,17 +57,64 @@ fn behavior_runner_escalates_without_signal_handler() {
 #[test]
 fn behavior_runner_allows_handled_adapter_failure() {
   let handled = Arc::new(AtomicBool::new(false));
-  let witness = handled.clone();
-  let behavior = Behaviors::receive_signal(move |_, signal| {
-    if matches!(signal, BehaviorSignal::AdapterFailed(_)) {
-      witness.store(true, Ordering::SeqCst);
-    }
-    Ok(Behaviors::same())
-  });
+  let behavior = signal_probe_behavior(|s| matches!(s, BehaviorSignal::MessageAdaptionFailure(_)), handled.clone());
   let mut runner = BehaviorRunner::new(behavior);
   let (mut ctx, mut registry) = build_context();
   let mut typed_ctx = TypedActorContextGeneric::from_untyped(&mut ctx, Some(&mut registry));
   let result = runner.on_adapter_failure(&mut typed_ctx, AdapterError::Custom(String::from("oops")));
   assert!(result.is_ok());
   assert!(handled.load(Ordering::SeqCst));
+}
+
+#[test]
+fn behavior_runner_dispatches_pre_restart_signal() {
+  let received = Arc::new(AtomicBool::new(false));
+  let behavior = signal_probe_behavior(|s| matches!(s, BehaviorSignal::PreRestart), received.clone());
+  let mut runner = BehaviorRunner::new(behavior);
+  let (mut ctx, mut registry) = build_context();
+  let mut typed_ctx = TypedActorContextGeneric::from_untyped(&mut ctx, Some(&mut registry));
+  let result = runner.pre_restart(&mut typed_ctx);
+  assert!(result.is_ok());
+  assert!(received.load(Ordering::SeqCst));
+}
+
+#[test]
+fn behavior_runner_dispatches_child_failed_signal() {
+  let received = Arc::new(AtomicBool::new(false));
+  let behavior = signal_probe_behavior(|s| matches!(s, BehaviorSignal::ChildFailed { .. }), received.clone());
+  let mut runner = BehaviorRunner::new(behavior);
+  let (system, pids) = build_context_with_pids(2);
+  let mut ctx = ActorContextGeneric::new(&system, pids[0]);
+  let mut registry = MessageAdapterRegistry::<ProbeMessage, NoStdToolbox>::new();
+  let mut typed_ctx = TypedActorContextGeneric::from_untyped(&mut ctx, Some(&mut registry));
+  let error = ActorError::recoverable("child boom");
+  let result = runner.on_child_failed(&mut typed_ctx, pids[1], error);
+  assert!(result.is_ok());
+  assert!(received.load(Ordering::SeqCst));
+}
+
+#[test]
+fn behavior_runner_death_pact_errors_without_signal_handler() {
+  let behavior = Behaviors::receive_message(|_, _msg: &ProbeMessage| Ok(Behaviors::same()));
+  let mut runner = BehaviorRunner::new(behavior);
+  let (system, pids) = build_context_with_pids(2);
+  let mut ctx = ActorContextGeneric::new(&system, pids[0]);
+  let mut registry = MessageAdapterRegistry::<ProbeMessage, NoStdToolbox>::new();
+  let mut typed_ctx = TypedActorContextGeneric::from_untyped(&mut ctx, Some(&mut registry));
+  let result = runner.on_terminated(&mut typed_ctx, pids[1]);
+  assert!(result.is_err());
+}
+
+#[test]
+fn behavior_runner_death_pact_succeeds_with_signal_handler() {
+  let received = Arc::new(AtomicBool::new(false));
+  let behavior = signal_probe_behavior(|s| matches!(s, BehaviorSignal::Terminated(_)), received.clone());
+  let mut runner = BehaviorRunner::new(behavior);
+  let (system, pids) = build_context_with_pids(2);
+  let mut ctx = ActorContextGeneric::new(&system, pids[0]);
+  let mut registry = MessageAdapterRegistry::<ProbeMessage, NoStdToolbox>::new();
+  let mut typed_ctx = TypedActorContextGeneric::from_untyped(&mut ctx, Some(&mut registry));
+  let result = runner.on_terminated(&mut typed_ctx, pids[1]);
+  assert!(result.is_ok());
+  assert!(received.load(Ordering::SeqCst));
 }

--- a/modules/actor/src/core/typed/behavior_signal.rs
+++ b/modules/actor/src/core/typed/behavior_signal.rs
@@ -12,5 +12,14 @@ pub enum BehaviorSignal {
   /// Indicates that a watched actor terminated with the provided pid.
   Terminated(Pid),
   /// Indicates that message adaptation failed before reaching the behavior.
-  AdapterFailed(AdapterError),
+  MessageAdaptionFailure(AdapterError),
+  /// Indicates that a child actor failed with the provided pid and error.
+  ChildFailed {
+    /// Pid of the child actor that failed.
+    pid:   Pid,
+    /// Error that caused the child to fail.
+    error: crate::core::error::ActorError,
+  },
+  /// Indicates that the actor is about to be restarted by its supervisor.
+  PreRestart,
 }

--- a/modules/actor/src/core/typed/tests.rs
+++ b/modules/actor/src/core/typed/tests.rs
@@ -550,8 +550,10 @@ fn signal_probe_behavior(
       | BehaviorSignal::Stopped => {
         stop_probe.fetch_add(1, Ordering::SeqCst);
       },
-      | BehaviorSignal::Terminated(_) => {},
-      | BehaviorSignal::AdapterFailed(_) => {},
+      | BehaviorSignal::Terminated(_)
+      | BehaviorSignal::MessageAdaptionFailure(_)
+      | BehaviorSignal::ChildFailed { .. }
+      | BehaviorSignal::PreRestart => {},
     }
     Ok(Behaviors::same())
   })

--- a/modules/actor/src/core/typed/typed_actor_adapter.rs
+++ b/modules/actor/src/core/typed/typed_actor_adapter.rs
@@ -192,4 +192,19 @@ where
     let mut typed_ctx = TypedActorContextGeneric::from_untyped(ctx, Some(&mut self.adapters));
     self.actor.on_mailbox_pressure(&mut typed_ctx, event)
   }
+
+  fn pre_restart(&mut self, ctx: &mut ActorContextGeneric<'_, TB>) -> Result<(), ActorError> {
+    let mut typed_ctx = TypedActorContextGeneric::from_untyped(ctx, Some(&mut self.adapters));
+    self.actor.pre_restart(&mut typed_ctx)
+  }
+
+  fn on_child_failed(
+    &mut self,
+    ctx: &mut ActorContextGeneric<'_, TB>,
+    child: crate::core::actor::Pid,
+    error: &ActorError,
+  ) -> Result<(), ActorError> {
+    let mut typed_ctx = TypedActorContextGeneric::from_untyped(ctx, Some(&mut self.adapters));
+    self.actor.on_child_failed(&mut typed_ctx, child, error.clone())
+  }
 }


### PR DESCRIPTION
## Summary

## Execution Report

Piece `pekko-porting` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core actor lifecycle, supervision, and death-watch paths (restart/termination/failure handling), which can change runtime semantics and error propagation despite good test coverage.
> 
> **Overview**
> Adds a `watch_with` API (untyped + typed) that lets a watcher register a custom user message to be delivered when a watched actor terminates, bypassing `on_terminated`; `unwatch` now clears any registered custom message, and death-watch tests are extended to validate the new behavior.
> 
> Expands typed lifecycle signaling by renaming `AdapterFailed` to `MessageAdaptionFailure` and adding `ChildFailed` and `PreRestart`; restart now calls `pre_restart` (defaulting to `post_stop`) and parents are notified via a new `on_child_failed` hook, while typed behaviors enforce a *death pact* by erroring on unhandled `Terminated` signals. Examples and unit tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 960cd783768dbd11c47d9525dced2c40cd309dd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * watch_with APIを追加：監視対象の終了時にカスタムメッセージを配信可能に
  * pre_restart、on_child_failedライフサイクルフックを追加：スーパーバイザー再起動時と子アクター障害時の処理を強化

* **改善**
  * シグナルハンドリングを改善し、ライフサイクルイベント通知をより詳細に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->