### PR TITLE
streams-medium-operators

### DIFF
--- a/modules/streams/src/core.rs
+++ b/modules/streams/src/core.rs
@@ -4,6 +4,8 @@ mod completion;
 mod demand;
 /// Demand tracking utilities.
 mod demand_tracker;
+/// Byte stream framing utilities.
+mod framing;
 /// Graph-related abstractions.
 pub mod graph;
 /// Dynamic fan-in/fan-out connectors.
@@ -30,6 +32,8 @@ pub mod operator;
 mod restart_settings;
 /// Stream topology shapes and connection points.
 pub mod shape;
+/// Shared pull handle for queue-based sink materialization.
+mod sink_queue;
 /// Stage definitions for source, flow, and sink.
 pub mod stage;
 /// Stream buffer implementation.
@@ -59,6 +63,7 @@ use core::any::{Any, TypeId};
 pub use completion::Completion;
 pub use demand::Demand;
 pub use demand_tracker::DemandTracker;
+pub use framing::Framing;
 pub use keep_both::KeepBoth;
 pub use keep_left::KeepLeft;
 pub use keep_none::KeepNone;
@@ -67,6 +72,7 @@ pub use mat_combine::MatCombine;
 pub use mat_combine_rule::MatCombineRule;
 pub use restart_settings::RestartSettings;
 use shape::PortId;
+pub use sink_queue::SinkQueue;
 use stage::StageKind;
 pub use stream_buffer::StreamBuffer;
 pub use stream_buffer_config::StreamBufferConfig;

--- a/modules/streams/src/core/framing.rs
+++ b/modules/streams/src/core/framing.rs
@@ -1,0 +1,153 @@
+use alloc::{boxed::Box, vec::Vec};
+use core::any::TypeId;
+
+use super::{
+  DynValue, FlowDefinition, FlowLogic, MatCombine, StageDefinition, StreamError, StreamNotUsed, SupervisionStrategy,
+  downcast_value,
+  graph::StreamGraph,
+  shape::{Inlet, Outlet},
+  stage::{Flow, StageKind},
+};
+
+#[cfg(test)]
+mod tests;
+
+/// Byte stream framing utilities.
+///
+/// Provides factory methods that produce flows splitting byte streams
+/// into frames based on delimiters or length fields.
+pub struct Framing;
+
+impl Framing {
+  /// Creates a flow that splits byte streams on a delimiter.
+  ///
+  /// Each input `Vec<u8>` chunk is accumulated into an internal buffer.
+  /// Complete frames (terminated by `delimiter`) are emitted downstream.
+  /// Frames exceeding `max_frame_length` cause a [`StreamError`].
+  /// When `allow_truncation` is true, remaining bytes without a trailing
+  /// delimiter are emitted on source completion.
+  #[must_use]
+  pub fn delimiter(
+    delimiter: Vec<u8>,
+    max_frame_length: usize,
+    allow_truncation: bool,
+  ) -> Flow<Vec<u8>, Vec<u8>, StreamNotUsed> {
+    let definition = delimiter_framing_definition(delimiter, max_frame_length, allow_truncation);
+    let mut graph = StreamGraph::new();
+    graph.push_stage(StageDefinition::Flow(definition));
+    Flow::from_graph(graph, StreamNotUsed::new())
+  }
+
+  /// Creates a flow that splits byte streams based on a length field.
+  ///
+  /// Each input `Vec<u8>` chunk is accumulated. The length field at
+  /// `field_offset` (big-endian, `field_length` bytes) determines the
+  /// total frame size. Complete frames are emitted downstream.
+  #[must_use]
+  pub fn length_field(field_offset: usize, field_length: usize) -> Flow<Vec<u8>, Vec<u8>, StreamNotUsed> {
+    Flow::new().stateful_map_concat(move || {
+      let mut buffer: Vec<u8> = Vec::new();
+      move |chunk: Vec<u8>| {
+        buffer.extend_from_slice(&chunk);
+        let mut frames: Vec<Vec<u8>> = Vec::new();
+        loop {
+          let header_end = field_offset + field_length;
+          if buffer.len() < header_end {
+            break;
+          }
+          let payload_len = read_big_endian_uint(&buffer[field_offset..header_end]);
+          let frame_len = header_end + payload_len;
+          if buffer.len() < frame_len {
+            break;
+          }
+          let frame: Vec<u8> = buffer[..frame_len].to_vec();
+          buffer = buffer[frame_len..].to_vec();
+          frames.push(frame);
+        }
+        frames
+      }
+    })
+  }
+}
+
+struct DelimiterFramingLogic {
+  delimiter:        Vec<u8>,
+  max_frame_length: usize,
+  allow_truncation: bool,
+  buffer:           Vec<u8>,
+  source_done:      bool,
+}
+
+impl FlowLogic for DelimiterFramingLogic {
+  fn apply(&mut self, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+    let chunk = downcast_value::<Vec<u8>>(input)?;
+    self.buffer.extend_from_slice(&chunk);
+    let mut frames: Vec<DynValue> = Vec::new();
+    loop {
+      let Some(pos) = find_delimiter(&self.buffer, &self.delimiter) else {
+        break;
+      };
+      let frame: Vec<u8> = self.buffer[..pos].to_vec();
+      let new_start = pos + self.delimiter.len();
+      self.buffer = self.buffer[new_start..].to_vec();
+      if frame.len() > self.max_frame_length {
+        return Err(StreamError::BufferOverflow);
+      }
+      frames.push(Box::new(frame) as DynValue);
+    }
+    if self.buffer.len() > self.max_frame_length {
+      return Err(StreamError::BufferOverflow);
+    }
+    Ok(frames)
+  }
+
+  fn on_source_done(&mut self) -> Result<(), StreamError> {
+    self.source_done = true;
+    Ok(())
+  }
+
+  fn drain_pending(&mut self) -> Result<Vec<DynValue>, StreamError> {
+    if self.allow_truncation && self.source_done && !self.buffer.is_empty() {
+      let remaining = core::mem::take(&mut self.buffer);
+      return Ok(alloc::vec![Box::new(remaining) as DynValue]);
+    }
+    Ok(Vec::new())
+  }
+
+  fn has_pending_output(&self) -> bool {
+    self.allow_truncation && self.source_done && !self.buffer.is_empty()
+  }
+}
+
+fn delimiter_framing_definition(delimiter: Vec<u8>, max_frame_length: usize, allow_truncation: bool) -> FlowDefinition {
+  let inlet: Inlet<Vec<u8>> = Inlet::new();
+  let outlet: Outlet<Vec<u8>> = Outlet::new();
+  let logic =
+    DelimiterFramingLogic { delimiter, max_frame_length, allow_truncation, buffer: Vec::new(), source_done: false };
+  FlowDefinition {
+    kind:        StageKind::FlowStatefulMapConcat,
+    inlet:       inlet.id(),
+    outlet:      outlet.id(),
+    input_type:  TypeId::of::<Vec<u8>>(),
+    output_type: TypeId::of::<Vec<u8>>(),
+    mat_combine: MatCombine::KeepLeft,
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    logic:       Box::new(logic),
+  }
+}
+
+fn find_delimiter(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+  if needle.is_empty() || haystack.len() < needle.len() {
+    return None;
+  }
+  haystack.windows(needle.len()).position(|window| window == needle)
+}
+
+fn read_big_endian_uint(bytes: &[u8]) -> usize {
+  let mut value: usize = 0;
+  for &byte in bytes {
+    value = (value << 8) | usize::from(byte);
+  }
+  value
+}

--- a/modules/streams/src/core/framing/tests.rs
+++ b/modules/streams/src/core/framing/tests.rs
@@ -1,0 +1,112 @@
+use alloc::{vec, vec::Vec};
+
+use super::{find_delimiter, read_big_endian_uint};
+
+#[test]
+fn should_find_delimiter_at_start() {
+  assert_eq!(find_delimiter(b"abc", b"a"), Some(0));
+}
+
+#[test]
+fn should_find_delimiter_in_middle() {
+  assert_eq!(find_delimiter(b"hello\nworld", b"\n"), Some(5));
+}
+
+#[test]
+fn should_return_none_when_delimiter_absent() {
+  assert_eq!(find_delimiter(b"hello", b"\n"), None);
+}
+
+#[test]
+fn should_return_none_for_empty_needle() {
+  assert_eq!(find_delimiter(b"hello", b""), None);
+}
+
+#[test]
+fn should_read_big_endian_u16() {
+  assert_eq!(read_big_endian_uint(&[0x00, 0x0A]), 10);
+}
+
+#[test]
+fn should_read_big_endian_u32() {
+  assert_eq!(read_big_endian_uint(&[0x00, 0x00, 0x01, 0x00]), 256);
+}
+
+#[test]
+fn should_read_single_byte() {
+  assert_eq!(read_big_endian_uint(&[0x05]), 5);
+}
+
+#[test]
+fn should_create_delimiter_flow() {
+  use crate::core::stage::Source;
+
+  let framing = super::Framing::delimiter(vec![b'\n'], 1024, false);
+  let source = Source::from(vec![b"hello\nwor".to_vec(), b"ld\nfoo".to_vec()]);
+  let result = source.via(framing).collect_values();
+  let frames = result.unwrap();
+  assert_eq!(frames, vec![b"hello".to_vec(), b"world".to_vec()]);
+}
+
+#[test]
+fn should_emit_trailing_bytes_when_allow_truncation_is_true() {
+  use crate::core::stage::Source;
+
+  let framing = super::Framing::delimiter(vec![b'\n'], 1024, true);
+  let source = Source::from(vec![b"hello\ntrailing".to_vec()]);
+  let result = source.via(framing).collect_values();
+  let frames = result.unwrap();
+  assert_eq!(frames, vec![b"hello".to_vec(), b"trailing".to_vec()]);
+}
+
+#[test]
+fn should_discard_trailing_bytes_when_allow_truncation_is_false() {
+  use crate::core::stage::Source;
+
+  let framing = super::Framing::delimiter(vec![b'\n'], 1024, false);
+  let source = Source::from(vec![b"hello\ntrailing".to_vec()]);
+  let result = source.via(framing).collect_values();
+  let frames = result.unwrap();
+  assert_eq!(frames, vec![b"hello".to_vec()]);
+}
+
+#[test]
+fn should_error_when_frame_exceeds_max_frame_length() {
+  use crate::core::{StreamError, stage::Source};
+
+  let framing = super::Framing::delimiter(vec![b'\n'], 5, false);
+  let source = Source::from(vec![b"toolong\nok".to_vec()]);
+  let result = source.via(framing).collect_values();
+  assert!(matches!(result, Err(StreamError::BufferOverflow)));
+}
+
+#[test]
+fn should_error_when_buffer_exceeds_max_frame_length_without_delimiter() {
+  use crate::core::{StreamError, stage::Source};
+
+  let framing = super::Framing::delimiter(vec![b'\n'], 5, false);
+  let source = Source::from(vec![b"abcdef".to_vec()]);
+  let result = source.via(framing).collect_values();
+  assert!(matches!(result, Err(StreamError::BufferOverflow)));
+}
+
+#[test]
+fn should_create_length_field_flow() {
+  use crate::core::stage::Source;
+
+  let framing = super::Framing::length_field(0, 2);
+  // frame1: length=3 (0x0003) + payload "abc"
+  // frame2: length=2 (0x0002) + payload "de"
+  let mut data = Vec::new();
+  data.extend_from_slice(&[0x00, 0x03]);
+  data.extend_from_slice(b"abc");
+  data.extend_from_slice(&[0x00, 0x02]);
+  data.extend_from_slice(b"de");
+
+  let source = Source::single(data);
+  let result = source.via(framing).collect_values();
+  let frames = result.unwrap();
+  assert_eq!(frames.len(), 2);
+  assert_eq!(&frames[0][2..], b"abc");
+  assert_eq!(&frames[1][2..], b"de");
+}

--- a/modules/streams/src/core/graph/stream_graph.rs
+++ b/modules/streams/src/core/graph/stream_graph.rs
@@ -208,6 +208,8 @@ impl StreamGraph {
             | StageKind::FlowZipWithIndex
             | StageKind::FlowConcat
             | StageKind::FlowWatchTermination
+            | StageKind::FlowDebounce
+            | StageKind::FlowSample
             | StageKind::Custom
         )
       },

--- a/modules/streams/src/core/sink_queue.rs
+++ b/modules/streams/src/core/sink_queue.rs
@@ -1,0 +1,59 @@
+use alloc::collections::VecDeque;
+
+use fraktor_utils_rs::core::sync::{ArcShared, sync_mutex_like::SpinSyncMutex};
+
+#[cfg(test)]
+mod tests;
+
+/// Shared pull handle for queue-based sink materialization.
+///
+/// Elements pushed into the sink can be pulled from this handle.
+pub struct SinkQueue<T> {
+  inner: ArcShared<SpinSyncMutex<VecDeque<T>>>,
+}
+
+impl<T> Clone for SinkQueue<T> {
+  fn clone(&self) -> Self {
+    Self { inner: self.inner.clone() }
+  }
+}
+
+impl<T> SinkQueue<T> {
+  /// Creates an empty sink queue.
+  #[must_use]
+  pub fn new() -> Self {
+    Self { inner: ArcShared::new(SpinSyncMutex::new(VecDeque::new())) }
+  }
+
+  /// Pulls the next element from the queue.
+  #[must_use]
+  pub fn pull(&self) -> Option<T> {
+    let mut guard = self.inner.lock();
+    guard.pop_front()
+  }
+
+  /// Returns the number of elements currently in the queue.
+  #[must_use]
+  pub fn len(&self) -> usize {
+    let guard = self.inner.lock();
+    guard.len()
+  }
+
+  /// Returns `true` when the queue contains no elements.
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    let guard = self.inner.lock();
+    guard.is_empty()
+  }
+
+  pub(crate) fn push(&self, value: T) {
+    let mut guard = self.inner.lock();
+    guard.push_back(value);
+  }
+}
+
+impl<T> Default for SinkQueue<T> {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/modules/streams/src/core/sink_queue/tests.rs
+++ b/modules/streams/src/core/sink_queue/tests.rs
@@ -1,0 +1,48 @@
+use super::SinkQueue;
+
+#[test]
+fn should_return_none_when_queue_is_empty() {
+  let queue = SinkQueue::<i32>::new();
+  assert!(queue.pull().is_none());
+  assert!(queue.is_empty());
+  assert_eq!(queue.len(), 0);
+}
+
+#[test]
+fn should_pull_elements_in_fifo_order() {
+  let queue = SinkQueue::<i32>::new();
+  queue.push(1);
+  queue.push(2);
+  queue.push(3);
+
+  assert_eq!(queue.len(), 3);
+  assert_eq!(queue.pull(), Some(1));
+  assert_eq!(queue.pull(), Some(2));
+  assert_eq!(queue.pull(), Some(3));
+  assert!(queue.pull().is_none());
+}
+
+#[test]
+fn should_share_state_across_clones() {
+  let queue = SinkQueue::<i32>::new();
+  let clone = queue.clone();
+
+  queue.push(42);
+  assert_eq!(clone.pull(), Some(42));
+  assert!(queue.is_empty());
+}
+
+#[test]
+fn should_report_length_correctly() {
+  let queue = SinkQueue::<i32>::new();
+  assert_eq!(queue.len(), 0);
+  assert!(queue.is_empty());
+
+  queue.push(10);
+  assert_eq!(queue.len(), 1);
+  assert!(!queue.is_empty());
+
+  let _ = queue.pull();
+  assert_eq!(queue.len(), 0);
+  assert!(queue.is_empty());
+}

--- a/modules/streams/src/core/stage.rs
+++ b/modules/streams/src/core/stage.rs
@@ -22,12 +22,16 @@ mod flow;
 mod flow_monitor;
 /// Flow-oriented substream surface.
 mod flow_sub_flow;
+/// Context-preserving flow wrapper.
+mod flow_with_context;
 /// Sink stage definitions.
 mod sink;
 /// Source stage definitions.
 mod source;
 /// Source-oriented substream surface.
 mod source_sub_flow;
+/// Context-preserving source wrapper.
+mod source_with_context;
 /// Stage execution context.
 mod stage_context;
 /// Built-in stage kinds.
@@ -47,9 +51,11 @@ pub(in crate::core) use flow::{
 };
 pub use flow_monitor::FlowMonitor;
 pub use flow_sub_flow::FlowSubFlow;
+pub use flow_with_context::FlowWithContext;
 pub use sink::Sink;
 pub use source::Source;
 pub use source_sub_flow::SourceSubFlow;
+pub use source_with_context::SourceWithContext;
 pub use stage_context::StageContext;
 pub use stage_kind::StageKind;
 pub use stream_stage::StreamStage;

--- a/modules/streams/src/core/stage/flow_with_context.rs
+++ b/modules/streams/src/core/stage/flow_with_context.rs
@@ -1,0 +1,82 @@
+use core::marker::PhantomData;
+
+use super::{StreamNotUsed, flow::Flow};
+
+#[cfg(test)]
+mod tests;
+
+/// Context-preserving flow wrapper.
+///
+/// Wraps an inner `Flow<(Ctx, In), (Ctx, Out), Mat>` and automatically
+/// propagates the context value through stream operators.
+pub struct FlowWithContext<Ctx, In, Out, Mat> {
+  inner: Flow<(Ctx, In), (Ctx, Out), Mat>,
+  _pd:   PhantomData<fn(Ctx)>,
+}
+
+impl<Ctx, In, Out, Mat> FlowWithContext<Ctx, In, Out, Mat>
+where
+  Ctx: Send + Sync + 'static,
+  In: Send + Sync + 'static,
+  Out: Send + Sync + 'static,
+{
+  /// Creates a context-preserving flow from an inner tuple flow.
+  #[must_use]
+  pub fn from_flow(inner: Flow<(Ctx, In), (Ctx, Out), Mat>) -> Self {
+    Self { inner, _pd: PhantomData }
+  }
+
+  /// Returns the inner tuple flow.
+  #[must_use]
+  pub fn as_flow(self) -> Flow<(Ctx, In), (Ctx, Out), Mat> {
+    self.inner
+  }
+
+  /// Maps the output value while preserving context.
+  #[must_use]
+  pub fn map<T, F>(self, mut func: F) -> FlowWithContext<Ctx, In, T, Mat>
+  where
+    T: Send + Sync + 'static,
+    F: FnMut(Out) -> T + Send + Sync + 'static, {
+    let mapped = self.inner.map(move |(ctx, value)| (ctx, func(value)));
+    FlowWithContext { inner: mapped, _pd: PhantomData }
+  }
+
+  /// Filters elements by value while preserving context.
+  #[must_use]
+  pub fn filter<F>(self, mut predicate: F) -> FlowWithContext<Ctx, In, Out, Mat>
+  where
+    F: FnMut(&Out) -> bool + Send + Sync + 'static, {
+    let filtered = self.inner.filter(move |(_, value)| predicate(value));
+    FlowWithContext { inner: filtered, _pd: PhantomData }
+  }
+
+  /// Remaps the context value on both input and output sides.
+  ///
+  /// Because a flow has both an input and an output side, remapping the
+  /// context requires a pair of functions: `forward` converts `Ctx` to
+  /// `Ctx2` on the output, while `reverse` converts `Ctx2` back to `Ctx`
+  /// on the input.
+  #[must_use]
+  pub fn map_context<Ctx2, F, G>(self, forward: F, reverse: G) -> FlowWithContext<Ctx2, In, Out, Mat>
+  where
+    Ctx2: Send + Sync + 'static,
+    F: Fn(Ctx) -> Ctx2 + Send + Sync + 'static,
+    G: Fn(Ctx2) -> Ctx + Send + Sync + 'static, {
+    let remap_input: Flow<(Ctx2, In), (Ctx, In), StreamNotUsed> =
+      Flow::from_function(move |(ctx2, value)| (reverse(ctx2), value));
+    let remap_output: Flow<(Ctx, Out), (Ctx2, Out), StreamNotUsed> =
+      Flow::from_function(move |(ctx, value)| (forward(ctx), value));
+    let inner = remap_input.via_mat(self.inner, super::keep_right::KeepRight).via(remap_output);
+    FlowWithContext { inner, _pd: PhantomData }
+  }
+
+  /// Composes with another context-preserving flow.
+  #[must_use]
+  pub fn via<T, Mat2>(self, other: FlowWithContext<Ctx, Out, T, Mat2>) -> FlowWithContext<Ctx, In, T, Mat>
+  where
+    T: Send + Sync + 'static, {
+    let composed = self.inner.via(other.inner);
+    FlowWithContext { inner: composed, _pd: PhantomData }
+  }
+}

--- a/modules/streams/src/core/stage/flow_with_context/tests.rs
+++ b/modules/streams/src/core/stage/flow_with_context/tests.rs
@@ -1,0 +1,46 @@
+use crate::core::{
+  StreamNotUsed,
+  stage::{Flow, FlowWithContext, Source},
+};
+
+#[test]
+fn should_map_output_preserving_context() {
+  let fwc: FlowWithContext<i32, &str, usize, StreamNotUsed> =
+    FlowWithContext::from_flow(Flow::new().map(|v: (i32, &str)| v)).map(|s: &str| s.len());
+  let values = Source::from(vec![(1_i32, "hello"), (2, "world")]).via(fwc.as_flow()).collect_values().unwrap();
+  assert_eq!(values, vec![(1, 5), (2, 5)]);
+}
+
+#[test]
+fn should_filter_by_value_preserving_context() {
+  let fwc: FlowWithContext<i32, i32, i32, StreamNotUsed> =
+    FlowWithContext::from_flow(Flow::new().map(|v: (i32, i32)| v)).filter(|v: &i32| *v > 0);
+  let values = Source::from(vec![(1_i32, 10), (2, -5), (3, 20)]).via(fwc.as_flow()).collect_values().unwrap();
+  assert_eq!(values, vec![(1, 10), (3, 20)]);
+}
+
+#[test]
+fn should_map_context() {
+  // Ctx=i32, Ctx2=i64 — different types ensure map_context cannot be a no-op
+  let fwc: FlowWithContext<i32, &str, &str, StreamNotUsed> =
+    FlowWithContext::from_flow(Flow::new().map(|v: (i32, &str)| v));
+  // forward and reverse are NOT inverses: output ctx differs from input ctx
+  let mapped = fwc.map_context(|ctx: i32| i64::from(ctx) * 10, |ctx2: i64| (ctx2 as i32) - 1);
+  // Input: (10_i64, "a"), (20_i64, "b")
+  // → reverse(10) = 9, reverse(20) = 19
+  // → inner (identity): (9, "a"), (19, "b")
+  // → forward(9) = 90, forward(19) = 190
+  let values = Source::from(vec![(10_i64, "a"), (20_i64, "b")]).via(mapped.as_flow()).collect_values().unwrap();
+  assert_eq!(values, vec![(90_i64, "a"), (190_i64, "b")]);
+}
+
+#[test]
+fn should_compose_via() {
+  let fwc1: FlowWithContext<i32, &str, &str, StreamNotUsed> =
+    FlowWithContext::from_flow(Flow::new().map(|v: (i32, &str)| v));
+  let fwc2: FlowWithContext<i32, &str, usize, StreamNotUsed> =
+    FlowWithContext::from_flow(Flow::new().map(|(ctx, s): (i32, &str)| (ctx, s.len())));
+  let composed = fwc1.via(fwc2);
+  let values = Source::from(vec![(1_i32, "hello"), (2, "hi")]).via(composed.as_flow()).collect_values().unwrap();
+  assert_eq!(values, vec![(1, 5), (2, 2)]);
+}

--- a/modules/streams/src/core/stage/source_with_context.rs
+++ b/modules/streams/src/core/stage/source_with_context.rs
@@ -1,0 +1,71 @@
+use core::marker::PhantomData;
+
+use super::{flow_with_context::FlowWithContext, source::Source};
+
+#[cfg(test)]
+mod tests;
+
+/// Context-preserving source wrapper.
+///
+/// Wraps an inner `Source<(Ctx, Out), Mat>` and automatically propagates
+/// the context value through stream operators.
+pub struct SourceWithContext<Ctx, Out, Mat> {
+  inner: Source<(Ctx, Out), Mat>,
+  _pd:   PhantomData<fn() -> Ctx>,
+}
+
+impl<Ctx, Out, Mat> SourceWithContext<Ctx, Out, Mat>
+where
+  Ctx: Send + Sync + 'static,
+  Out: Send + Sync + 'static,
+{
+  /// Creates a context-preserving source from an inner tuple source.
+  #[must_use]
+  pub fn from_source(inner: Source<(Ctx, Out), Mat>) -> Self {
+    Self { inner, _pd: PhantomData }
+  }
+
+  /// Returns the inner tuple source.
+  #[must_use]
+  pub fn as_source(self) -> Source<(Ctx, Out), Mat> {
+    self.inner
+  }
+
+  /// Maps the output value while preserving context.
+  #[must_use]
+  pub fn map<T, F>(self, mut func: F) -> SourceWithContext<Ctx, T, Mat>
+  where
+    T: Send + Sync + 'static,
+    F: FnMut(Out) -> T + Send + Sync + 'static, {
+    let mapped = self.inner.map(move |(ctx, value)| (ctx, func(value)));
+    SourceWithContext { inner: mapped, _pd: PhantomData }
+  }
+
+  /// Filters elements by value while preserving context.
+  #[must_use]
+  pub fn filter<F>(self, mut predicate: F) -> SourceWithContext<Ctx, Out, Mat>
+  where
+    F: FnMut(&Out) -> bool + Send + Sync + 'static, {
+    let filtered = self.inner.filter(move |(_, value)| predicate(value));
+    SourceWithContext { inner: filtered, _pd: PhantomData }
+  }
+
+  /// Maps the context value while preserving the output.
+  #[must_use]
+  pub fn map_context<Ctx2, F>(self, mut func: F) -> SourceWithContext<Ctx2, Out, Mat>
+  where
+    Ctx2: Send + Sync + 'static,
+    F: FnMut(Ctx) -> Ctx2 + Send + Sync + 'static, {
+    let mapped = self.inner.map(move |(ctx, value)| (func(ctx), value));
+    SourceWithContext { inner: mapped, _pd: PhantomData }
+  }
+
+  /// Composes with a context-preserving flow.
+  #[must_use]
+  pub fn via<T, Mat2>(self, flow: FlowWithContext<Ctx, Out, T, Mat2>) -> SourceWithContext<Ctx, T, Mat>
+  where
+    T: Send + Sync + 'static, {
+    let composed = self.inner.via(flow.as_flow());
+    SourceWithContext { inner: composed, _pd: PhantomData }
+  }
+}

--- a/modules/streams/src/core/stage/source_with_context/tests.rs
+++ b/modules/streams/src/core/stage/source_with_context/tests.rs
@@ -1,0 +1,50 @@
+use crate::core::{
+  StreamNotUsed,
+  stage::{Flow, FlowWithContext, Source, SourceWithContext},
+};
+
+#[test]
+fn should_create_from_source() {
+  let source = Source::from(vec![(1_i32, "a"), (2, "b")]);
+  let swc = SourceWithContext::from_source(source);
+  let inner = swc.as_source();
+  let values = inner.collect_values().unwrap();
+  assert_eq!(values, vec![(1, "a"), (2, "b")]);
+}
+
+#[test]
+fn should_map_output_preserving_context() {
+  let source = Source::from(vec![(1_i32, "hello"), (2, "world")]);
+  let swc = SourceWithContext::from_source(source);
+  let mapped = swc.map(|s: &str| s.len());
+  let values = mapped.as_source().collect_values().unwrap();
+  assert_eq!(values, vec![(1, 5), (2, 5)]);
+}
+
+#[test]
+fn should_filter_by_value_preserving_context() {
+  let source = Source::from(vec![(1_i32, 10), (2, -5), (3, 20)]);
+  let swc = SourceWithContext::from_source(source);
+  let filtered = swc.filter(|v: &i32| *v > 0);
+  let values = filtered.as_source().collect_values().unwrap();
+  assert_eq!(values, vec![(1, 10), (3, 20)]);
+}
+
+#[test]
+fn should_map_context() {
+  let source = Source::from(vec![(1_i32, "a"), (2, "b")]);
+  let swc = SourceWithContext::from_source(source);
+  let mapped = swc.map_context(|ctx: i32| ctx * 10);
+  let values = mapped.as_source().collect_values().unwrap();
+  assert_eq!(values, vec![(10, "a"), (20, "b")]);
+}
+
+#[test]
+fn should_compose_via() {
+  let fwc: FlowWithContext<i32, &str, usize, StreamNotUsed> =
+    FlowWithContext::from_flow(Flow::new().map(|(ctx, s): (i32, &str)| (ctx, s.len())));
+  let swc = SourceWithContext::from_source(Source::from(vec![(1_i32, "hello"), (2, "hi")]));
+  let composed = swc.via(fwc);
+  let values = composed.as_source().collect_values().unwrap();
+  assert_eq!(values, vec![(1, 5), (2, 2)]);
+}

--- a/modules/streams/src/core/stage/stage_kind.rs
+++ b/modules/streams/src/core/stage/stage_kind.rs
@@ -111,6 +111,10 @@ pub enum StageKind {
   FlowConcat,
   /// Flow stage that watches stream termination and completes a handle.
   FlowWatchTermination,
+  /// Flow stage that emits the held element after silence period expires.
+  FlowDebounce,
+  /// Flow stage that samples the latest element at fixed tick intervals.
+  FlowSample,
   /// Sink that ignores elements.
   SinkIgnore,
   /// Sink that folds elements.


### PR DESCRIPTION
## Summary

## Execution Report

Piece `pekko-porting` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core stream stage kinds and flow logic (new tick-driven behaviors) and changes the return types of `as_flow_with_context`/`as_source_with_context`, which may impact downstream API users and runtime semantics.
> 
> **Overview**
> Adds **byte framing utilities** via `Framing` with delimiter- and length-field-based `Flow<Vec<u8>, Vec<u8>>` factories, including max-frame overflow handling and truncation-on-complete behavior.
> 
> Introduces **new time-based operators** `debounce` and `sample` for both `Flow` and `Source`, backed by new `StageKind`s and flow logic that emits based on interpreter ticks, plus validation for non-zero `ticks`.
> 
> Adds **context-preserving wrappers** `FlowWithContext`/`SourceWithContext` and updates `as_*_with_context` APIs to return these wrappers (instead of raw tuple streams), along with `named()` no-op stubs and `from_materializer()` convenience constructors. Also adds `Sink::queue()` with a new shared `SinkQueue` materialized handle for pulling elements after run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6baa9cbadce19cac7fb94fa19ce46cebe5bfc4eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added byte stream framing utilities supporting delimiter-based and length-field-based frame extraction
  * Added debounce and sample stream operators for output throttling and periodic sampling
  * Added queue-based sink for collecting elements into a shared queue
  * Added context-preserving wrappers for enhanced flow and source composition

* **Tests**
  * Added comprehensive test coverage for framing, operators, and new stream utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->