### PR TITLE
chore(package): update `takt` to `0.27.0-alpha.1` and rename scripts …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "takt": "0.26.0"
+        "takt": "0.27.0-alpha.1"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -1116,9 +1116,9 @@
       "license": "MIT"
     },
     "node_modules/takt": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/takt/-/takt-0.26.0.tgz",
-      "integrity": "sha512-2fhWLVXMW7HcusIDwOftpPpAARnNyAYlqsoMuPRVcxborB8OcJ5u+vu1Ous/fl1ZIQxhXb/I1Ycghe3KNAI2uA==",
+      "version": "0.27.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/takt/-/takt-0.27.0-alpha.1.tgz",
+      "integrity": "sha512-G5fmEOP3A1oa/c7qyYr4+0wfNNdiyexDiKrYlAdGunkK9ww5oYU4L4tsglwdTh71jC+j3zpNkzgrWi3E0Sk2dQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
   "private": true,
   "scripts": {
-    "sdd": "takt --pipeline --skip-git --create-worktree no -w sdd -t",
-    "sdd:requirements": "takt --pipeline --skip-git --create-worktree no -w sdd-requirements -t",
-    "sdd:validate-gap": "takt --pipeline --skip-git --create-worktree no -w sdd-validate-gap -t",
-    "sdd:design": "takt --pipeline --skip-git --create-worktree no -w sdd-design -t",
-    "sdd:validate-design": "takt --pipeline --skip-git --create-worktree no -w sdd-validate-design -t",
-    "sdd:tasks": "takt --pipeline --skip-git --create-worktree no -w sdd-tasks -t",
-    "sdd:impl": "takt --pipeline --skip-git --create-worktree no -w sdd-impl -t",
-    "sdd:validate-impl": "takt --pipeline --skip-git --create-worktree no -w sdd-validate-impl -t",
-    "issue:resolve": "takt --pipeline --skip-git --create-worktree no -w issue-resolve -t",
-    "steering": "takt --pipeline --skip-git --create-worktree no -w steering -t",
-    "steering:custom": "takt --pipeline --skip-git --create-worktree no -w steering-custom -t",
-    "takt:run": "takt run"
+    "takt:cc-sdd:full": "takt --pipeline --skip-git --create-worktree no -w sdd -t",
+    "takt:cc-sdd:requirements": "takt --pipeline --skip-git --create-worktree no -w sdd-requirements -t",
+    "takt:cc-sdd:validate-gap": "takt --pipeline --skip-git --create-worktree no -w sdd-validate-gap -t",
+    "takt:cc-sdd:design": "takt --pipeline --skip-git --create-worktree no -w sdd-design -t",
+    "takt:cc-sdd:validate-design": "takt --pipeline --skip-git --create-worktree no -w sdd-validate-design -t",
+    "takt:cc-sdd:tasks": "takt --pipeline --skip-git --create-worktree no -w sdd-tasks -t",
+    "takt:cc-sdd:impl": "takt --pipeline --skip-git --create-worktree no -w sdd-impl -t",
+    "takt:cc-sdd:validate-impl": "takt --pipeline --skip-git --create-worktree no -w sdd-validate-impl -t",
+    "takt:cc-sdd:steering": "takt --pipeline --skip-git --create-worktree no -w steering -t",
+    "takt:cc-sdd:steering:custom": "takt --pipeline --skip-git --create-worktree no -w steering-custom -t",
+    "takt:run": "takt run",
+    "takt:issue:resolve": "takt --pipeline --skip-git --create-worktree no -w issue-resolve -t"
   },
   "devDependencies": {
-    "takt": "0.26.0"
+    "takt": "0.27.0-alpha.1"
   }
 }


### PR DESCRIPTION
…for clarity

- Bumped `takt` dependency from `0.26.0` to `0.27.0-alpha.1` in `package.json` and `package-lock.json`.
- Refactored npm scripts to use `takt:cc-` prefixes for better naming consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/script update; main impact is that existing CI/docs/users must switch to the renamed npm script names and the alpha `takt` version could introduce behavior changes.
> 
> **Overview**
> Updates the dev dependency `takt` from `0.26.0` to `0.27.0-alpha.1` (including lockfile resolution).
> 
> Renames the `takt`-driven npm scripts to a clearer `takt:cc-sdd:*` / `takt:issue:resolve` naming scheme while keeping the underlying command flags the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bffdac169b6c50e1a975db5c0357da60059462cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * パッケージ構築スクリプトを新しい命名規則に再編成しました。
  * 開発ツール依存関係をアップグレードしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->