### PR TITLE
refactor: address CodeRabbit findings from PR #488

### DIFF
--- a/modules/actor/src/core/typed/fsm_builder.rs
+++ b/modules/actor/src/core/typed/fsm_builder.rs
@@ -4,7 +4,7 @@
 mod tests;
 
 use alloc::{boxed::Box, vec::Vec};
-use core::hash::Hash;
+use core::{fmt::Debug, hash::Hash};
 
 use ahash::RandomState;
 use fraktor_utils_rs::core::sync::{ArcShared, RuntimeMutex};
@@ -17,7 +17,7 @@ type TransitionHandler<State, Message> = dyn Fn(&Message) -> Option<State> + Sen
 /// Minimal FSM builder for composing state transition behaviors.
 pub struct FsmBuilder<State, Message>
 where
-  State: Clone + Eq + Hash + Send + Sync + 'static,
+  State: Clone + Debug + Eq + Hash + Send + Sync + 'static,
   Message: Send + Sync + 'static, {
   initial_state: State,
   transitions:   Vec<(State, Box<TransitionHandler<State, Message>>)>,
@@ -25,7 +25,7 @@ where
 
 impl<State, Message> FsmBuilder<State, Message>
 where
-  State: Clone + Eq + Hash + Send + Sync + 'static,
+  State: Clone + Debug + Eq + Hash + Send + Sync + 'static,
   Message: Send + Sync + 'static,
 {
   /// Creates a new FSM builder with the provided initial state.
@@ -51,7 +51,8 @@ where
   pub fn build(self) -> Behavior<Message> {
     let mut transition_map = HashMap::with_capacity_and_hasher(self.transitions.len(), RandomState::new());
     for (state, handler) in self.transitions {
-      transition_map.insert(state, handler);
+      let prev = transition_map.insert(state.clone(), handler);
+      debug_assert!(prev.is_none(), "FsmBuilder: duplicate transition for state {:?}", state);
     }
     let transitions = ArcShared::new(transition_map);
     let state = ArcShared::new(RuntimeMutex::new(self.initial_state));

--- a/modules/actor/src/core/typed/fsm_builder/tests.rs
+++ b/modules/actor/src/core/typed/fsm_builder/tests.rs
@@ -12,7 +12,7 @@ use crate::core::{
   },
 };
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum ProbeState {
   Idle,
   Active,

--- a/modules/actor/src/core/typed/pool_router_builder.rs
+++ b/modules/actor/src/core/typed/pool_router_builder.rs
@@ -115,6 +115,8 @@ where
       let routees_for_msg = routees.clone();
       let routees_for_sig = routees;
 
+      let mut dispatch_counts_for_sig: Option<ArcShared<RuntimeMutex<Vec<usize>>>> = None;
+
       let select_targets: ArcShared<RouteSelector<M>> = match strategy.clone() {
         | PoolRouteStrategy::RoundRobin => {
           let index = AtomicUsize::new(0);
@@ -140,6 +142,7 @@ where
         },
         | PoolRouteStrategy::SmallestMailbox => {
           let dispatch_counts = ArcShared::new(RuntimeMutex::new(vec![0_usize; routee_count]));
+          dispatch_counts_for_sig = Some(dispatch_counts.clone());
           ArcShared::new(move |guard: &[TypedActorRef<M>], _message: &M| {
             let idx = select_smallest_mailbox_index(guard, &dispatch_counts);
             vec![guard[idx].clone()]
@@ -163,7 +166,14 @@ where
       .receive_signal(move |_ctx, signal| match signal {
         | BehaviorSignal::Terminated(pid) => {
           let mut guard = routees_for_sig.lock();
-          guard.retain(|r| r.pid() != *pid);
+          if let Some(pos) = guard.iter().position(|r| r.pid() == *pid) {
+            guard.remove(pos);
+            if let Some(ref dc) = dispatch_counts_for_sig {
+              let mut counts = dc.lock();
+              debug_assert!(pos < counts.len(), "dispatch_counts size mismatch: pos={}, len={}", pos, counts.len());
+              counts.remove(pos);
+            }
+          }
           if guard.is_empty() {
             return Ok(Behaviors::stopped());
           }

--- a/modules/cluster/src/core/pub_sub/delivery_endpoint_shared_generic.rs
+++ b/modules/cluster/src/core/pub_sub/delivery_endpoint_shared_generic.rs
@@ -24,12 +24,6 @@ impl DeliveryEndpointShared {
   pub const fn from_inner(inner: ArcShared<RuntimeMutex<Box<dyn DeliveryEndpoint>>>) -> Self {
     Self { inner }
   }
-
-  /// Returns a cloned handle to the inner shared mutex.
-  #[must_use]
-  pub fn inner(&self) -> ArcShared<RuntimeMutex<Box<dyn DeliveryEndpoint>>> {
-    self.inner.clone()
-  }
 }
 
 impl Clone for DeliveryEndpointShared {

--- a/modules/persistence/tests/persistence_flow.rs
+++ b/modules/persistence/tests/persistence_flow.rs
@@ -26,6 +26,7 @@ use fraktor_persistence_rs::core::{
   PersistentActor, PersistentRepr, Snapshot, SnapshotMetadata, SnapshotStore, persistent_props, spawn_persistent,
 };
 use fraktor_utils_rs::core::sync::{ArcShared, RuntimeMutex};
+use test_utils::shared_mutex;
 type SharedValue = ArcShared<RuntimeMutex<i32>>;
 type SharedFlag = ArcShared<RuntimeMutex<bool>>;
 type SharedRefs = ArcShared<RuntimeMutex<Vec<ActorRef>>>;
@@ -138,8 +139,6 @@ impl Actor for Guardian {
 }
 
 struct Start;
-
-use test_utils::shared_mutex;
 
 fn drive_ready<F: Future>(future: F) -> F::Output {
   let waker = Waker::noop();

--- a/modules/persistence/tests/persistent_actor_example.rs
+++ b/modules/persistence/tests/persistent_actor_example.rs
@@ -22,6 +22,7 @@ use fraktor_persistence_rs::core::{
   PersistentActor, PersistentRepr, Snapshot, persistent_props, spawn_persistent,
 };
 use fraktor_utils_rs::core::sync::{ArcShared, RuntimeMutex};
+use test_utils::shared_mutex;
 type SharedValue = ArcShared<RuntimeMutex<i32>>;
 type SharedRefs = ArcShared<RuntimeMutex<Vec<ActorRef>>>;
 
@@ -112,8 +113,6 @@ impl Actor for Guardian {
 }
 
 struct Start;
-
-use test_utils::shared_mutex;
 
 #[test]
 fn batch_flow_applies_all_events() {


### PR DESCRIPTION
## Summary

- Move mid-file `use test_utils::shared_mutex` to file-level imports (#492, #494)
- Remove unused `inner()` method from `DeliveryEndpointShared` (#493)
- Add `Debug` bound to `FsmBuilder` State and `debug_assert!` for duplicate transitions (#490)
- Sync `dispatch_counts` on routee removal in SmallestMailbox strategy (#495)

## Notes

- #491 (`const fn` 除去): nightly clippy が `missing_const_for_fn` を要求するため対応不要
- #489 (SAFETY コメント改善): 既に各フィールド型の Send+Sync 根拠を具体的に記述済み。対応不要
- #496 (単一宛先の Vec 過剰生成): YAGNI に反するため対応不要

## Test plan

- [x] `./scripts/ci-check.sh test -m fraktor-actor-rs` passed
- [x] `./scripts/ci-check.sh test -m fraktor-cluster-rs` passed
- [x] `./scripts/ci-check.sh test -m fraktor-persistence-rs` passed
- [x] `./scripts/ci-check.sh all` passed

Closes #489, closes #490, closes #491, closes #492, closes #493, closes #494, closes #495, closes #496

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds new trait bounds and changes routee-termination handling in the pool router, which can affect routing behavior and compilation for downstream users. Other changes are small refactors (debug assertions, unused API removal, test import cleanup).
> 
> **Overview**
> **Typed actor FSM builder** now requires `State: Debug` and adds a `debug_assert!` to catch duplicate per-state transition registrations at build time.
> 
> **Pool router `SmallestMailbox` strategy** now keeps its `dispatch_counts` vector in sync when a watched routee terminates (removing the corresponding count entry instead of leaving stale indices).
> 
> **Cluster pub/sub** removes the unused `DeliveryEndpointShared::inner()` accessor, and **persistence tests** move `test_utils::shared_mutex` to top-level imports (plus deriving `Debug` for the FSM test state).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f7a5e7fb806c99d8b58986b38e25ac085028b25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プール・ルーターのディスパッチ数追跡が改善され、ルーティー終了時の同期ズレが解決されました
  * FSMビルダーでデバッグモード時の重複遷移検出機能が追加されました

* **API変更**
  * DeliveryEndpointSharedの内部メソッドが削除されました

* **改善**
  * FSMBuilderコンストラクタに#[must_use]属性を追加し、使用忘れの防止が強化されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->