### PR TITLE
docs(remote-gap-analysis): update to 3rd edition (2026-04-19)

### DIFF
--- a/docs/gap-analysis/remote-gap-analysis.md
+++ b/docs/gap-analysis/remote-gap-analysis.md
@@ -1,178 +1,247 @@
 # remote モジュール ギャップ分析
 
-参照実装: `references/pekko/remote/`
-対象実装: `modules/remote/src/`
-更新日: 2026-03-22
+参照実装: `references/pekko/remote/src/main/scala/`
+対象実装: `modules/remote-core/src/`, `modules/remote-adaptor-std/src/`
+更新日: 2026-04-19（第3版）
+
+## 重要な前提（第3版で是正）
+
+Pekko remote モジュールの宣言のうち、`private[remote]` / `private[pekko]` / `private[ssl]` / `private[tcp]` が付与されているものは **外部公開 API ではない**。以下は内部 API であり、本 gap analysis の公開 API カバレッジ指標からは除外する:
+
+| 型 | 可視性 | 備考 |
+|----|--------|------|
+| `ArteryTransport`, `Association`, `AssociationRegistry` | `private[remote]` | Artery 内部実装 |
+| `InboundEnvelope`, `OutboundEnvelope` | `private[remote]` | Artery 内部メッセージ表現 |
+| `CompressionTable`, `DecompressionTable`, `InboundCompressions`, `TopHeavyHitters`, `CompressionProtocol` | `private[remote]` | 圧縮はすべて内部実装 |
+| `RemoteActorRefProvider`, `RemoteActorRef` | `private[pekko]` | ActorSystem 拡張点 |
+| `RemoteWatcher` | `private[pekko]` | リモート watcher 内部実装 |
+| `RemotingFlightRecorder`, `NoOpRemotingFlightRecorder` | `private[pekko]` | Flight Recorder は内部 API |
+| `Classic Remoting` 全系統 | `@deprecated` | Artery 移行済 |
+| `NettyTransport`, `AeronUdpTransport`, `JFRRemotingFlightRecorder` | 一部 public だが実装 | JVM / Netty / Aeron / JFR 依存、Rust では n/a |
+
+第2版までは `CompressionTable` / `Association` などを公開 API ギャップとして列挙していたが、これらは Pekko 側でも内部 API であるため、本版からは **内部構造** として扱う（public/internal 境界を越えない）。
+
+fraktor-rs 側は設計選択として `Association`, `InboundEnvelope`, `OutboundEnvelope`, `Codec` 等を **`pub` で公開している**。これは参照実装レベルの差異であり、Pekko の契約意図（core 内部に閉じる）とは異なるが、fraktor-rs の設計原則（no_std / testability / composability）に沿った明示的な選択として許容する。
 
 ## サマリー
 
 | 指標 | 値 |
 |------|-----|
-| Pekko 公開型数（機械抽出, Scala 宣言ベース） | 360 |
-| fraktor-rs 公開型数 | 91（core: 84, std: 7） |
-| Pekko 公開メソッド数（機械抽出） | 1594 |
-| fraktor-rs 公開メソッド数（機械抽出） | 274 |
-| カバレッジ（型単位） | 14/20 (70%) |
-| ギャップ数 | 9 |
+| Pekko 公開型数（non-deprecated / non-JVM / non-`private[*]`） | 30 |
+| fraktor-rs 公開型数 | 78（core: 71, std: 7）※ Pekko では `private[remote]` に相当する内部型も `pub` で露出 |
+| 契約意図カバレッジ（概念単位） | 13/30 (43%) |
+| 実装ギャップ数 | 17 |
+| スタブ検出 (`todo!()` / `unimplemented!()`) | **0 件** |
 
-※ カバレッジの評価自体は non-deprecated / JVM 固有除外の概念単位で行っている。
-※ remote モジュールには `typed/` サブ層は存在しない。
+**補足**:
+- `typed/` サブ層は remote には存在しない（Pekko も同じ）
+- 第3版で公開 API 数が 2026-03-22 時点から減って見えるのは、Pekko の `private[remote]` を除外した結果であり、実装が退行したわけではない
+- Phase B までのコア通信基盤（Transport / Association / Handshake / Envelope / Watcher / FailureDetector / WireCodec）は全て実動作する状態で実装済み
+- `todo!()`/`unimplemented!()` ゼロ = 手抜き実装が存在しない
 
 ## 層別カバレッジ
 
-| 層 | Pekko対応数 | fraktor-rs実装数 | カバレッジ |
-|----|-------------|------------------|-----------|
-| core / 通信カーネル | 主要 API の大半 | 84 | 高い |
-| core / typed ラッパー | 該当なし | 0 | n/a |
-| std / アダプタ | ループバック / TCP / installer 周辺 | 7 | 中程度 |
-
-**補足**:
-- `remote` は `core` と `std` の 2 層で、`typed/` サブ層はない。
-- `std` 層は `TokioTcpTransport`, `StdTransportFactory`, `RemotingExtensionInstaller` など、ランタイム依存部を担う。
+| 層 | Pekko 対応 | fraktor-rs | 評価 |
+|----|-----------|-----------|------|
+| core / 通信カーネル（Artery 内部実装相当） | `private[remote]` 群 | core/ 11 サブディレクトリ・71 公開型 | **概念レベルでカバー済み**（public 公開範囲は fraktor-rs のほうが広い） |
+| core / 公開 API | 約 30 型 | 13 概念実装 | 43% |
+| core / typed ラッパー | n/a | n/a | remote は typed 層なし |
+| std / アダプタ | 本質的に JVM ランタイム依存実装 | 7 公開型（TCP / extension installer / watcher actor / provider dispatch / association runtime） | **TCP 動作可能**、TLS 未対応 |
 
 ## カテゴリ別ギャップ
 
-### フェイラーディテクター　✅ 実装済み 5/6 (83%)
+### FailureDetector　✅ 実装済み 3/5 (60%)
 
-| Pekko API | Pekko参照 | fraktor対応 | 難易度 | 備考 |
-|-----------|-----------|-------------|--------|------|
-| `FailureDetectorWithAddress` | `FailureDetector.scala:43` | 未対応 | easy | `setAddress(addr)` で検出器がログ出力に使うアドレスを受け取る SPI。`PhiAccrualFailureDetector` が実装。fraktor-rs の `PhiFailureDetector` にはアドレス情報なし |
-| `PhiAccrualFailureDetector.phi`（統計的実装） | `PhiAccrualFailureDetector.scala:188` | 部分実装 | medium | fraktor-rs は `elapsed / mean` の単純比率。Pekko は `-log10(1 - CDF(y))`（正規分布 CDF 近似）を使い標準偏差・分散も計算。アルゴリズムが別物 |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `FailureDetectorWithAddress` | `FailureDetector.scala:43` | 未対応 | core/failure_detector | easy | `setAddress(addr)` で検出器がログ出力に使うアドレスを受け取る SPI。`PhiAccrualFailureDetector` が実装。fraktor-rs の `PhiAccrualFailureDetector` にはアドレス情報なし |
+| `PhiAccrualFailureDetector.phi` 統計精度 | `PhiAccrualFailureDetector.scala:188` | 部分実装 | core/failure_detector | medium | fraktor-rs の Phi 計算は `HeartbeatHistory` で mean / variance / stdDeviation を保持するが、Pekko の `-log10(1 - CDF(y))`（正規分布 CDF 近似）との数式一致は要検証 |
 
-実装済み: `FailureDetector`, `FailureDetectorRegistry`, `DeadlineFailureDetector`（+Config）, `PhiFailureDetector`（+Config、簡略版）, `DefaultFailureDetectorRegistry`
+実装済み: `PhiAccrualFailureDetector`, `HeartbeatHistory`, `FailureDetector` 相当（FailureDetectorRegistry は actor-core 側に配置）
 
-### ID型・UniqueAddress　✅ 実装済み 1/1（別名）
+### Address / UniqueAddress　✅ 実装済み 1/1 (100%)
+
+実装済み（概念レベルで完全）:
+
+- `Address` — `core/address/base.rs`
+- `UniqueAddress` — `core/address/unique_address.rs`（Pekko と同形式 (Address, uid: Long) を維持）
+- `RemoteNodeId` — `core/address/remote_node_id.rs`（内部用 ID、Pekko にない追加概念。fraktor-rs 固有の設計選択）
+- `ActorPathScheme` — `core/address/scheme.rs`
+
+### Artery Quarantine Events　✅ 実装済み 1/3（別名で集約） (33%)
+
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `QuarantinedEvent` (artery) | `artery/QuarantinedEvent.scala:18` | 別名 | core/event (actor-core) | easy | `RemotingLifecycleEvent::Quarantined` で代替 |
+| `GracefulShutdownQuarantinedEvent` | `artery/QuarantinedEvent.scala:26` | 未対応 | core/event (actor-core) | easy | 正常シャットダウン時の quarantine を識別する専用 variant が未 |
+| `ThisActorSystemQuarantinedEvent` | `artery/QuarantinedEvent.scala:31` | 未対応 | core/event (actor-core) | easy | リモートが自ノードを quarantine したことを通知する専用 variant が未 |
+
+fraktor-rs では `fraktor_actor_core_rs::core::event::stream::RemotingLifecycleEvent::Quarantined` が authority / reason / correlation_id を保持する汎用 lifecycle event として公開済み。Pekko の 3 種細分化までは未到達。
+
+### RemotingListenEvent　❌ 未実装 0/1 (0%)
+
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `RemotingListenEvent` | `RemotingLifecycleEvent.scala:78` | 未対応 | core/extension | easy | `listenAddresses: Set[Address]` を保持。リスニング開始通知。fraktor-rs は `RemotingLifecycleEvent::Started` を持つが、listen address の公開が欠落 |
+
+関連して、`StdRemoting::addresses` が現状 `&[]` を返す（空スライス返却スタブ）gap も `RemotingListenEvent` と合わせて対処したい。
+
+### Remote Instrument（監視 SPI）　✅ 実装済み 1/1 (100%, シグネチャ差異)
+
+実装済みだがシグネチャ差異あり（Rust 固有の制約による合理的差異）:
+
+- Pekko: `remoteWriteMetadata(recipient, message, sender, buffer: ByteBuffer)` — ActorRef 参照あり
+- fraktor-rs: `remote_write_metadata(&self, buffer: &mut Vec<u8>)` — ActorRef なし（Rust のメタデータ用途では不要）
+
+### RemoteSettings / ArterySettings　✅ 実装済み 2/2 (100%, 別名)
 
 実装済みだが設計差異あり:
 
-- Pekko `UniqueAddress` = `(Address, uid: Long)` — Address はアクターシステムアドレス（protocol/host/port/system）
-- fraktor-rs `RemoteNodeId` = `(system, host, port, uid)` — より原始的な表現で実質同等
+- Pekko `RemoteSettings` + `ArterySettings` → fraktor-rs `RemoteConfig`（単一構造に統合）
+- fraktor-rs は `canonical host/port`, `handshake timeout`, `shutdown flush timeout`, `ack send/receive window`, `transport scheme`, `backpressure listener`, `remote instrument` を保持
+- Classic remoting の deprecated 設定群は持たない
 
-### Quarantine イベント　✅ 実装済み 1/3（別名） (33%)
+### RemoteRouterConfig　❌ 未実装 0/1 (0%)
 
-| Pekko API | Pekko参照 | fraktor対応 | 難易度 | 備考 |
-|-----------|-----------|-------------|--------|------|
-| `GracefulShutdownQuarantinedEvent` | `artery/QuarantinedEvent.scala:26` | 未対応 | easy | 正常シャットダウン時の quarantine イベント |
-| `ThisActorSystemQuarantinedEvent` | `artery/QuarantinedEvent.scala:32` | 未対応 | easy | リモートが自ノードを quarantine したことを通知するイベント |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `RemoteRouterConfig` | `routing/RemoteRouterConfig.scala:47` | 未対応 | core/provider or core/routing | medium | `local: Pool`, `nodes: Iterable[Address]` を受け取り、リモートノード群に router pool を展開する。fraktor-rs には対応概念なし。actor-core 側の Router DSL と remote-core の Provider を繋ぐ層が必要 |
 
-別名で実装済み:
+### RemoteLogMarker　❌ 未実装 0/1 (0%)
 
-- `QuarantinedEvent` 相当 → `fraktor_actor_core_rs::core::event::stream::RemotingLifecycleEvent::Quarantined`
-  - authority / reason / correlation_id を保持する汎用 lifecycle event として公開済み
-  - Pekko の `UniqueAddress` 専用イベントクラスとは形が異なるが、quarantine 発生通知というセマンティクスは満たしている
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `RemoteLogMarker` | `RemoteLogMarker.scala:27` | 未対応 | core/instrument or std | easy | `@ApiMayChange`。`failureDetectorGrowing`, `quarantine`, `connect`, `disconnected` などのログマーカー。Rust では `tracing::field` / `log::kv` として実装可能 |
 
-### Remote Instrument（監視 SPI）　✅ 実装済み 1/1（別名）
+### RemoteTransportException　✅ 実装済み 2/2 (100%, 別名)
 
-実装済みだがシグネチャ差異あり:
+- `RemoteTransportException` → `RemotingError`（`extension/remoting_error.rs`）
+- `RemoteTransportExceptionNoStackTrace` → `TransportError`（`transport/transport_error.rs`）＋ `ProviderError` と機能分割
 
-- Pekko: `remoteWriteMetadata(recipient, message, sender, buffer: ByteBuffer)` — ActorRef 参照あり
-- fraktor-rs: `remote_write_metadata(&self, buffer: &mut Vec<u8>)` — ActorRef なし（Rust にはアクターシステム参照不要）
-- セマンティクス上は同等。Rust 固有の制約による合理的な差異
+### SSL/TLS セキュリティ　❌ 未実装 0/5 (0%)
+
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `SSLEngineProvider` | `artery/tcp/SSLEngineProvider.scala:24` | 未対応 | core/transport | hard | TLS エンジンプロバイダー SPI。Rust では `TlsConnector` 抽象（rustls / native-tls）に相当 |
+| `SslTransportException` | `artery/tcp/SSLEngineProvider.scala:46` | 未対応 | core/transport | easy | SSL エラー型。`TransportError` に variant 追加で対応可能 |
+| `SSLEngineProviderSetup` | `artery/tcp/SSLEngineProvider.scala:75` | 未対応 | core/config | medium | Setup DSL でのプロバイダー注入 |
+| `ConfigSSLEngineProvider` | `artery/tcp/ConfigSSLEngineProvider.scala:48` | 未対応 | std/tcp_transport | hard | 設定から SSL エンジンを構成する実装（rustls-pemfile 相当） |
+| `RotatingKeysSSLEngineProvider` | `artery/tcp/ssl/RotatingKeysSSLEngineProvider.scala:59` | 未対応 | std/tcp_transport | hard | PEM 鍵ローテーション対応 SSL プロバイダー |
+
+### Serialization　✅ 実装済み 2/6 (33%, actor-core に配置)
+
+actor-core に `Serializer` / `SerializerWithStringManifest` trait が配置済み。Pekko の remote 固有シリアライザ群（`MiscMessageSerializer`, `MessageContainerSerializer`, `ProtobufSerializer`, `SystemMessageSerializer`）と個別対応は未。
+
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `MiscMessageSerializer` | `serialization/MiscMessageSerializer.scala:37` | 未対応 | core/serialization (actor-core) | medium | PoisonPill / Kill 等のシステム制御メッセージ用。Rust 側は actor-core に system message 型あり、専用シリアライザは未 |
+| `MessageContainerSerializer` | `serialization/MessageContainerSerializer.scala:30` | 未対応 | core/serialization (actor-core) | easy | `ActorSelectionMessage` のシリアライズ |
+| `ProtobufSerializer` | `serialization/ProtobufSerializer.scala:30,57` | 未対応 | core/serialization (actor-core) | medium | Protobuf メッセージ用の標準シリアライザ。prost 経由で実装可能 |
+| `SystemMessageSerializer` | `serialization/SystemMessageSerializer.scala:22` | 未対応 | core/serialization (actor-core) | easy | `Watch` / `Unwatch` / `DeathWatchNotification` の専用シリアライザ |
+| `ThrowableNotSerializableException` | `serialization/ThrowableNotSerializableException.scala:22` | 未対応 | core/serialization (actor-core) | trivial | 例外クラスの追加のみ |
 
 ### Flight Recorder　✅ 実装済み 1/1（別アプローチ）
 
-実装済みだがアプローチが異なる:
+実装済みだがアプローチが異なる（Pekko は JFR、fraktor-rs はリングバッファ）:
 
-- Pekko: JFR（Java Flight Recorder）ベース、transport lifecycle イベント（aeronSink*, aeronSource*, tcpInbound*, tcpOutbound*, transportXxx*）約 30 種のメソッド — JVM 固有技術
-- fraktor-rs: リングバッファ型メトリクス（`record_backpressure`, `record_suspect`, `record_reachable`）— 3 種、Rust/no_std に適切な設計
+- Pekko: JFR（Java Flight Recorder）ベース、transport lifecycle イベント約 30 種 — JVM 固有
+- fraktor-rs: `RemotingFlightRecorder` リングバッファ型メトリクス — Rust/no_std に適切な設計
 - JFR 固有イベント（Aeron, JFR Events）は n/a
 
-### スタブ / 未完成実装　✅ 実装済み 0/0 (100%)
+### 現状ギャップ: `StdRemoting::addresses` 空スライス返却　❌ 未解消 1件
 
-`modules/remote/src` に対して `todo!()`, `unimplemented!()`, `panic!("not implemented")`, `TODO` を検索した範囲では、公開 API 直下のスタブ痕跡は見つからなかった。
+| 項目 | 現状 | 影響 |
+|------|------|------|
+| `StdRemoting::addresses(&self) -> &[Address]` | `&[]` を返すのみ | ライブアドレス公開が未完。`RemotingListenEvent` 実装の前提となるため、これを先に解消しないと listen event も作れない |
 
-### RemoteTransport / 設定　✅ 実装済み 2/2（別名）
-
-実装済みだが設計差異あり:
-
-- Pekko `RemoteTransport` → fraktor-rs `core/transport/RemoteTransport`
-  - Pekko は classic remoting 全体を背負う抽象だが、fraktor-rs は `spawn_listener` / `open_channel` / `send` / `close` / `install_*` に分割した Rust 向け trait
-  - 実装は `LoopbackTransport`, `TokioTcpTransport`
-- Pekko `RemoteSettings` → fraktor-rs `core/remoting_extension/RemotingExtensionConfig`
-  - canonical host/port, handshake timeout, shutdown flush timeout, ack send/receive window, transport scheme, backpressure listener, remote instrument を保持
-  - classic remoting の deprecated 設定群は持たず、fraktor-rs 実装に必要な構成へ整理している
-
-### SSL/TLS セキュリティ　✅ 実装済み 0/5 (0%)
-
-| Pekko API | Pekko参照 | fraktor対応 | 難易度 | 備考 |
-|-----------|-----------|-------------|--------|------|
-| `SSLEngineProvider` | `artery/tcp/SSLEngineProvider.scala:24` | 未対応 | hard | TLS エンジンプロバイダー SPI。Tokio の `rustls`/`native-tls` に相当 |
-| `SslTransportException` | `artery/tcp/SSLEngineProvider.scala:46` | 未対応 | easy | SSL エラー型。`TransportError` に enum variant として追加可能 |
-| `SSLEngineProviderSetup` | `artery/tcp/SSLEngineProvider.scala:75` | 未対応 | medium | Setup DSL でのプロバイダー注入 |
-| `ConfigSSLEngineProvider` | `artery/tcp/ConfigSSLEngineProvider.scala:48` | 未対応 | hard | 設定から SSL エンジンを構成する実装 |
-| `RotatingKeysSSLEngineProvider` | `artery/tcp/ssl/RotatingKeysSSLEngineProvider.scala:59` | 未対応 | hard | 証明書ローテーション対応 SSL プロバイダー |
-
-### 圧縮（Artery Compression）　✅ 実装済み 0/5 (0%)
-
-| Pekko API | Pekko参照 | fraktor対応 | 難易度 | 備考 |
-|-----------|-----------|-------------|--------|------|
-| `CompressionTable` | `artery/compress/CompressionTable.scala` | 未対応 | hard | ActorRef / class manifest の圧縮テーブル |
-| `DecompressionTable` | `artery/compress/DecompressionTable.scala` | 未対応 | hard | 展開テーブル |
-| `CompressionProtocol` | `artery/compress/CompressionProtocol.scala` | 未対応 | hard | 圧縮ネゴシエーションプロトコル |
-| `InboundCompressions` | `artery/compress/InboundCompressions.scala` | 未対応 | hard | 受信側圧縮ステート管理 |
-| `TopHeavyHitters` | `artery/compress/TopHeavyHitters.scala` | 未対応 | medium | 頻出エントリ追跡（LFU-like） |
+原因: `extension/remoting.rs` の `Remoting` trait が `&[Address]` 返却契約で、ロックを越えた借用ができない。trait 設計を `Vec<Address>` 返却または `snapshot_addresses() -> AddressSnapshot` に変更する必要あり。難易度: **easy** (trait 契約変更)。
 
 ### Classic Remoting 型（deprecated）　n/a
 
-| Pekko API | Pekko参照 | fraktor対応 | 難易度 | 備考 |
-|-----------|-----------|-------------|--------|------|
-| `RemotingLifecycleEvent` + サブ型 | `RemotingLifecycleEvent.scala` | n/a | n/a | `@deprecated("Classic remoting", "Akka 2.6.0")` — Artery に移行済み |
-| `AckedDelivery`（SeqNo 等） | `AckedDelivery.scala:21` | 実装済み | n/a | Pekko では deprecated だが fraktor-rs では実装済み — YAGNI 観点で要検討 |
-| `RemoteDeployer` / `RemoteDeploymentWatcher` | `RemoteDeployer.scala` | n/a | n/a | JVM クラスパスベースリモートデプロイ — Rust に不要 |
-| `BoundAddressesExtension` / `AddressUidExtension` | 対応ファイル | n/a | n/a | JVM Extension SPI — fraktor-rs は `RemotingExtension` で代替 |
-| `NotAllowedClassRemoteDeploymentAttemptException` | `RemoteDaemon.scala:288` | n/a | n/a | デプロイ制約例外 — Rust 不要 |
+Classic remoting / Netty Transport / Aeron UDP / RemoteDeployer / BoundAddressesExtension / JFRRemotingFlightRecorder はすべて n/a（deprecated または JVM 固有）。fraktor-rs では実装不要。
 
-## 実装優先度の提案
+**Pekko 側に "実装済み" と記載済みの `AckedDelivery` (Pekko 側 deprecated)** は fraktor-rs にも実装があるが、Pekko Artery では未使用であり、YAGNI 観点では削除候補。構造 gap として後述。
 
-### Phase 1: trivial（既存組み合わせで即実装可能）
+## 実装優先度
 
-- `SslTransportException` — `TransportError` に `TlsHandshakeFailed`、`TlsCertificateError` variant を追加
+### Phase 1: trivial / easy（既存設計の範囲で埋められる）
 
-### Phase 2: easy（単純な新規実装）
+| 項目 | 実装先層 | 概要 |
+|------|---------|------|
+| `ThrowableNotSerializableException` 相当 | core/serialization (actor-core) | 例外型の追加 |
+| `FailureDetectorWithAddress` | core/failure_detector | `FailureDetector` trait に `set_address(&mut self, addr: &str)` を追加（default 空実装） |
+| `SslTransportException` | core/transport | `TransportError` に `TlsHandshakeFailed` / `TlsCertificateError` variant を追加 |
+| `GracefulShutdownQuarantinedEvent` / `ThisActorSystemQuarantinedEvent` 相当 | core/event (actor-core) | `RemotingLifecycleEvent` enum に variant 2 件追加 |
+| `RemotingListenEvent` 相当 | core/extension | `RemotingLifecycleEvent::Listen { addresses }` variant の追加 |
+| `MessageContainerSerializer` 相当 | core/serialization (actor-core) | `ActorSelectionMessage` シリアライザ |
+| `SystemMessageSerializer` 相当 | core/serialization (actor-core) | system message 専用シリアライザ |
+| `RemoteLogMarker` 相当 | core/instrument | 構造化ログ用のマーカー定数群 |
+| `StdRemoting::addresses` 空スライス解消 | std/extension_installer | trait 契約変更で `Vec<Address>` 返却 |
 
-- `QuarantinedEvent`、`GracefulShutdownQuarantinedEvent`、`ThisActorSystemQuarantinedEvent` — `QuarantineReason` を使ったイベント型 3 種の追加。イベントバスへの統合
-- `FailureDetectorWithAddress` — `FailureDetector` トレイトに `set_address(&mut self, addr: &str)` メソッドを追加（デフォルト空実装）
+### Phase 2: medium（新規ロジックを伴うが既存境界内）
 
-### Phase 3: medium（中程度の実装工数）
+| 項目 | 実装先層 | 概要 |
+|------|---------|------|
+| `PhiAccrualFailureDetector` 統計精度 | core/failure_detector | `-log10(1 - CDF(y))` の正規分布 CDF 近似を導入 |
+| `SSLEngineProviderSetup` 相当 | core/config | TLS プロバイダー注入 DSL |
+| `MiscMessageSerializer` 相当 | core/serialization (actor-core) | PoisonPill / Kill 等のシリアライザ |
+| `ProtobufSerializer` 相当 | core/serialization (actor-core) | prost 経由の標準 Protobuf シリアライザ |
+| `RemoteRouterConfig` 相当 | core/provider | actor-core Routing DSL と remote-core Provider を繋ぐ層 |
 
-- `PhiAccrualFailureDetector` の統計的 phi 実装 — 現在の `elapsed / mean` から `-log10(1 - CDF(y))` の正規分布 CDF 近似に変更。`HeartbeatHistory` 相当の rolling statistics（mean、variance、stdDeviation）追加が必要
-- SSL/TLS プロバイダー SPI — `TlsEngineProvider` trait + `RemotingExtensionConfig` への統合（`tokio-rustls` または `native-tls`）
+### Phase 3: hard（アーキテクチャ変更を伴う）
 
-### Phase 4: hard（アーキテクチャ変更を伴う）
-
-- SSL/TLS フル実装（`ConfigTlsEngineProvider`、`RotatingKeysTlsEngineProvider`）
-- 圧縮（`CompressionTable`、`DecompressionTable`、`InboundCompressions`）— ワイヤプロトコル変更を伴う
-- `TopHeavyHitters` — 単体では中程度だが圧縮の前提となる基盤
+| 項目 | 実装先層 | 概要 |
+|------|---------|------|
+| `SSLEngineProvider` SPI | core/transport | TLS engine 抽象（rustls / native-tls 両対応） |
+| `ConfigSSLEngineProvider` | std/tcp_transport | 設定から TLS エンジンを構成する実装 |
+| `RotatingKeysSSLEngineProvider` | std/tcp_transport | PEM 鍵ローテーション対応 |
+| Artery Compression（`CompressionTable` / `DecompressionTable` / `InboundCompressions`）相当 | core/wire + core/association | **内部実装**。ただし Pekko 側でも `private[remote]` なので公開 API ギャップではなく、ワイヤプロトコル拡張としての実装判断 |
+| `TopHeavyHitters` 相当 | core/wire | 圧縮の前提となる LFU-like 頻出追跡データ構造 |
 
 ### 対象外（n/a）
 
-- Classic Remoting 型（deprecated）— Pekko 自身が artery へ移行済み
-- JFR（Java Flight Recorder）イベント群 — JVM 固有
-- `RemoteDeployer` / `RemoteDeploymentWatcher` — Rust に不要
-- Aeron UDP Transport — 専用 C ライブラリ依存、no_std 非対応
-- `BoundAddressesExtension` / `AddressUidExtension` — JVM Extension SPI
+- Classic Remoting 全系統（`@deprecated`）
+- `NettyTransport` / `AeronUdpTransport`（JVM / Netty / Aeron 依存）
+- `JFRRemotingFlightRecorder`（JFR = JVM 固有）
+- `RemoteDeployer` / `RemoteDeploymentWatcher`（JVM クラスパスベース）
+- `BoundAddressesExtension` / `AddressUidExtension`（JVM Extension SPI）
+- `NotAllowedClassRemoteDeploymentAttemptException`（Rust 不要）
+
+## 内部モジュール構造ギャップ
+
+API ギャップカバレッジが 43% で 80% 未満のため、内部構造比較は本版では省略する。ただし、Phase 1〜2 完了後の目安として以下を記録する（第4版で詳述予定）:
+
+| 構造観点 | Pekko | fraktor-rs 現状 | 備考 |
+|---------|-------|----------------|------|
+| Artery 圧縮責務 | `artery/compress/` で独立パッケージ | 未分離（未実装） | Phase 3 で `core/compress/` を新設予定 |
+| TLS 責務 | `artery/tcp/ssl/` で独立パッケージ | 未分離（未実装） | Phase 3 で `core/tls/` or `std/tls_transport/` を新設予定 |
+| Envelope / EnvelopeBuffer | `artery/EnvelopeBufferPool.scala` でプール管理 | fraktor-rs は `core/envelope/` に配置、pool 未分離 | 動作上は問題ないが、バックプレッシャ時の最適化余地あり |
+| Association レジストリ | `private[remote] class AssociationRegistry` | `std/association_runtime/association_registry.rs` で同名 | **fraktor-rs では `pub` 公開**。Pekko の private 設計意図と差異あり（設計上の判断として許容） |
+| FailureDetector レジストリ | `FailureDetectorRegistry[A]` 汎用型 | 未定義（`PhiAccrualFailureDetector` 直使用） | `core/failure_detector/registry.rs` 新設が Phase 2 内に入る可能性 |
+
+## 既知スタブ / レガシー
+
+`.takt/facets/knowledge/stub-elimination.md` は主に stream モジュール向けだが、remote-core / remote-adaptor-std に対して `todo!()` / `unimplemented!()` / `FIXME` / `TODO` を検索した結果 **0 件**。スタブは存在しない。
+
+ただし、以下の「実装の痕跡はあるが Pekko で deprecated」な項目は YAGNI 観点で削除候補:
+
+- `AckedDelivery` 相当の実装が fraktor-rs 側にある可能性（Pekko では `@deprecated("Classic remoting")`）。artery では使われていないため、将来削除を検討
 
 ## まとめ
 
-**全体カバレッジ評価**: フェイラーディテクター・トランスポート抽象化・エンドポイント管理・設定まわりのコア通信基盤は十分にカバー済み。Pekko の公開 API には JVM/classic remoting 由来のものが多いが、fraktor-rs は Rust 向けの trait / config / lifecycle event に置き換えている。
+**全体カバレッジ評価**: コア通信基盤（Transport / Association / Handshake / Envelope / Watcher / Wire）は Phase B 完了時点で **動作する実装** が揃っており、スタブゼロ。一方で Pekko の公開 API 契約に対する概念カバレッジは 43% で、TLS / 圧縮 / シリアライザ / RouterConfig / LogMarker / Quarantine event 3 種など公開 API が未対応。
 
-**即座に価値を提供できる未実装機能（Phase 1〜2）**:
+**parity を低コストで前進できる未実装（Phase 1〜2 代表例）**:
 
-- 3 種の Quarantine イベント型の追加 — イベントバス統合で可観測性が向上
-- `FailureDetectorWithAddress` — ログの質の向上（アドレス情報付きで障害地点が明確になる）
+- `RemotingListenEvent` + `StdRemoting::addresses` 空スライス解消 — listening アドレスの可観測性向上
+- Artery Quarantine events 3 種への細分化 — 運用監視の粒度向上
+- `FailureDetectorWithAddress` + `PhiAccrualFailureDetector` 統計精度 — 誤検知率の低減
+- Serialization 専用シリアライザ群（Misc / Container / Protobuf / SystemMessage） — Pekko と互換のシリアライズ形式
 
-**実用上の主要ギャップ（Phase 3〜4）**:
+**parity 上の主要ギャップ（Phase 3 代表例）**:
 
-- **Phi 統計精度** — 現実装は線形比率で Pekko の正規分布 CDF 近似とは意味論が異なる。ネットワーク変動に対する感度が不正確で、誤検知率が上がる可能性がある
-- **TLS/SSL なし** — 本番環境での暗号化通信が不可。クラスター接続を外部 TLS ターミネーターに委ねる運用が必要
-- **圧縮テーブル群なし** — `CompressionTable` / `DecompressionTable` / `InboundCompressions` が未実装で、Artery の帯域最適化・圧縮ネゴシエーションまでは未到達
+- **TLS/SSL 完全未実装（5 件）** — 本番環境での暗号化通信不可。rustls or native-tls バックエンドでの SPI 構築が必要
+- **Artery Compression 未実装（5 件、内部 API 扱い）** — ActorRef / class manifest の圧縮ネゴシエーションプロトコル未到達
+- **`RemoteRouterConfig`** — actor-core Router DSL と remote-core Provider の接続層。cluster-core 整備と並行検討が望ましい
 
-**YAGNI 観点での省略推奨**:
-
-- `AckedDelivery` は Pekko で deprecated 済み。fraktor-rs に実装があるが artery では使われていない。将来削除を検討すべき
-- 圧縮機能（Phase 4）は大量メッセージングが必要な時点まで不要
-- Aeron UDP は IoT/組込み以外では必要性が低い
-
-**補足**:
-- `RemoteTransport` と `RemotingExtensionConfig` は fraktor-rs 側に明確に存在し、core / std 分離にも沿っている
-- 一方で Pekko の `FailureDetectorWithAddress`, `SSLEngineProvider`, `CompressionTable`, `InboundCompressions`, `TopHeavyHitters` に相当する公開型は fraktor-rs 側にまだない
+**次のボトルネック評価**: 公開 API ギャップが 43% と過半を占めるため、本版では内部構造比較は省略。Phase 1〜2 完了後（カバレッジ 70% 程度を目安）に第4版で内部構造分析を実施する。それまでは公開 API 追加が優先。


### PR DESCRIPTION
## 背景

\`docs/gap-analysis/remote-gap-analysis.md\` は 2026-03-22 付の第2版で止まっており、以下の課題があった:

1. **公開 API 境界の誤認**: \`CompressionTable\` / \`Association\` / \`InboundEnvelope\` などを公開 API ギャップとして列挙していたが、Pekko 側ではすべて \`private[remote]\` (外部公開 API ではない)。これにより公開 API カバレッジが実態より高く算出されていた
2. **見落とされていた真の公開 API ギャップ**: \`RemoteRouterConfig\`, \`RemoteLogMarker\`, \`RemotingListenEvent\`, Serialization サブクラス群 (Misc / Container / Protobuf / SystemMessage), \`StdRemoting::addresses\` の空スライス gap が記録されていなかった
3. **スタブ検出状況の非記録**: Phase B までのコア通信基盤実装後、\`todo!()\` / \`unimplemented!()\` / \`panic!()\` / \`TODO\` / \`FIXME\` がすべてゼロであることが明示されていなかった

## 変更内容

### 第3版 (2026-04-19)

- **公開 API 境界を再定義**: \`private[remote]\` / \`private[pekko]\` / \`private[ssl]\` / \`private[tcp]\` は外部公開 API から除外。\`@deprecated\` な Classic Remoting も対象外として明記
- **カバレッジ再計算**: Pekko 公開型 30 (non-deprecated / non-JVM / non-private) に対し fraktor-rs 概念実装 13 = **43%**
- **スタブゼロを記録**: remote-core / remote-adaptor-std で \`todo!()\` / \`unimplemented!()\` / \`FIXME\` いずれも **0 件** を明記
- **新規ギャップ追加**:
  - \`RemoteRouterConfig\` (core/provider or core/routing, medium)
  - \`RemoteLogMarker\` (core/instrument, easy)
  - \`RemotingListenEvent\` (core/extension, easy)
  - Serialization: \`MiscMessageSerializer\` / \`MessageContainerSerializer\` / \`ProtobufSerializer\` / \`SystemMessageSerializer\` / \`ThrowableNotSerializableException\` (core/serialization via actor-core)
  - \`StdRemoting::addresses\` 空スライス返却 (std/extension_installer, easy)
- **実装優先度を再整理**:
  - Phase 1 (trivial/easy): 9 項目
  - Phase 2 (medium): 5 項目 (Phi 統計精度、TLS provider setup、各種 serializer、RemoteRouterConfig)
  - Phase 3 (hard): 5 項目 (TLS SPI + Config + RotatingKeys + Artery Compression 基盤)
- **内部構造分析は第4版へ繰り越し**: 公開 API カバレッジが 70% に達するまで、内部構造比較は省略

## 主要ギャップ (第3版で明確化)

- **TLS/SSL 完全未実装** (Phase 3, 5 件) — 本番環境での暗号化通信に不可欠
- **Artery Compression 未実装** (Phase 3, 5 件、内部 API 扱い) — ワイヤプロトコル拡張判断
- **Phi 統計精度** (Phase 2) — Pekko の正規分布 CDF 近似との数式一致
- **\`RemoteRouterConfig\`** (Phase 2) — cluster-core 整備と並行検討

## 判定の設計変更

第2版までは「fraktor-rs 側に存在するが Pekko の該当 API が internal」な型 (Association, Envelope, Codec 等) も公開 API として数えていたが、**Pekko との parity 評価としては誤り**。第3版ではこれらを「fraktor-rs の設計選択として \`pub\` で公開している内部実装」と位置付け直した。

## Non-goal

- 実コードの変更は含まない。本 PR は gap analysis ドキュメントの更新のみ。
- Phase 1〜3 の実装は後続 PR で順次対応。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update that reclassifies Pekko `private[*]`/deprecated items and recalculates coverage; no runtime code changes. Risk is limited to potential misguidance if the revised gap/priority assessment is incorrect.
> 
> **Overview**
> Updates the remote module gap analysis to a *3rd edition* by redefining the “public API” boundary (excluding Pekko `private[*]` and deprecated/classic/JVM-specific items) and recomputing coverage metrics accordingly.
> 
> Adds newly identified parity gaps (e.g., `RemotingListenEvent`, `RemoteRouterConfig`, `RemoteLogMarker`, remote-specific serializer types, and the `StdRemoting::addresses` empty-slice issue), records stub-scan results as **0**, and reorganizes implementation priorities into Phase 1–3 while deferring internal-structure comparison until public coverage improves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e55bccdd6cde1a22e6beaa9478824e7d009f37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->