### PR TITLE
Fix issue triage findings for event-stream imports and stream contract tests

### DIFF
--- a/modules/actor/src/core/kernel/event/stream/event_stream_event/tests.rs
+++ b/modules/actor/src/core/kernel/event/stream/event_stream_event/tests.rs
@@ -4,18 +4,21 @@ use alloc::string::String;
 use core::time::Duration;
 
 #[cfg(feature = "alloc")]
-#[cfg(feature = "alloc")]
 use super::EventStreamEvent;
 #[cfg(feature = "alloc")]
-use crate::core::{
-  kernel::actor::Pid,
-  kernel::actor::actor_ref::dead_letter::DeadLetterEntry,
-  kernel::actor::lifecycle::{LifecycleEvent, LifecycleStage},
-  kernel::actor::messaging::AnyMessage,
-  kernel::dispatch::mailbox::metrics_event::MailboxMetricsEvent,
-  kernel::event::logging::{LogEvent, LogLevel},
-  kernel::event::stream::{AdapterFailureEvent, TypedUnhandledMessageEvent},
-  kernel::serialization::{SerializationErrorEvent, SerializerId},
+use crate::core::kernel::{
+  actor::{
+    Pid,
+    actor_ref::dead_letter::DeadLetterEntry,
+    lifecycle::{LifecycleEvent, LifecycleStage},
+    messaging::AnyMessage,
+  },
+  dispatch::mailbox::metrics_event::MailboxMetricsEvent,
+  event::{
+    logging::{LogEvent, LogLevel},
+    stream::{AdapterFailureEvent, TypedUnhandledMessageEvent},
+  },
+  serialization::{SerializationErrorEvent, SerializerId},
 };
 
 #[cfg(feature = "alloc")]

--- a/modules/stream/tests/pekko_porting_api_contracts.rs
+++ b/modules/stream/tests/pekko_porting_api_contracts.rs
@@ -312,3 +312,111 @@ fn flow_prepend_mat_is_public_and_preserves_existing_data_path_contract() {
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
+
+// ---------------------------------------------------------------------------
+// Flow::merge_mat — 公開 API 契約
+// ---------------------------------------------------------------------------
+
+// Flow::new().merge_mat() はソースノードが最初のノード（head_inlet
+// なし）となるグラフを作成するため、.via()/.into_mat() で上流を正しく接続できない。
+// マテリアライズ値の結合ロジックはユニットテスト merge_mat_combines_materialized_values
+// で検証済み。グラフ配線の実装が進んだら ignore を外して通常テストとして機能させる。
+#[test]
+#[ignore = "Flow::new().merge_mat() graph wiring limitation — mat combine verified in unit tests"]
+fn flow_merge_mat_is_public_and_combines_materialized_values() {
+  let flow =
+    Flow::<u32, u32, StreamNotUsed>::new().merge_mat(Source::single(9_u32).map_materialized_value(|_| 8_u32), KeepBoth);
+  let graph = Source::single(1_u32).via_mat(flow, KeepRight).into_mat(Sink::<u32, _>::ignore(), KeepLeft);
+
+  assert_eq!(graph.materialized(), &(StreamNotUsed::new(), 8_u32));
+}
+
+// Flow::new().merge_mat() を .via() 経由で使用すると、空のフローに上流接続用の head_inlet
+// がないため、マージステージの最初の入力が未接続のままになる。
+// データパスは Source::merge_mat 経由で正しく動作する（ユニットテスト参照）。
+// グラフ配線の実装が進んだら ignore を外して通常テストとして機能させる。
+#[test]
+#[ignore = "Flow::new().merge_mat() via .via() graph wiring limitation — use Source::merge_mat for data path"]
+fn flow_merge_mat_is_public_and_preserves_existing_data_path_contract() {
+  let values = Source::single(7_u32)
+    .via(
+      Flow::<u32, u32, StreamNotUsed>::new()
+        .merge_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft),
+    )
+    .collect_values()
+    .expect("collect_values");
+
+  assert!(values.contains(&7_u32));
+  assert!(values.contains(&8_u32));
+  assert_eq!(values.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Flow::merge_preferred_mat — 公開 API 契約
+// ---------------------------------------------------------------------------
+
+// merge_mat と同じグラフ配線の制限。マテリアライズ値の結合ロジックは
+// ユニットテスト merge_preferred_mat_combines_materialized_values で検証済み。
+// グラフ配線の実装が進んだら ignore を外して通常テストとして機能させる。
+#[test]
+#[ignore = "Flow::new().merge_preferred_mat() graph wiring limitation — mat combine verified in unit tests"]
+fn flow_merge_preferred_mat_is_public_and_combines_materialized_values() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new()
+    .merge_preferred_mat(Source::single(9_u32).map_materialized_value(|_| 8_u32), KeepBoth);
+  let graph = Source::single(1_u32).via_mat(flow, KeepRight).into_mat(Sink::<u32, _>::ignore(), KeepLeft);
+
+  assert_eq!(graph.materialized(), &(StreamNotUsed::new(), 8_u32));
+}
+
+// Flow::new().merge_preferred_mat() を .via() 経由で使用すると merge_mat
+// と同じグラフ配線の制限がある。データパスは Source::merge_preferred_mat 経由で動作する。
+// グラフ配線の実装が進んだら ignore を外して通常テストとして機能させる。
+#[test]
+#[ignore = "Flow::new().merge_preferred_mat() via .via() graph wiring limitation — use Source::merge_preferred_mat for data path"]
+fn flow_merge_preferred_mat_is_public_and_preserves_existing_data_path_contract() {
+  let values = Source::single(7_u32)
+    .via(
+      Flow::<u32, u32, StreamNotUsed>::new()
+        .merge_preferred_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft),
+    )
+    .collect_values()
+    .expect("collect_values");
+
+  assert!(values.contains(&7_u32));
+  assert!(values.contains(&8_u32));
+  assert_eq!(values.len(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Flow::merge_sorted_mat — 公開 API 契約
+// ---------------------------------------------------------------------------
+
+// merge_mat と同じグラフ配線の制限。マテリアライズ値の結合ロジックは
+// ユニットテスト merge_sorted_mat_combines_materialized_values で検証済み。
+// グラフ配線の実装が進んだら ignore を外して通常テストとして機能させる。
+#[test]
+#[ignore = "Flow::new().merge_sorted_mat() graph wiring limitation — mat combine verified in unit tests"]
+fn flow_merge_sorted_mat_is_public_and_combines_materialized_values() {
+  let flow = Flow::<u32, u32, StreamNotUsed>::new()
+    .merge_sorted_mat(Source::single(9_u32).map_materialized_value(|_| 8_u32), KeepBoth);
+  let graph = Source::single(1_u32).via_mat(flow, KeepRight).into_mat(Sink::<u32, _>::ignore(), KeepLeft);
+
+  assert_eq!(graph.materialized(), &(StreamNotUsed::new(), 8_u32));
+}
+
+// Flow::new().merge_sorted_mat() を .via() 経由で使用すると merge_mat
+// と同じグラフ配線の制限がある。データパスは Source::merge_sorted_mat 経由で動作する。
+// グラフ配線の実装が進んだら ignore を外して通常テストとして機能させる。
+#[test]
+#[ignore = "Flow::new().merge_sorted_mat() via .via() graph wiring limitation — use Source::merge_sorted_mat for data path"]
+fn flow_merge_sorted_mat_is_public_and_preserves_existing_data_path_contract() {
+  let values = Source::from_array([1_u32, 3_u32, 5_u32])
+    .via(
+      Flow::<u32, u32, StreamNotUsed>::new()
+        .merge_sorted_mat(Source::from_array([2_u32, 4_u32, 6_u32]).map_materialized_value(|_| 99_u32), KeepLeft),
+    )
+    .collect_values()
+    .expect("collect_values");
+
+  assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32, 5_u32, 6_u32]);
+}


### PR DESCRIPTION
## Summary
- align the event stream test imports with the repository's kernel import style
- restore the documented ignored `Flow::merge_*_mat` contract tests removed by mistake
- clarify in comments that the ignored tests should become active once graph wiring is implemented

## Validation
- cargo test -p fraktor-stream-rs --test pekko_porting_api_contracts
- ./scripts/ci-check.sh ai all

Closes #1409
Closes #1417

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to tests and import organization, with newly added tests explicitly `#[ignore]` so they don’t affect CI execution.
> 
> **Overview**
> Aligns `event_stream_event` test imports to the repository’s `crate::core::kernel::{...}` grouping style (no functional behavior change).
> 
> Restores previously removed *public API contract* tests for `Flow::merge_mat`, `Flow::merge_preferred_mat`, and `Flow::merge_sorted_mat` in `pekko_porting_api_contracts.rs`; the tests remain `#[ignore]` and add comments documenting current graph-wiring limitations until the implementation supports upstream connection via `.via()`/`.into_mat()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6367bd418a3168b7751d0af381bf07d5752e9d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * 内部モジュールのインポートパス構造を整理しました

* **テスト**
  * API仕様検証用の新しいテストケースを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->