### PR TITLE
refactor: eliminate double-lock in StashBuffer::stash()

### DIFF
--- a/modules/actor/src/core/typed/actor/actor_context.rs
+++ b/modules/actor/src/core/typed/actor/actor_context.rs
@@ -168,6 +168,16 @@ where
     self.inner().stash()
   }
 
+  /// Stashes the currently processed message with an explicit capacity limit.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error when no current message is active, when the stash reached `max_messages`,
+  /// or when the actor cell is unavailable.
+  pub fn stash_with_limit(&self, max_messages: usize) -> Result<(), ActorError> {
+    self.inner().stash_with_limit(max_messages)
+  }
+
   /// Re-enqueues the oldest stashed message back to the actor mailbox.
   ///
   /// # Errors

--- a/modules/actor/src/core/typed/stash_buffer.rs
+++ b/modules/actor/src/core/typed/stash_buffer.rs
@@ -7,7 +7,7 @@ use core::marker::PhantomData;
 
 use fraktor_utils_rs::core::runtime_toolbox::{NoStdToolbox, RuntimeToolbox};
 
-use crate::core::{actor::STASH_OVERFLOW_REASON, error::ActorError, typed::actor::TypedActorContextGeneric};
+use crate::core::{error::ActorError, typed::actor::TypedActorContextGeneric};
 
 /// Bounded stash helper inspired by Pekko's `StashBuffer`.
 pub struct StashBufferGeneric<M, TB = NoStdToolbox>
@@ -76,10 +76,7 @@ where
   ///
   /// Returns an error when the stash capacity is reached or when context stashing fails.
   pub fn stash(&self, ctx: &TypedActorContextGeneric<'_, M, TB>) -> Result<(), ActorError> {
-    if self.is_full(ctx)? {
-      return Err(ActorError::recoverable(STASH_OVERFLOW_REASON));
-    }
-    ctx.stash()
+    ctx.stash_with_limit(self.capacity)
   }
 
   /// Re-enqueues all stashed messages back to the mailbox.


### PR DESCRIPTION
## Summary
- `StashBuffer::stash()` がアクターセルのロックを2回取得していた問題を解消（`is_full()` で1回、`ctx.stash()` で1回）
- `TypedActorContextGeneric` に `stash_with_limit()` を追加し、`StashBuffer::stash()` を単一の `ctx.stash_with_limit(self.capacity)` 呼び出しに簡素化
- `stash_with_limit` の `current_message` 不在時エッジケースの回帰テストを追加

## Test plan
- [x] `cargo test -p fraktor-actor-rs --lib -- stash` 全11テストパス

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core actor stashing APIs and error paths; while intended as a behavior-preserving refactor, it changes how overflow/invalid-state errors are produced and could impact message deferral semantics if misused.
> 
> **Overview**
> Simplifies typed `StashBuffer::stash()` to a single `ctx.stash_with_limit(capacity)` call, avoiding the previous pre-check (`is_full`) that caused double-locking of the actor cell.
> 
> Adds `TypedActorContextGeneric::stash_with_limit()` as a typed wrapper over the untyped context, and extends actor-context tests to cover the `stash_with_limit` error when no active user message is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31532dae32bcba3b204b9a464afb97f0c898ce22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * メッセージスタッシュの上限を制御するための新しいメソッドが追加されました。

* **テスト**
  * メッセージスタッシュの上限制御機能のユニットテストが追加されました。

* **リファクタリング**
  * メッセージスタッシュの内部処理流れを簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->