### PR TITLE
feat(actor): add baseline benchmarks

### DIFF
--- a/modules/actor/Cargo.toml
+++ b/modules/actor/Cargo.toml
@@ -218,3 +218,9 @@ required-features = ["test-support"]
 name = "system_lifecycle"
 path = "tests/system_lifecycle.rs"
 required-features = ["test-support"]
+
+[[bench]]
+name = "actor_baseline"
+path = "benches/actor_baseline.rs"
+harness = false
+required-features = ["test-support", "std", "tokio-executor"]

--- a/modules/actor/benches/actor_baseline.rs
+++ b/modules/actor/benches/actor_baseline.rs
@@ -1,0 +1,325 @@
+use std::{
+  hint::black_box,
+  sync::mpsc::{Receiver, SyncSender, sync_channel},
+  time::Duration,
+};
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use fraktor_actor_rs::{
+  core::{
+    dispatch::mailbox::{Mailbox, MailboxOverflowStrategy, MailboxPolicy},
+    error::ActorError,
+  },
+  std::{
+    actor::{Actor, ActorContext, ActorRef},
+    futures::ActorFutureListener,
+    messaging::{AnyMessage, AnyMessageView},
+    props::Props,
+    system::ActorSystem,
+  },
+};
+use tokio::runtime::{Builder, Runtime};
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+
+struct SpawnOnce {
+  done: SyncSender<()>,
+}
+
+struct RegisterChild {
+  reply_to: SyncSender<ActorRef>,
+}
+
+struct Notify {
+  done: SyncSender<()>,
+}
+
+struct PingPong {
+  done:      SyncSender<()>,
+  peer:      ActorRef,
+  remaining: usize,
+}
+
+struct SilentActor;
+
+impl Actor for SilentActor {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_, '_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}
+
+struct SpawnGuardian;
+
+impl Actor for SpawnGuardian {
+  fn receive(&mut self, ctx: &mut ActorContext<'_, '_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    if let Some(command) = message.downcast_ref::<SpawnOnce>() {
+      let child =
+        ctx.spawn_child(&Props::from_fn(|| SilentActor)).map_err(|_| ActorError::recoverable("spawn failed"))?;
+      black_box(child);
+      command.done.send(()).expect("spawn bench ack");
+    }
+    Ok(())
+  }
+}
+
+struct NotifyActor;
+
+impl Actor for NotifyActor {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_, '_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    if let Some(command) = message.downcast_ref::<Notify>() {
+      command.done.send(()).expect("notify bench ack");
+    }
+    Ok(())
+  }
+}
+
+struct RegistryGuardian;
+
+impl Actor for RegistryGuardian {
+  fn receive(&mut self, ctx: &mut ActorContext<'_, '_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    if let Some(command) = message.downcast_ref::<RegisterChild>() {
+      let child = ctx
+        .spawn_child(&Props::from_fn(|| NotifyActor))
+        .map_err(|_| ActorError::recoverable("spawn notify child failed"))?;
+      command.reply_to.send(child.actor_ref().clone()).expect("register child ref");
+    }
+    Ok(())
+  }
+}
+
+struct PingPongRegistryGuardian;
+
+impl Actor for PingPongRegistryGuardian {
+  fn receive(&mut self, ctx: &mut ActorContext<'_, '_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    if let Some(command) = message.downcast_ref::<RegisterChild>() {
+      let child = ctx
+        .spawn_child(&Props::from_fn(|| PingPongActor))
+        .map_err(|_| ActorError::recoverable("spawn ping-pong child failed"))?;
+      command.reply_to.send(child.actor_ref().clone()).expect("register ping-pong child ref");
+    }
+    Ok(())
+  }
+}
+
+struct PingPongActor;
+
+impl Actor for PingPongActor {
+  fn receive(&mut self, ctx: &mut ActorContext<'_, '_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    if let Some(command) = message.downcast_ref::<PingPong>() {
+      if command.remaining == 0 {
+        command.done.send(()).expect("ping-pong bench ack");
+      } else {
+        let next =
+          PingPong { done: command.done.clone(), peer: ctx.self_ref(), remaining: command.remaining - 1 };
+        command
+          .peer
+          .clone()
+          .tell(AnyMessage::new(next))
+          .map_err(|_| ActorError::recoverable("ping-pong send failed"))?;
+      }
+    }
+    Ok(())
+  }
+}
+
+struct TokioBenchSystem {
+  runtime: Runtime,
+  system:  ActorSystem,
+}
+
+impl TokioBenchSystem {
+  fn new(props: &Props) -> Self {
+    let runtime = Builder::new_multi_thread().worker_threads(2).enable_time().build().expect("tokio runtime");
+    let system = runtime.block_on(async { ActorSystem::quickstart(props).expect("actor system") });
+    Self { runtime, system }
+  }
+
+  fn terminate(self) {
+    self.runtime.block_on(async {
+      self.system.terminate().expect("terminate system");
+      ActorFutureListener::new(self.system.when_terminated()).await;
+    });
+  }
+}
+
+struct SpawnBenchFixture {
+  system: TokioBenchSystem,
+}
+
+impl SpawnBenchFixture {
+  fn new() -> Self {
+    let props = Props::from_fn(|| SpawnGuardian);
+    Self { system: TokioBenchSystem::new(&props) }
+  }
+
+  fn spawn_once(&self) {
+    let receiver = send_and_receive(|done| SpawnOnce { done }, self.system.system.user_guardian_ref());
+    wait_for(receiver);
+  }
+
+  fn terminate(self) {
+    self.system.terminate();
+  }
+}
+
+struct TellBenchFixture {
+  actor_ref: ActorRef,
+  system:    TokioBenchSystem,
+}
+
+impl TellBenchFixture {
+  fn new() -> Self {
+    let props = Props::from_fn(|| RegistryGuardian);
+    let system = TokioBenchSystem::new(&props);
+    let (reply_to, receiver) = sync_channel(1);
+    system.system.user_guardian_ref().tell(AnyMessage::new(RegisterChild { reply_to })).expect("register child");
+    let actor_ref = receiver.recv_timeout(WAIT_TIMEOUT).expect("registered child ref");
+    Self { actor_ref, system }
+  }
+
+  fn tell_once(&self) {
+    let receiver = send_and_receive(|done| Notify { done }, self.actor_ref.clone());
+    wait_for(receiver);
+  }
+
+  fn terminate(self) {
+    self.system.terminate();
+  }
+}
+
+struct PingPongBenchFixture {
+  ping_ref: ActorRef,
+  pong_ref: ActorRef,
+  system:   TokioBenchSystem,
+}
+
+impl PingPongBenchFixture {
+  fn new() -> Self {
+    let props = Props::from_fn(|| PingPongRegistryGuardian);
+    let system = TokioBenchSystem::new(&props);
+    let ping_ref = register_child(&system.system);
+    let pong_ref = register_child(&system.system);
+    Self { ping_ref, pong_ref, system }
+  }
+
+  fn run_roundtrip(&self, rounds: usize) {
+    let (done, receiver) = sync_channel(1);
+    let message = PingPong { done, peer: self.pong_ref.clone(), remaining: rounds };
+    self.ping_ref.clone().tell(AnyMessage::new(message)).expect("start ping-pong");
+    wait_for(receiver);
+  }
+
+  fn terminate(self) {
+    self.system.terminate();
+  }
+}
+
+fn send_and_receive<T, F>(message_factory: F, target: ActorRef) -> Receiver<()>
+where
+  F: FnOnce(SyncSender<()>) -> T,
+  T: Send + Sync + 'static, {
+  let (done, receiver) = sync_channel(1);
+  target.tell(AnyMessage::new(message_factory(done))).expect("send benchmark message");
+  receiver
+}
+
+fn wait_for(receiver: Receiver<()>) {
+  receiver.recv_timeout(WAIT_TIMEOUT).expect("benchmark completion");
+}
+
+fn register_child(system: &ActorSystem) -> ActorRef {
+  let (reply_to, receiver) = sync_channel(1);
+  system.user_guardian_ref().tell(AnyMessage::new(RegisterChild { reply_to })).expect("register child");
+  receiver.recv_timeout(WAIT_TIMEOUT).expect("registered child ref")
+}
+
+fn bench_spawn(c: &mut Criterion) {
+  let mut group = c.benchmark_group("actor_spawn");
+  group.sample_size(10);
+  group.measurement_time(Duration::from_secs(2));
+  group.bench_function("spawn_child", |b| {
+    b.iter_batched(
+      SpawnBenchFixture::new,
+      |fixture| {
+        fixture.spawn_once();
+        fixture.terminate();
+      },
+      BatchSize::SmallInput,
+    );
+  });
+  group.finish();
+}
+
+fn bench_tell(c: &mut Criterion) {
+  let mut group = c.benchmark_group("actor_tell");
+  group.sample_size(10);
+  group.measurement_time(Duration::from_secs(2));
+  group.bench_function("single_tell", |b| {
+    b.iter_batched(
+      TellBenchFixture::new,
+      |fixture| {
+        fixture.tell_once();
+        fixture.terminate();
+      },
+      BatchSize::SmallInput,
+    );
+  });
+  group.finish();
+}
+
+fn bench_ping_pong(c: &mut Criterion) {
+  let mut group = c.benchmark_group("actor_ping_pong");
+  group.sample_size(10);
+  group.measurement_time(Duration::from_secs(2));
+
+  for rounds in [100_usize, 1_000_usize] {
+    group.throughput(Throughput::Elements(rounds as u64));
+    group.bench_with_input(format!("roundtrip_{rounds}"), &rounds, |b, &rounds| {
+      b.iter_batched(
+        PingPongBenchFixture::new,
+        |fixture| {
+          fixture.run_roundtrip(rounds);
+          fixture.terminate();
+        },
+        BatchSize::SmallInput,
+      );
+    });
+  }
+
+  group.finish();
+}
+
+fn bench_mailbox(c: &mut Criterion) {
+  use core::num::NonZeroUsize;
+
+  let mut group = c.benchmark_group("mailbox_enqueue");
+  group.sample_size(10);
+  group.measurement_time(Duration::from_secs(2));
+
+  for capacity in [1_usize, 64_usize] {
+    group.throughput(Throughput::Elements(capacity as u64));
+    group.bench_with_input(format!("bounded_capacity_{capacity}"), &capacity, |b, &capacity| {
+      b.iter_batched(
+        || {
+          Mailbox::new(MailboxPolicy::bounded(
+            NonZeroUsize::new(capacity).expect("non-zero capacity"),
+            MailboxOverflowStrategy::DropNewest,
+            None,
+          ))
+        },
+        |mailbox| {
+          for sequence in 0..capacity {
+            mailbox.enqueue_user(AnyMessage::new(sequence)).expect("enqueue benchmark message");
+          }
+          black_box(mailbox);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+  }
+
+  group.finish();
+}
+
+criterion_group!(actor_baseline, bench_spawn, bench_tell, bench_ping_pong, bench_mailbox);
+criterion_main!(actor_baseline);

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -48,7 +48,7 @@ usage() {
   examples               : ワークスペース配下の examples をビルドします
   embedded / embassy     : embedded 系 (utils / actor) のチェックとテストを実行します
   test                   : ワークスペース全体のテストを実行します
-  perf                   : Scheduler ストレス／ベンチマークテストを実行します
+  perf                   : Scheduler ストレスと actor ベンチマークを実行します
   actor-path-e2e         : fraktor-actor-rs の actor_path_e2e テストを単体実行します
   all                    : 上記すべてを順番に実行します (引数なし時と同じ)
 複数指定で部分実行が可能です (例: scripts/ci-check.sh lint dylint module-wiring-lint)
@@ -906,6 +906,9 @@ PY
 run_perf() {
   log_step "cargo test -p fraktor-actor-rs stress_scheduler_handles_"
   run_cargo test -p fraktor-actor-rs stress_scheduler_handles_ || return 1
+
+  log_step "cargo +${DEFAULT_TOOLCHAIN} bench -p fraktor-actor-rs --bench actor_baseline --features test-support,std,tokio-executor -- --warm-up-time 0.1 --measurement-time 0.2 --sample-size 10"
+  run_cargo bench -p fraktor-actor-rs --bench actor_baseline --features test-support,std,tokio-executor -- --warm-up-time 0.1 --measurement-time 0.2 --sample-size 10 || return 1
 }
 
 run_all() {


### PR DESCRIPTION
## 概要
actor モジュールに退行検知用の baseline benchmark を追加します。

## 変更点
- Criterion ベースの actor benchmark を追加
- `spawn` / `single tell` / `ping-pong` / `bounded mailbox enqueue` を計測対象に追加
- `scripts/ci-check.sh perf` から benchmark を実行するよう変更

## 検証
- `./scripts/ci-check.sh perf`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the CI `perf` workflow to run a new benchmark target, which can introduce CI time/flake sensitivity and feature/toolchain coupling, but it does not alter runtime production behavior.
> 
> **Overview**
> Adds a new Criterion benchmark suite (`actor_baseline`) to `fraktor-actor-rs` to track performance regressions for **actor spawn**, **single `tell`**, **ping-pong roundtrips**, and **bounded mailbox enqueue**.
> 
> Registers the benchmark in `modules/actor/Cargo.toml` and updates `scripts/ci-check.sh perf` to execute `cargo bench --bench actor_baseline` with `test-support,std,tokio-executor` and short warmup/measurement settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9a0143bf6a2b58784de71e2c5cd658ac27134c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * アクターシステムの包括的なパフォーマンスベンチマークスイートを追加し、複数の操作シナリオ（アクター生成、メッセージ送信、ping-pong通信、メールボックス動作）を測定
  * CI パイプラインに自動ベンチマーク実行を統合

<!-- end of auto-generated comment: release notes by coderabbit.ai -->