### PR TITLE
Fix unbounded stream decompression

### DIFF
--- a/modules/streams/src/core/stage/flow.rs
+++ b/modules/streams/src/core/stage/flow.rs
@@ -4275,6 +4275,17 @@ fn inflate_bytes(bytes: &[u8]) -> Result<Vec<u8>, StreamError> {
 }
 
 #[cfg(feature = "compression")]
+fn inflate_gzip_payload_bytes(bytes: &[u8]) -> Result<Vec<u8>, StreamError> {
+  let limit = MAX_DECOMPRESSED_BYTES.saturating_add(1);
+  let decompressed = miniz_oxide::inflate::decompress_to_vec_with_limit(bytes, limit)
+    .map_err(|_| StreamError::CompressionError { kind: "deflate" })?;
+  if decompressed.len() > MAX_DECOMPRESSED_BYTES {
+    return Err(StreamError::CompressionError { kind: "gzip_too_large" });
+  }
+  Ok(decompressed)
+}
+
+#[cfg(feature = "compression")]
 fn gzip_bytes(bytes: &[u8]) -> Vec<u8> {
   let payload = deflate_bytes(bytes);
   let mut output = Vec::with_capacity(payload.len() + 18);
@@ -4340,7 +4351,7 @@ fn gunzip_bytes(bytes: &[u8]) -> Result<Vec<u8>, StreamError> {
   if usize::try_from(expected_len).ok().filter(|expected_len| *expected_len <= MAX_DECOMPRESSED_BYTES).is_none() {
     return Err(StreamError::CompressionError { kind: "gzip_too_large" });
   }
-  let decompressed = inflate_bytes(payload)?;
+  let decompressed = inflate_gzip_payload_bytes(payload)?;
   if crc32(&decompressed) != expected_crc || (decompressed.len() as u32) != expected_len {
     return Err(StreamError::CompressionError { kind: "gzip_trailer" });
   }

--- a/modules/streams/src/core/stage/flow/tests.rs
+++ b/modules/streams/src/core/stage/flow/tests.rs
@@ -1841,6 +1841,25 @@ fn gzip_decompress_rejects_payload_exceeding_decompression_limit() {
 }
 
 #[test]
+#[cfg(feature = "compression")]
+fn gzip_decompress_rejects_payload_exceeding_decompression_limit_with_spoofed_isize() {
+  let payload = vec![0x44_u8; super::MAX_DECOMPRESSED_BYTES.saturating_add(1)];
+  let mut encoded = Source::single(payload)
+    .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip())
+    .collect_values()
+    .expect("collect_values")
+    .pop()
+    .expect("encoded payload");
+  let trailer_start = encoded.len().saturating_sub(4);
+  encoded[trailer_start..].copy_from_slice(&0_u32.to_le_bytes());
+
+  let result =
+    Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress()).collect_values();
+
+  assert!(matches!(result, Err(StreamError::CompressionError { kind: "gzip_too_large" })));
+}
+
+#[test]
 fn limit_weighted_stops_before_exceeding_budget() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[2, 2, 1]))
     .via(Flow::new().limit_weighted(3, |value| *value as usize))


### PR DESCRIPTION
## Summary
- add a decompression size limit for stream inflate/gzip_decompress paths
- reject oversized gzip payloads before inflate using the gzip trailer size
- add regression tests that reproduced the issue first and now pass

## Test
- cargo test -p fraktor-streams-rs --features compression decompression_limit
- cargo test -p fraktor-streams-rs --features compression
- ./scripts/ci-check.sh dylint -m streams
- ./scripts/ci-check.sh all

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes decompression behavior by enforcing a hard size limit, which could cause previously-accepted large payloads to fail and may affect any consumers relying on large compressed frames.
> 
> **Overview**
> **Adds bounded decompression for compression stages.** `inflate` now uses `miniz_oxide`'s `decompress_to_vec_with_limit` with a new `MAX_DECOMPRESSED_BYTES` cap.
> 
> **Hardens `gzip_decompress` against zip bombs.** It rejects payloads whose trailer `ISIZE` exceeds the cap and also enforces the limit during raw-deflate inflation (including when `ISIZE` is spoofed), returning `CompressionError { kind: "gzip_too_large" }`.
> 
> Adds regression tests covering over-limit `inflate` and `gzip_decompress` cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 506efd492e1121636c0c3ace2e8b3221c4a26e57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 圧縮データの解凍処理にサイズ上限チェックを実装しました。上限を超えるペイロードは適切なエラーで拒否されるようになります。

* **テスト**
  * 圧縮データサイズ上限を超える場合のエラーハンドリングを検証するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->