### PR TITLE
actor-mojuuru-gyappu-2026-03-1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "references/okite-ai"]
 	path = references/okite-ai
 	url = git@github.com:j5ik2o/okite-ai.git
+[submodule "references/takt"]
+	path = references/takt
+	url = git@github.com:j5ik2o/takt.git

--- a/modules/actor/Cargo.toml
+++ b/modules/actor/Cargo.toml
@@ -120,6 +120,11 @@ path = "examples/scheduler_diagnostics_typed_no_std/main.rs"
 required-features = ["test-support"]
 
 [[example]]
+name = "pattern_api_no_std"
+path = "examples/pattern_api_no_std/main.rs"
+required-features = ["test-support"]
+
+[[example]]
 name = "ping_pong_tokio_std"
 path = "examples/ping_pong_tokio_std/main.rs"
 required-features = ["tokio-executor"]

--- a/modules/actor/examples/pattern_api_no_std/main.rs
+++ b/modules/actor/examples/pattern_api_no_std/main.rs
@@ -1,0 +1,204 @@
+//! Pattern API example using a deterministic tick driver.
+//!
+//! Demonstrates `ask_with_timeout`, `graceful_stop`, and `retry` with the
+//! same `core` APIs that are available in no_std-oriented code paths.
+
+#![cfg_attr(all(not(test), target_os = "none"), no_std)]
+
+extern crate alloc;
+
+#[cfg(not(target_os = "none"))]
+#[path = "../no_std_tick_driver_support.rs"]
+mod no_std_tick_driver_support;
+
+use alloc::boxed::Box;
+use core::{
+  future::{Future, ready},
+  pin::Pin,
+  sync::atomic::{AtomicUsize, Ordering},
+  task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+  time::Duration,
+};
+#[cfg(not(target_os = "none"))]
+use std::{thread, time::Duration as StdDuration};
+
+use fraktor_actor_rs::core::{
+  actor::{
+    Actor, ActorCell, ActorContext, Pid,
+    actor_ref::{ActorRef, ActorRefSender},
+  },
+  error::{ActorError, SendError},
+  messaging::{AnyMessage, AnyMessageView},
+  pattern::{graceful_stop, retry},
+  props::Props,
+  scheduler::{ExecutionBatch, SchedulerCommand, SchedulerRunnable},
+  system::ActorSystem,
+};
+use fraktor_utils_rs::core::sync::{ArcShared, SharedAccess};
+
+struct ReplyingSender;
+
+impl ActorRefSender for ReplyingSender {
+  fn send(&mut self, message: AnyMessage) -> Result<fraktor_actor_rs::core::actor::actor_ref::SendOutcome, SendError> {
+    if let Some(sender) = message.sender() {
+      sender.tell(AnyMessage::new(7_u32))?;
+    }
+    Ok(fraktor_actor_rs::core::actor::actor_ref::SendOutcome::Delivered)
+  }
+}
+
+struct NoopActor;
+
+impl Actor for NoopActor {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}
+
+struct RemoveCellRunnable {
+  pid:    Pid,
+  system: fraktor_actor_rs::core::system::state::SystemStateShared,
+}
+
+impl SchedulerRunnable for RemoveCellRunnable {
+  fn run(&self, _batch: &ExecutionBatch) {
+    self.system.remove_cell(&self.pid);
+  }
+}
+
+fn poll_future<F>(mut future: Pin<&mut F>) -> Poll<F::Output>
+where
+  F: Future + ?Sized, {
+  let waker = noop_waker();
+  let mut context = Context::from_waker(&waker);
+  future.as_mut().poll(&mut context)
+}
+
+fn noop_waker() -> Waker {
+  const VTABLE: RawWakerVTable = RawWakerVTable::new(clone_waker, wake_noop, wake_by_ref_noop, drop_noop);
+
+  unsafe fn raw_waker() -> RawWaker {
+    // SAFETY: this no-op waker never dereferences the data pointer, so a null pointer is valid
+    // as long as every vtable function treats it as opaque.
+    RawWaker::new(core::ptr::null(), &VTABLE)
+  }
+
+  unsafe fn clone_waker(data: *const ()) -> RawWaker {
+    // SAFETY: cloning preserves the same opaque pointer and shares the same no-op vtable, so
+    // the cloned waker has identical behavior and ownership requirements.
+    RawWaker::new(data, &VTABLE)
+  }
+
+  unsafe fn wake_noop(_data: *const ()) {}
+
+  unsafe fn wake_by_ref_noop(_data: *const ()) {}
+
+  unsafe fn drop_noop(_data: *const ()) {}
+
+  // SAFETY: `raw_waker()` returns a `RawWaker` whose vtable never touches the null data pointer
+  // and whose clone/drop operations preserve those invariants.
+  unsafe { Waker::from_raw(raw_waker()) }
+}
+
+#[cfg(not(target_os = "none"))]
+fn main() {
+  fn wait_until_ready<F>(future: Pin<&mut F>) -> F::Output
+  where
+    F: Future + ?Sized, {
+    let mut future = future;
+    loop {
+      match poll_future(future.as_mut()) {
+        | Poll::Ready(result) => return result,
+        | Poll::Pending => thread::sleep(StdDuration::from_millis(20)),
+      }
+    }
+  }
+
+  let props = Props::from_fn(|| NoopActor);
+  let (tick_driver, _pulse_handle) = no_std_tick_driver_support::hardware_tick_driver_config();
+  let system = ActorSystem::new(&props, tick_driver).expect("system");
+  let state = system.state();
+
+  let ask_actor = ActorRef::with_system(Pid::new(10, 0), ReplyingSender, &state);
+  let ask_response =
+    ask_actor.ask_with_timeout(AnyMessage::new("ping"), Duration::from_millis(50)).expect("ask should send");
+  let ask_result = ask_response.future().with_write(|inner| inner.try_take()).expect("reply result");
+  let reply = ask_result.expect("successful reply");
+  assert_eq!(reply.payload().downcast_ref::<u32>(), Some(&7_u32));
+
+  let pid = state.allocate_pid();
+  let props = Props::from_fn(|| NoopActor);
+  let cell = ActorCell::create(state.clone(), pid, None, "graceful-example".into(), &props).expect("create actor");
+  state.register_cell(cell.clone());
+
+  let runnable: ArcShared<dyn SchedulerRunnable> = ArcShared::new(RemoveCellRunnable { pid, system: state.clone() });
+  state.scheduler().with_write(|scheduler| {
+    scheduler
+      .schedule_command(Duration::from_millis(20), SchedulerCommand::RunRunnable { runnable, dispatcher: None })
+      .expect("schedule removal");
+  });
+
+  let actor_ref = cell.actor_ref();
+  let mut graceful = Box::pin(graceful_stop(&actor_ref, Duration::from_millis(200)));
+  wait_until_ready(graceful.as_mut()).expect("graceful stop");
+
+  let attempts = ArcShared::new(AtomicUsize::new(0));
+  let attempts_for_op = attempts.clone();
+  let mut delay_provider = system.delay_provider();
+  let mut retried = Box::pin(retry(
+    3,
+    &mut delay_provider,
+    |_| Duration::from_millis(20),
+    move || {
+      let current = attempts_for_op.fetch_add(1, Ordering::SeqCst);
+      if current == 0 { ready(Err::<u32, u32>(1)) } else { ready(Ok::<u32, u32>(7)) }
+    },
+  ));
+  assert_eq!(wait_until_ready(retried.as_mut()), Ok(7));
+
+  let termination = system.when_terminated();
+  system.terminate().expect("terminate");
+  while termination.with_read(|inner| !inner.is_ready()) {
+    thread::sleep(StdDuration::from_millis(20));
+  }
+}
+
+#[cfg(target_os = "none")]
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+  use core::future::Future;
+
+  use super::*;
+
+  struct PendingOnce {
+    polled: bool,
+  }
+
+  impl Future for PendingOnce {
+    type Output = u32;
+
+    fn poll(mut self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Self::Output> {
+      if self.polled {
+        Poll::Ready(9)
+      } else {
+        self.polled = true;
+        Poll::Pending
+      }
+    }
+  }
+
+  #[test]
+  fn should_poll_ready_future_in_no_std_helpers() {
+    let mut future = Box::pin(ready(7_u32));
+    assert!(matches!(poll_future(future.as_mut()), Poll::Ready(7_u32)));
+  }
+
+  #[test]
+  fn should_keep_pending_polling_std_free_in_no_std_helpers() {
+    let mut future = Box::pin(PendingOnce { polled: false });
+    assert!(matches!(poll_future(future.as_mut()), Poll::Pending));
+    assert!(matches!(poll_future(future.as_mut()), Poll::Ready(9)));
+  }
+}

--- a/modules/actor/src/core.rs
+++ b/modules/actor/src/core.rs
@@ -8,6 +8,7 @@ pub mod extension;
 pub mod futures;
 pub mod lifecycle;
 pub mod messaging;
+pub mod pattern;
 pub mod props;
 pub mod scheduler;
 pub mod serialization;

--- a/modules/actor/src/core/actor/actor_ref/base.rs
+++ b/modules/actor/src/core/actor/actor_ref/base.rs
@@ -6,6 +6,7 @@ mod tests;
 use core::{
   fmt,
   hash::{Hash, Hasher},
+  time::Duration,
 };
 
 use crate::core::{
@@ -17,6 +18,7 @@ use crate::core::{
   error::SendError,
   futures::ActorFutureShared,
   messaging::{AnyMessage, AskResponse, AskResult, system_message::SystemMessage},
+  pattern,
   system::state::{SystemStateShared, SystemStateWeak},
 };
 
@@ -138,6 +140,15 @@ impl ActorRef {
       system.register_ask_future(future.clone());
     }
     Ok(AskResponse::new(reply_ref, future))
+  }
+
+  /// Sends a request and arranges timeout completion on the returned ask future.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the request cannot be delivered.
+  pub fn ask_with_timeout(&self, message: AnyMessage, timeout: Duration) -> Result<AskResponse, SendError> {
+    pattern::ask_with_timeout(self, message, timeout)
   }
 
   /// Creates a placeholder reference that rejects all messages.

--- a/modules/actor/src/core/actor/child_ref.rs
+++ b/modules/actor/src/core/actor/child_ref.rs
@@ -1,6 +1,6 @@
 //! Handle used by parents to interact with child actors.
 
-use core::fmt;
+use core::{fmt, time::Duration};
 
 use crate::core::{
   actor::{Pid, actor_ref::ActorRef},
@@ -48,6 +48,15 @@ impl ChildRef {
   /// Returns an error when the message cannot be enqueued.
   pub fn ask(&mut self, message: AnyMessage) -> Result<AskResponse, SendError> {
     self.actor.ask(message)
+  }
+
+  /// Sends a request to the child actor and arranges timeout completion on the response future.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error when the message cannot be enqueued.
+  pub fn ask_with_timeout(&mut self, message: AnyMessage, timeout: Duration) -> Result<AskResponse, SendError> {
+    self.actor.ask_with_timeout(message, timeout)
   }
 
   /// Sends a stop signal to the child actor.

--- a/modules/actor/src/core/pattern.rs
+++ b/modules/actor/src/core/pattern.rs
@@ -1,0 +1,12 @@
+//! Pekko-inspired helper patterns built on top of core actor primitives.
+
+mod ask;
+mod graceful_stop;
+mod retry;
+
+pub use ask::ask_with_timeout;
+pub use graceful_stop::{graceful_stop, graceful_stop_with_message};
+pub use retry::retry;
+
+#[cfg(test)]
+mod tests;

--- a/modules/actor/src/core/pattern/ask.rs
+++ b/modules/actor/src/core/pattern/ask.rs
@@ -1,0 +1,70 @@
+//! Timeout-aware ask helpers.
+
+use core::time::Duration;
+
+use fraktor_utils_rs::core::sync::{ArcShared, SharedAccess};
+
+use crate::core::{
+  actor::actor_ref::ActorRef,
+  error::SendError,
+  futures::ActorFutureShared,
+  messaging::{AnyMessage, AskError, AskResponse, AskResult},
+  scheduler::{ExecutionBatch, SchedulerCommand, SchedulerRunnable},
+  system::state::SystemStateShared,
+};
+
+/// Sends a request and arranges timeout completion on the returned ask future.
+///
+/// # Errors
+///
+/// Returns an error if the request cannot be delivered.
+pub fn ask_with_timeout(
+  actor_ref: &ActorRef,
+  message: AnyMessage,
+  timeout: Duration,
+) -> Result<AskResponse, SendError> {
+  let response = actor_ref.ask(message)?;
+  if let Some(system) = actor_ref.system_state() {
+    install_ask_timeout(response.future(), &system, timeout);
+  } else {
+    complete_with_timeout(response.future());
+  }
+  Ok(response)
+}
+
+pub(crate) fn install_ask_timeout(
+  future: &ActorFutureShared<AskResult>,
+  system: &SystemStateShared,
+  timeout: Duration,
+) {
+  if timeout.is_zero() {
+    complete_with_timeout(future);
+    return;
+  }
+
+  let runnable: ArcShared<dyn SchedulerRunnable> = ArcShared::new(AskTimeoutRunnable { future: future.clone() });
+  let result = system.scheduler().with_write(|scheduler| {
+    scheduler
+      .schedule_command(timeout, SchedulerCommand::RunRunnable { runnable: runnable.clone(), dispatcher: None })
+  });
+  if result.is_err() {
+    complete_with_timeout(future);
+  }
+}
+
+fn complete_with_timeout(future: &ActorFutureShared<AskResult>) {
+  let waker = future.with_write(|inner| inner.complete(Err(AskError::Timeout)));
+  if let Some(waker) = waker {
+    waker.wake();
+  }
+}
+
+struct AskTimeoutRunnable {
+  future: ActorFutureShared<AskResult>,
+}
+
+impl SchedulerRunnable for AskTimeoutRunnable {
+  fn run(&self, _batch: &ExecutionBatch) {
+    complete_with_timeout(&self.future);
+  }
+}

--- a/modules/actor/src/core/pattern/graceful_stop.rs
+++ b/modules/actor/src/core/pattern/graceful_stop.rs
@@ -1,0 +1,64 @@
+//! Graceful stop helper.
+
+use core::{cmp, time::Duration};
+
+use fraktor_utils_rs::core::timing::delay::{DelayFuture, DelayProvider};
+
+use crate::core::{
+  actor::actor_ref::ActorRef,
+  messaging::{AnyMessage, AskError, system_message::SystemMessage},
+};
+
+const STOP_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Sends `PoisonPill` and waits until the target actor disappears from the system registry.
+///
+/// # Errors
+///
+/// Returns [`AskError::SendFailed`] when the stop message cannot be delivered,
+/// or [`AskError::Timeout`] when the actor does not stop before `timeout`.
+pub async fn graceful_stop(target: &ActorRef, timeout: Duration) -> Result<(), AskError> {
+  graceful_stop_with_message(target, AnyMessage::new(SystemMessage::PoisonPill), timeout).await
+}
+
+/// Sends the supplied stop message and waits until the target actor disappears from the system
+/// registry.
+///
+/// # Errors
+///
+/// Returns [`AskError::SendFailed`] when the stop message cannot be delivered,
+/// or [`AskError::Timeout`] when the actor does not stop before `timeout`.
+pub async fn graceful_stop_with_message(
+  target: &ActorRef,
+  stop_message: AnyMessage,
+  timeout: Duration,
+) -> Result<(), AskError> {
+  let Some(system) = target.system_state() else {
+    return Err(AskError::SendFailed);
+  };
+  let pid = target.pid();
+  if system.cell(&pid).is_none() {
+    return Ok(());
+  }
+  if target.tell(stop_message).is_err() {
+    if system.cell(&pid).is_none() {
+      return Ok(());
+    }
+    return Err(AskError::SendFailed);
+  }
+
+  let mut remaining = timeout;
+  let mut delay_provider = system.delay_provider();
+  loop {
+    if system.cell(&pid).is_none() {
+      return Ok(());
+    }
+    if remaining.is_zero() {
+      return Err(AskError::Timeout);
+    }
+    let delay_duration = cmp::min(remaining, STOP_POLL_INTERVAL);
+    let delay: DelayFuture = delay_provider.delay(delay_duration);
+    delay.await;
+    remaining = remaining.saturating_sub(delay_duration);
+  }
+}

--- a/modules/actor/src/core/pattern/retry.rs
+++ b/modules/actor/src/core/pattern/retry.rs
@@ -1,0 +1,45 @@
+//! Minimal retry helper.
+
+use core::{future::Future, time::Duration};
+
+use fraktor_utils_rs::core::timing::delay::{DelayFuture, DelayProvider};
+
+/// Retries an async operation up to `attempts` times with caller-provided delays.
+///
+/// The delay closure receives the 1-based retry index. For example, the first retry
+/// after an initial failure is invoked with `1`.
+///
+/// # Errors
+///
+/// Returns the last error produced by `operation` when all attempts are exhausted.
+///
+/// # Panics
+///
+/// Panics when `attempts` is zero.
+pub async fn retry<T, E, F, Fut, D>(
+  attempts: usize,
+  delay_provider: &mut impl DelayProvider,
+  mut delay_for: D,
+  mut operation: F,
+) -> Result<T, E>
+where
+  F: FnMut() -> Fut,
+  Fut: Future<Output = Result<T, E>>,
+  D: FnMut(usize) -> Duration, {
+  assert!(attempts > 0, "retry attempts must be greater than zero");
+
+  let mut current_attempt = 1;
+  loop {
+    match operation().await {
+      | Ok(value) => return Ok(value),
+      | Err(error) => {
+        if current_attempt >= attempts {
+          return Err(error);
+        }
+        let delay: DelayFuture = delay_provider.delay(delay_for(current_attempt));
+        delay.await;
+        current_attempt += 1;
+      },
+    }
+  }
+}

--- a/modules/actor/src/core/pattern/tests.rs
+++ b/modules/actor/src/core/pattern/tests.rs
@@ -1,0 +1,311 @@
+use alloc::{boxed::Box, vec::Vec};
+use core::{
+  future::{Future, ready},
+  pin::Pin,
+  sync::atomic::{AtomicUsize, Ordering},
+  task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+  time::Duration,
+};
+
+use fraktor_utils_rs::core::sync::{ArcShared, NoStdMutex, SharedAccess};
+
+use super::{graceful_stop, graceful_stop_with_message, retry};
+use crate::core::{
+  actor::{
+    Actor, ActorCell, ActorContext, Pid,
+    actor_ref::{ActorRef, ActorRefSender},
+  },
+  error::{ActorError, SendError},
+  messaging::{AnyMessage, AnyMessageView, AskError},
+  props::Props,
+  scheduler::{ExecutionBatch, SchedulerCommand, SchedulerRunnable},
+  system::ActorSystem,
+};
+
+struct ReplyingSender {
+  replies: ArcShared<NoStdMutex<Vec<u32>>>,
+}
+
+impl ActorRefSender for ReplyingSender {
+  fn send(&mut self, message: AnyMessage) -> Result<crate::core::actor::actor_ref::SendOutcome, SendError> {
+    if let Some(sender) = message.sender() {
+      sender.tell(AnyMessage::new(7_u32))?;
+      self.replies.lock().push(7);
+    }
+    Ok(crate::core::actor::actor_ref::SendOutcome::Delivered)
+  }
+}
+
+struct NoopActor;
+
+impl Actor for NoopActor {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}
+
+struct SilentSender;
+
+impl ActorRefSender for SilentSender {
+  fn send(&mut self, _message: AnyMessage) -> Result<crate::core::actor::actor_ref::SendOutcome, SendError> {
+    Ok(crate::core::actor::actor_ref::SendOutcome::Delivered)
+  }
+}
+
+struct DisappearingSender {
+  pid:    Pid,
+  system: crate::core::system::state::SystemStateShared,
+}
+
+impl ActorRefSender for DisappearingSender {
+  fn send(&mut self, message: AnyMessage) -> Result<crate::core::actor::actor_ref::SendOutcome, SendError> {
+    self.system.remove_cell(&self.pid);
+    Err(SendError::closed(message))
+  }
+}
+
+struct RemoveCellRunnable {
+  pid:    Pid,
+  system: crate::core::system::state::SystemStateShared,
+}
+
+impl SchedulerRunnable for RemoveCellRunnable {
+  fn run(&self, _batch: &ExecutionBatch) {
+    self.system.remove_cell(&self.pid);
+  }
+}
+
+fn poll_future<F>(mut future: Pin<&mut F>) -> Poll<F::Output>
+where
+  F: Future + ?Sized, {
+  let waker = noop_waker();
+  let mut context = Context::from_waker(&waker);
+  future.as_mut().poll(&mut context)
+}
+
+fn noop_waker() -> Waker {
+  const VTABLE: RawWakerVTable = RawWakerVTable::new(clone_waker, wake_noop, wake_by_ref_noop, drop_noop);
+
+  unsafe fn raw_waker() -> RawWaker {
+    // SAFETY: this no-op waker never dereferences the data pointer, so a null pointer is valid
+    // as long as every vtable function treats it as opaque.
+    RawWaker::new(core::ptr::null(), &VTABLE)
+  }
+
+  unsafe fn clone_waker(data: *const ()) -> RawWaker {
+    // SAFETY: cloning preserves the same opaque pointer and shares the same no-op vtable, so
+    // the cloned waker has identical behavior and ownership requirements.
+    RawWaker::new(data, &VTABLE)
+  }
+
+  unsafe fn wake_noop(_data: *const ()) {}
+
+  unsafe fn wake_by_ref_noop(_data: *const ()) {}
+
+  unsafe fn drop_noop(_data: *const ()) {}
+
+  // SAFETY: `raw_waker()` returns a `RawWaker` whose vtable never touches the null data pointer
+  // and whose clone/drop operations preserve those invariants.
+  unsafe { Waker::from_raw(raw_waker()) }
+}
+
+#[test]
+fn ask_with_timeout_completes_with_timeout_after_scheduler_tick() {
+  let system = ActorSystem::new_empty().state();
+  let replies = ArcShared::new(NoStdMutex::new(Vec::new()));
+  let actor = ActorRef::with_system(Pid::new(40, 0), ReplyingSender { replies }, &system);
+
+  let response = actor.ask_with_timeout(AnyMessage::new("ping"), Duration::from_millis(1)).expect("ask should send");
+  let result = response.future().with_write(|inner| inner.try_take()).expect("reply result");
+  let reply = result.expect("successful reply");
+  assert_eq!(reply.payload().downcast_ref::<u32>(), Some(&7_u32));
+}
+
+#[test]
+fn ask_with_timeout_without_system_times_out_immediately() {
+  let actor = ActorRef::new(Pid::new(41, 0), SilentSender);
+
+  let response = actor.ask_with_timeout(AnyMessage::new("ping"), Duration::from_millis(1)).expect("ask should send");
+
+  let result = response.future().with_write(|inner| inner.try_take()).expect("timeout result");
+  assert!(matches!(result, Err(AskError::Timeout)));
+}
+
+#[test]
+fn ask_with_timeout_times_out_after_scheduler_tick() {
+  let system = ActorSystem::new_empty();
+  let state = system.state();
+  let pid = state.allocate_pid();
+  let props = Props::from_fn(|| NoopActor);
+  let cell = ActorCell::create(state.clone(), pid, None, "ask-timeout".into(), &props).expect("create actor");
+  state.register_cell(cell.clone());
+
+  let response =
+    cell.actor_ref().ask_with_timeout(AnyMessage::new("ping"), Duration::from_millis(1)).expect("ask should send");
+  assert!(response.future().with_read(|inner| !inner.is_ready()));
+
+  state.scheduler().with_write(|scheduler| scheduler.run_for_test(1));
+
+  let result = response.future().with_write(|inner| inner.try_take()).expect("timeout result");
+  assert!(matches!(result, Err(AskError::Timeout)));
+}
+
+#[test]
+fn child_ref_ask_with_timeout_times_out_after_scheduler_tick() {
+  let system = ActorSystem::new_empty();
+  let state = system.state();
+  let parent_pid = state.allocate_pid();
+  let parent_props = Props::from_fn(|| NoopActor);
+  let parent_cell =
+    ActorCell::create(state.clone(), parent_pid, None, "parent".into(), &parent_props).expect("create parent");
+  state.register_cell(parent_cell);
+
+  let context = ActorContext::new(&system, parent_pid);
+  let child_props = Props::from_fn(|| NoopActor);
+  let mut child = context.spawn_child(&child_props).expect("spawn child");
+
+  let response = child.ask_with_timeout(AnyMessage::new("ping"), Duration::from_millis(1)).expect("ask should send");
+  assert!(response.future().with_read(|inner| !inner.is_ready()));
+
+  state.scheduler().with_write(|scheduler| scheduler.run_for_test(1));
+
+  let result = response.future().with_write(|inner| inner.try_take()).expect("timeout result");
+  assert!(matches!(result, Err(AskError::Timeout)));
+}
+
+#[test]
+fn graceful_stop_finishes_after_target_disappears() {
+  let system = ActorSystem::new_empty();
+  let state = system.state();
+  let pid = state.allocate_pid();
+  let props = Props::from_fn(|| NoopActor);
+  let cell = ActorCell::create(state.clone(), pid, None, "graceful".into(), &props).expect("create actor");
+  state.register_cell(cell.clone());
+
+  let runnable: ArcShared<dyn SchedulerRunnable> = ArcShared::new(RemoveCellRunnable { pid, system: state.clone() });
+  state.scheduler().with_write(|scheduler| {
+    scheduler
+      .schedule_command(Duration::from_millis(1), SchedulerCommand::RunRunnable { runnable, dispatcher: None })
+      .expect("schedule removal");
+  });
+
+  let actor_ref = cell.actor_ref();
+  let mut future = Box::pin(graceful_stop(&actor_ref, Duration::from_millis(5)));
+  match poll_future(future.as_mut()) {
+    | Poll::Ready(Ok(())) => {},
+    | Poll::Pending => {
+      state.scheduler().with_write(|scheduler| scheduler.run_for_test(1));
+      assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Ok(()))));
+    },
+    | other => panic!("unexpected graceful_stop result: {other:?}"),
+  }
+}
+
+#[test]
+fn graceful_stop_with_message_returns_timeout_when_target_stays_alive() {
+  let system = ActorSystem::new_empty();
+  let state = system.state();
+  let pid = state.allocate_pid();
+  let props = Props::from_fn(|| NoopActor);
+  let cell = ActorCell::create(state.clone(), pid, None, "stubborn".into(), &props).expect("create actor");
+  state.register_cell(cell.clone());
+
+  let actor_ref = cell.actor_ref();
+  let mut future = Box::pin(graceful_stop_with_message(&actor_ref, AnyMessage::new("stop"), Duration::from_millis(1)));
+  assert!(matches!(poll_future(future.as_mut()), Poll::Pending));
+
+  state.scheduler().with_write(|scheduler| scheduler.run_for_test(1));
+
+  assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Err(AskError::Timeout))));
+}
+
+#[test]
+fn graceful_stop_returns_send_failed_without_system() {
+  let actor_ref = ActorRef::new(Pid::new(90, 0), SilentSender);
+  let mut future = Box::pin(graceful_stop(&actor_ref, Duration::from_millis(1)));
+
+  assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Err(AskError::SendFailed))));
+}
+
+#[test]
+fn graceful_stop_succeeds_when_target_is_already_terminated() {
+  let system = ActorSystem::new_empty().state();
+  let actor_ref = ActorRef::with_system(Pid::new(91, 0), SilentSender, &system);
+  let mut future = Box::pin(graceful_stop(&actor_ref, Duration::from_millis(1)));
+
+  assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Ok(()))));
+}
+
+#[test]
+fn graceful_stop_returns_send_failed_when_stop_message_cannot_be_delivered() {
+  let system = ActorSystem::new_empty();
+  let state = system.state();
+  let pid = state.allocate_pid();
+  let props = Props::from_fn(|| NoopActor);
+  let cell = ActorCell::create(state.clone(), pid, None, "send-failed".into(), &props).expect("create actor");
+  state.register_cell(cell);
+
+  let actor_ref = ActorRef::with_system(pid, crate::core::actor::actor_ref::NullSender, &state);
+  let mut future = Box::pin(graceful_stop(&actor_ref, Duration::from_millis(1)));
+
+  assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Err(AskError::SendFailed))));
+}
+
+#[test]
+fn graceful_stop_succeeds_when_target_disappears_during_send() {
+  let system = ActorSystem::new_empty();
+  let state = system.state();
+  let pid = state.allocate_pid();
+  let props = Props::from_fn(|| NoopActor);
+  let cell = ActorCell::create(state.clone(), pid, None, "disappearing".into(), &props).expect("create actor");
+  state.register_cell(cell);
+
+  let actor_ref = ActorRef::with_system(pid, DisappearingSender { pid, system: state.clone() }, &state);
+  let mut future = Box::pin(graceful_stop(&actor_ref, Duration::from_millis(1)));
+
+  assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Ok(()))));
+}
+
+#[test]
+fn retry_returns_success_after_intermediate_failure() {
+  let system = ActorSystem::new_empty();
+  let mut delay_provider = system.delay_provider();
+  let attempts = ArcShared::new(AtomicUsize::new(0));
+  let attempts_for_op = attempts.clone();
+
+  let mut future = Box::pin(retry(
+    3,
+    &mut delay_provider,
+    |_| Duration::from_millis(1),
+    move || {
+      let current = attempts_for_op.fetch_add(1, Ordering::SeqCst);
+      if current == 0 { ready(Err::<u32, u32>(1)) } else { ready(Ok::<u32, u32>(7)) }
+    },
+  ));
+
+  assert!(matches!(poll_future(future.as_mut()), Poll::Pending));
+  system.scheduler().with_write(|scheduler| scheduler.run_for_test(1));
+  assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Ok(7))));
+}
+
+#[test]
+fn retry_returns_last_error_after_attempts_exhausted() {
+  let system = ActorSystem::new_empty();
+  let mut delay_provider = system.delay_provider();
+  let attempts = ArcShared::new(AtomicUsize::new(0));
+  let attempts_for_op = attempts.clone();
+
+  let mut future = Box::pin(retry(
+    2,
+    &mut delay_provider,
+    |_| Duration::from_millis(1),
+    move || {
+      let value = attempts_for_op.fetch_add(1, Ordering::SeqCst) as u32;
+      ready(Err::<u32, u32>(value + 1))
+    },
+  ));
+
+  assert!(matches!(poll_future(future.as_mut()), Poll::Pending));
+  system.scheduler().with_write(|scheduler| scheduler.run_for_test(1));
+  assert!(matches!(poll_future(future.as_mut()), Poll::Ready(Err(2))));
+}

--- a/modules/actor/src/std.rs
+++ b/modules/actor/src/std.rs
@@ -12,6 +12,9 @@ pub mod event;
 pub mod futures;
 /// Messaging primitives specialised for the standard toolbox.
 pub mod messaging;
+/// Pekko-inspired helper patterns for the standard toolbox.
+pub mod pattern; // allow module_wiring::no_parent_reexport
+pub use pattern::*;
 /// Props and dispatcher configuration bindings for the standard toolbox.
 pub mod props;
 /// Scheduler bindings for the standard toolbox.
@@ -20,4 +23,3 @@ pub mod scheduler;
 pub mod system;
 /// Typed actor utilities specialised for the standard toolbox runtime.
 pub mod typed;
-// allow module_wiring::no_parent_reexport

--- a/modules/actor/src/std/pattern.rs
+++ b/modules/actor/src/std/pattern.rs
@@ -1,0 +1,73 @@
+//! Pekko-inspired helper patterns for the standard toolbox.
+
+use core::{future::Future, time::Duration};
+
+use fraktor_utils_rs::core::timing::delay::DelayProvider;
+
+#[cfg(test)]
+mod tests;
+
+/// Sends a request and arranges timeout completion on the returned ask future.
+///
+/// # Errors
+///
+/// Returns an error if the request cannot be delivered.
+pub fn ask_with_timeout(
+  actor_ref: &crate::std::actor::ActorRef,
+  message: crate::std::messaging::AnyMessage,
+  timeout: Duration,
+) -> Result<crate::std::messaging::AskResponse, crate::std::error::SendError> {
+  crate::core::pattern::ask_with_timeout(actor_ref, message, timeout)
+}
+
+/// Sends `PoisonPill` and waits until the target actor disappears from the system registry.
+///
+/// # Errors
+///
+/// Returns [`crate::core::messaging::AskError::SendFailed`] when the stop message cannot be
+/// delivered, or [`crate::core::messaging::AskError::Timeout`] when the actor does not stop
+/// before `timeout`.
+pub async fn graceful_stop(
+  target: &crate::std::actor::ActorRef,
+  timeout: Duration,
+) -> Result<(), crate::core::messaging::AskError> {
+  crate::core::pattern::graceful_stop(target, timeout).await
+}
+
+/// Sends the supplied stop message and waits until the target actor disappears from the system
+/// registry.
+///
+/// # Errors
+///
+/// Returns [`crate::core::messaging::AskError::SendFailed`] when the stop message cannot be
+/// delivered, or [`crate::core::messaging::AskError::Timeout`] when the actor does not stop
+/// before `timeout`.
+pub async fn graceful_stop_with_message(
+  target: &crate::std::actor::ActorRef,
+  stop_message: crate::std::messaging::AnyMessage,
+  timeout: Duration,
+) -> Result<(), crate::core::messaging::AskError> {
+  crate::core::pattern::graceful_stop_with_message(target, stop_message, timeout).await
+}
+
+/// Retries an async operation up to `attempts` times with caller-provided delays.
+///
+/// # Errors
+///
+/// Returns the last error produced by `operation` when all attempts are exhausted.
+///
+/// # Panics
+///
+/// Panics when `attempts` is zero.
+pub async fn retry<T, E, F, Fut, D>(
+  attempts: usize,
+  delay_provider: &mut impl DelayProvider,
+  delay_for: D,
+  operation: F,
+) -> Result<T, E>
+where
+  F: FnMut() -> Fut,
+  Fut: Future<Output = Result<T, E>>,
+  D: FnMut(usize) -> Duration, {
+  crate::core::pattern::retry(attempts, delay_provider, delay_for, operation).await
+}

--- a/modules/actor/src/std/pattern/tests.rs
+++ b/modules/actor/src/std/pattern/tests.rs
@@ -1,0 +1,13 @@
+#[test]
+fn std_pattern_reexports_core_helpers() {
+  let _ = crate::std::pattern::ask_with_timeout;
+  let _ = crate::std::pattern::graceful_stop;
+  let _ = crate::std::pattern::graceful_stop_with_message;
+  let mut delay_provider = fraktor_utils_rs::core::timing::delay::ManualDelayProvider::new();
+  let _future = crate::std::pattern::retry(
+    1,
+    &mut delay_provider,
+    |_| core::time::Duration::ZERO,
+    || core::future::ready(Ok::<(), ()>(())),
+  );
+}


### PR DESCRIPTION
## Summary

## Execution Report

Piece `pekko-porting` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new core async patterns that schedule timeouts and poll for actor termination, touching message/ask flows and scheduler interactions; bugs here could cause spurious timeouts or hangs. Changes are mostly additive but introduce new public APIs on `ActorRef`/`ChildRef`.
> 
> **Overview**
> Adds a new `core::pattern` module exposing `ask_with_timeout`, `graceful_stop(_with_message)`, and `retry`, including scheduler-driven ask timeouts and a polling-based graceful shutdown that waits for actor deregistration.
> 
> Extends `ActorRef` and `ChildRef` with `ask_with_timeout`, adds `std::pattern` reexports, and includes comprehensive tests plus a new `pattern_api_no_std` example. Also adds the `references/takt` git submodule.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8284e235c31baf45b582a592f58c33f9385ea704. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->