### PR TITLE
Rename event stream tests and comments

### DIFF
--- a/docs/plan/2026-04-20-pekko-default-pre-restart-deferred-proposal-plan.md
+++ b/docs/plan/2026-04-20-pekko-default-pre-restart-deferred-proposal-plan.md
@@ -1,0 +1,5 @@
+# 計画メモ: pekko-default-pre-restart-deferred proposal
+
+1. restart 経路の現状整理と、separate change に切り出す論点の確定
+2. 既存 OpenSpec proposal の形式確認と、新規 change 名の決定
+3. `proposal.md` のみ作成し、`design.md` / `tasks.md` は着手直前まで保留

--- a/modules/actor-core/src/core/kernel/event/stream/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/event/stream/base/tests.rs
@@ -220,7 +220,7 @@ fn with_capacity_creates_stream_with_specified_capacity() {
 }
 
 #[test]
-fn es_h1_t1_concrete_key_receives_only_matching_events() {
+fn concrete_key_subscriber_receives_only_matching_events() {
   let stream = EventStreamShared::default();
   let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let subscriber = subscriber_handle(RecordingSubscriber::new(events.clone()));
@@ -236,7 +236,7 @@ fn es_h1_t1_concrete_key_receives_only_matching_events() {
 }
 
 #[test]
-fn es_h1_t2_all_key_receives_all_variants() {
+fn all_key_subscriber_receives_all_event_variants() {
   let stream = EventStreamShared::default();
   let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let subscriber = subscriber_handle(RecordingSubscriber::new(events.clone()));
@@ -267,7 +267,7 @@ fn es_h1_t2_all_key_receives_all_variants() {
 }
 
 #[test]
-fn es_h1_t3_multiple_subscribers_fan_out_independently() {
+fn multiple_subscribers_receive_events_independently() {
   let stream = EventStreamShared::default();
 
   let lifecycle_events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
@@ -299,7 +299,7 @@ fn es_h1_t3_multiple_subscribers_fan_out_independently() {
 }
 
 #[test]
-fn es_h1_t4_publish_prepare_filters_subscribers_by_key() {
+fn publish_prepare_filters_subscribers_by_key() {
   let mut stream = EventStream::default();
 
   let log_subscriber = subscriber_handle(RecordingSubscriber::new(ArcShared::new(SpinSyncMutex::new(Vec::new()))));
@@ -327,7 +327,7 @@ fn es_h1_t4_publish_prepare_filters_subscribers_by_key() {
 }
 
 #[test]
-fn es_h1_t5_replay_filters_buffered_events_by_key() {
+fn replay_filters_buffered_events_by_key() {
   let stream = EventStreamShared::default();
 
   stream.publish(&EventStreamEvent::Log(log_event("buffered-log", 1)));

--- a/modules/actor-core/src/core/kernel/event/stream/event_stream_shared.rs
+++ b/modules/actor-core/src/core/kernel/event/stream/event_stream_shared.rs
@@ -67,7 +67,7 @@ impl EventStreamShared {
     key: ClassifierKey,
     subscriber: &EventStreamSubscriberShared,
   ) -> EventStreamSubscription {
-    // Phase 1: Acquire lock, register subscriber, get replay snapshot
+    // ロック中に購読登録と replay 対象確定を終え、解放後の通知でも一貫した見え方を保つ。
     let (id, snapshot) = self.inner.with_write(|guard| guard.subscribe_with_key(key, subscriber.clone()));
     // Lock released here!
 
@@ -103,7 +103,7 @@ impl EventStreamShared {
   ///
   /// Subscribers are notified after releasing the lock to prevent deadlocks.
   pub fn publish(&self, event: &EventStreamEvent) {
-    // Phase 1: Acquire lock, store event, get the filtered subscriber snapshot
+    // ロック中に配送先を確定してから解放し、通知中の再入や競合で購読者集合がぶれないようにする。
     let subscribers = self.inner.with_write(|guard| guard.publish_prepare(event.clone()));
     // Lock released here!
 

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1234,19 +1234,24 @@ run_examples() {
     rustflags_value="-Dwarnings --force-warn deprecated"
   fi
 
-  local example_file
-  example_file="$(mktemp)"
-  local metadata_file
-  metadata_file="$(mktemp)"
+  local example_file=""
+  example_file="$(mktemp)" || return 1
+  local metadata_file=""
+  metadata_file="$(mktemp)" || {
+    rm -f "${example_file}"
+    return 1
+  }
   if [[ -n "${DEFAULT_TOOLCHAIN}" ]]; then
     if ! env -u CARGO_TARGET_DIR CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" cargo "+${DEFAULT_TOOLCHAIN}" metadata --format-version 1 --no-deps > "${metadata_file}"; then
-      rm -f "${example_file}" "${metadata_file}"
+      [[ -n "${example_file}" ]] && rm -f "${example_file}"
+      [[ -n "${metadata_file}" ]] && rm -f "${metadata_file}"
       echo "エラー: cargo metadata の取得に失敗しました。" >&2
       return 1
     fi
   else
     if ! env -u CARGO_TARGET_DIR CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" cargo metadata --format-version 1 --no-deps > "${metadata_file}"; then
-      rm -f "${example_file}" "${metadata_file}"
+      [[ -n "${example_file}" ]] && rm -f "${example_file}"
+      [[ -n "${metadata_file}" ]] && rm -f "${metadata_file}"
       echo "エラー: cargo metadata の取得に失敗しました。" >&2
       return 1
     fi
@@ -1280,10 +1285,11 @@ for package in metadata.get("packages", []):
             features_str = ",".join(required_features) if required_features else ""
             print(f"{name}\t{target_name}\t{features_str}")
 PY
-    rm -f "${example_file}" "${metadata_file}"
+    [[ -n "${example_file}" ]] && rm -f "${example_file}"
+    [[ -n "${metadata_file}" ]] && rm -f "${metadata_file}"
     return 1
   fi
-  rm -f "${metadata_file}"
+  [[ -n "${metadata_file}" ]] && rm -f "${metadata_file}"
 
   local had_examples=""
   while IFS=$'\t' read -r package_name example_name features; do
@@ -1301,13 +1307,13 @@ PY
     fi
     RUSTFLAGS="${rustflags_value}" run_cargo "${cargo_args[@]}" \
       || {
-        rm -f "${example_file}"
+        [[ -n "${example_file}" ]] && rm -f "${example_file}"
         return 1
       }
     echo
   done <"${example_file}"
 
-  rm -f "${example_file}"
+  [[ -n "${example_file}" ]] && rm -f "${example_file}"
 
   if [[ -z "${had_examples}" ]]; then
     echo "info: 実行可能な example が見つかりませんでした" >&2


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test name/comment clarity, a small CI script robustness tweak, and a new planning doc with no runtime behavior changes.
> 
> **Overview**
> **Renames and clarifies event stream tests** by replacing opaque test identifiers with descriptive names around key-based subscription, fan-out, `publish_prepare`, and replay filtering.
> 
> **Improves documentation/comments** in `EventStreamShared` to better explain the lock/snapshot behavior during subscribe/publish.
> 
> **Hardens `scripts/ci-check.sh` temp-file handling** in `run_examples()` by checking `mktemp` failures and cleaning up partially-created files more safely. Adds a small planning note doc under `docs/plan/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62016ecda04f88ef168e884e2ce3f4a2901f2ef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->