### PR TITLE
Enable let_underscore_future clippy lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fraktor_disable_tell)'] }
 
 [workspace.lints.clippy]
 let_underscore_must_use = "deny"
+let_underscore_future = "deny"
 
 [workspace.dependencies]
 fraktor-actor-core-rs = { path = "modules/actor-core", version = "0.2.11" }


### PR DESCRIPTION
## Summary
This change enables the `let_underscore_future` clippy lint at the workspace level to enforce stricter code quality standards.

## Key Changes
- Added `let_underscore_future = "deny"` to the workspace clippy lints configuration in `Cargo.toml`

## Details
The `let_underscore_future` lint prevents accidentally discarding futures by assigning them to underscore variables, which would cause them to be immediately dropped instead of being awaited. This complements the existing `let_underscore_must_use` lint and helps catch common async/await bugs at compile time.

https://claude.ai/code/session_01WgFP4kMxyj6EH6zb31eDQF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration-only change that tightens compile-time linting; may surface new warnings/errors in existing async code where futures are intentionally discarded.
> 
> **Overview**
> Enables the Clippy `let_underscore_future` lint at the workspace level (set to `deny`) in `Cargo.toml`, preventing accidentally dropping `Future`s via `let _ = ...` and making such cases fail the build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0064c24728d84b62ac0b8c15d466acf978ccbaab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の改善**
  * コード品質チェックの設定を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->