### PR TITLE
feat(quality): let-underscore-forbid パイロット後続 — 3 小規模クレート修正 (6 件)

### DIFF
--- a/modules/actor-adaptor-std/src/std/dispatch/dispatcher/pinned_executor.rs
+++ b/modules/actor-adaptor-std/src/std/dispatch/dispatcher/pinned_executor.rs
@@ -62,7 +62,7 @@ impl Executor for PinnedExecutor {
     let same_thread = self.thread_id.is_some_and(|id| id == thread::current().id());
     if same_thread {
       // Cannot join from inside the worker thread; release the handle.
-      let _ = self.join.take();
+      drop(self.join.take());
       return;
     }
     if let Some(join) = self.join.take() {

--- a/modules/cluster-adaptor-std/src/std/tokio_gossiper.rs
+++ b/modules/cluster-adaptor-std/src/std/tokio_gossiper.rs
@@ -94,11 +94,14 @@ impl Gossiper for TokioGossiper {
 
   fn stop(&mut self) -> Result<(), &'static str> {
     let shutdown = self.shutdown.take().ok_or("not started")?;
+    // must-ignore: shutdown best-effort。receiver 先行 drop の Result<(), ()> 失敗は意図どおり。
     let _ = shutdown.send(());
     if let Some(task) = self.task.take() {
-      let _ = self.runtime.spawn(async move {
+      // spawn は JoinHandle を返すが、join 不要の fire-and-forget shutdown 経路のため破棄する。
+      drop(self.runtime.spawn(async move {
+        // must-ignore: task 終了理由 (Ok/Err/Cancelled) は後片付けパスでは参照しない。
         let _ = task.await;
-      });
+      }));
     }
     Ok(())
   }

--- a/modules/persistence-core/src/core/persistence_context.rs
+++ b/modules/persistence-core/src/core/persistence_context.rs
@@ -462,7 +462,7 @@ impl<A: 'static> PersistenceContext<A> {
       .iter()
       .position(|invocation| !invocation.is_deferred() && invocation.sequence_nr() == sequence_nr)
     {
-      let _ = self.pending_invocations.remove(index);
+      drop(self.pending_invocations.remove(index));
     }
   }
 

--- a/modules/persistence-core/src/core/persistent_actor_adapter.rs
+++ b/modules/persistence-core/src/core/persistent_actor_adapter.rs
@@ -278,7 +278,9 @@ where
         )));
       }
       if self.should_unstash_after_journal_response(response, current_instance_id) {
-        let _ = ctx.unstash_all()?;
+        // unstash_all は Result<usize, ActorError>。`?` でエラーを伝播したうえで
+        // 件数 usize は分岐に不要なため捨てる (式文扱い)。
+        ctx.unstash_all()?;
       }
       return Ok(());
     }


### PR DESCRIPTION
## 背景

[PR #1585](https://github.com/j5ik2o/fraktor-rs/pull/1585) (パイロット) のフォローアップ。 plan ドキュメント [\`docs/plan/ignored-return-values-eradication.md\`](./docs/plan/ignored-return-values-eradication.md) §11.3 の残件を、影響範囲が小さいクレートから順次対応する。

本 PR では独立性の高い **3 小規模クレート** を対象とする:

| クレート | 違反件数 |
|----------|---------:|
| actor-adaptor-std | 1 |
| cluster-adaptor-std | 3 |
| persistence-core | 2 |
| **合計** | **6** |

## 変更内容

| カテゴリ | 件数 | 適用ケース |
|----------|-----:|-----------|
| **D** (`drop(...)` 明示) | 3 | `Option::take` / `Vec::remove` / `spawn` JoinHandle |
| **A** (`// must-ignore:`) | 2 | shutdown best-effort の `Result<(), ()>` 送信 / JoinHandle.await |
| **式文化** | 1 | \`Result<usize, E>?\` の後に usize (Copy) のため drop 不可 → 式文に |

### 修正箇所

- \`modules/actor-adaptor-std/src/std/dispatch/dispatcher/pinned_executor.rs:65\` — D (`Option::take` を `drop(...)` で明示)
- \`modules/cluster-adaptor-std/src/std/tokio_gossiper.rs:97-103\` — A × 2 + D × 1 (shutdown best-effort / spawn / await)
- \`modules/persistence-core/src/core/persistence_context.rs:465\` — D (`Vec::remove` を `drop(...)` で明示)
- \`modules/persistence-core/src/core/persistent_actor_adapter.rs:281\` — 式文化 (\`ctx.unstash_all()?;\` で usize を捨てる)

### 実装ノート

`drop()` 適用時の注意点: 戻り値が \`Copy\` 型 (\`()\`, \`usize\`, \`Result<(), ()>\`) の場合は \`dropping_copy_types\` 警告が出るため、must-ignore または式文化で回避する。

- \`shutdown.send(())\` の戻り値 \`Result<(), ()>\` は Copy → must-ignore で対応
- \`ctx.unstash_all()?\` 後の \`usize\` は Copy → \`drop()\` 不可なので式文 \`;\` のみ
- \`self.runtime.spawn(...)\` の戻り値 \`JoinHandle\` は非 Copy → \`drop()\` で OK

## スコープ外 (別 PR)

- **cluster-core** (13 件 + CI exclude 条件の見直し)
- **stream-core** (32 件、最大級)
- **lint の CI 配線** (\`Cargo.toml\` dylint libraries / \`scripts/ci-check.sh\`) → 全クレートの修正完了後に別 PR で実施
- **test モジュール** (~500 件)

本 PR の依存経由で検出された cluster-core の 13 件は本 PR では修正しない (対象クレートのスコープ外)。

## 検証

- \`./scripts/ci-check.sh ai all\` → **exit 0**
- \`cargo dylint --lib let_underscore_forbid_lint -- -p <各クレート>\` で対象クレートの違反が 0 件になったことを確認

## 関連

- Plan: \`docs/plan/ignored-return-values-eradication.md\` (§11.3)
- Rule: \`.agents/rules/ignored-return-values.md\`
- 先行: #1585 (パイロット PR、マージ済み)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to explicitly discarding return values/handles (`drop(...)` or intentional `let _ = ...`) in shutdown/cleanup code paths, without altering control flow or external behavior.
> 
> **Overview**
> Tightens cleanup/shutdown code across a few crates to satisfy a “no ignored return values” policy by making discarded values explicit.
> 
> This replaces `let _ = ...` with `drop(...)` where appropriate (e.g., `Option::take`, `Vec::remove`, `JoinHandle`), adds comments marking best-effort ignores (e.g., oneshot shutdown send/await), and adjusts one call site to use an expression statement (`ctx.unstash_all()?;`) so the `usize` result is intentionally unused while still propagating errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2811db76a8e77ca01d3de853b16b108c04132066. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->