### PR TITLE
[#479] github-issue-479-refactor-util

### DIFF
--- a/modules/utils/src/core/collections.rs
+++ b/modules/utils/src/core/collections.rs
@@ -2,4 +2,5 @@ mod priority_message;
 pub mod queue;
 pub mod wait;
 
-pub use priority_message::{DEFAULT_PRIORITY, PRIORITY_LEVELS, PriorityMessage};
+pub use priority_message::PriorityMessage;
+pub(crate) use priority_message::{DEFAULT_PRIORITY, PRIORITY_LEVELS};

--- a/modules/utils/src/core/collections/priority_message.rs
+++ b/modules/utils/src/core/collections/priority_message.rs
@@ -6,13 +6,13 @@ use crate::core::sync::shared::SharedBound;
 ///
 /// By default, supports 8 priority levels.
 /// Ranges from 0 (lowest priority) to 7 (highest priority).
-pub const PRIORITY_LEVELS: usize = 8;
+pub(crate) const PRIORITY_LEVELS: usize = 8;
 
 /// Default priority level
 ///
 /// Used when message priority is not specified.
 /// Defaults to the midpoint of PRIORITY_LEVELS (4).
-pub const DEFAULT_PRIORITY: i8 = (PRIORITY_LEVELS / 2) as i8;
+pub(crate) const DEFAULT_PRIORITY: i8 = (PRIORITY_LEVELS / 2) as i8;
 
 /// Trait for messages with priority.
 pub trait PriorityMessage: Debug + SharedBound + 'static {

--- a/modules/utils/src/core/sync.rs
+++ b/modules/utils/src/core/sync.rs
@@ -1,13 +1,13 @@
 #[allow(clippy::disallowed_types)]
 mod arc_shared;
 /// Async-aware mutex abstractions shared across runtimes.
-pub mod async_mutex_like;
+pub(crate) mod async_mutex_like;
 #[allow(clippy::disallowed_types)]
 mod flag;
 /// Helper traits for shared function and factory closures.
-pub mod function;
+pub(crate) mod function;
 /// Policies for detecting interrupt contexts prior to blocking operations.
-pub mod interrupt;
+pub(crate) mod interrupt;
 #[cfg(feature = "alloc")]
 #[allow(clippy::disallowed_types)]
 mod rc_shared;
@@ -26,12 +26,16 @@ pub mod sync_rwlock_like;
 mod weak_shared;
 
 pub use arc_shared::ArcShared;
-pub use flag::Flag;
+#[allow(unused_imports)]
+pub(crate) use flag::Flag;
 #[cfg(feature = "alloc")]
-pub use rc_shared::RcShared;
-pub use runtime_lock_alias::{NoStdMutex, NoStdRwLock, RuntimeMutex, RuntimeRwLock};
+#[allow(unused_imports)]
+pub(crate) use rc_shared::RcShared;
+pub use runtime_lock_alias::{NoStdMutex, RuntimeMutex, RuntimeRwLock};
 pub use shared_access::SharedAccess;
 pub use shared_error::SharedError;
-pub use state::StateCell;
-pub use static_ref_shared::StaticRefShared;
+#[allow(unused_imports)]
+pub(crate) use state::StateCell;
+#[allow(unused_imports)]
+pub(crate) use static_ref_shared::StaticRefShared;
 pub use weak_shared::WeakShared;

--- a/modules/utils/src/core/sync/async_mutex_like.rs
+++ b/modules/utils/src/core/sync/async_mutex_like.rs
@@ -3,13 +3,15 @@ use core::ops::{Deref, DerefMut};
 
 use async_trait::async_trait;
 mod spin_async_mutex;
-pub use spin_async_mutex::*;
+#[allow(unused_imports)]
+pub(crate) use spin_async_mutex::*;
 
 use crate::core::sync::SharedError;
 
 /// Async-aware mutex abstraction.
+#[allow(dead_code)]
 #[async_trait(?Send)]
-pub trait AsyncMutexLike<T> {
+pub(crate) trait AsyncMutexLike<T> {
   /// Guard type returned by [`AsyncMutexLike::lock`].
   type Guard<'a>: Deref<Target = T> + DerefMut
   where
@@ -27,4 +29,5 @@ pub trait AsyncMutexLike<T> {
 }
 
 /// Convenience alias for guards produced by [`AsyncMutexLike`].
-pub type AsyncMutexLikeGuard<'a, M, T> = <M as AsyncMutexLike<T>>::Guard<'a>;
+#[allow(dead_code)]
+pub(crate) type AsyncMutexLikeGuard<'a, M, T> = <M as AsyncMutexLike<T>>::Guard<'a>;

--- a/modules/utils/src/core/sync/async_mutex_like/spin_async_mutex.rs
+++ b/modules/utils/src/core/sync/async_mutex_like/spin_async_mutex.rs
@@ -11,11 +11,12 @@ use crate::core::sync::{
   interrupt::{InterruptContextPolicy, NeverInterruptPolicy},
 };
 
+#[allow(dead_code)]
 type SpinGuard<'a, T> = spin::MutexGuard<'a, T>;
 
 /// Thin wrapper around [`spin::Mutex`] implementing [`AsyncMutexLike`].
 #[allow(dead_code)]
-pub struct SpinAsyncMutex<T, P = NeverInterruptPolicy>
+pub(crate) struct SpinAsyncMutex<T, P = NeverInterruptPolicy>
 where
   P: InterruptContextPolicy, {
   inner:   spin::Mutex<T>,
@@ -29,23 +30,23 @@ where
 {
   /// Creates a new spinlock-protected value.
   #[must_use]
-  pub const fn new(value: T) -> Self {
+  pub(crate) const fn new(value: T) -> Self {
     Self { inner: spin::Mutex::new(value), _policy: PhantomData }
   }
 
   /// Returns a reference to the inner spin mutex.
   #[must_use]
-  pub const fn as_inner(&self) -> &spin::Mutex<T> {
+  pub(crate) const fn as_inner(&self) -> &spin::Mutex<T> {
     &self.inner
   }
 
   /// Consumes the wrapper and returns the underlying value.
-  pub fn into_inner(self) -> T {
+  pub(crate) fn into_inner(self) -> T {
     self.inner.into_inner()
   }
 
   /// Locks the mutex and returns a guard to the protected value.
-  pub fn lock(&self) -> SpinGuard<'_, T> {
+  pub(crate) fn lock(&self) -> SpinGuard<'_, T> {
     self.inner.lock()
   }
 }
@@ -76,9 +77,11 @@ where
 }
 
 /// Default spin-based async mutex that never flags interrupt contexts.
-pub type SpinAsyncMutexDefault<T> = SpinAsyncMutex<T, NeverInterruptPolicy>;
+#[allow(dead_code)]
+pub(crate) type SpinAsyncMutexDefault<T> = SpinAsyncMutex<T, NeverInterruptPolicy>;
 
 /// Spin-based async mutex tailored for Cortex-M targets; operations are only allowed in thread
 /// mode.
 #[cfg(feature = "interrupt-cortex-m")]
-pub type SpinAsyncMutexCritical<T> = SpinAsyncMutex<T, CriticalSectionInterruptPolicy>;
+#[allow(dead_code)]
+pub(crate) type SpinAsyncMutexCritical<T> = SpinAsyncMutex<T, CriticalSectionInterruptPolicy>;

--- a/modules/utils/src/core/sync/flag.rs
+++ b/modules/utils/src/core/sync/flag.rs
@@ -20,23 +20,9 @@ mod tests;
 /// - When `alloc` feature is enabled: Provides thread-safe implementation using `Arc<AtomicBool>`
 /// - When `alloc` feature is disabled: Provides lightweight implementation for single-threaded
 ///   environments using `Cell<bool>`
-///
-/// # Examples
-///
-/// ```
-/// use fraktor_utils_rs::core::sync::Flag;
-///
-/// let flag = Flag::new(false);
-/// assert!(!flag.get());
-///
-/// flag.set(true);
-/// assert!(flag.get());
-///
-/// flag.clear();
-/// assert!(!flag.get());
-/// ```
 #[derive(Clone)]
-pub struct Flag {
+#[allow(dead_code)]
+pub(crate) struct Flag {
   #[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
   inner: Arc<AtomicBool>,
   #[cfg(all(feature = "alloc", not(target_has_atomic = "ptr")))]
@@ -45,23 +31,15 @@ pub struct Flag {
   inner: Cell<bool>,
 }
 
+#[allow(dead_code)]
 impl Flag {
   /// Creates a new `Flag` with the specified initial value
   ///
   /// # Arguments
   ///
   /// * `value` - Initial value of the flag
-  ///
-  /// # Examples
-  ///
-  /// ```
-  /// use fraktor_utils_rs::core::sync::Flag;
-  ///
-  /// let flag = Flag::new(true);
-  /// assert!(flag.get());
-  /// ```
   #[must_use]
-  pub fn new(value: bool) -> Self {
+  pub(crate) fn new(value: bool) -> Self {
     #[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
     {
       Self { inner: Arc::new(AtomicBool::new(value)) }
@@ -83,17 +61,7 @@ impl Flag {
   /// # Arguments
   ///
   /// * `value` - New value to set
-  ///
-  /// # Examples
-  ///
-  /// ```
-  /// use fraktor_utils_rs::core::sync::Flag;
-  ///
-  /// let flag = Flag::new(false);
-  /// flag.set(true);
-  /// assert!(flag.get());
-  /// ```
-  pub fn set(&self, value: bool) {
+  pub(crate) fn set(&self, value: bool) {
     #[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
     {
       self.inner.store(value, Ordering::SeqCst);
@@ -115,17 +83,8 @@ impl Flag {
   /// # Returns
   ///
   /// Current value of the flag
-  ///
-  /// # Examples
-  ///
-  /// ```
-  /// use fraktor_utils_rs::core::sync::Flag;
-  ///
-  /// let flag = Flag::new(true);
-  /// assert!(flag.get());
-  /// ```
   #[must_use]
-  pub fn get(&self) -> bool {
+  pub(crate) fn get(&self) -> bool {
     #[cfg(all(feature = "alloc", target_has_atomic = "ptr"))]
     {
       self.inner.load(Ordering::SeqCst)
@@ -145,17 +104,7 @@ impl Flag {
   /// Clears the flag (sets it to `false`)
   ///
   /// This method is equivalent to `set(false)`.
-  ///
-  /// # Examples
-  ///
-  /// ```
-  /// use fraktor_utils_rs::core::sync::Flag;
-  ///
-  /// let flag = Flag::new(true);
-  /// flag.clear();
-  /// assert!(!flag.get());
-  /// ```
-  pub fn clear(&self) {
+  pub(crate) fn clear(&self) {
     self.set(false);
   }
 }

--- a/modules/utils/src/core/sync/function.rs
+++ b/modules/utils/src/core/sync/function.rs
@@ -1,7 +1,9 @@
 #[cfg(target_has_atomic = "ptr")]
+#[allow(dead_code)]
 pub(crate) type SharedFnTarget<Args, Output> = dyn Fn(Args) -> Output + Send + Sync + 'static;
 
 #[cfg(not(target_has_atomic = "ptr"))]
+#[allow(dead_code)]
 pub(crate) type SharedFnTarget<Args, Output> = dyn Fn(Args) -> Output + 'static;
 
 /// Shared factory helpers.
@@ -9,5 +11,7 @@ mod shared_factory;
 /// Shared function helpers.
 mod shared_fn;
 
-pub use shared_factory::SharedFactory;
-pub use shared_fn::SharedFn;
+#[allow(unused_imports)]
+pub(crate) use shared_factory::SharedFactory;
+#[allow(unused_imports)]
+pub(crate) use shared_fn::SharedFn;

--- a/modules/utils/src/core/sync/function/shared_factory.rs
+++ b/modules/utils/src/core/sync/function/shared_factory.rs
@@ -1,7 +1,8 @@
 use crate::core::sync::shared::{Shared, SharedBound};
 
 /// Trait alias for shared factories (Send + Sync closures returning a type).
-pub trait SharedFactory<Args, Output>: Shared<super::SharedFnTarget<Args, Output>> + SharedBound {}
+#[allow(dead_code)]
+pub(crate) trait SharedFactory<Args, Output>: Shared<super::SharedFnTarget<Args, Output>> + SharedBound {}
 
 impl<T, Args, Output> SharedFactory<Args, Output> for T where
   T: Shared<super::SharedFnTarget<Args, Output>> + SharedBound

--- a/modules/utils/src/core/sync/function/shared_fn.rs
+++ b/modules/utils/src/core/sync/function/shared_fn.rs
@@ -1,6 +1,7 @@
 use crate::core::sync::shared::{Shared, SharedBound};
 
 /// Trait alias for shared function pointers used in actor-core.
-pub trait SharedFn<Args, Output>: Shared<super::SharedFnTarget<Args, Output>> + SharedBound {}
+#[allow(dead_code)]
+pub(crate) trait SharedFn<Args, Output>: Shared<super::SharedFnTarget<Args, Output>> + SharedBound {}
 
 impl<T, Args, Output> SharedFn<Args, Output> for T where T: Shared<super::SharedFnTarget<Args, Output>> + SharedBound {}

--- a/modules/utils/src/core/sync/interrupt.rs
+++ b/modules/utils/src/core/sync/interrupt.rs
@@ -3,14 +3,16 @@ mod never_interrupt_policy;
 #[cfg(test)]
 mod tests;
 
-pub use critical_section_interrupt_policy::CriticalSectionInterruptPolicy;
-pub use never_interrupt_policy::NeverInterruptPolicy;
+#[allow(unused_imports)]
+pub(crate) use critical_section_interrupt_policy::CriticalSectionInterruptPolicy;
+pub(crate) use never_interrupt_policy::NeverInterruptPolicy;
 
 use crate::core::sync::SharedError;
 
 /// Policy interface for determining whether blocking operations are permitted in the
 /// current execution context.
-pub trait InterruptContextPolicy {
+#[allow(dead_code)]
+pub(crate) trait InterruptContextPolicy {
   /// Checks whether blocking operations are allowed.
   ///
   /// # Errors

--- a/modules/utils/src/core/sync/interrupt/critical_section_interrupt_policy.rs
+++ b/modules/utils/src/core/sync/interrupt/critical_section_interrupt_policy.rs
@@ -5,7 +5,8 @@ use crate::core::sync::SharedError;
 mod tests;
 
 /// Policy that consults platform-specific interrupt state before allowing blocking operations.
-pub struct CriticalSectionInterruptPolicy;
+#[allow(dead_code)]
+pub(crate) struct CriticalSectionInterruptPolicy;
 
 impl InterruptContextPolicy for CriticalSectionInterruptPolicy {
   fn check_blocking_allowed() -> Result<(), SharedError> {

--- a/modules/utils/src/core/sync/interrupt/never_interrupt_policy.rs
+++ b/modules/utils/src/core/sync/interrupt/never_interrupt_policy.rs
@@ -5,7 +5,8 @@ use crate::core::sync::SharedError;
 mod tests;
 
 /// Policy that never reports an active interrupt context.
-pub struct NeverInterruptPolicy;
+#[allow(dead_code)]
+pub(crate) struct NeverInterruptPolicy;
 
 impl InterruptContextPolicy for NeverInterruptPolicy {
   fn check_blocking_allowed() -> Result<(), SharedError> {

--- a/modules/utils/src/core/sync/rc_shared.rs
+++ b/modules/utils/src/core/sync/rc_shared.rs
@@ -16,33 +16,36 @@ mod tests;
 /// thread-safety guarantees, making it suitable for single-threaded runtimes or
 /// bare-metal targets where atomic pointer operations are unavailable.
 #[cfg(feature = "alloc")]
-pub struct RcShared<T: ?Sized>(Rc<T>);
+#[allow(dead_code)]
+pub(crate) struct RcShared<T: ?Sized>(Rc<T>);
 
 #[cfg(feature = "alloc")]
+#[allow(dead_code)]
 impl<T> RcShared<T> {
   /// Creates a new `RcShared` by wrapping the provided value.
-  pub fn new(value: T) -> Self {
+  pub(crate) fn new(value: T) -> Self {
     Self(Rc::new(value))
   }
 }
 
 #[cfg(feature = "alloc")]
+#[allow(dead_code)]
 impl<T: ?Sized> RcShared<T> {
   /// Wraps an existing `Rc` in the shared wrapper.
   #[must_use]
-  pub const fn ___from_rc(inner: Rc<T>) -> Self {
+  pub(crate) const fn ___from_rc(inner: Rc<T>) -> Self {
     Self(inner)
   }
 
   /// Consumes the wrapper and returns the inner `Rc`.
   #[must_use]
-  pub fn ___into_rc(self) -> Rc<T> {
+  pub(crate) fn ___into_rc(self) -> Rc<T> {
     self.0
   }
 
   /// Converts the shared handle into another dynamically sized representation.
   #[cfg(feature = "alloc")]
-  pub fn into_dyn<U: ?Sized, F>(self, cast: F) -> RcShared<U>
+  pub(crate) fn into_dyn<U: ?Sized, F>(self, cast: F) -> RcShared<U>
   where
     F: FnOnce(&T) -> &U, {
     let raw = Rc::into_raw(self.0);

--- a/modules/utils/src/core/sync/runtime_lock_alias.rs
+++ b/modules/utils/src/core/sync/runtime_lock_alias.rs
@@ -11,6 +11,3 @@ pub type RuntimeRwLock<T> = crate::RuntimeRwLockBackend<T>;
 
 /// No-std mutex alias.
 pub type NoStdMutex<T> = RuntimeMutex<T>;
-
-/// No-std rwlock alias.
-pub type NoStdRwLock<T> = RuntimeRwLock<T>;

--- a/modules/utils/src/core/sync/shared.rs
+++ b/modules/utils/src/core/sync/shared.rs
@@ -5,9 +5,10 @@ mod shared_bound;
 mod shared_dyn;
 mod shared_trait;
 
-pub use send_bound::SendBound;
+#[allow(unused_imports)]
+pub(crate) use send_bound::SendBound;
 pub use shared_bound::SharedBound;
-pub use shared_dyn::SharedDyn;
+pub(crate) use shared_dyn::SharedDyn;
 pub use shared_trait::Shared;
 
 #[cfg(test)]

--- a/modules/utils/src/core/sync/shared/send_bound.rs
+++ b/modules/utils/src/core/sync/shared/send_bound.rs
@@ -1,13 +1,15 @@
 #[cfg(target_has_atomic = "ptr")]
 /// Marker trait that enforces `Send` only when pointer atomics are available.
-pub trait SendBound: Send {}
+#[allow(dead_code)]
+pub(crate) trait SendBound: Send {}
 
 #[cfg(target_has_atomic = "ptr")]
 impl<T: Send> SendBound for T {}
 
 #[cfg(not(target_has_atomic = "ptr"))]
 /// Marker trait for single-threaded targets where `Send` is not required.
-pub trait SendBound {}
+#[allow(dead_code)]
+pub(crate) trait SendBound {}
 
 #[cfg(not(target_has_atomic = "ptr"))]
 impl<T> SendBound for T {}

--- a/modules/utils/src/core/sync/shared/shared_dyn.rs
+++ b/modules/utils/src/core/sync/shared/shared_dyn.rs
@@ -1,7 +1,8 @@
 use super::shared_trait::Shared;
 
 /// Extensions for shared handles that can be converted into trait objects.
-pub trait SharedDyn<T: ?Sized>: Shared<T> {
+#[allow(dead_code)]
+pub(crate) trait SharedDyn<T: ?Sized>: Shared<T> {
   /// Shared wrapper yielded after converting to a new dynamically sized view.
   type Dyn<U: ?Sized + 'static>: Shared<U>;
 

--- a/modules/utils/src/core/sync/state.rs
+++ b/modules/utils/src/core/sync/state.rs
@@ -60,7 +60,8 @@ mod tests;
 ///   }
 /// }
 /// ```
-pub trait StateCell<T>: Clone {
+#[allow(dead_code)]
+pub(crate) trait StateCell<T>: Clone {
   /// Immutable reference guard type.
   ///
   /// Functions as an RAII type implementing `Deref<Target = T>` that automatically

--- a/modules/utils/src/core/sync/static_ref_shared.rs
+++ b/modules/utils/src/core/sync/static_ref_shared.rs
@@ -12,18 +12,20 @@ mod tests;
 /// Shared wrapper backed by a `'static` reference.
 ///
 /// Thin wrapper that exposes user-supplied `'static` values through the [`Shared`] abstraction.
-pub struct StaticRefShared<T: ?Sized + 'static>(&'static T);
+#[allow(dead_code)]
+pub(crate) struct StaticRefShared<T: ?Sized + 'static>(&'static T);
 
+#[allow(dead_code)]
 impl<T: ?Sized + 'static> StaticRefShared<T> {
   /// Creates a new wrapper from a `'static` reference.
   #[must_use]
-  pub const fn new(reference: &'static T) -> Self {
+  pub(crate) const fn new(reference: &'static T) -> Self {
     Self(reference)
   }
 
   /// Returns the raw `'static` reference.
   #[must_use]
-  pub const fn as_ref(self) -> &'static T {
+  pub(crate) const fn as_ref(self) -> &'static T {
     self.0
   }
 }

--- a/modules/utils/src/core/sync/sync_mutex_like.rs
+++ b/modules/utils/src/core/sync/sync_mutex_like.rs
@@ -21,6 +21,3 @@ pub trait SyncMutexLike<T> {
   /// Locks the mutex and returns a guard to the protected value.
   fn lock(&self) -> Self::Guard<'_>;
 }
-
-/// Convenience alias for guards produced by [`SyncMutexLike`].
-pub type SyncMutexLikeGuard<'a, M, T> = <M as SyncMutexLike<T>>::Guard<'a>;

--- a/modules/utils/src/core/sync/sync_rwlock_like.rs
+++ b/modules/utils/src/core/sync/sync_rwlock_like.rs
@@ -30,8 +30,3 @@ pub trait SyncRwLockLike<T> {
   /// Acquires an exclusive write guard.
   fn write(&self) -> Self::WriteGuard<'_>;
 }
-
-/// Convenience alias for guards produced by [`SyncRwLockLike::read`].
-pub type SyncRwLockReadGuard<'a, L, T> = <L as SyncRwLockLike<T>>::ReadGuard<'a>;
-/// Convenience alias for guards produced by [`SyncRwLockLike::write`].
-pub type SyncRwLockWriteGuard<'a, L, T> = <L as SyncRwLockLike<T>>::WriteGuard<'a>;

--- a/modules/utils/src/std.rs
+++ b/modules/utils/src/std.rs
@@ -19,5 +19,3 @@ pub use sync_rwlock_write_guard::StdSyncRwLockWriteGuard;
 
 /// Convenience alias for the default std mutex.
 pub type StdMutex<T> = crate::core::sync::RuntimeMutex<T>;
-/// Convenience alias for the default std rwlock.
-pub type StdRwLock<T> = crate::core::sync::RuntimeRwLock<T>;

--- a/modules/utils/src/std/collections/queue.rs
+++ b/modules/utils/src/std/collections/queue.rs
@@ -4,22 +4,11 @@ extern crate std;
 pub mod backend;
 
 use crate::{
-  core::collections::queue::{
-    SyncQueue, SyncQueueShared,
-    type_keys::{FifoKey, MpscKey, PriorityKey, SpscKey},
-  },
+  core::collections::queue::{SyncQueue, SyncQueueShared, type_keys::MpscKey},
   std::sync_mutex::StdSyncMutex,
 };
 
 /// Type alias for an MPSC queue using [`std::sync::Mutex`].
-pub type StdSyncMpscQueueShared<T, B, M = StdSyncMutex<SyncQueue<T, MpscKey, B>>> = SyncQueueShared<T, MpscKey, B, M>;
-
-/// Type alias for an SPSC queue using [`std::sync::Mutex`].
-pub type StdSyncSpscQueueShared<T, B, M = StdSyncMutex<SyncQueue<T, SpscKey, B>>> = SyncQueueShared<T, SpscKey, B, M>;
-
-/// Type alias for a FIFO queue using [`std::sync::Mutex`].
-pub type StdSyncFifoQueueShared<T, B, M = StdSyncMutex<SyncQueue<T, FifoKey, B>>> = SyncQueueShared<T, FifoKey, B, M>;
-
-/// Type alias for a priority queue using [`std::sync::Mutex`].
-pub type StdSyncPriorityQueueShared<T, B, M = StdSyncMutex<SyncQueue<T, PriorityKey, B>>> =
-  SyncQueueShared<T, PriorityKey, B, M>;
+#[allow(dead_code)]
+pub(crate) type StdSyncMpscQueueShared<T, B, M = StdSyncMutex<SyncQueue<T, MpscKey, B>>> =
+  SyncQueueShared<T, MpscKey, B, M>;

--- a/modules/utils/src/std/collections/queue/backend.rs
+++ b/modules/utils/src/std/collections/queue/backend.rs
@@ -1,3 +1,4 @@
 mod mpsc_backend;
 
-pub use mpsc_backend::*;
+#[allow(unused_imports)]
+pub(crate) use mpsc_backend::*;

--- a/modules/utils/src/std/collections/queue/backend/mpsc_backend.rs
+++ b/modules/utils/src/std/collections/queue/backend/mpsc_backend.rs
@@ -21,16 +21,18 @@ use crate::core::{
 /// This backend provides unbounded queue semantics backed by the standard library's
 /// multi-producer, single-consumer channel. It supports concurrent producers and
 /// maintains approximate length tracking via atomic counters.
-pub struct MpscBackend<T> {
+#[allow(dead_code)]
+pub(crate) struct MpscBackend<T> {
   sender:   std::sync::mpsc::Sender<T>,
   receiver: std::sync::mpsc::Receiver<T>,
   len:      ArcShared<AtomicUsize>,
 }
 
+#[allow(dead_code)]
 impl<T> MpscBackend<T> {
   /// Creates a new unbounded MPSC backend.
   #[must_use]
-  pub fn new() -> Self {
+  pub(crate) fn new() -> Self {
     let (sender, receiver) = mpsc::channel();
     Self { sender, receiver, len: ArcShared::new(AtomicUsize::new(0)) }
   }
@@ -39,13 +41,13 @@ impl<T> MpscBackend<T> {
   ///
   /// This can be cloned to create multiple producers.
   #[must_use]
-  pub const fn sender(&self) -> &std::sync::mpsc::Sender<T> {
+  pub(crate) const fn sender(&self) -> &std::sync::mpsc::Sender<T> {
     &self.sender
   }
 
   /// Returns a reference to the receiver half of the channel.
   #[must_use]
-  pub const fn receiver(&self) -> &std::sync::mpsc::Receiver<T> {
+  pub(crate) const fn receiver(&self) -> &std::sync::mpsc::Receiver<T> {
     &self.receiver
   }
 }


### PR DESCRIPTION
## Summary

Parent issue: #410

## 目的

`modules/utils/` で他モジュールから参照されていないが utils 内部で使用されている型の `pub` を `pub(crate)` に縮小し、公開 API を最小化する。

## 背景

Sub 1 (#477)、Sub 2 (#478) で未使用型を削除した後、残る型のうち約70型が utils 内部でのみ使用されている。これらの `pub` を剥がすことで公開型数を大幅に削減できる。

主な対象領域:
- `queue/` 内部型 (~38型): `AsyncQueueBackend`, `SyncQueueBackend`, `MpscKey`, `SpscKey`, `PriorityKey`, `TypeKey`, 各種 Producer/Consumer Shared 型等
- `sync/` 内部型 (~14型): `SendBound`, `SharedBound`, `SharedDyn`, `SharedError`, `SharedFactory`, `Flag`, `InterruptContextPolicy` 等
- `std/` 内部型 (~8型): `MpscBackend`, `StdSyncFifoQueueShared`, `StdSyncMutexGuard` 等

## タスク

- [ ] Sub 1, Sub 2 完了後に着手
- [ ] 他モジュール未参照 & utils 内部でのみ使用の型を特定
- [ ] `pub` → `pub(crate)` への変更
- [ ] `mod.rs` のリエクスポート整理
- [ ] `./scripts/ci-check.sh all` でグリーン確認

## 受け入れ基準

- 他モジュールから参照される型のみが `pub` であること
- CI が全パスすること
- 他モジュールのコンパイル・テストに影響がないこと

## 推定変更ファイル数

~40ファイル

## 依存関係

#477, #478 の完了後に着手

## Execution Report

Piece `refactoring` completed successfully.

Closes #479

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the crate’s public API (many `pub` items removed or downgraded to `pub(crate)` and several type aliases deleted), which can break downstream users. Runtime behavior should be unchanged since changes are mostly visibility/export hygiene.
> 
> **Overview**
> This PR **minimizes the public API of `modules/utils`** by converting numerous sync/collections/std helper types and constants from `pub` to `pub(crate)` and adjusting re-exports to keep only the intended surface area public.
> 
> It also **removes a few public convenience type aliases** (e.g., `NoStdRwLock`, `StdRwLock`, and guard aliases in `sync_mutex_like`/`sync_rwlock_like`) and trims std queue aliases to only an internal `StdSyncMpscQueueShared`, adding targeted `#[allow(...)]` annotations to avoid warnings after de-publicizing items.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 894e80d1876d77dabe116320abd5f3a2db7cb0d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* **API サーフェス最適化** - ユーティリティライブラリの内部 API を整理し、外部向けに公開されるコンポーネント数を削減しました。これにより、ライブラリの公開インターフェースがより明確で保守しやすくなります。また、不要な型エイリアスを削除し、内部実装の詳細を隠蔽しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->