### PR TITLE
chore(takt-pekko-porting): set claude.effort to high by default, low for final-ci

### DIFF
--- a/.takt/workflows/pekko-porting.yaml
+++ b/.takt/workflows/pekko-porting.yaml
@@ -6,6 +6,8 @@ workflow_config:
       network_access: true
     opencode:
       network_access: true
+    claude:
+      effort: high
 max_steps: 100
 initial_step: plan
 
@@ -461,6 +463,7 @@ steps:
       - fraktor-coding
     provider_options:
       claude:
+        effort: low
         allowed_tools:
           - Read
           - Glob


### PR DESCRIPTION
## 背景

takt 0.36.0 で \`provider_options.claude.effort\` がサポートされており（`CLAUDE_EFFORT_VALUES = ['low', 'medium', 'high', 'max']`）、pekko-porting ワークフローでは活用されていなかった。

Pekko 互換実装は「見た目を似せる」ではなく **契約意図を Rust 設計原則を壊さずに翻訳する** 作業であり、以下のステップは深い推論を要する:

- **plan**: バッチ選定、fake-impl 検出、stub-elimination との突合
- **write_tests**: 境界網羅テストの設計
- **implement**: Pekko 契約と Rust 設計制約の両立
- **reviewers** (qa / pekko-compat / test 並列): 互換性レビュー
- **review-fix**: 指摘を正しく汲んだ修正
- **supervise**: 最終 validation
- **loop-monitor judges**: サイクル判定の質

第8版 actor-gap-analysis (PR #1592) で検出された「内部セマンティクス逸脱 24 件」のように、表面実装は通過しても契約を守れていない箇所が出やすい。reasoning budget を高めに設定して取りこぼしを減らす。

## 変更内容

### \`workflow_config.provider_options\` に \`claude.effort: high\` を追加

workflow デフォルトとして \`high\` を設定。各 step の \`provider_options.claude\` で \`effort\` を明示していない場合はこれを継承する。

\`\`\`yaml
workflow_config:
  provider_options:
    codex:
      network_access: true
    opencode:
      network_access: true
    claude:
      effort: high
\`\`\`

### \`final-ci\` step のみ \`effort: low\` で上書き

\`final-ci\` は \`scripts/ci-check.sh ai all\` の成否を報告するだけで、深い推論を必要としない。reasoning budget を浪費しないよう \`low\` に明示。

\`\`\`yaml
- name: final-ci
  provider_options:
    claude:
      effort: low
      allowed_tools: [Read, Glob, Grep, Bash]
\`\`\`

## 仕様根拠

takt 0.36.0 の実装を確認:

- \`dist/infra/config/providerOptionsContract.js\`: \`provider_options.claude.effort\` を公式スキーマに登録
- \`dist/core/models/workflow-types.js\`: \`CLAUDE_EFFORT_VALUES = ['low', 'medium', 'high', 'max']\`
- \`dist/infra/claude-headless/client.js\`: \`if (options.effort) args.push('--effort', options.effort)\` で Claude CLI に \`--effort\` フラグを伝搬
- \`dist/infra/config/providerOptions.js\`: step レベルの \`effort\` が workflow レベルを上書きする merge ロジック (\`selectProviderValue\`) を実装済み

## 期待する効果

- **plan / implement / reviewers / supervise の推論品質向上**: 契約の取りこぼしが減る
- **loop-monitor 判定の質向上**: 「進捗あり/非生産的」の判定が正確になる
- **final-ci のコスト削減**: CI 実行結果確認に reasoning budget を使わない

## Non-goal

- 他の workflow (pekko-gap-analysis, refactoring, opsx-*, cc-sdd-*, issue-resolve 等) への一括適用は本 PR では扱わない。pekko-porting での運用結果を見てから判断する。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes workflow provider configuration (Claude `effort` defaults/override) and does not touch product code or data handling logic.
> 
> **Overview**
> Sets a workflow-level default `provider_options.claude.effort: high` for `.takt/workflows/pekko-porting.yaml` so steps inherit higher reasoning budget unless overridden.
> 
> Overrides the `final-ci` step to use `effort: low` while keeping its existing tool allowlist, reducing cost for the CI-reporting step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a93faca0cfef7ae909a36d51b65d2456fc708f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->