### PR TITLE
fix(takt): prevent CI check timeout and false interruption

### DIFF
--- a/.takt/facets/instructions/pekko-porting-final-ci.md
+++ b/.takt/facets/instructions/pekko-porting-final-ci.md
@@ -4,8 +4,29 @@
 失敗時は、最初の失敗箇所（コマンドと要点）を短くまとめて報告してください。
 **重要**: 失敗時は Report Directory 内の `coder-decisions.md` にエラー詳細を追記すること（差し戻し先の fix ムーブメントがエラー内容を参照できるようにするため）。
 
-**必須実行:**
-1. `./scripts/ci-check.sh ai all`
+**実行方法（重要 — タイムアウト・誤中断回避）:**
+
+`ci-check.sh ai all` は全モジュールのビルド・テスト・lintを実行するため **15〜30分** かかります。
+
+**絶対にやってはいけないこと:**
+- 実行中に「出力が止まった」「フリーズした」と判断して中断すること。テストやlintのフェーズ間で数分間出力がないのは正常
+- バックグラウンドタスクの状態を繰り返し確認すること
+- 途中で再実行すること
+
+**実行手順:**
+1. 以下のコマンドを **`run_in_background: true`** で実行する:
+   ```
+   ./scripts/ci-check.sh ai all > /tmp/ci-check-result.txt 2>&1; echo "EXIT_CODE=$?" >> /tmp/ci-check-result.txt
+   ```
+2. **完了通知が来るまで何もせず待つ**。ポーリングしない。確認しない。待つだけ
+3. 完了通知を受け取ったら、結果を確認:
+   ```
+   tail -20 /tmp/ci-check-result.txt
+   ```
+4. 失敗した場合はエラー箇所を `grep` で特定:
+   ```
+   grep -E "^error|FAILED|Exit code" /tmp/ci-check-result.txt | head -20
+   ```
 
 **必須出力（見出しを含める）**
 ## 実行コマンド


### PR DESCRIPTION
- Use run_in_background with file redirect to avoid stream timeout
- Explicitly forbid polling/re-checking during execution
- Document that 15-30min execution time with silent phases is normal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that updates how to run the long `ci-check.sh ai all` command; no production code or runtime behavior is modified.
> 
> **Overview**
> Updates the `pekko-porting-final-ci.md` final-gate instructions to avoid CI check timeouts and accidental interruption by running `./scripts/ci-check.sh ai all` in the background with output redirected to a file.
> 
> Adds explicit guidance that the command can take 15–30 minutes with silent phases, forbids polling/re-running, and documents how to inspect results (`tail`) and quickly locate failures (`grep`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0415ba60ca3aec9ec38499e96a2417ef4b31d0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->