### PR TITLE
fix(mailbox): remove outer lock from dequeue/metrics, rename to put_lock

### DIFF
--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs
@@ -35,7 +35,16 @@ pub struct Mailbox {
   policy:          MailboxPolicy,
   system:          SystemQueue,
   user:            Box<dyn MessageQueue>,
-  user_queue_lock: MailboxLocked<()>,
+  /// Compound-op lock (Pekko `putLock` equivalent).
+  ///
+  /// Protects multi-step operations that must be atomic with respect to
+  /// `finalize_cleanup`: `enqueue_envelope_locked` (is_closed + enqueue),
+  /// `prepend_user_messages_deque_locked` (is_closed + O(k) prepend), and
+  /// `finalize_cleanup` itself (drain + clean_up + finish_cleanup).
+  ///
+  /// Single-step operations (dequeue, metrics reads) do **not** acquire
+  /// this lock — the inner queue mutex provides sufficient synchronization.
+  put_lock:        MailboxLocked<()>,
   state:           MailboxScheduleState,
   /// Write-once instrumentation hooks. Set once via
   /// [`set_instrumentation`](Self::set_instrumentation), read lock-free thereafter via
@@ -115,7 +124,7 @@ impl Mailbox {
       policy,
       system: SystemQueue::new(),
       user: queue,
-      user_queue_lock: shared_set.user_queue_lock(),
+      put_lock: shared_set.put_lock(),
       state: MailboxScheduleState::new(),
       instrumentation: Once::new(),
       cleanup_policy: MailboxCleanupPolicy::DrainToDeadLetters,
@@ -147,7 +156,7 @@ impl Mailbox {
       policy,
       system: SystemQueue::new(),
       user: queue,
-      user_queue_lock: shared_set.user_queue_lock(),
+      put_lock: shared_set.put_lock(),
       state: MailboxScheduleState::new(),
       instrumentation: Once::new(),
       cleanup_policy: MailboxCleanupPolicy::LeaveSharedQueue,
@@ -185,7 +194,7 @@ impl Mailbox {
       policy,
       system: SystemQueue::new(),
       user: queue,
-      user_queue_lock: shared_set.user_queue_lock(),
+      put_lock: shared_set.put_lock(),
       state: MailboxScheduleState::new(),
       instrumentation: Once::new(),
       cleanup_policy: MailboxCleanupPolicy::DrainToDeadLetters,
@@ -415,13 +424,13 @@ impl Mailbox {
 
   /// Locked critical section of [`Self::enqueue_envelope`].
   ///
-  /// Acquires `user_queue_lock` and performs the authoritative close
+  /// Acquires `put_lock` and performs the authoritative close
   /// re-check before handing the envelope to the underlying queue. This
   /// must only be called from [`Self::enqueue_envelope`] in production
   /// code; the fast path preceding this method is what makes the common
   /// closed / suspended paths lock-free.
   fn enqueue_envelope_locked(&self, envelope: Envelope) -> Result<(), SendError> {
-    let enqueue_result = self.user_queue_lock.with_lock(|_| {
+    let enqueue_result = self.put_lock.with_lock(|_| {
       // Authoritative re-check under lock: cleanup may have won the lock
       // race between the fast path and this acquisition. Without this, a
       // producer could phantom-enqueue into a drained queue.
@@ -478,7 +487,7 @@ impl Mailbox {
 
   /// Locked critical section of [`Self::prepend_user_messages_deque`].
   ///
-  /// Acquires `user_queue_lock`, performs the authoritative close re-check,
+  /// Acquires `put_lock`, performs the authoritative close re-check,
   /// and prepends in O(k). Must only be called
   /// from [`Self::prepend_user_messages_deque`] after the fast path has cleared.
   fn prepend_user_messages_deque_locked(
@@ -487,7 +496,7 @@ impl Mailbox {
     messages: &VecDeque<AnyMessage>,
     first_message: AnyMessage,
   ) -> Result<(), SendError> {
-    self.user_queue_lock.with_lock(|_| {
+    self.put_lock.with_lock(|_| {
       // Authoritative re-check under lock: cleanup may have won the lock race
       // between the fast path and this acquisition.
       if self.is_closed() {
@@ -527,12 +536,7 @@ impl Mailbox {
       return None;
     }
 
-    let result = self.user_queue_lock.with_lock(|_| {
-      if self.state.is_close_requested() {
-        return None;
-      }
-      self.user.dequeue().map(MailboxMessage::User)
-    });
+    let result = if self.state.is_close_requested() { None } else { self.user.dequeue().map(MailboxMessage::User) };
     if result.is_some() {
       self.publish_metrics();
     }
@@ -617,7 +621,7 @@ impl Mailbox {
   fn finalize_cleanup(&self) {
     let pid = self.pid();
     let system_state = self.system_state();
-    let user_len_after_cleanup = self.user_queue_lock.with_lock(|_| {
+    let user_len_after_cleanup = self.put_lock.with_lock(|_| {
       if matches!(self.cleanup_policy, MailboxCleanupPolicy::DrainToDeadLetters) {
         while let Some(envelope) = self.user.dequeue() {
           if let Some(ref state) = system_state {
@@ -648,7 +652,7 @@ impl Mailbox {
   /// Returns the number of user messages awaiting processing.
   #[must_use]
   pub(crate) fn user_len(&self) -> usize {
-    self.user_queue_lock.with_read(|_| self.user.number_of_messages())
+    self.user.number_of_messages()
   }
 
   /// Returns the number of system messages awaiting processing.
@@ -664,8 +668,7 @@ impl Mailbox {
   }
 
   fn publish_metrics(&self) {
-    let user_len = self.user_queue_lock.with_read(|_| self.user.number_of_messages());
-    self.publish_metrics_with_user_len(user_len);
+    self.publish_metrics_with_user_len(self.user.number_of_messages());
   }
 
   fn publish_metrics_with_user_len(&self, user_len: usize) {

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/base/tests.rs
@@ -590,7 +590,7 @@ fn mailbox_prepend_user_messages_deque_returns_closed_after_mailbox_close() {
 /// critical section must observe the authoritative `is_closed()` re-check
 /// when cleanup has closed the state.
 ///
-/// The test thread takes `user_queue_lock`, starts a producer, waits until the
+/// The test thread takes `put_lock`, starts a producer, waits until the
 /// producer is blocked on the same lock, then closes and cleans the mailbox
 /// while still holding the lock. Once the lock is released, the producer must
 /// observe the under-lock `is_closed()` re-check and fail with `Closed`.
@@ -607,7 +607,7 @@ fn cleanup_close_wins_against_inflight_enqueue() {
   let (release_lock_tx, release_lock_rx) = mpsc::channel();
   let mailbox_for_lock = Arc::clone(&mailbox);
   let lock_handle = thread::spawn(move || {
-    mailbox_for_lock.user_queue_lock.with_lock(|_| {
+    mailbox_for_lock.put_lock.with_lock(|_| {
       lock_held_tx.send(()).expect("lock 取得シグナルが送信されるべき");
       release_lock_rx.recv().expect("lock 解放シグナルを受信できるべき");
     });
@@ -623,10 +623,7 @@ fn cleanup_close_wins_against_inflight_enqueue() {
   });
 
   started_rx.recv().expect("enqueue スレッドが起動するべき");
-  assert!(
-    result_rx.recv_timeout(Duration::from_millis(200)).is_err(),
-    "producer は user_queue_lock 上でブロックされるべき",
-  );
+  assert!(result_rx.recv_timeout(Duration::from_millis(200)).is_err(), "producer は put_lock 上でブロックされるべき",);
 
   assert_eq!(mailbox.state.request_close(), CloseRequestOutcome::CallerOwnsFinalizer);
   mailbox.user.clean_up();
@@ -660,7 +657,7 @@ fn cleanup_close_wins_against_inflight_prepend() {
   let (release_lock_tx, release_lock_rx) = mpsc::channel();
   let mailbox_for_lock = Arc::clone(&mailbox);
   let lock_handle = thread::spawn(move || {
-    mailbox_for_lock.user_queue_lock.with_lock(|_| {
+    mailbox_for_lock.put_lock.with_lock(|_| {
       lock_held_tx.send(()).expect("lock 取得シグナルが送信されるべき");
       release_lock_rx.recv().expect("lock 解放シグナルを受信できるべき");
     });
@@ -678,10 +675,7 @@ fn cleanup_close_wins_against_inflight_prepend() {
   });
 
   started_rx.recv().expect("prepend スレッドが起動するべき");
-  assert!(
-    result_rx.recv_timeout(Duration::from_millis(200)).is_err(),
-    "prepend は user_queue_lock 上でブロックされるべき",
-  );
+  assert!(result_rx.recv_timeout(Duration::from_millis(200)).is_err(), "prepend は put_lock 上でブロックされるべき",);
 
   assert_eq!(mailbox.state.request_close(), CloseRequestOutcome::CallerOwnsFinalizer);
   mailbox.user.clean_up();

--- a/modules/actor-core/src/core/kernel/system/shared_factory/mailbox_shared_set.rs
+++ b/modules/actor-core/src/core/kernel/system/shared_factory/mailbox_shared_set.rs
@@ -2,30 +2,31 @@
 
 use fraktor_utils_core_rs::core::sync::{DefaultMutex, SharedLock};
 
-/// Lock bundle used by mailbox hot-path state.
+/// Lock bundle used by mailbox compound-op synchronization.
 ///
-/// Currently holds only the `user_queue_lock` barrier. The former
-/// `invoker` / `actor` / `instrumentation` fields were write-once and are now
-/// stored directly in [`Mailbox`](crate::core::kernel::dispatch::mailbox::Mailbox)
-/// as `spin::Once<T>` for lock-free reads on the hot path.
+/// Holds only the `put_lock` barrier (Pekko `putLock` equivalent).
+/// The former `invoker` / `actor` / `instrumentation` fields were write-once
+/// and are now stored directly in
+/// [`Mailbox`](crate::core::kernel::dispatch::mailbox::Mailbox) as
+/// `spin::Once<T>` for lock-free reads on the hot path.
 #[derive(Clone)]
 pub struct MailboxSharedSet {
-  user_queue_lock: MailboxLocked<()>,
+  put_lock: MailboxLocked<()>,
 }
 
 impl MailboxSharedSet {
   /// Creates a mailbox lock bundle from an already materialized shared lock.
   #[must_use]
-  pub(crate) const fn new(user_queue_lock: MailboxLocked<()>) -> Self {
-    Self { user_queue_lock }
+  pub(crate) const fn new(put_lock: MailboxLocked<()>) -> Self {
+    Self { put_lock }
   }
 
   pub(crate) fn builtin() -> Self {
     Self::new(MailboxLocked::new_with_driver::<DefaultMutex<()>>(()))
   }
 
-  pub(crate) fn user_queue_lock(&self) -> MailboxLocked<()> {
-    self.user_queue_lock.clone()
+  pub(crate) fn put_lock(&self) -> MailboxLocked<()> {
+    self.put_lock.clone()
   }
 }
 

--- a/openspec/changes/mailbox-outer-lock-reduction/design.md
+++ b/openspec/changes/mailbox-outer-lock-reduction/design.md
@@ -1,61 +1,81 @@
 ## Context
 
-Mailbox の `user_queue_lock: SharedLock<()>` は全 enqueue/dequeue で取得される barrier lock。調査 A の結果、7 箇所のうち compound op は 2 箇所のみで、残り 5 箇所は外側 lock 不要。Pekko の `putLock` は compound op 時のみ取得する設計であり、これに準拠する。
+Mailbox の `user_queue_lock: SharedLock<()>` は全 enqueue/dequeue で取得される barrier lock。調査 A の結果、6 箇所のうち compound op は 3 箇所（enqueue, prepend, finalize_cleanup）で、残り 3 箇所（dequeue, user_len, publish_metrics）は外側 lock 不要。
 
 前提条件（close correctness, stash deque requirement, prepend deque-only 契約）は全て完了済み。
 
 ## Goals / Non-Goals
 
 **Goals:**
-- 通常 enqueue/dequeue/read から `user_queue_lock` の取得を除去
-- compound op (prepend, close+cleanup) のみ `put_lock` として取得
+- dequeue / metrics 読み取りから `user_queue_lock` の取得を除去
+- compound op (enqueue+close-check, prepend, close+cleanup) は `put_lock` として維持
 - ベンチマークで効果を計測
 
 **Non-Goals:**
+- enqueue 側の lock 除去（TOCTOU race のため不可）
 - 内側 lock (QueueStateHandle, SyncQueueShared) の統合
 - lock-free queue への移行
 - `put_lock` 自体の撤廃
 
 ## Decisions
 
-### 1. user_queue_lock → put_lock への改名と限定化（案 a2 採用）
+### 1. user_queue_lock → put_lock への改名と限定化
 
-`docs/plan/lock-strategy-analysis.md` の案 a2 を採用:
+`docs/plan/lock-strategy-analysis.md` の案 a2 を部分採用。dequeue / metrics のみ lock 除去:
 
 ```rust
-// Before: 全 enqueue/dequeue で取得
-pub(crate) fn enqueue_envelope_locked(&self, envelope: Envelope) -> Result<(), SendError> {
-  self.user_queue_lock.with_lock(|_| {
-    if self.is_closed() { return Err(...); }
-    self.user.enqueue(envelope)
-  })
+// Before: dequeue で取得
+pub(crate) fn dequeue(&self) -> Option<MailboxMessage> {
+  let result = self.user_queue_lock.with_lock(|_| {
+    if self.state.is_close_requested() {
+      return None;
+    }
+    self.user.dequeue().map(MailboxMessage::User)
+  });
+  ...
 }
 
-// After: 通常 enqueue では取得しない
-pub(crate) fn enqueue_envelope_locked(&self, envelope: Envelope) -> Result<(), SendError> {
-  if self.is_closed() { return Err(SendError::closed(...)); }
-  self.user.enqueue(envelope)
+// After: dequeue では取得しない
+pub(crate) fn dequeue(&self) -> Option<MailboxMessage> {
+  let result = {
+    if self.state.is_close_requested() {
+      None
+    } else {
+      self.user.dequeue().map(MailboxMessage::User)
+    }
+  };
+  ...
 }
 ```
 
-### 2. close correctness の維持
+### 2. enqueue 側の lock を維持する理由（TOCTOU race 分析）
 
-`enqueue_envelope_locked` から lock を外すと、`become_closed_and_clean_up` との race が理論上起きる。しかし:
+`enqueue_envelope_locked` は `is_closed()` チェック + `user.enqueue()` の compound op。lock を外すと以下の race が発生:
 
-1. `is_closed()` は atomic flag チェック（lock 不要）
-2. `become_closed_and_clean_up` は `put_lock` を取得し、close flag を立ててから drain する
-3. close flag が立った後の enqueue は `is_closed()` で弾かれる
-4. flag 立て → drain の間に到着したメッセージは drain で回収される
+```
+Producer                          Closer (finalize_cleanup)
+────────                          ──────
+is_closed() → false
+                                  request_close() → FLAG_CLOSE_REQUESTED (lock 外)
+                                  finalize_cleanup() acquires put_lock
+                                    drain all messages
+                                    clean_up()          ← queue リセット
+                                    finish_cleanup()    ← FLAG_CLEANUP_DONE
+                                  release put_lock
+user.enqueue(msg)                 ← phantom enqueue into cleaned queue
+```
 
-ただし `is_closed()` チェックと `user.enqueue()` の間に close が起きると、enqueue 成功後に drain が走る。これは Pekko でも同じ挙動（atomic flag ベースなので同一の race window が存在）であり、許容される。drain がメッセージを dead letters に転送するため、メッセージは失われない。
+`clean_up()` 後に enqueue されたメッセージは drain されず失われる。Pekko は lock-free queue（`AbstractNodeQueue`）を使うため drain 後の enqueue は次回 drain で回収されるが、fraktor-rs の queue 実装では保証されない。
 
-### 3. dequeue の lock 除去
+したがって、lock-free queue 導入（Phase VII）まで enqueue 側の lock は維持する。
 
-dequeue は single consumer (dispatcher thread の `run()` ループ)。producer (enqueue) との同期は内部 queue の mutex で担保される。compound op (prepend) との排他は `put_lock` で担保される。したがって dequeue 側で `user_queue_lock` を取る必要はない。
+### 3. dequeue の lock 除去の安全性
 
-ただし `prepend_user_messages_deque_locked` が dequeue と同時に走る可能性がある。prepend は `put_lock` を取得するが、dequeue は取得しない場合、prepend 中に dequeue が割り込む。
+dequeue は single consumer（dispatcher thread の `run()` ループ、`FLAG_RUNNING` で排他）。
 
-対策: `prepend_user_messages_deque_locked` は **deque の内部 lock** を取得して操作するため、dequeue と prepend は内部 lock で直列化される。外側 lock は不要。
+- producer (enqueue) との同期: 内部 queue の mutex で担保
+- compound op (prepend) との排他: prepend は内部 queue の deque API (`enqueue_first`) を使うため、内部 mutex で直列化される
+- close check (`is_close_requested()`): atomic flag チェック。dequeue 側で TOCTOU があっても、close 後に dequeue が空を返すだけで harm はない
 
 ### 4. metrics の近似値許容
 
@@ -63,8 +83,8 @@ dequeue は single consumer (dispatcher thread の `run()` ループ)。producer
 
 ## Risks / Trade-offs
 
-- [Risk] close race window でメッセージが close 後に enqueue される → Mitigation: drain が dead letters に転送するため失われない。Pekko と同じ挙動
-- [Risk] prepend と dequeue の並行実行 → Mitigation: 内部 queue の mutex で直列化される
+- [Risk] dequeue と prepend の並行実行 → Mitigation: 内部 queue の mutex で直列化される
+- [Risk] dequeue と close の並行実行 → Mitigation: close 後に dequeue が空を返すだけ。harm なし
 - [Risk] 将来の compound op 追加時に put_lock の取得を忘れる → Mitigation: put_lock のドキュメントに「compound op では必ず取得」を明記
 
 ## Open Questions

--- a/openspec/changes/mailbox-outer-lock-reduction/proposal.md
+++ b/openspec/changes/mailbox-outer-lock-reduction/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-`docs/plan/lock-strategy-analysis.md` の調査 A で判明した通り、Mailbox の `user_queue_lock` は **全ての enqueue/dequeue で取得されている** が、本来は compound op（prepend、close+cleanup）との排他のためだけに存在する。
+`docs/plan/lock-strategy-analysis.md` の調査 A で判明した通り、Mailbox の `user_queue_lock` は **全ての enqueue/dequeue で取得されている** が、本来は compound op（enqueue+close-check、prepend、close+cleanup）との排他のためだけに存在する。
 
 現状のロック段数:
 - `BoundedMessageQueue` 経路: **3 段** (user_queue_lock → QueueStateHandle → SyncQueueShared)
@@ -8,11 +8,22 @@
 
 参照実装（Pekko / protoactor-go）は通常 enqueue で **0 段**（lock-free queue ベース）。
 
-通常の enqueue/dequeue から `user_queue_lock` を外すことで:
-- Bounded: 3 → 2 段
-- Unbounded: 2 → 1 段
+dequeue / metrics 読み取りから `user_queue_lock` を外すことで:
+- dequeue 側: Bounded 3 → 2 段、Unbounded 2 → 1 段
+- metrics 読み取り: lock-free 化
 
 に削減できる。
+
+### enqueue 側の lock は維持する理由
+
+`enqueue_envelope_locked` は `is_closed()` チェック + `user.enqueue()` を compound op として `user_queue_lock` で保護している。この lock を外すと TOCTOU race が発生する:
+
+1. producer が `is_closed() → false` を確認
+2. closer が `request_close()` で `FLAG_CLOSE_REQUESTED` を立てる（lock 外）
+3. closer が `finalize_cleanup()` で lock を取得し、drain + `clean_up()` + `finish_cleanup()` を実行
+4. producer が `user.enqueue(msg)` を実行 → **cleaned queue への phantom enqueue**
+
+Pekko は lock-free queue を使うため drain 後の enqueue が次回 drain で回収されるが、fraktor-rs の現在の queue 実装では `clean_up()` 後に enqueue されたメッセージは回収されない。したがって enqueue 側の lock は維持する。
 
 ## 前提条件（全て充足済み）
 
@@ -25,28 +36,31 @@
 
 ## What Changes
 
-- `Mailbox::enqueue_envelope_locked` から `user_queue_lock` の取得を除去する（内部 queue の mutex で十分）
-- `Mailbox::dequeue` から `user_queue_lock` の取得を除去する（single consumer + 内部 queue の mutex で十分）
-- `Mailbox::user_len` / `Mailbox::publish_metrics` から `user_queue_lock` の取得を除去する（metrics は厳密でなくてよい）
-- `user_queue_lock` を `put_lock` に改名し、以下の compound op **のみ** で取得する:
-  - `prepend_user_messages_deque_locked`（deque prepend の atomicity 保証）
-  - `become_closed_and_clean_up`（close + drain の直列化）
-- Pekko の `BoundedControlAwareMailbox.putLock` と同じ責務に限定
+- `user_queue_lock` を `put_lock` に改名し、Pekko の `BoundedControlAwareMailbox.putLock` と同じ責務に限定
+- 以下の **3 箇所** から `put_lock` の取得を除去:
+  - `Mailbox::dequeue`（single consumer — `FLAG_RUNNING` で保護、内部 queue の mutex で十分）
+  - `Mailbox::user_len`（metrics 読み取り — 近似値許容、内部 queue の mutex で十分）
+  - `Mailbox::publish_metrics`（同上）
+- 以下の **3 箇所** は `put_lock` を維持:
+  - `enqueue_envelope_locked`（`is_closed()` + `enqueue` の compound op — TOCTOU race 防止）
+  - `prepend_user_messages_deque_locked`（`is_closed()` + O(k) prepend の compound op）
+  - `finalize_cleanup`（drain + `clean_up()` + `finish_cleanup()` の serialization anchor）
 
 ## Capabilities
 
 ### Modified Capabilities
-- `mailbox-enqueue-performance`: 通常 enqueue の lock 段数が 1 段減少
-- `mailbox-dequeue-performance`: 通常 dequeue の lock 段数が 1 段減少
+- `mailbox-dequeue-performance`: dequeue の lock 段数が 1 段減少
+- `mailbox-metrics-performance`: metrics 読み取りが lock-free 化
 
 ## Impact
 
 - 対象コード: `modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs`
 - 影響内容:
-  - 通常 enqueue/dequeue の hot path から Mutex 1 段除去
-  - compound op (prepend, close+cleanup) は lock を維持（安全性に影響なし）
-  - metrics 読み取りは近似値を許容（中間値が見える可能性あるが致命的でない）
+  - dequeue の hot path から Mutex 1 段除去
+  - metrics 読み取りから Mutex 除去
+  - enqueue / compound op (prepend, close+cleanup) は lock を維持（安全性に影響なし）
 - 非目標:
+  - enqueue 側の lock 除去（TOCTOU race のため現時点では不可）
   - 内側 2 段（QueueStateHandle + SyncQueueShared）の統合（別 change）
-  - MessageQueue の lock-free 化（Phase VII）
+  - MessageQueue の lock-free 化（Phase VII — lock-free queue 導入後に enqueue 側 lock も除去可能）
   - stream-core の同型問題（Phase IX）

--- a/openspec/changes/mailbox-outer-lock-reduction/specs/outer-lock-reduction/spec.md
+++ b/openspec/changes/mailbox-outer-lock-reduction/specs/outer-lock-reduction/spec.md
@@ -1,23 +1,32 @@
 ## ADDED Requirements
 
-### Requirement: 通常 enqueue/dequeue は user_queue_lock (put_lock) を取得してはならない
+### Requirement: dequeue と metrics 読み取りは put_lock を取得してはならない
 
-通常の単一 enqueue (`enqueue_envelope_locked`) および単一 dequeue (`dequeue`) は `put_lock` を取得してはならない（MUST NOT）。内部 queue の mutex のみで同期する。
-
-#### Scenario: 通常 enqueue で put_lock を取得しない
-
-- **WHEN** `enqueue_envelope_locked` が呼ばれる
-- **THEN** `put_lock` (旧 `user_queue_lock`) の lock 取得は行われない
-- **AND** 内部 queue の `enqueue` メソッドのみが呼ばれる
-- **AND** close チェックは atomic flag (`is_closed()`) で行われる
+通常の単一 dequeue (`dequeue`) および metrics 読み取り (`user_len`, `publish_metrics`) は `put_lock` を取得してはならない（MUST NOT）。内部 queue の mutex のみで同期する。
 
 #### Scenario: 通常 dequeue で put_lock を取得しない
 
 - **WHEN** `dequeue` が呼ばれる
-- **THEN** `put_lock` の lock 取得は行われない
+- **THEN** `put_lock` (旧 `user_queue_lock`) の lock 取得は行われない
 - **AND** 内部 queue の `dequeue` メソッドのみが呼ばれる
 
-### Requirement: compound op は put_lock を取得しなければならない
+#### Scenario: metrics 読み取りで put_lock を取得しない
+
+- **WHEN** `user_len` または `publish_metrics` が呼ばれる
+- **THEN** `put_lock` の lock 取得は行われない
+- **AND** 内部 queue の `number_of_messages` メソッドのみが呼ばれる
+
+### Requirement: enqueue の compound op は put_lock を取得しなければならない
+
+`enqueue_envelope_locked` は `is_closed()` チェック + `user.enqueue()` の compound op であり、`put_lock` を取得しなければならない（MUST）。lock を外すと `finalize_cleanup` との TOCTOU race で phantom enqueue が発生する。
+
+#### Scenario: enqueue は put_lock で保護される
+
+- **WHEN** `enqueue_envelope_locked` が呼ばれる
+- **THEN** `put_lock` を取得してから `is_closed()` チェック + `user.enqueue()` を実行する
+- **AND** `finalize_cleanup` の drain + `clean_up()` と直列化される
+
+### Requirement: prepend と close+cleanup の compound op は put_lock を取得しなければならない
 
 複数の queue 操作を atomic 化する compound op（prepend、close+cleanup）は `put_lock` を取得しなければならない（MUST）。
 
@@ -25,21 +34,21 @@
 
 - **WHEN** `prepend_user_messages_deque_locked` が呼ばれる
 - **THEN** `put_lock` を取得してから deque 操作を行う
-- **AND** lock 保持中に capacity チェック → 複数 enqueue_first を atomic に実行する
+- **AND** lock 保持中に `is_closed()` チェック → 複数 `enqueue_first` を atomic に実行する
 
-#### Scenario: close+cleanup は put_lock で保護される
+#### Scenario: finalize_cleanup は put_lock で保護される
 
-- **WHEN** `become_closed_and_clean_up` が呼ばれる
-- **THEN** `put_lock` を取得してから drain を行う
-- **AND** close flag 立て → drain が直列化される
+- **WHEN** `finalize_cleanup` が呼ばれる
+- **THEN** `put_lock` を取得してから drain + `clean_up()` + `finish_cleanup()` を行う
+- **AND** enqueue / prepend と直列化される
 
 ### Requirement: close 後のメッセージは失われてはならない
 
-close race window（`is_closed()` チェック → `user.enqueue()` の間に close が起きる）で到着したメッセージは、drain で dead letters に転送されなければならない（MUST）。
+enqueue の compound op が `put_lock` で保護されていることで、`is_closed()` が false を返した後に close が起きた場合でも、`finalize_cleanup` の drain で確実に回収される。
 
 #### Scenario: close 直前の enqueue はメッセージを失わない
 
-- **GIVEN** producer が `is_closed()` チェックを通過した直後に close が実行される
-- **WHEN** producer が `user.enqueue(envelope)` を完了する
-- **THEN** `become_closed_and_clean_up` の drain でそのメッセージが回収される
-- **AND** dead letters に転送される
+- **GIVEN** producer が `put_lock` を取得し `is_closed() → false` を確認
+- **WHEN** lock 保持中に `user.enqueue(envelope)` を完了する
+- **THEN** `finalize_cleanup` は put_lock 取得を待ってから drain する
+- **AND** そのメッセージは drain で回収され dead letters に転送される

--- a/openspec/changes/mailbox-outer-lock-reduction/tasks.md
+++ b/openspec/changes/mailbox-outer-lock-reduction/tasks.md
@@ -1,25 +1,29 @@
 ## 1. user_queue_lock → put_lock 改名
 
-- [ ] 1.1 `Mailbox` struct の `user_queue_lock` フィールドを `put_lock` に改名する
-- [ ] 1.2 `MailboxSharedSet` の `user_queue_lock` を `put_lock` に改名する
-- [ ] 1.3 全参照箇所のフィールド名を更新する
+- [x] 1.1 `Mailbox` struct の `user_queue_lock` フィールドを `put_lock` に改名する
+- [x] 1.2 `MailboxSharedSet` の `user_queue_lock` を `put_lock` に改名する
+- [x] 1.3 全参照箇所のフィールド名を更新する（base.rs, tests.rs, mailbox_shared_set.rs）
 
-## 2. 通常 enqueue/dequeue から lock 除去
+## 2. dequeue / metrics から lock 除去
 
-- [ ] 2.1 `enqueue_envelope_locked` から `put_lock` の取得を除去する（`is_closed()` チェック + `user.enqueue()` を直接呼び出し）
-- [ ] 2.2 `dequeue` から `put_lock` の取得を除去する（`user.dequeue()` を直接呼び出し）
-- [ ] 2.3 `user_len` から `put_lock` の取得を除去する（`user.number_of_messages()` を直接呼び出し）
-- [ ] 2.4 `publish_metrics` から `put_lock` の取得を除去する
+- [x] 2.1 `dequeue` から `put_lock` の取得を除去する（`is_close_requested()` + `user.dequeue()` を直接呼び出し）
+- [x] 2.2 `user_len` から `put_lock` の取得を除去する（`user.number_of_messages()` を直接呼び出し）
+- [x] 2.3 `publish_metrics` から `put_lock` の取得を除去する
 
 ## 3. compound op の lock 維持を確認
 
-- [ ] 3.1 `prepend_user_messages_deque_locked` が `put_lock` を取得していることを確認する
-- [ ] 3.2 `become_closed_and_clean_up` が `put_lock` を取得していることを確認する
-- [ ] 3.3 `put_lock` のドキュメントに「compound op のみで取得」を明記する
+- [x] 3.1 `enqueue_envelope_locked` が `put_lock` を取得していることを確認する（TOCTOU race 防止のため維持必須）
+- [x] 3.2 `prepend_user_messages_deque_locked` が `put_lock` を取得していることを確認する
+- [x] 3.3 `finalize_cleanup` が `put_lock` を取得していることを確認する
+- [x] 3.4 `put_lock` のドキュメントに「compound op のみで取得」を明記する
 
 ## 4. 検証
 
-- [ ] 4.1 `cargo check --lib --workspace` がクリーンにビルドされることを確認する
-- [ ] 4.2 `cargo check --tests --workspace` がクリーンにビルドされることを確認する
-- [ ] 4.3 `./scripts/ci-check.sh` が全パスすることを確認する
-- [ ] 4.4 `cargo bench --features tokio-executor -p fraktor-actor-adaptor-std-rs` で before/after を比較する（Bounded 3→2 段、Unbounded 2→1 段の効果を計測）
+- [x] 4.1 `cargo check --lib --workspace` がクリーンにビルドされることを確認する
+- [x] 4.2 `cargo check --tests --workspace` がクリーンにビルドされることを確認する
+- [x] 4.3 `./scripts/ci-check.sh` が全パスすることを確認する（146 tests passed）
+- [x] 4.4 `cargo bench --features tokio-executor -p fraktor-actor-adaptor-std-rs` で before/after を比較する
+  - `bounded_capacity_1`: **-5.7%** (231.60ns, p=0.00) Performance improved
+  - `bounded_capacity_64`: 変化なし (p=0.58)
+  - `default_dispatcher_baseline`: **-8.9%** (p=0.00) Performance improved
+  - enqueue ベンチマーク: 変化なし（lock を維持したため期待通り）


### PR DESCRIPTION
## Summary

Mailbox の `user_queue_lock` を `put_lock` に改名し、dequeue / metrics 読み取りから lock 取得を除去。

## Changes

| メソッド | Before | After | 理由 |
|---|---|---|---|
| `dequeue` | `put_lock.with_lock` | 直接呼び出し | single consumer（`FLAG_RUNNING`）+ 内部 mutex で十分 |
| `user_len` | `put_lock.with_read` | 直接呼び出し | metrics — 近似値許容 |
| `publish_metrics` | `put_lock.with_read` | 直接呼び出し | 同上 |
| `enqueue_envelope_locked` | `put_lock.with_lock` | **維持** | TOCTOU race 防止（`is_closed` + `enqueue` の compound op） |
| `prepend_user_messages_deque_locked` | `put_lock.with_lock` | **維持** | compound op |
| `finalize_cleanup` | `put_lock.with_lock` | **維持** | serialization anchor |

## Why enqueue retains the lock

元の proposal では enqueue からも lock を外す予定だったが、コードレビューで TOCTOU race を発見:

```
Producer                          Closer (finalize_cleanup)
────────                          ──────
is_closed() → false
                                  request_close() → FLAG_CLOSE_REQUESTED
                                  finalize_cleanup() acquires put_lock
                                    drain + clean_up()
                                  release put_lock
user.enqueue(msg)  ← phantom enqueue into cleaned queue
```

Pekko は lock-free queue を使うため drain 後の enqueue は次回 drain で回収されるが、fraktor-rs の queue では `clean_up()` 後のメッセージは失われる。Phase VII（lock-free queue）導入まで enqueue 側は lock 維持。

## Benchmark Results

| Benchmark | Change | p-value |
|---|---|---|
| `bounded_capacity_1` | **-5.7%** | 0.00 |
| `default_dispatcher_baseline` | **-8.9%** | 0.00 |
| `bounded_capacity_64` | no change | 0.58 |
| enqueue benchmarks | no change | expected (lock retained) |

## Related

- OpenSpec: `openspec/changes/mailbox-outer-lock-reduction/`
- Follows: `mailbox-once-cell` (#1570), `reduce-unnecessary-mutex` (#1571)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mailbox synchronization in the dispatch hot path; incorrect assumptions about queue internal locking or close/cleanup ordering could cause subtle races or message loss, though compound operations remain protected by `put_lock`.
> 
> **Overview**
> Reduces mailbox lock contention by renaming the outer `user_queue_lock` to `put_lock` and scoping it to **compound operations only** (`enqueue_envelope_locked`, `prepend_user_messages_deque_locked`, `finalize_cleanup`).
> 
> Removes outer-lock acquisition from the hot paths `Mailbox::dequeue`, `Mailbox::user_len`, and `Mailbox::publish_metrics`, relying on the underlying queue mutex for synchronization and allowing metrics reads to be effectively lock-free at the mailbox layer. Tests and shared lock bundle (`MailboxSharedSet`) are updated accordingly, and the OpenSpec docs are revised to match the new locking requirements and TOCTOU rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1a29e09f5d382ff270f2e8c2b22d6bd256cbcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->