### PR TITLE
[#232] github-issue-232-takt-cluster

### DIFF
--- a/modules/actor/src/core/dispatch/mailbox/base.rs
+++ b/modules/actor/src/core/dispatch/mailbox/base.rs
@@ -68,7 +68,7 @@ where
 
   /// Returns the system state handle if instrumentation has been installed.
   pub(crate) fn system_state(&self) -> Option<SystemStateSharedGeneric<TB>> {
-    self.instrumentation.lock().as_ref().map(|inst| inst.system_state())
+    self.instrumentation.lock().as_ref().and_then(|inst| inst.system_state())
   }
 
   /// Returns the actor pid associated with this mailbox when instrumentation is installed.

--- a/modules/actor/src/core/dispatch/mailbox/base/tests.rs
+++ b/modules/actor/src/core/dispatch/mailbox/base/tests.rs
@@ -36,6 +36,20 @@ fn mailbox_set_instrumentation() {
 }
 
 #[test]
+fn mailbox_enqueue_system_after_system_state_drop_does_not_panic() {
+  let mailbox = Mailbox::new(MailboxPolicy::unbounded(None));
+  let system_state = ActorSystem::new_empty().state();
+  let pid = Pid::new(2, 0);
+  let instrumentation = MailboxInstrumentation::new(system_state.clone(), pid, Some(8), Some(4), Some(6));
+  mailbox.set_instrumentation(instrumentation);
+
+  drop(system_state);
+
+  let result = mailbox.enqueue_system(SystemMessage::Stop);
+  assert!(result.is_ok());
+}
+
+#[test]
 fn mailbox_enqueue_system() {
   let mailbox = Mailbox::new(MailboxPolicy::unbounded(None));
   let message = SystemMessage::Stop;

--- a/modules/actor/src/core/event/stream/base.rs
+++ b/modules/actor/src/core/event/stream/base.rs
@@ -45,6 +45,12 @@ impl<TB: RuntimeToolbox + 'static> EventStreamGeneric<TB> {
     (id, snapshot)
   }
 
+  /// Adds a subscriber without replaying buffered events.
+  #[must_use]
+  pub fn subscribe_no_replay(&mut self, subscriber: EventStreamSubscriberShared<TB>) -> u64 {
+    self.subscribers.add(subscriber)
+  }
+
   /// Removes the subscriber associated with the identifier.
   pub fn unsubscribe(&mut self, id: u64) {
     self.subscribers.remove(id);

--- a/modules/actor/src/core/event/stream/event_stream_shared.rs
+++ b/modules/actor/src/core/event/stream/event_stream_shared.rs
@@ -77,6 +77,19 @@ impl<TB: RuntimeToolbox + 'static> EventStreamSharedGeneric<TB> {
     EventStreamSubscriptionGeneric::new(self.clone(), id)
   }
 
+  /// Subscribes without replaying buffered events.
+  #[must_use]
+  pub fn subscribe_no_replay(
+    &self,
+    subscriber: &EventStreamSubscriberShared<TB>,
+  ) -> EventStreamSubscriptionGeneric<TB> {
+    let id = {
+      let mut guard = self.inner.write();
+      guard.subscribe_no_replay(subscriber.clone())
+    };
+    EventStreamSubscriptionGeneric::new(self.clone(), id)
+  }
+
   /// Subscribes an ActorRef to this event stream.
   ///
   /// Events will be delivered **asynchronously** to the actor's mailbox.

--- a/modules/cluster/examples/membership_gossip_failure_std/main.rs
+++ b/modules/cluster/examples/membership_gossip_failure_std/main.rs
@@ -155,10 +155,14 @@ impl DemoNode {
   ) -> Self {
     let table = MembershipTable::new(3);
     let threshold = config.phi_threshold;
+    let cluster_config = ClusterExtensionConfig::new()
+      .with_advertised_address(authority)
+      .with_app_version("1.0.0")
+      .with_roles(vec![String::from("member")]);
     let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
       Box::new(PhiFailureDetector::new(PhiFailureDetectorConfig::new(threshold, 10, 1)))
     }));
-    let mut coordinator = MembershipCoordinatorGeneric::<StdToolbox>::new(config, table, registry);
+    let mut coordinator = MembershipCoordinatorGeneric::<StdToolbox>::new(config, cluster_config, table, registry);
     coordinator.start_member().expect("start_member");
     let shared = MembershipCoordinatorSharedGeneric::new(coordinator);
     let transport = DemoTransport::new(authority.to_string(), bus);
@@ -168,7 +172,11 @@ impl DemoNode {
 
   fn handle_join(&mut self, node_id: &str, authority: &str, now: TimerInstant) {
     println!("[{}][join] {} -> {}", self.name, node_id, authority);
-    self.driver.handle_join(node_id, authority, now).expect("handle_join");
+    let joining_config = ClusterExtensionConfig::new()
+      .with_advertised_address(authority)
+      .with_app_version("1.0.0")
+      .with_roles(vec![String::from("member")]);
+    self.driver.handle_join(node_id, authority, &joining_config, now).expect("handle_join");
   }
 
   fn handle_heartbeat(&mut self, authority: &str, now: TimerInstant) {

--- a/modules/cluster/examples/membership_gossip_tokio/main.rs
+++ b/modules/cluster/examples/membership_gossip_tokio/main.rs
@@ -17,7 +17,7 @@ use fraktor_actor_rs::core::event::stream::{
 };
 use fraktor_cluster_rs::{
   core::{
-    ClusterEvent,
+    ClusterEvent, ClusterExtensionConfig,
     membership::{
       GossipOutbound, GossipTransport, Gossiper, MembershipCoordinatorConfig, MembershipCoordinatorGeneric,
       MembershipCoordinatorSharedGeneric, MembershipDelta, MembershipTable, MembershipVersion, NodeRecord, NodeStatus,
@@ -64,13 +64,21 @@ fn build_coordinator() -> MembershipCoordinatorSharedGeneric<StdToolbox> {
   let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
     Box::new(PhiFailureDetector::new(PhiFailureDetectorConfig::new(threshold, 10, 1)))
   }));
-  let mut coordinator = MembershipCoordinatorGeneric::<StdToolbox>::new(config, table, registry);
+  let mut coordinator =
+    MembershipCoordinatorGeneric::<StdToolbox>::new(config, ClusterExtensionConfig::new(), table, registry);
   coordinator.start_member().expect("start_member");
   MembershipCoordinatorSharedGeneric::new(coordinator)
 }
 
 fn delta_for(node_id: &str, authority: &str, status: NodeStatus, version: u64) -> MembershipDelta {
-  let record = NodeRecord::new(node_id.to_string(), authority.to_string(), status, MembershipVersion::new(version));
+  let record = NodeRecord::new(
+    node_id.to_string(),
+    authority.to_string(),
+    status,
+    MembershipVersion::new(version),
+    String::from("1.0.0"),
+    vec![String::from("member")],
+  );
   MembershipDelta::new(MembershipVersion::new(version.saturating_sub(1)), MembershipVersion::new(version), vec![record])
 }
 

--- a/modules/cluster/examples/membership_gossip_topology_std/main.rs
+++ b/modules/cluster/examples/membership_gossip_topology_std/main.rs
@@ -158,10 +158,14 @@ impl DemoNode {
   ) -> Self {
     let table = MembershipTable::new(3);
     let threshold = config.phi_threshold;
+    let cluster_config = ClusterExtensionConfig::new()
+      .with_advertised_address(authority)
+      .with_app_version("1.0.0")
+      .with_roles(vec![String::from("member")]);
     let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
       Box::new(PhiFailureDetector::new(PhiFailureDetectorConfig::new(threshold, 10, 1)))
     }));
-    let mut coordinator = MembershipCoordinatorGeneric::<StdToolbox>::new(config, table, registry);
+    let mut coordinator = MembershipCoordinatorGeneric::<StdToolbox>::new(config, cluster_config, table, registry);
     coordinator.start_member().expect("start_member");
     let shared = MembershipCoordinatorSharedGeneric::new(coordinator);
     let transport = DemoTransport::new(authority.to_string(), bus);
@@ -171,7 +175,11 @@ impl DemoNode {
 
   fn handle_join(&mut self, node_id: &str, authority: &str, now: TimerInstant) {
     println!("[{}][join] {} -> {}", self.name, node_id, authority);
-    self.driver.handle_join(node_id, authority, now).expect("handle_join");
+    let joining_config = ClusterExtensionConfig::new()
+      .with_advertised_address(authority)
+      .with_app_version("1.0.0")
+      .with_roles(vec![String::from("member")]);
+    self.driver.handle_join(node_id, authority, &joining_config, now).expect("handle_join");
   }
 
   fn handle_heartbeat(&mut self, authority: &str, now: TimerInstant) {

--- a/modules/cluster/examples/quickstart/main.rs
+++ b/modules/cluster/examples/quickstart/main.rs
@@ -59,8 +59,12 @@ async fn main() -> Result<()> {
 
   // Membership を事前に揃え、IdentityTable へ配布するための delta を作成
   let mut membership_a = MembershipTable::new(3);
-  let delta_a = membership_a.try_join("node-a".to_string(), format!("{HOST}:{NODE_A_PORT}")).expect("join a");
-  let delta_b = membership_a.try_join("node-b".to_string(), format!("{HOST}:{NODE_B_PORT}")).expect("join b");
+  let delta_a = membership_a
+    .try_join("node-a".to_string(), format!("{HOST}:{NODE_A_PORT}"), "1.0.0".to_string(), vec!["member".to_string()])
+    .expect("join a");
+  let delta_b = membership_a
+    .try_join("node-b".to_string(), format!("{HOST}:{NODE_B_PORT}"), "1.0.0".to_string(), vec!["member".to_string()])
+    .expect("join b");
   let full_delta =
     MembershipDelta::new(delta_a.from, delta_b.to, vec![delta_a.entries[0].clone(), delta_b.entries[0].clone()]);
 

--- a/modules/cluster/src/core.rs
+++ b/modules/cluster/src/core.rs
@@ -18,10 +18,12 @@ mod cluster_provider_shared;
 mod cluster_request_error;
 mod cluster_resolve_error;
 mod cluster_topology;
+mod config_validation;
 /// Virtual actor (grain) API, RPC routing, and codec abstraction.
 pub mod grain;
 /// PID resolution, identity lookup, and rendezvous hashing.
 pub mod identity;
+mod join_config_compat_checker;
 /// Membership management, gossip dissemination, and node lifecycle.
 pub mod membership;
 mod metrics_error;
@@ -51,6 +53,8 @@ pub use cluster_provider_shared::ClusterProviderShared;
 pub use cluster_request_error::ClusterRequestError;
 pub use cluster_resolve_error::ClusterResolveError;
 pub use cluster_topology::ClusterTopology;
+pub use config_validation::ConfigValidation;
+pub use join_config_compat_checker::JoinConfigCompatChecker;
 pub use metrics_error::MetricsError;
 pub use startup_mode::StartupMode;
 pub use topology_apply_error::TopologyApplyError;

--- a/modules/cluster/src/core/cluster_core/tests.rs
+++ b/modules/cluster/src/core/cluster_core/tests.rs
@@ -463,11 +463,11 @@ fn new_core_stores_dependencies_and_startup_params() {
 
   // 構成が保持されていること
   // startup_state内部のアドレスが正しく設定されていることを確認
-  assert_eq!(core.startup_address(), config.advertised_address());
+  assert_eq!(core.startup_address(), config.advertised_address().as_str());
 
   // 起動パラメータが両モードで再利用できる形で保持されること
-  assert_eq!(core.startup_address(), config.advertised_address());
-  assert_eq!(core.startup_address(), config.advertised_address());
+  assert_eq!(core.startup_address(), config.advertised_address().as_str());
+  assert_eq!(core.startup_address(), config.advertised_address().as_str());
 }
 
 #[test]

--- a/modules/cluster/src/core/cluster_extension.rs
+++ b/modules/cluster/src/core/cluster_extension.rs
@@ -22,8 +22,11 @@ use crate::core::{
   ClusterCore, ClusterError, ClusterEvent, ClusterMetricsSnapshot, MetricsError, TopologyUpdate,
   grain::{GrainMetrics, GrainMetricsSharedGeneric, GrainMetricsSnapshot},
   identity::IdentitySetupError,
+  membership::NodeStatus,
   placement::ActivatedKind,
 };
+
+const CLUSTER_EVENT_STREAM_NAME: &str = "cluster";
 
 /// Internal subscriber that applies topology updates to ClusterCore.
 struct ClusterTopologySubscriber<TB: RuntimeToolbox + 'static> {
@@ -42,7 +45,7 @@ impl<TB: RuntimeToolbox + 'static> EventStreamSubscriber<TB> for ClusterTopology
     // cluster 拡張イベントの TopologyUpdated のみを処理
     // （既に EventStream 経由で受信したイベントなので再 publish しない）
     if let EventStreamEvent::Extension { name, payload } = event
-      && name == "cluster"
+      && name == CLUSTER_EVENT_STREAM_NAME
       && let Some(ClusterEvent::TopologyUpdated { update }) = payload.payload().downcast_ref::<ClusterEvent>()
     {
       let result = self.core.lock().try_apply_topology(update);
@@ -50,20 +53,146 @@ impl<TB: RuntimeToolbox + 'static> EventStreamSubscriber<TB> for ClusterTopology
         let reason = format!("{error:?}");
         let failed = ClusterEvent::TopologyApplyFailed { reason, observed_at: update.observed_at };
         let payload = AnyMessageGeneric::new(failed);
-        let extension_event = EventStreamEvent::Extension { name: String::from("cluster"), payload };
+        let extension_event = EventStreamEvent::Extension { name: String::from(CLUSTER_EVENT_STREAM_NAME), payload };
         self.event_stream.publish(&extension_event);
       }
     }
   }
 }
 
+struct MemberStatusSubscriberState {
+  subscription_id:       Option<u64>,
+  unsubscribe_requested: bool,
+}
+
+impl MemberStatusSubscriberState {
+  const fn new() -> Self {
+    Self { subscription_id: None, unsubscribe_requested: false }
+  }
+}
+
+struct MemberStatusCallbackState<F> {
+  callback: F,
+  fired:    bool,
+}
+
+impl<F> MemberStatusCallbackState<F> {
+  const fn new(callback: F) -> Self {
+    Self { callback, fired: false }
+  }
+}
+
+fn trigger_member_status_callback<TB, F>(
+  callback_state: &ArcShared<ToolboxMutex<MemberStatusCallbackState<F>, TB>>,
+  node_id: &str,
+  authority: &str,
+) -> bool
+where
+  TB: RuntimeToolbox + 'static,
+  F: FnMut(&str, &str) + Send + Sync + 'static, {
+  let mut state = callback_state.lock();
+  if state.fired {
+    return false;
+  }
+  state.fired = true;
+  (state.callback)(node_id, authority);
+  true
+}
+
+#[derive(Clone)]
+struct SelfMemberStatus {
+  node_id:   String,
+  authority: String,
+  status:    NodeStatus,
+}
+
+struct SelfMemberStatusTrackerSubscriber<TB: RuntimeToolbox + 'static> {
+  self_address: String,
+  self_status:  ArcShared<ToolboxMutex<Option<SelfMemberStatus>, TB>>,
+}
+
+impl<TB: RuntimeToolbox + 'static> SelfMemberStatusTrackerSubscriber<TB> {
+  const fn new(self_address: String, self_status: ArcShared<ToolboxMutex<Option<SelfMemberStatus>, TB>>) -> Self {
+    Self { self_address, self_status }
+  }
+}
+
+impl<TB: RuntimeToolbox + 'static> EventStreamSubscriber<TB> for SelfMemberStatusTrackerSubscriber<TB> {
+  fn on_event(&mut self, event: &EventStreamEvent<TB>) {
+    if let EventStreamEvent::Extension { name, payload } = event
+      && name == CLUSTER_EVENT_STREAM_NAME
+      && let Some(ClusterEvent::MemberStatusChanged { node_id, authority, to, .. }) =
+        payload.payload().downcast_ref::<ClusterEvent>()
+      && authority == &self.self_address
+    {
+      let status = SelfMemberStatus { node_id: node_id.clone(), authority: authority.clone(), status: *to };
+      *self.self_status.lock() = Some(status);
+    }
+  }
+}
+
+struct MemberStatusSubscriber<TB: RuntimeToolbox + 'static, F: FnMut(&str, &str) + Send + Sync + 'static> {
+  target:         NodeStatus,
+  self_address:   String,
+  callback_state: ArcShared<ToolboxMutex<MemberStatusCallbackState<F>, TB>>,
+  state:          ArcShared<ToolboxMutex<MemberStatusSubscriberState, TB>>,
+  event_stream:   EventStreamSharedGeneric<TB>,
+}
+
+impl<TB: RuntimeToolbox + 'static, F: FnMut(&str, &str) + Send + Sync + 'static> MemberStatusSubscriber<TB, F> {
+  const fn new(
+    target: NodeStatus,
+    self_address: String,
+    callback_state: ArcShared<ToolboxMutex<MemberStatusCallbackState<F>, TB>>,
+    state: ArcShared<ToolboxMutex<MemberStatusSubscriberState, TB>>,
+    event_stream: EventStreamSharedGeneric<TB>,
+  ) -> Self {
+    Self { target, self_address, callback_state, state, event_stream }
+  }
+}
+
+impl<TB, F> EventStreamSubscriber<TB> for MemberStatusSubscriber<TB, F>
+where
+  TB: RuntimeToolbox + 'static,
+  F: FnMut(&str, &str) + Send + Sync + 'static,
+{
+  fn on_event(&mut self, event: &EventStreamEvent<TB>) {
+    if let EventStreamEvent::Extension { name, payload } = event
+      && name == CLUSTER_EVENT_STREAM_NAME
+      && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
+      && let ClusterEvent::MemberStatusChanged { node_id, authority, to, .. } = cluster_event
+      && authority == &self.self_address
+      && *to == self.target
+      && trigger_member_status_callback::<TB, F>(&self.callback_state, node_id, authority)
+    {
+      let subscription_id = {
+        let mut state = self.state.lock();
+        state.unsubscribe_requested = true;
+        state.subscription_id
+      };
+      if let Some(id) = subscription_id {
+        self.event_stream.unsubscribe(id);
+      }
+    }
+  }
+}
+
+struct NoopMemberStatusSubscriber;
+
+impl<TB: RuntimeToolbox + 'static> EventStreamSubscriber<TB> for NoopMemberStatusSubscriber {
+  fn on_event(&mut self, _event: &EventStreamEvent<TB>) {}
+}
+
 /// Cluster extension registered into `ActorSystemGeneric`.
 pub struct ClusterExtensionGeneric<TB: RuntimeToolbox + 'static> {
-  core:          ArcShared<ToolboxMutex<ClusterCore<TB>, TB>>,
-  event_stream:  EventStreamSharedGeneric<TB>,
+  core: ArcShared<ToolboxMutex<ClusterCore<TB>, TB>>,
+  event_stream: EventStreamSharedGeneric<TB>,
   grain_metrics: Option<GrainMetricsSharedGeneric<TB>>,
-  subscription:  ToolboxMutex<Option<EventStreamSubscriptionGeneric<TB>>, TB>,
-  _system:       ActorSystemWeakGeneric<TB>,
+  subscription: ToolboxMutex<Option<EventStreamSubscriptionGeneric<TB>>, TB>,
+  terminated: ToolboxMutex<bool, TB>,
+  self_member_status: ArcShared<ToolboxMutex<Option<SelfMemberStatus>, TB>>,
+  _self_member_status_subscription: EventStreamSubscriptionGeneric<TB>,
+  _system: ActorSystemWeakGeneric<TB>,
 }
 
 impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
@@ -73,11 +202,26 @@ impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
   #[must_use]
   pub fn new(system: &ActorSystemGeneric<TB>, core: ClusterCore<TB>) -> Self {
     let event_stream = system.event_stream();
+    let self_address = core.startup_address();
     let grain_metrics =
       if core.metrics_enabled() { Some(GrainMetricsSharedGeneric::new(GrainMetrics::new())) } else { None };
+    let self_member_status = ArcShared::new(<TB::MutexFamily as SyncMutexFamily>::create(None));
+    let status_subscriber =
+      subscriber_handle::<TB>(SelfMemberStatusTrackerSubscriber::<TB>::new(self_address, self_member_status.clone()));
+    let self_member_status_subscription = event_stream.subscribe_no_replay(&status_subscriber);
     let locked = <TB::MutexFamily as SyncMutexFamily>::create(core);
     let subscription = <TB::MutexFamily as SyncMutexFamily>::create(None);
-    Self { core: ArcShared::new(locked), event_stream, grain_metrics, subscription, _system: system.downgrade() }
+    let terminated = <TB::MutexFamily as SyncMutexFamily>::create(false);
+    Self {
+      core: ArcShared::new(locked),
+      event_stream,
+      grain_metrics,
+      subscription,
+      terminated,
+      self_member_status,
+      _self_member_status_subscription: self_member_status_subscription,
+      _system: system.downgrade(),
+    }
   }
 
   /// Returns the shared cluster core handle.
@@ -121,6 +265,8 @@ impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
   pub fn start_member(&self) -> Result<(), ClusterError> {
     let result = self.core.lock().start_member();
     if result.is_ok() {
+      *self.terminated.lock() = false;
+      *self.self_member_status.lock() = None;
       self.subscribe_topology_events();
     }
     result
@@ -134,6 +280,8 @@ impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
   pub fn start_client(&self) -> Result<(), ClusterError> {
     let result = self.core.lock().start_client();
     if result.is_ok() {
+      *self.terminated.lock() = false;
+      *self.self_member_status.lock() = None;
       self.subscribe_topology_events();
     }
     result
@@ -147,7 +295,12 @@ impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
   pub fn shutdown(&self, graceful: bool) -> Result<(), ClusterError> {
     // 購読を解除
     *self.subscription.lock() = None;
-    self.core.lock().shutdown(graceful)
+    let result = self.core.lock().shutdown(graceful);
+    if result.is_ok() {
+      *self.terminated.lock() = true;
+      *self.self_member_status.lock() = None;
+    }
+    result
   }
 
   /// Registers kinds for member mode.
@@ -180,7 +333,7 @@ impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
     match result {
       | Ok(Some(event)) => {
         let payload = AnyMessageGeneric::new(event);
-        let extension_event = EventStreamEvent::Extension { name: String::from("cluster"), payload };
+        let extension_event = EventStreamEvent::Extension { name: String::from(CLUSTER_EVENT_STREAM_NAME), payload };
         self.event_stream.publish(&extension_event);
       },
       | Ok(None) => {},
@@ -188,10 +341,32 @@ impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
         let reason = format!("{error:?}");
         let failed = ClusterEvent::TopologyApplyFailed { reason, observed_at: update.observed_at };
         let payload = AnyMessageGeneric::new(failed);
-        let extension_event = EventStreamEvent::Extension { name: String::from("cluster"), payload };
+        let extension_event = EventStreamEvent::Extension { name: String::from(CLUSTER_EVENT_STREAM_NAME), payload };
         self.event_stream.publish(&extension_event);
       },
     }
+  }
+
+  /// Registers a callback invoked when a member reaches `Up` status.
+  #[must_use]
+  pub fn register_on_member_up<F>(&self, callback: F) -> EventStreamSubscriptionGeneric<TB>
+  where
+    F: FnMut(&str, &str) + Send + Sync + 'static, {
+    self.register_on_member_status(NodeStatus::Up, callback)
+  }
+
+  /// Registers a callback invoked when a member reaches `Removed` status.
+  #[must_use]
+  pub fn register_on_member_removed<F>(&self, callback: F) -> EventStreamSubscriptionGeneric<TB>
+  where
+    F: FnMut(&str, &str) + Send + Sync + 'static, {
+    if *self.terminated.lock() {
+      let self_address = self.core.lock().startup_address();
+      let mut immediate = callback;
+      immediate(&self_address, &self_address);
+      return self.already_unsubscribed_subscription();
+    }
+    self.register_on_member_status(NodeStatus::Removed, callback)
   }
 
   /// Returns metrics snapshot if enabled.
@@ -223,6 +398,47 @@ impl<TB: RuntimeToolbox + 'static> ClusterExtensionGeneric<TB> {
   /// Returns blocked members cache.
   pub fn blocked_members(&self) -> Vec<String> {
     self.core.lock().blocked_members().to_vec()
+  }
+
+  fn register_on_member_status<F>(&self, target: NodeStatus, callback: F) -> EventStreamSubscriptionGeneric<TB>
+  where
+    F: FnMut(&str, &str) + Send + Sync + 'static, {
+    let self_address = self.core.lock().startup_address();
+    let state = ArcShared::new(<TB::MutexFamily as SyncMutexFamily>::create(MemberStatusSubscriberState::new()));
+    let callback_state =
+      ArcShared::new(<TB::MutexFamily as SyncMutexFamily>::create(MemberStatusCallbackState::new(callback)));
+    let subscriber = subscriber_handle::<TB>(MemberStatusSubscriber::new(
+      target,
+      self_address.clone(),
+      callback_state.clone(),
+      state.clone(),
+      self.event_stream.clone(),
+    ));
+    let subscription = self.event_stream.subscribe_no_replay(&subscriber);
+    let subscription_id = subscription.id();
+    {
+      let mut guard = state.lock();
+      guard.subscription_id = Some(subscription_id);
+    }
+    if let Some(current) = self.self_member_status.lock().clone()
+      && current.authority == self_address.as_str()
+      && current.status == target
+      && trigger_member_status_callback::<TB, F>(&callback_state, &current.node_id, &current.authority)
+    {
+      state.lock().unsubscribe_requested = true;
+    }
+    let unsubscribe_now = state.lock().unsubscribe_requested;
+    if unsubscribe_now {
+      self.event_stream.unsubscribe(subscription_id);
+    }
+    subscription
+  }
+
+  fn already_unsubscribed_subscription(&self) -> EventStreamSubscriptionGeneric<TB> {
+    let subscriber = subscriber_handle::<TB>(NoopMemberStatusSubscriber);
+    let subscription = self.event_stream.subscribe(&subscriber);
+    self.event_stream.unsubscribe(subscription.id());
+    subscription
   }
 }
 

--- a/modules/cluster/src/core/cluster_extension_config/tests.rs
+++ b/modules/cluster/src/core/cluster_extension_config/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::{ConfigValidation, JoinConfigCompatChecker};
 
 #[test]
 fn metrics_flag_and_address_are_preserved() {
@@ -19,4 +20,63 @@ fn pubsub_config_is_preserved() {
     crate::core::pub_sub::PubSubConfig::new(core::time::Duration::from_secs(5), core::time::Duration::from_secs(12));
   let config = ClusterExtensionConfig::new().with_pubsub_config(custom);
   assert_eq!(config.pubsub_config(), &custom);
+}
+
+#[test]
+fn static_topology_is_preserved() {
+  let topology = crate::core::cluster_topology::ClusterTopology::new(
+    7,
+    vec!["node-a".to_string()],
+    vec!["node-b".to_string()],
+    vec!["node-c".to_string()],
+  );
+  let config = ClusterExtensionConfig::new().with_static_topology(topology.clone());
+  assert_eq!(config.static_topology(), Some(&topology));
+}
+
+#[test]
+fn roles_are_sorted_and_deduplicated() {
+  let config = ClusterExtensionConfig::new().with_roles(vec![
+    "frontend".to_string(),
+    "backend".to_string(),
+    "frontend".to_string(),
+  ]);
+  assert_eq!(config.roles(), &["backend".to_string(), "frontend".to_string()]);
+}
+
+#[test]
+fn app_version_is_preserved() {
+  let config = ClusterExtensionConfig::new().with_app_version("2.3.4");
+  assert_eq!(config.app_version(), "2.3.4");
+}
+
+#[test]
+fn join_compatibility_reports_pubsub_mismatch() {
+  let local = ClusterExtensionConfig::new()
+    .with_pubsub_config(crate::core::pub_sub::PubSubConfig::new(
+      core::time::Duration::from_secs(3),
+      core::time::Duration::from_secs(30),
+    ))
+    .with_roles(vec!["backend".to_string()]);
+  let joining = ClusterExtensionConfig::new()
+    .with_pubsub_config(crate::core::pub_sub::PubSubConfig::new(
+      core::time::Duration::from_secs(5),
+      core::time::Duration::from_secs(30),
+    ))
+    .with_roles(vec!["frontend".to_string()]);
+
+  let validation = local.check_join_compatibility(&joining);
+  assert_eq!(validation, ConfigValidation::Incompatible { reason: "pubsub configuration mismatch".to_string() });
+}
+
+#[test]
+fn join_compatibility_accepts_same_pubsub_config() {
+  let shared =
+    crate::core::pub_sub::PubSubConfig::new(core::time::Duration::from_secs(4), core::time::Duration::from_secs(40));
+  let local = ClusterExtensionConfig::new().with_pubsub_config(shared).with_roles(vec!["backend".to_string()]);
+  let joining = ClusterExtensionConfig::new().with_pubsub_config(shared).with_roles(vec!["frontend".to_string()]);
+
+  let validation = local.check_join_compatibility(&joining);
+  assert_eq!(validation, ConfigValidation::Compatible);
+  assert!(validation.is_compatible());
 }

--- a/modules/cluster/src/core/config_validation.rs
+++ b/modules/cluster/src/core/config_validation.rs
@@ -1,0 +1,23 @@
+//! Join configuration validation result.
+
+use alloc::string::String;
+
+/// Outcome of join configuration compatibility checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigValidation {
+  /// Configurations are compatible and joining is allowed.
+  Compatible,
+  /// Configurations are incompatible and joining must be rejected.
+  Incompatible {
+    /// Human-readable reason for incompatibility.
+    reason: String,
+  },
+}
+
+impl ConfigValidation {
+  /// Returns true if the configuration is compatible.
+  #[must_use]
+  pub const fn is_compatible(&self) -> bool {
+    matches!(self, Self::Compatible)
+  }
+}

--- a/modules/cluster/src/core/identity/identity_table.rs
+++ b/modules/cluster/src/core/identity/identity_table.rs
@@ -88,7 +88,7 @@ impl IdentityTable {
     };
 
     match record.status {
-      | NodeStatus::Removed | NodeStatus::Dead => {
+      | NodeStatus::Leaving | NodeStatus::Exiting | NodeStatus::Removed | NodeStatus::Dead => {
         self.events.push(IdentityEvent::UnknownAuthority { authority: authority.to_string(), version });
         return Ok(ResolveResult::Unreachable { authority: authority.to_string(), version });
       },

--- a/modules/cluster/src/core/join_config_compat_checker.rs
+++ b/modules/cluster/src/core/join_config_compat_checker.rs
@@ -1,0 +1,9 @@
+//! Join configuration compatibility checker.
+
+use crate::core::{ClusterExtensionConfig, ConfigValidation};
+
+/// Checks whether a joining node configuration is compatible with local settings.
+pub trait JoinConfigCompatChecker {
+  /// Validates compatibility between local and joining configurations.
+  fn check_join_compatibility(&self, joining: &ClusterExtensionConfig) -> ConfigValidation;
+}

--- a/modules/cluster/src/core/membership/gossip_dissemination_coordinator/tests.rs
+++ b/modules/cluster/src/core/membership/gossip_dissemination_coordinator/tests.rs
@@ -8,7 +8,9 @@ use crate::core::membership::{
 #[test]
 fn diffusing_reaches_confirmed_after_all_peers_ack() {
   let mut table = MembershipTable::new(3);
-  let delta = table.try_join("node-1".to_string(), "n1:4050".to_string()).expect("join succeeds");
+  let delta = table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["member".to_string()])
+    .expect("join succeeds");
   table.drain_events();
 
   let mut coordinator = GossipDisseminationCoordinator::new(table, vec!["node-2".to_string(), "node-3".to_string()]);
@@ -34,7 +36,9 @@ fn diffusing_reaches_confirmed_after_all_peers_ack() {
 #[test]
 fn conflict_moves_engine_to_reconciling_and_emits_event() {
   let mut table = MembershipTable::new(3);
-  table.try_join("node-1".to_string(), "n1:4050".to_string()).expect("join succeeds");
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["member".to_string()])
+    .expect("join succeeds");
   table.drain_events();
 
   let mut coordinator = GossipDisseminationCoordinator::new(table, vec!["node-2".to_string()]);
@@ -45,6 +49,8 @@ fn conflict_moves_engine_to_reconciling_and_emits_event() {
       "n1:4050".to_string(),
       NodeStatus::Up,
       MembershipVersion::zero(),
+      "1.0.0".to_string(),
+      vec!["member".to_string()],
     )]);
 
   coordinator.apply_incoming(&conflict_delta, "node-2");
@@ -61,7 +67,9 @@ fn conflict_moves_engine_to_reconciling_and_emits_event() {
 #[test]
 fn missing_range_request_enters_reconciling() {
   let mut table = MembershipTable::new(3);
-  table.try_join("node-1".to_string(), "n1:4050".to_string()).expect("join succeeds");
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["member".to_string()])
+    .expect("join succeeds");
   table.drain_events();
 
   let mut coordinator = GossipDisseminationCoordinator::new(table, vec!["node-2".to_string()]);

--- a/modules/cluster/src/core/membership/membership_coordinator/tests.rs
+++ b/modules/cluster/src/core/membership/membership_coordinator/tests.rs
@@ -9,11 +9,12 @@ use fraktor_utils_rs::core::time::TimerInstant;
 
 use super::MembershipCoordinatorGeneric;
 use crate::core::{
-  ClusterEvent,
+  ClusterEvent, ClusterExtensionConfig,
   membership::{
     MembershipCoordinatorConfig, MembershipCoordinatorError, MembershipCoordinatorState, MembershipDelta,
-    MembershipError, MembershipTable, MembershipVersion, NodeStatus, QuarantineEvent,
+    MembershipError, MembershipEvent, MembershipTable, MembershipVersion, NodeStatus, QuarantineEvent,
   },
+  pub_sub::PubSubConfig,
 };
 
 fn base_config() -> MembershipCoordinatorConfig {
@@ -38,12 +39,21 @@ fn now(ticks: u64) -> TimerInstant {
   TimerInstant::from_ticks(ticks, Duration::from_secs(1))
 }
 
+fn local_cluster_config() -> ClusterExtensionConfig {
+  ClusterExtensionConfig::new().with_app_version("1.0.0").with_roles(vec![String::from("backend")])
+}
+
+fn joining_cluster_config() -> ClusterExtensionConfig {
+  ClusterExtensionConfig::new().with_app_version("1.1.0").with_roles(vec![String::from("frontend")])
+}
+
 #[test]
 fn stopped_rejects_inputs() {
   let table = MembershipTable::new(3);
   let config = base_config();
   let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
     config,
+    local_cluster_config(),
     table,
     registry(1.0),
   );
@@ -62,12 +72,14 @@ fn client_rejects_join_and_leave() {
   let config = base_config();
   let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
     config,
+    local_cluster_config(),
     table,
     registry(1.0),
   );
   coordinator.start_client().unwrap();
 
-  let err = coordinator.handle_join("node-1".to_string(), "node-a".to_string(), now(1)).unwrap_err();
+  let err =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap_err();
   assert_eq!(err, MembershipCoordinatorError::InvalidState { state: MembershipCoordinatorState::Client });
 
   let err = coordinator.handle_leave("node-a", now(1)).unwrap_err();
@@ -80,12 +92,14 @@ fn join_then_heartbeat_promotes_to_up() {
   let config = base_config();
   let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
     config,
+    local_cluster_config(),
     table,
     registry(1.0),
   );
   coordinator.start_member().unwrap();
 
-  let outcome = coordinator.handle_join("node-1".to_string(), "node-a".to_string(), now(1)).unwrap();
+  let outcome =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap();
   assert!(
     outcome
       .member_events
@@ -103,18 +117,57 @@ fn join_then_heartbeat_promotes_to_up() {
 }
 
 #[test]
+fn leave_emits_exiting_then_removed() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
+    config,
+    local_cluster_config(),
+    table,
+    registry(1.0),
+  );
+  coordinator.start_member().unwrap();
+
+  let _ =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a", now(2)).unwrap();
+
+  let outcome = coordinator.handle_leave("node-a", now(3)).unwrap();
+  assert!(
+    outcome
+      .member_events
+      .iter()
+      .any(|event| matches!(event, ClusterEvent::MemberStatusChanged { to: NodeStatus::Exiting, .. }))
+  );
+  assert!(
+    outcome
+      .member_events
+      .iter()
+      .any(|event| matches!(event, ClusterEvent::MemberStatusChanged { to: NodeStatus::Removed, .. }))
+  );
+  assert!(
+    outcome
+      .membership_events
+      .iter()
+      .any(|event| matches!(event, MembershipEvent::Left { authority, .. } if authority == "node-a"))
+  );
+}
+
+#[test]
 fn topology_emits_after_interval() {
   let table = MembershipTable::new(3);
   let mut config = base_config();
   config.topology_emit_interval = Duration::from_secs(2);
   let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
     config,
+    local_cluster_config(),
     table,
     registry(1.0),
   );
   coordinator.start_member().unwrap();
 
-  let _ = coordinator.handle_join("node-1".to_string(), "node-a".to_string(), now(1)).unwrap();
+  let _ =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap();
 
   let outcome = coordinator.poll(now(1)).unwrap();
   assert!(outcome.topology_event.is_none());
@@ -130,6 +183,7 @@ fn quarantine_rejects_join_and_expires() {
   config.quarantine_ttl = Duration::from_secs(1);
   let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
     config,
+    local_cluster_config(),
     table,
     registry(1.0),
   );
@@ -138,7 +192,8 @@ fn quarantine_rejects_join_and_expires() {
   let outcome = coordinator.handle_quarantine("node-a".to_string(), "manual".to_string(), now(1)).unwrap();
   assert!(outcome.quarantine_events.iter().any(|event| matches!(event, QuarantineEvent::Quarantined { .. })));
 
-  let err = coordinator.handle_join("node-1".to_string(), "node-a".to_string(), now(1)).unwrap_err();
+  let err =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap_err();
   assert!(matches!(err, MembershipCoordinatorError::Membership(MembershipError::Quarantined { .. })));
 
   let outcome = coordinator.poll(now(3)).unwrap();
@@ -153,12 +208,14 @@ fn suspect_timeout_marks_dead_and_quarantines() {
   config.topology_emit_interval = Duration::from_secs(10);
   let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
     config,
+    local_cluster_config(),
     table,
     registry(1.0),
   );
   coordinator.start_member().unwrap();
 
-  let _ = coordinator.handle_join("node-1".to_string(), "node-a".to_string(), now(1)).unwrap();
+  let _ =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap();
   let _ = coordinator.handle_heartbeat("node-a", now(2)).unwrap();
   let _ = coordinator.handle_heartbeat("node-a", now(3)).unwrap();
 
@@ -178,4 +235,54 @@ fn suspect_timeout_marks_dead_and_quarantines() {
       .any(|event| matches!(event, ClusterEvent::MemberStatusChanged { to: NodeStatus::Dead, .. }))
   );
   assert!(outcome.member_events.iter().any(|event| matches!(event, ClusterEvent::MemberQuarantined { .. })));
+}
+
+#[test]
+fn join_rejects_incompatible_cluster_config() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let local = ClusterExtensionConfig::new()
+    .with_pubsub_config(PubSubConfig::new(Duration::from_secs(3), Duration::from_secs(30)));
+  let joining = ClusterExtensionConfig::new()
+    .with_pubsub_config(PubSubConfig::new(Duration::from_secs(5), Duration::from_secs(30)));
+  let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
+    config,
+    local,
+    table,
+    registry(1.0),
+  );
+  coordinator.start_member().unwrap();
+
+  let err = coordinator
+    .handle_join("node-1".to_string(), "node-a".to_string(), &joining, now(1))
+    .expect_err("incompatible join must be rejected");
+  assert!(matches!(
+    err,
+    MembershipCoordinatorError::Membership(MembershipError::IncompatibleConfig { reason })
+    if reason == "pubsub configuration mismatch"
+  ));
+}
+
+#[test]
+fn join_uses_joining_config_metadata() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let mut coordinator = MembershipCoordinatorGeneric::<fraktor_utils_rs::core::runtime_toolbox::NoStdToolbox>::new(
+    config,
+    local_cluster_config(),
+    table,
+    registry(1.0),
+  );
+  coordinator.start_member().unwrap();
+
+  let joining = ClusterExtensionConfig::new()
+    .with_app_version("2.0.0")
+    .with_roles(vec![String::from("edge"), String::from("frontend")]);
+  let _ =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining, now(1)).expect("join should succeed");
+
+  let snapshot = coordinator.snapshot();
+  assert_eq!(snapshot.entries.len(), 1);
+  assert_eq!(snapshot.entries[0].app_version, "2.0.0");
+  assert_eq!(snapshot.entries[0].roles, vec![String::from("edge"), String::from("frontend")]);
 }

--- a/modules/cluster/src/core/membership/membership_error.rs
+++ b/modules/cluster/src/core/membership/membership_error.rs
@@ -35,4 +35,9 @@ pub enum MembershipError {
     /// Quarantine reason.
     reason:    String,
   },
+  /// Join rejected due to incompatible cluster configuration.
+  IncompatibleConfig {
+    /// Human-readable incompatibility reason.
+    reason: String,
+  },
 }

--- a/modules/cluster/src/core/membership/membership_table/tests.rs
+++ b/modules/cluster/src/core/membership/membership_table/tests.rs
@@ -1,4 +1,4 @@
-use alloc::string::ToString;
+use alloc::{string::ToString, vec};
 
 use super::MembershipTable;
 use crate::core::membership::{MembershipError, MembershipEvent, MembershipVersion, NodeStatus};
@@ -7,13 +7,21 @@ use crate::core::membership::{MembershipError, MembershipEvent, MembershipVersio
 fn join_registers_joining_and_snapshots_latest_table() {
   let mut table = MembershipTable::new(3);
 
-  let delta = table.try_join("node-1".to_string(), "n1:4050".to_string()).expect("join should succeed");
+  let delta = table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.2.3".to_string(), vec![
+      "backend".to_string(),
+      "edge".to_string(),
+    ])
+    .expect("join should succeed");
 
   assert_eq!(delta.from, MembershipVersion::zero());
   assert_eq!(delta.to, MembershipVersion::new(1));
   assert_eq!(delta.entries.len(), 1);
   let joined = &delta.entries[0];
   assert_eq!(joined.status, NodeStatus::Joining);
+  assert_eq!(joined.join_version, MembershipVersion::new(1));
+  assert_eq!(joined.app_version, "1.2.3");
+  assert_eq!(joined.roles, vec!["backend".to_string(), "edge".to_string()]);
 
   let snapshot = table.snapshot();
   assert_eq!(snapshot.version, MembershipVersion::new(1));
@@ -31,10 +39,14 @@ fn join_registers_joining_and_snapshots_latest_table() {
 fn joining_with_conflicting_authority_is_rejected() {
   let mut table = MembershipTable::new(3);
 
-  table.try_join("node-1".to_string(), "n1:4050".to_string()).expect("first join succeeds");
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("first join succeeds");
   table.drain_events();
 
-  let err = table.try_join("node-2".to_string(), "n1:4050".to_string()).expect_err("conflict should be rejected");
+  let err = table
+    .try_join("node-2".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect_err("conflict should be rejected");
 
   assert_eq!(err, MembershipError::AuthorityConflict {
     authority:         "n1:4050".to_string(),
@@ -55,19 +67,25 @@ fn joining_with_conflicting_authority_is_rejected() {
 }
 
 #[test]
-fn leaving_transitions_to_removed_and_updates_version() {
+fn leaving_transitions_from_exiting_to_removed_and_updates_version() {
   let mut table = MembershipTable::new(3);
-  table.try_join("node-1".to_string(), "n1:4050".to_string()).expect("join succeeds");
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("join succeeds");
   table.drain_events();
 
-  let delta = table.mark_left("n1:4050").expect("leave should succeed");
+  let exiting_delta = table.mark_left("n1:4050").expect("first leave should mark exiting");
+  assert_eq!(exiting_delta.from, MembershipVersion::new(1));
+  assert_eq!(exiting_delta.to, MembershipVersion::new(2));
+  assert_eq!(exiting_delta.entries[0].status, NodeStatus::Exiting);
 
-  assert_eq!(delta.from, MembershipVersion::new(1));
-  assert_eq!(delta.to, MembershipVersion::new(2));
-  assert_eq!(delta.entries[0].status, NodeStatus::Removed);
+  let removed_delta = table.mark_left("n1:4050").expect("second leave should mark removed");
+  assert_eq!(removed_delta.from, MembershipVersion::new(2));
+  assert_eq!(removed_delta.to, MembershipVersion::new(3));
+  assert_eq!(removed_delta.entries[0].status, NodeStatus::Removed);
 
   let snapshot = table.snapshot();
-  assert_eq!(snapshot.version, MembershipVersion::new(2));
+  assert_eq!(snapshot.version, MembershipVersion::new(3));
   assert_eq!(snapshot.entries[0].status, NodeStatus::Removed);
 
   let events = table.drain_events();
@@ -77,7 +95,9 @@ fn leaving_transitions_to_removed_and_updates_version() {
 #[test]
 fn heartbeat_miss_marks_suspect_after_threshold() {
   let mut table = MembershipTable::new(2);
-  table.try_join("node-1".to_string(), "n1:4050".to_string()).expect("join succeeds");
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("join succeeds");
   table.drain_events();
 
   assert!(table.mark_heartbeat_miss("n1:4050").is_none());
@@ -96,4 +116,94 @@ fn heartbeat_miss_marks_suspect_after_threshold() {
     node_id:   "node-1".to_string(),
     authority: "n1:4050".to_string(),
   }],);
+}
+
+#[test]
+fn heartbeat_miss_is_ignored_for_exiting_member() {
+  let mut table = MembershipTable::new(1);
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("join succeeds");
+  table.drain_events();
+  table.mark_left("n1:4050").expect("leave to exiting");
+
+  assert!(table.mark_heartbeat_miss("n1:4050").is_none());
+  let status = table.record("n1:4050").expect("record").status;
+  assert_eq!(status, NodeStatus::Exiting);
+}
+
+#[test]
+fn rejoin_from_removed_updates_metadata() {
+  let mut table = MembershipTable::new(3);
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("join succeeds");
+  table.drain_events();
+  table.mark_left("n1:4050").expect("first leave should mark exiting");
+  table.mark_left("n1:4050").expect("second leave should mark removed");
+
+  let delta = table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "2.0.0".to_string(), vec![
+      "frontend".to_string(),
+      "canary".to_string(),
+    ])
+    .expect("rejoin from removed should succeed");
+
+  assert_eq!(delta.entries[0].status, NodeStatus::Joining);
+  assert_eq!(delta.entries[0].join_version, MembershipVersion::new(4));
+  assert_eq!(delta.entries[0].app_version, "2.0.0");
+  assert_eq!(delta.entries[0].roles, vec!["frontend".to_string(), "canary".to_string()]);
+
+  let record = table.record("n1:4050").expect("record should exist after rejoin");
+  assert_eq!(record.join_version, MembershipVersion::new(4));
+  assert_eq!(record.app_version, "2.0.0");
+  assert_eq!(record.roles, vec!["frontend".to_string(), "canary".to_string()]);
+}
+
+#[test]
+fn rejoin_from_dead_updates_metadata() {
+  let mut table = MembershipTable::new(3);
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("join succeeds");
+  table.drain_events();
+  table.mark_suspect("n1:4050").expect("mark suspect should succeed");
+  table.mark_dead("n1:4050").expect("mark dead should succeed");
+
+  let delta = table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "2.0.0".to_string(), vec![
+      "frontend".to_string(),
+      "canary".to_string(),
+    ])
+    .expect("rejoin from dead should succeed");
+
+  assert_eq!(delta.entries[0].status, NodeStatus::Joining);
+  assert_eq!(delta.entries[0].join_version, MembershipVersion::new(4));
+  assert_eq!(delta.entries[0].app_version, "2.0.0");
+  assert_eq!(delta.entries[0].roles, vec!["frontend".to_string(), "canary".to_string()]);
+
+  let record = table.record("n1:4050").expect("record should exist after rejoin");
+  assert_eq!(record.join_version, MembershipVersion::new(4));
+  assert_eq!(record.app_version, "2.0.0");
+  assert_eq!(record.roles, vec!["frontend".to_string(), "canary".to_string()]);
+}
+
+#[test]
+fn status_update_does_not_change_age_ordering() {
+  let mut table = MembershipTable::new(3);
+  table
+    .try_join("node-1".to_string(), "n1:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("first join succeeds");
+  table
+    .try_join("node-2".to_string(), "n2:4050".to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+    .expect("second join succeeds");
+
+  let _ = table.mark_up("n1:4050").expect("mark up succeeds");
+
+  let older = table.record("n1:4050").expect("older record");
+  let newer = table.record("n2:4050").expect("newer record");
+
+  assert!(older.version > newer.version);
+  assert!(older.is_older_than(newer));
+  assert!(!newer.is_older_than(older));
 }

--- a/modules/cluster/src/core/membership/node_record.rs
+++ b/modules/cluster/src/core/membership/node_record.rs
@@ -1,6 +1,9 @@
 //! Node record stored in the membership table.
 
-use alloc::string::String;
+#[cfg(test)]
+mod tests;
+
+use alloc::{string::String, vec::Vec};
 
 use super::{MembershipVersion, NodeStatus};
 
@@ -8,19 +11,52 @@ use super::{MembershipVersion, NodeStatus};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NodeRecord {
   /// Unique node identifier.
-  pub node_id:   String,
+  pub node_id:      String,
   /// Authority string such as `host:port`.
-  pub authority: String,
+  pub authority:    String,
   /// Current membership status.
-  pub status:    NodeStatus,
+  pub status:       NodeStatus,
   /// Version the record was last updated at.
-  pub version:   MembershipVersion,
+  pub version:      MembershipVersion,
+  /// Version when the node joined most recently.
+  pub join_version: MembershipVersion,
+  /// Application version advertised by the node.
+  pub app_version:  String,
+  /// Roles assigned to the node.
+  pub roles:        Vec<String>,
 }
 
 impl NodeRecord {
   /// Creates a new record with the given parameters.
   #[must_use]
-  pub const fn new(node_id: String, authority: String, status: NodeStatus, version: MembershipVersion) -> Self {
-    Self { node_id, authority, status, version }
+  pub const fn new(
+    node_id: String,
+    authority: String,
+    status: NodeStatus,
+    version: MembershipVersion,
+    app_version: String,
+    roles: Vec<String>,
+  ) -> Self {
+    Self { node_id, authority, status, version, join_version: version, app_version, roles }
+  }
+
+  /// Returns true if this record is older than `other` by join version.
+  #[must_use]
+  pub fn is_older_than(&self, other: &Self) -> bool {
+    if self.join_version == other.join_version {
+      authority_order_key(self.authority.as_str()) < authority_order_key(other.authority.as_str())
+    } else {
+      self.join_version < other.join_version
+    }
+  }
+}
+
+fn authority_order_key(authority: &str) -> (&str, u32) {
+  if let Some((host, port_text)) = authority.rsplit_once(':')
+    && let Ok(port) = port_text.parse::<u32>()
+  {
+    (host, port)
+  } else {
+    (authority, 0)
   }
 }

--- a/modules/cluster/src/core/membership/node_record/tests.rs
+++ b/modules/cluster/src/core/membership/node_record/tests.rs
@@ -1,0 +1,70 @@
+use alloc::{string::String, vec};
+
+use super::NodeRecord;
+use crate::core::membership::{MembershipVersion, NodeStatus};
+
+#[test]
+fn node_record_new_keeps_app_version_and_roles() {
+  let roles = vec![String::from("frontend"), String::from("edge")];
+  let record = NodeRecord::new(
+    String::from("node-1"),
+    String::from("n1:4050"),
+    NodeStatus::Up,
+    MembershipVersion::new(10),
+    String::from("1.2.3"),
+    roles.clone(),
+  );
+
+  assert_eq!(record.app_version, "1.2.3");
+  assert_eq!(record.roles, roles);
+  assert_eq!(record.join_version, MembershipVersion::new(10));
+}
+
+#[test]
+fn is_older_than_uses_join_version_after_status_update() {
+  let mut older = NodeRecord::new(
+    String::from("node-1"),
+    String::from("n1:4050"),
+    NodeStatus::Up,
+    MembershipVersion::new(4),
+    String::from("1.0.0"),
+    vec![String::from("core")],
+  );
+  older.version = MembershipVersion::new(40);
+
+  let newer = NodeRecord::new(
+    String::from("node-1"),
+    String::from("n1:4050"),
+    NodeStatus::Up,
+    MembershipVersion::new(5),
+    String::from("1.0.1"),
+    vec![String::from("core")],
+  );
+
+  assert!(older.is_older_than(&newer));
+  assert!(!newer.is_older_than(&older));
+}
+
+#[test]
+fn is_older_than_uses_numeric_port_for_tie_breaker() {
+  let lower_port = NodeRecord::new(
+    String::from("node-1"),
+    String::from("n1:999"),
+    NodeStatus::Up,
+    MembershipVersion::new(10),
+    String::from("1.0.0"),
+    vec![String::from("core")],
+  );
+
+  let higher_port = NodeRecord::new(
+    String::from("node-2"),
+    String::from("n1:10000"),
+    NodeStatus::Up,
+    MembershipVersion::new(10),
+    String::from("1.0.0"),
+    vec![String::from("core")],
+  );
+
+  assert!(lower_port.is_older_than(&higher_port));
+  assert!(!higher_port.is_older_than(&lower_port));
+}

--- a/modules/cluster/src/core/membership/node_status.rs
+++ b/modules/cluster/src/core/membership/node_status.rs
@@ -1,5 +1,8 @@
 //! Node status representation.
 
+#[cfg(test)]
+mod tests;
+
 /// Represents the membership state of a cluster node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeStatus {
@@ -11,6 +14,8 @@ pub enum NodeStatus {
   Suspect,
   /// Node initiated a graceful leave.
   Leaving,
+  /// Node completed leaving and is about to be removed.
+  Exiting,
   /// Node has completed leave and is removed from the view.
   Removed,
   /// Node is considered dead and removed from active membership.

--- a/modules/cluster/src/core/membership/node_status/tests.rs
+++ b/modules/cluster/src/core/membership/node_status/tests.rs
@@ -1,0 +1,16 @@
+use crate::core::membership::NodeStatus;
+
+#[test]
+fn exiting_is_not_active() {
+  assert!(!NodeStatus::Exiting.is_active());
+}
+
+#[test]
+fn active_statuses_remain_joining_up_and_suspect() {
+  assert!(NodeStatus::Joining.is_active());
+  assert!(NodeStatus::Up.is_active());
+  assert!(NodeStatus::Suspect.is_active());
+  assert!(!NodeStatus::Leaving.is_active());
+  assert!(!NodeStatus::Removed.is_active());
+  assert!(!NodeStatus::Dead.is_active());
+}

--- a/modules/cluster/src/std/gossip_wire_node_record.rs
+++ b/modules/cluster/src/std/gossip_wire_node_record.rs
@@ -1,6 +1,9 @@
 //! Wire representation of a membership node record.
 
-use alloc::string::String;
+#[cfg(test)]
+mod tests;
+
+use alloc::{string::String, vec::Vec};
 
 use serde::{Deserialize, Serialize};
 
@@ -10,28 +13,45 @@ use crate::core::membership::{MembershipVersion, NodeRecord, NodeStatus};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct GossipWireNodeRecord {
   /// Unique node identifier.
-  pub node_id:   String,
+  pub node_id:      String,
   /// Authority string such as `host:port`.
-  pub authority: String,
+  pub authority:    String,
   /// Node status encoded as u8.
-  pub status:    u8,
+  pub status:       u8,
   /// Membership version.
-  pub version:   u64,
+  pub version:      u64,
+  /// Join version used for age ordering.
+  pub join_version: u64,
+  /// Application version.
+  pub app_version:  String,
+  /// Roles assigned to the node.
+  pub roles:        Vec<String>,
 }
 
 impl GossipWireNodeRecord {
   pub(crate) fn from_record(record: &NodeRecord) -> Self {
     Self {
-      node_id:   record.node_id.clone(),
-      authority: record.authority.clone(),
-      status:    status_to_u8(record.status),
-      version:   record.version.value(),
+      node_id:      record.node_id.clone(),
+      authority:    record.authority.clone(),
+      status:       status_to_u8(record.status),
+      version:      record.version.value(),
+      join_version: record.join_version.value(),
+      app_version:  record.app_version.clone(),
+      roles:        record.roles.clone(),
     }
   }
 
   pub(crate) fn to_record(&self) -> Option<NodeRecord> {
     let status = status_from_u8(self.status)?;
-    Some(NodeRecord::new(self.node_id.clone(), self.authority.clone(), status, MembershipVersion::new(self.version)))
+    Some(NodeRecord {
+      node_id: self.node_id.clone(),
+      authority: self.authority.clone(),
+      status,
+      version: MembershipVersion::new(self.version),
+      join_version: MembershipVersion::new(self.join_version),
+      app_version: self.app_version.clone(),
+      roles: self.roles.clone(),
+    })
   }
 }
 
@@ -43,6 +63,7 @@ fn status_to_u8(status: NodeStatus) -> u8 {
     | NodeStatus::Leaving => 3,
     | NodeStatus::Removed => 4,
     | NodeStatus::Dead => 5,
+    | NodeStatus::Exiting => 6,
   }
 }
 
@@ -54,6 +75,7 @@ fn status_from_u8(value: u8) -> Option<NodeStatus> {
     | 3 => Some(NodeStatus::Leaving),
     | 4 => Some(NodeStatus::Removed),
     | 5 => Some(NodeStatus::Dead),
+    | 6 => Some(NodeStatus::Exiting),
     | _ => None,
   }
 }

--- a/modules/cluster/src/std/gossip_wire_node_record/tests.rs
+++ b/modules/cluster/src/std/gossip_wire_node_record/tests.rs
@@ -1,0 +1,37 @@
+use alloc::{string::String, vec};
+
+use super::GossipWireNodeRecord;
+use crate::core::membership::{MembershipVersion, NodeRecord, NodeStatus};
+
+#[test]
+fn to_record_preserves_app_version_roles_and_exiting_status() {
+  let mut record = NodeRecord::new(
+    String::from("node-1"),
+    String::from("n1:4050"),
+    NodeStatus::Exiting,
+    MembershipVersion::new(9),
+    String::from("2.0.0"),
+    vec![String::from("backend"), String::from("edge")],
+  );
+  record.version = MembershipVersion::new(12);
+
+  let wire = GossipWireNodeRecord::from_record(&record);
+  let decoded = wire.to_record().expect("decode record");
+
+  assert_eq!(decoded, record);
+}
+
+#[test]
+fn to_record_returns_none_for_unknown_status_code() {
+  let wire = GossipWireNodeRecord {
+    node_id:      String::from("node-1"),
+    authority:    String::from("n1:4050"),
+    status:       99,
+    version:      1,
+    join_version: 1,
+    app_version:  String::from("1.0.0"),
+    roles:        vec![String::from("role-a")],
+  };
+
+  assert!(wire.to_record().is_none());
+}

--- a/modules/cluster/src/std/membership_coordinator_driver.rs
+++ b/modules/cluster/src/std/membership_coordinator_driver.rs
@@ -9,7 +9,7 @@ use fraktor_actor_rs::core::{
 use fraktor_utils_rs::core::{runtime_toolbox::RuntimeToolbox, sync::SharedAccess, time::TimerInstant};
 
 use crate::core::{
-  ClusterEvent,
+  ClusterEvent, ClusterExtensionConfig,
   membership::{
     GossipTransport, MembershipCoordinatorError, MembershipCoordinatorOutcome, MembershipCoordinatorSharedGeneric,
   },
@@ -49,10 +49,12 @@ impl<TB: RuntimeToolbox + 'static, TTransport: GossipTransport> MembershipCoordi
     &mut self,
     node_id: impl Into<String>,
     authority: impl Into<String>,
+    joining_config: &ClusterExtensionConfig,
     now: TimerInstant,
   ) -> Result<(), MembershipCoordinatorError> {
-    let outcome =
-      self.coordinator.with_write(|coordinator| coordinator.handle_join(node_id.into(), authority.into(), now))?;
+    let outcome = self
+      .coordinator
+      .with_write(|coordinator| coordinator.handle_join(node_id.into(), authority.into(), joining_config, now))?;
     self.apply_outcome(outcome)
   }
 

--- a/modules/cluster/src/std/tokio_gossip_transport/tests.rs
+++ b/modules/cluster/src/std/tokio_gossip_transport/tests.rs
@@ -13,8 +13,14 @@ fn free_udp_addr() -> std::net::SocketAddr {
 }
 
 fn sample_delta() -> MembershipDelta {
-  let record =
-    NodeRecord::new(String::from("node-a"), String::from("127.0.0.1:11000"), NodeStatus::Up, MembershipVersion::new(1));
+  let record = NodeRecord::new(
+    String::from("node-a"),
+    String::from("127.0.0.1:11000"),
+    NodeStatus::Up,
+    MembershipVersion::new(1),
+    String::from("1.0.0"),
+    vec![String::from("member")],
+  );
   MembershipDelta::new(MembershipVersion::new(0), MembershipVersion::new(1), vec![record])
 }
 

--- a/modules/cluster/src/std/tokio_gossiper/tests.rs
+++ b/modules/cluster/src/std/tokio_gossiper/tests.rs
@@ -8,9 +8,12 @@ use fraktor_remote_rs::core::failure_detector::{
 use fraktor_utils_rs::std::runtime_toolbox::StdToolbox;
 
 use crate::{
-  core::membership::{
-    Gossiper, MembershipCoordinatorConfig, MembershipCoordinatorGeneric, MembershipCoordinatorSharedGeneric,
-    MembershipTable,
+  core::{
+    ClusterExtensionConfig,
+    membership::{
+      Gossiper, MembershipCoordinatorConfig, MembershipCoordinatorGeneric, MembershipCoordinatorSharedGeneric,
+      MembershipTable,
+    },
   },
   std::{TokioGossipTransport, TokioGossipTransportConfig, TokioGossiper, TokioGossiperConfig},
 };
@@ -30,7 +33,8 @@ fn build_coordinator() -> MembershipCoordinatorSharedGeneric<StdToolbox> {
   let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
     Box::new(PhiFailureDetector::new(PhiFailureDetectorConfig::new(threshold, 10, 1)))
   }));
-  let mut coordinator = MembershipCoordinatorGeneric::<StdToolbox>::new(config, table, registry);
+  let mut coordinator =
+    MembershipCoordinatorGeneric::<StdToolbox>::new(config, ClusterExtensionConfig::new(), table, registry);
   coordinator.start_member().expect("start_member");
   MembershipCoordinatorSharedGeneric::new(coordinator)
 }

--- a/modules/cluster/tests/gossip_tokio_integration.rs
+++ b/modules/cluster/tests/gossip_tokio_integration.rs
@@ -8,7 +8,7 @@ use fraktor_actor_rs::core::event::stream::{
 };
 use fraktor_cluster_rs::{
   core::{
-    ClusterEvent,
+    ClusterEvent, ClusterExtensionConfig,
     membership::{
       GossipOutbound, GossipTransport, Gossiper, MembershipCoordinatorConfig, MembershipCoordinatorGeneric,
       MembershipCoordinatorSharedGeneric, MembershipDelta, MembershipTable, MembershipVersion, NodeRecord, NodeStatus,
@@ -55,14 +55,21 @@ fn build_coordinator() -> MembershipCoordinatorSharedGeneric<StdToolbox> {
   let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
     Box::new(PhiFailureDetector::new(PhiFailureDetectorConfig::new(threshold, 10, 1)))
   }));
-  let mut coordinator = MembershipCoordinatorGeneric::<StdToolbox>::new(config, table, registry);
+  let mut coordinator =
+    MembershipCoordinatorGeneric::<StdToolbox>::new(config, ClusterExtensionConfig::new(), table, registry);
   coordinator.start_member().expect("start_member");
   MembershipCoordinatorSharedGeneric::new(coordinator)
 }
 
 fn join_delta(authority: &str) -> MembershipDelta {
-  let record =
-    NodeRecord::new(String::from("node-a"), authority.to_string(), NodeStatus::Up, MembershipVersion::new(1));
+  let record = NodeRecord::new(
+    String::from("node-a"),
+    authority.to_string(),
+    NodeStatus::Up,
+    MembershipVersion::new(1),
+    String::from("1.0.0"),
+    vec![String::from("member")],
+  );
   MembershipDelta::new(MembershipVersion::new(0), MembershipVersion::new(1), vec![record])
 }
 


### PR DESCRIPTION
## Summary

## 元タスク
- slug: 20260224-100007-cls-mbr
- task_dir: .takt/tasks/20260224-100007-cls-mbr
- source: .takt/tasks/20260224-100007-cls-mbr/order.md

## タスク仕様（order.md）

# タスク仕様

## 目的

clusterモジュールにメンバーモデルの拡張フィールドとステータス（Phase 1-2: trivial〜easy）を実装し、Pekko Clusterのメンバー管理との互換性を向上させる。

## 要件

- [ ] `NodeRecord`（Member相当）に `app_version` フィールドを追加する
- [ ] `NodeRecord` に `roles` フィールドを追加する
- [ ] `NodeStatus` に `Exiting` ステータスを追加する
- [ ] `is_older_than` メソッドを実装する（メンバー間の年齢比較）
- [ ] `register_on_member_up` / `register_on_member_removed` コールバック登録を実装する
- [ ] `JoinConfigCompatChecker` traitを実装する（ノード参加時の設定互換性検証）
- [ ] `ClusterSettings` にロール設定を追加する
- [ ] 各機能に対するテストを追加する

## 受け入れ基準

- NodeRecordがPekkoのMemberクラスと同等のフィールドを持つ
- メンバーステータスにExitingが追加され、状態遷移が正しく動作する
- コールバック登録APIが利用可能
- `./scripts/ci-check.sh all` がパスする

## 参考情報

- ギャップ分析: `docs/gap-analysis/cluster-gap-analysis.md`（カテゴリ1, 2, 6）
- Pekko参照: `references/pekko/cluster/src/main/scala/org/apache/pekko/cluster/Member.scala`
- Pekko参照: `references/pekko/cluster/src/main/scala/org/apache/pekko/cluster/MemberStatus.scala`
- Pekko参照: `references/pekko/cluster/src/main/scala/org/apache/pekko/cluster/JoinConfigCompatChecker.scala`


## Execution Report

Piece `pekko-porting` completed successfully.

Closes #232

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core cluster membership state/serialization and join validation, which can affect join/leave propagation and compatibility across nodes. Also changes event-stream subscription semantics (no-replay) and makes mailbox instrumentation no-op after shutdown, so regressions would surface as missing events/metrics rather than panics.
> 
> **Overview**
> **Cluster membership is extended and made more Pekko-compatible.** `NodeRecord` now carries `app_version`, `roles`, and `join_version` plus a new `NodeStatus::Exiting` phase; join/leave flows were updated to use this metadata and to transition `Exiting -> Removed`, and identity resolution treats `Leaving/Exiting` nodes as unreachable.
> 
> **Join compatibility + lifecycle callbacks are added.** `ClusterExtensionConfig` now includes roles/version defaults and implements `JoinConfigCompatChecker` via a new `ConfigValidation` result; `MembershipCoordinator` rejects joins with incompatible configs and requires the joining config. `ClusterExtension` adds `register_on_member_up` / `register_on_member_removed`, using a new `EventStreamShared::subscribe_no_replay` to avoid firing callbacks from buffered historical events and tracking termination for immediate “removed” callbacks after shutdown.
> 
> **Wire format, examples, and tests are updated accordingly.** Gossip wire records encode the new fields/status, examples and drivers pass `ClusterExtensionConfig` on joins, and extensive new tests cover the new transitions/metadata/subscribe-no-replay behavior. Separately, mailbox instrumentation now gracefully no-ops (instead of panicking) when the actor system state has already been dropped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7260b0a2cf84fb455e97c63ca49bd7b907e73028. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **New Features**
  * クラスタメンバーの状態変化時に自動的にコールバックを実行する機能を追加しました。メンバーがアップ状態に達したときや削除されたときにイベントをキャプチャできます。
  * クラスタノードにアプリケーションバージョンとロール情報を格納できるようになりました。

* **Bug Fixes**
  * システム状態が利用不可の場合のメールボックス処理を安定化しました。パニックが発生しなくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->