### PR TITLE
refactor(actor-core): drop direct critical-section dependency from tick_feed

### DIFF
--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -1,0 +1,57 @@
+# actor-core critical-section 関連の hand-off 残課題
+
+`drop-actor-core-critical-section-dep` change の実装で対象外とした残課題のメモ。
+
+## 背景
+
+`drop-actor-core-critical-section-dep` は「`actor-core` の production code から `critical-section` クレートへの直接利用を撤去」を目的とした change。`tick_feed.rs` の `critical_section::Mutex<RefCell<VecDeque<u32>>>` を `SharedLock + DefaultMutex` 抽象に置換し、`Cargo.toml` の `critical-section` 依存を `optional = true` 化、`test-support` feature を `["dep:critical-section", "critical-section/std"]` に更新した。
+
+「源を絶つ」目標は達成したが、関連する残課題が複数発見された。
+
+## 残課題
+
+### 1. `test-support` feature の責務分離
+
+`actor-core/Cargo.toml:19` の `test-support` feature は現状 3 つの異なる責務を抱えている:
+
+- 責務 A: `critical-section/std` impl provider 提供（std 環境でリンクを通すため）
+- 責務 B: ダウンストリーム統合テスト用 API 公開（`TestTickDriver`, `new_empty` 等）
+- 責務 C: 内部 API の `pub(crate)` → `pub` 格上げ（`Behavior::handle_message` 等）
+
+`showcases/std` が `test-support` を `[dependencies]` で常時有効化している事実が、責務の混乱を示している。本来は `std-impl` / `test-support` / `internal-api` のような分離を検討すべき。
+
+### 2. `portable-atomic` の `critical-section` feature 再評価
+
+`actor-core/Cargo.toml:26` の `portable-atomic = { features = ["critical-section"] }` は組み込み 32-bit ターゲット向けの `AtomicU64` fallback として有効化されている。実際に組み込み 32-bit ターゲットでビルド・運用される実績があるか不明な場合は、std/64-bit 系のみ想定として `core::sync::atomic` への置換を検討する余地あり。
+
+ただし、`actor-core` の他 16 ファイルで `portable_atomic` が使われており、影響範囲は広い。
+
+### 3. `enqueue_from_isr` API 名と実装意図の乖離
+
+`tick_feed.rs:88` の `pub fn enqueue_from_isr(&self, ticks: u32)` は API 名から ISR セーフティを示唆するが、実装は `try_push` を呼ぶだけで `enqueue` と完全に同じパス。本 change の起案時調査で production caller が存在しない（`tick_driver/tests.rs:83-84` のテストのみ）ことが判明した。
+
+選択肢:
+- A: `enqueue_from_isr` を削除し、`enqueue` に一本化
+- B: ISR 専用の backend を `DefaultMutex` の feature variant（例: `irq-locks`）として追加し、`enqueue_from_isr` の実装を分岐
+- C: API 名を維持し、ドキュメントで「実装上は `enqueue` と同じ」を明記
+
+### 4. `actor-core/Cargo.toml:36` `spin` 直接依存の Requirement 2 違反
+
+本 change で追加した `actor-lock-construction-governance` Requirement 2「`actor-*` の `Cargo.toml` は primitive lock crate を non-optional な直接依存として宣言してはならない」に対し、`actor-core/Cargo.toml:36` の `spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "once"] }` が違反している。
+
+本 change のスコープは `critical-section` のみだったため、`spin` 直接依存の解消は別 change として対応する必要がある。検討事項:
+
+- `spin` の利用箇所を `actor-core` 内で grep
+- `utils-core` の `SpinSyncMutex` / `SpinSyncRwLock` 抽象に置き換え可能か検証
+- 置き換え不能なケースがあれば、そのケースだけ allow-list 化
+
+### 5. `dev-dependencies` の `critical-section` 直接宣言
+
+`actor-core/Cargo.toml:42` で `critical-section = { workspace = true, features = ["std"] }` が `[dev-dependencies]` に直接宣言されている。これは `actor-core` 自身の `cargo test` 実行時に std impl provider を提供するため。本 change で `[dependencies]` 側を `optional = true` に変更したので、`[dev-dependencies]` 側は `optional` の有無に関わらず常に有効化される。整合性を取るなら `[dev-dependencies]` 宣言を削除し、`test-support` feature 経由のみで impl 提供することも可能（要検証）。
+
+## 参照
+
+- 元 change: `openspec/changes/drop-actor-core-critical-section-dep/`
+- design.md Decision 3: ISR セマンティクスの判断
+- design.md Decision 6: optional 化の主選択 X
+- 関連 spec: `actor-lock-construction-governance`、`compile-time-lock-backend`

--- a/modules/actor-core/Cargo.toml
+++ b/modules/actor-core/Cargo.toml
@@ -16,12 +16,12 @@ autoexamples = false
 default = []
 alloc = []
 alloc-metrics = []
-test-support = ["critical-section/std"]
+test-support = ["dep:critical-section", "critical-section/std"]
 
 [dependencies]
 async-trait = { workspace = true }
 fraktor-utils-core-rs = { workspace = true, default-features = false, features = ["alloc", "unsize"] }
-critical-section = { workspace = true, default-features = false }
+critical-section = { workspace = true, default-features = false, optional = true }
 heapless = { workspace = true, default-features = false, features = ["portable-atomic"] }
 portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }
 portable-atomic-util = { workspace = true, default-features = false, features = ["alloc"] }

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs
@@ -2,15 +2,13 @@
 
 use alloc::collections::VecDeque;
 use core::{
-  cell::RefCell,
   marker::PhantomData,
   sync::atomic::{AtomicBool, Ordering},
   time::Duration,
 };
 
-use critical_section::Mutex;
 use fraktor_utils_core_rs::core::{
-  sync::ArcShared,
+  sync::{ArcShared, DefaultMutex, SharedLock},
   time::{SchedulerTickHandle, TimerInstant},
 };
 use portable_atomic::AtomicU64;
@@ -28,7 +26,7 @@ pub type TickFeedHandle = ArcShared<TickFeed>;
 /// Maintains buffered ticks plus metrics accounting.
 pub struct TickFeed {
   _marker:             PhantomData<()>,
-  queue:               Mutex<RefCell<VecDeque<u32>>>,
+  queue:               SharedLock<VecDeque<u32>>,
   capacity:            usize,
   signal:              TickExecutorSignal,
   handle:              SchedulerTickHandleOwned,
@@ -49,7 +47,7 @@ impl TickFeed {
     let queue = VecDeque::with_capacity(bounded_capacity);
     let feed = Self {
       _marker: PhantomData,
-      queue: Mutex::new(RefCell::new(queue)),
+      queue: SharedLock::new_with_driver::<DefaultMutex<_>>(queue),
       capacity: bounded_capacity,
       signal,
       handle: SchedulerTickHandleOwned::new(),
@@ -154,8 +152,7 @@ impl TickFeed {
   }
 
   fn try_push(&self, ticks: u32) -> bool {
-    critical_section::with(|cs| {
-      let mut queue = self.queue.borrow(cs).borrow_mut();
+    self.queue.with_lock(|queue| {
       if queue.len() >= self.capacity {
         false
       } else {
@@ -166,7 +163,7 @@ impl TickFeed {
   }
 
   fn pop_front(&self) -> Option<u32> {
-    critical_section::with(|cs| self.queue.borrow(cs).borrow_mut().pop_front())
+    self.queue.with_lock(|queue| queue.pop_front())
   }
 
   fn record_enqueue(&self, ticks: u32) {

--- a/openspec/changes/drop-actor-core-critical-section-dep/.openspec.yaml
+++ b/openspec/changes/drop-actor-core-critical-section-dep/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/drop-actor-core-critical-section-dep/design.md
+++ b/openspec/changes/drop-actor-core-critical-section-dep/design.md
@@ -1,0 +1,138 @@
+## Context
+
+`actor-core` の `tick_driver` モジュール内 `tick_feed.rs` は、tick イベントの内部キュー保護のために `critical_section::Mutex<RefCell<VecDeque<u32>>>` を直接 use している。これは以下の構造的問題を生んでいる:
+
+1. **`utils-core` 抽象の素通り**: `actor-core` 内・`cluster-core` 内で 27 箇所超が `SharedLock::new_with_driver::<DefaultMutex<_>>(...)` パターンを使っているのに対し、tick_feed のみが直接 `critical-section` クレートに依存している
+2. **`actor-core/Cargo.toml:24` の non-optional な直接依存**: 上記の唯一の利用者のために `critical-section = { workspace = true, default-features = false }` がトップレベル依存（non-optional）として残っている
+3. **`test-support` feature の存在理由の片方**: `actor-core/Cargo.toml:19` の `test-support = ["critical-section/std"]` は、std 環境でのテスト実行時に `critical-section` の impl provider を提供する必要があるために存在する。tick_feed が直接 `critical_section::Mutex` を要求していることがその一因
+4. **既存ガバナンスとの逸脱**: `actor-lock-construction-governance` spec が「`actor-*` の production code は固定 backend 指定や直接 lock 構築を行ってはならない」と定めているが、`critical_section::Mutex` の直接 use は文言上カバーされておらず、ガバナンスの精神には反する
+
+「源を絶つ」= `actor-core` の **production code（ソースコード）から `critical-section` クレートへの直接利用を撤去** することを目的とする。Cargo features 構文制約により `[dependencies]` の `critical-section` エントリ自体は完全削除できず `optional = true` で残す（詳細は Decision 6）。`portable-atomic` 経由の間接依存は本 change の対象外（`portable-atomic` のような low-level crate は別途 lint allow-list で扱う）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `actor-core` の production code から `critical-section` クレートへの直接 use を撤去し、`utils-core` 抽象（`SharedLock + DefaultMutex`）経由に置換する
+- `actor-core` から `critical-section` への direct dependency edge を **通常ビルドで無効化** する（Cargo features 構文制約により宣言自体は `optional = true` で残す。詳細は Decision 6）
+- `actor-lock-construction-governance` spec を拡張し、同種の逸脱を予防する 2 要件（primitive lock crate 直接 use 禁止 + Cargo.toml non-optional 直接依存禁止）を spec として宣言する
+- `tick_feed.rs` の public API シグネチャ互換性を維持する（メソッドシグネチャ不変）
+- 既存の単体・統合テストが従来どおり通る
+
+**Non-Goals:**
+- `test-support` feature 自体の撤去（impl provider 提供機能は維持する。実装表現を `dep:critical-section` 追加に調整するのみ）
+- `actor-core/Cargo.toml` から `critical-section` エントリの完全削除（Cargo features 構文制約により optional として残す）
+- `portable-atomic` の `critical-section` feature 撤去（組み込み 32-bit ターゲット向けの atomic fallback として必要）
+- `actor-core` の他 16 ファイルでの `portable_atomic` 利用見直し
+- `test-support` feature の責務 B（ダウンストリーム統合テスト用 API 公開）/ 責務 C（内部 API の pub 格上げ）の分離議論
+- `utils-core` 側の同期抽象（`SpinSyncMutex`、`StdSyncMutex` 等）の変更
+- ロックファミリ自動切り替えの新規メカニズム導入
+
+## Decisions
+
+### Decision 1: 抽象として `SharedLock + DefaultMutex` を採用する
+
+**選択**: `queue: SharedLock<VecDeque<u32>>` とし、コンストラクタで `SharedLock::new_with_driver::<DefaultMutex<_>>(queue)` を使う。
+
+**根拠**:
+- `actor-core` および `cluster-core` の production code 27 箇所超で同一パターンが既に確立されている（例: `circuit_breaker_shared.rs:34`、`event_stream_subscriber_shared.rs:18`、`pool_router.rs`、`group_router.rs`）
+- `DefaultMutex` は `utils-core/src/core/sync.rs:88-94` で feature ベースに backend 切り替えされる（`debug-locks` → `CheckedSpinSyncMutex`、`std-locks` → `StdSyncMutex`、それ以外 → `SpinSyncMutex`）。caller は backend を選ばない
+- `actor-lock-construction-governance` spec が要求する「provider または抽象 boundary を通す」設計に準拠
+
+**代替案と却下理由**:
+- 案 A: `SpinSyncMutex<VecDeque<u32>>` を直接使う → ガバナンス違反（固定 backend 指定）。CI lint で検出されるべきパターン
+- 案 B: `LockDriverFactory` 経由で provider 注入 → 過剰設計。`tick_feed` は actor-core 内部の固定構築要素であり、provider を外部から差し込む要件はない。`SharedLock::new_with_driver::<DefaultMutex<_>>` で feature 切り替えに任せるだけで十分
+- 案 C: 自前で trait `TickFeedQueue` を切る → YAGNI。既存の `SharedLock` 抽象で十分
+
+### Decision 2: `RefCell` 二重ラップを除去する
+
+**選択**: `Mutex<RefCell<VecDeque<u32>>>` → `SharedLock<VecDeque<u32>>`。`RefCell` を取り除く。
+
+**根拠**:
+- `critical_section::Mutex` は `Sync` だが内部の値への可変アクセスを許さないため、`RefCell` で内部可変性を確保する必要があった
+- `SharedLock::with_lock(|q| ...)` は closure に `&mut T` を直接渡す（`shared_lock.rs:72-85`）ため、`RefCell` は不要
+- コードが 1 段薄くなる
+
+### Decision 3: ISR セーフティ要件を厳密に再評価しない
+
+**選択**: `SharedLock + DefaultMutex` への置換を行う。ISR セマンティクスの厳密化は本 change のスコープ外とする。
+
+**根拠（事実ベース）**:
+- 本 change 起案時に `enqueue_from_isr` の caller を `Grep` で全数調査した結果、唯一の caller は `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs:83-84` のテストコードであり、**production code からの呼び出しは存在しない**
+- 現状の `enqueue_from_isr` は `try_push` を呼ぶだけで、`enqueue` と完全に同じパスを通っている。ISR 専用の処理（割り込み禁止区間の明示、bare-metal 用 spin 戦略など）は一切実装されていない
+- つまり「`critical_section::Mutex` を選んだ」という事実が ISR 安全性を担保している唯一の根拠だが、実際にはその担保を必要とする production caller が存在せず、API 名と実装意図の乖離が起きている
+- `DefaultMutex` の no_std 既定は `SpinSyncMutex`（spin-wait）。`std-locks` 有効時は `std::sync::Mutex`（OS スケジューラ依存）。どちらも厳密な ISR 安全性は持たないが、production caller が存在しない以上実害はない
+- 本 change は API 名 `enqueue_from_isr` を維持する（呼び出し側互換性のため）。API 名と実装の整合性、または ISR 用 backend 設計は別 change で扱う
+
+**リスク許容理由**:
+- 上記の grep 調査により、ISR 内からの呼び出しは production には存在しないことが確認済み
+- 将来 ISR 用 backend が必要になれば、`DefaultMutex` の feature 切り替えに新たな variant（例: `irq-locks`）を追加する道が残る
+- 厳密な ISR 安全性が必要なユーザーは、`tick_feed` を直接使わず独自実装を持つ判断ができる
+
+### Decision 4: `actor-lock-construction-governance` を拡張する（新規 spec を作らない）
+
+**選択**: 既存 spec `actor-lock-construction-governance/spec.md` に「primitive lock crate の直接 use 禁止」と「Cargo.toml 直接依存禁止」の 2 要件を ADDED Requirements として追加する。
+
+**根拠**:
+- 既存 spec の精神（lock backend を caller が固定しない）と完全に同一方向
+- 関連 spec `compile-time-lock-backend` も `DefaultMutex` 利用を要求しており、本追加要件はこれを補完する形になる（compile-time-lock-backend は backend 切り替え機構の宣言、actor-lock-construction-governance は caller 側の使用規律、本追加は primitive crate 利用境界の明示）
+- 新規 spec を作ると同じ趣旨の要件が 3 箇所に散らばる
+- `critical-section`、`spin`、`parking_lot` といった primitive lock crate の直接 use 禁止は、既存ガバナンスの自然な拡張
+
+**代替案と却下理由**:
+- 案 A: 新規 spec `actor-core-no-direct-primitive-lock-crate` を作る → 既存 spec と趣旨重複、capability 粒度の細分化
+- 案 B: 既存 spec を MODIFIED で書き換える → 既存要件はそのまま残り、新要件は ADDED で追記する形が自然
+
+### Decision 5: `test-support` feature の機能を維持する（実装表現は Decision 6 で調整）
+
+**選択**: `actor-core/Cargo.toml:19` の `test-support` feature の **機能**（std 環境での `critical-section` impl provider 提供）は維持する。
+
+**根拠**:
+- std 環境でテスト・bench・showcase を動かす際、`critical-section` の impl provider 選択（`std` feature 有効化）が必要なことは tick_feed の変更前後で変わらない（`portable-atomic` 経由の依存があるため）
+- `test-support` feature 自体の責務分離（impl provider 提供 vs テスト用 API 公開 vs 内部 API 公開）は別 change で議論する
+- Cargo features 構文制約への対応は Decision 6 の主選択 X に集約（実装表現の具体的調整方法）
+
+### Decision 6: `critical-section` を `[dependencies]` から完全削除せず `optional = true` で残す
+
+**選択（以降「主選択 X」と呼ぶ）**: `actor-core/Cargo.toml:24` の `critical-section = { workspace = true, default-features = false }` を `critical-section = { workspace = true, default-features = false, optional = true }` に変更する（**完全削除はしない**）。`test-support` feature は `["dep:critical-section", "critical-section/std"]` に変更する。
+
+**背景となる Cargo features 構文制約**:
+- Cargo の `<dep>/<feature>` 構文（例: `critical-section/std`）は、`<dep>` が `[dependencies]` または `[dev-dependencies]` に **直接宣言されている** ことを要求する
+- 推移的依存（本件では `portable-atomic` 経由）に対しては `<dep>/<feature>` 構文を使えない
+- もし `[dependencies]` から `critical-section` を完全削除すると、`test-support = ["critical-section/std"]` は `error: invalid feature ... dependency does not exist` になる
+
+**根拠**:
+- 「源を絶つ」の本来の目的は「actor-core の **production code（ソースコード）** が `critical-section` を直接 use しないこと」であり、Cargo.toml の `[dependencies]` エントリ自体の完全削除ではない
+- `optional = true` にすれば、feature 無効時（通常ビルド）には `actor-core` から `critical-section` への **direct edge** は消える。ただし `Cargo.lock` 全体には `portable-atomic` 経由の transitive edge で `critical-section` が依然として存在する（これは Non-Goals）
+- `test-support` feature 有効時のみ `actor-core` からの direct edge が現れ、`critical-section` の `std` feature が有効化される
+- `dep:critical-section` を features 配列に明示することで、Cargo に「この feature が `critical-section` という optional dep を有効化する」ことを伝える（Cargo 1.60+ で導入された明示構文）
+
+**代替案と却下理由**:
+- 案 A: `critical-section` を `[dev-dependencies]` に移動 → bench / integration test では使えるが、`actor-core` 自身を library として使うダウンストリームの test code から `test-support` feature 経由で利用できなくなる。現状の利用パターンを壊す
+- 案 B: `portable-atomic/critical-section-impl` のような portable-atomic 側の feature 経由で impl 有効化 → 起案時の起点理解では「`portable-atomic/critical-section` は逆に『`portable-atomic` が `critical-section` を使う』feature であり、『`critical-section` の `std` impl を有効化する』用途ではない」と推定。実機での確認は tasks 1.7 に委譲する。仮に該当 feature が見つかった場合は、案 X（optional 化）よりこちらが優れる可能性があるため、tasks 1.7 の結果次第で本 Decision を再検討する
+- 案 C: `actor-core/build.rs` で `critical-section/std` を強制有効化 → 過剰複雑化。Cargo features の表現範囲で完結する **主選択 X**（optional + dep:critical-section 明示）が自然
+
+**spec への影響**:
+- Requirement 2（`Cargo.toml` 直接依存禁止）は「non-optional な直接宣言禁止、optional + feature gated は例外」と明示する必要がある
+- 例外条項を spec に明記することで、本 change の処置と要件 B の整合を保つ
+
+## Risks / Trade-offs
+
+- **[Risk] ISR 優先度逆転の理論的可能性** → Mitigation: 現状の `enqueue_from_isr` が既に特別な ISR 配慮を持たないため、実害は理論上のみ。design.md Decision 3 で許容理由を明記。将来 ISR 用 backend が必要になれば `DefaultMutex` の feature variant 追加で対応可能
+- **[Risk] `actor-lock-construction-governance` 拡張により既存コードに新規違反が見つかる可能性** → Mitigation: 本 change の対象は `tick_feed.rs` の修正と spec 拡張のみ。他 file の違反検出は CI lint 整備（別 change）で対応。本 change は「拡張要件を spec として宣言する」までを完了とする
+- **[Trade-off] `DefaultMutex` の backend 選択は tick_feed の caller が指定できない** → 受容: そもそも `DefaultMutex` は workspace 全体で feature 統一切替されることを前提とした抽象。具体的には、tick_feed の caller が「ISR 安全性のために `critical_section::Mutex` ベースの mutex が欲しい」と思っても選択できない。しかし Decision 3 のとおり production caller が存在しないため実害なし
+
+## Migration Plan
+
+本 change はライブラリ内部実装の置換であり、ダウンストリーム移行手順は不要。
+
+1. **Phase 1**: `tick_feed.rs` の実装置換と単体テスト確認
+2. **Phase 2**: `actor-core/Cargo.toml` の `critical-section` を `optional = true` に変更し、`test-support` feature を `["dep:critical-section", "critical-section/std"]` に更新
+3. **Phase 3**: `cargo build --features test-support` および `cargo build --no-default-features` の両方で成功することを確認
+4. **Phase 4**: `openspec validate --strict` で artifact 整合確認、`openspec apply` 時の自動 merge を経て `actor-lock-construction-governance` spec に 2 要件（optional 例外条項を含む）が反映される
+5. **Phase 5**: `./scripts/ci-check.sh ai all` 実行確認
+
+ロールバックはソースコード変更のみであれば git revert で完結する。spec 変更を含む場合は、`openspec` の archive 機構との整合に注意（apply 後 archive 前であればファイル revert で十分）。
+
+## Open Questions
+
+- なし（必要な設計判断は本 design で確定済み）

--- a/openspec/changes/drop-actor-core-critical-section-dep/proposal.md
+++ b/openspec/changes/drop-actor-core-critical-section-dep/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`actor-core` は no_std クレートでありプラットフォーム固定ではない。共有ロック構築は `utils-core` が提供する `SharedLock + DefaultMutex` 抽象（feature による backend 切り替えを前提）を通すというガバナンス（`actor-lock-construction-governance`）が既に確立されている。
+
+ところが `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs` の 1 ファイルだけが、この抽象を素通りして `critical_section::Mutex<RefCell<VecDeque<u32>>>` を直接 use している。これにより:
+
+1. `actor-core/Cargo.toml:24` に `critical-section` クレートへの **non-optional な直接依存** が宣言されている
+2. `actor-core/Cargo.toml:19` の `test-support = ["critical-section/std"]` の存在理由の片方（impl provider 提供）を生み続けている
+3. ガバナンス（`actor-lock-construction-governance` および `compile-time-lock-backend`）が lock backend 固定指定を禁じている文脈に対し、`critical-section` 直接 use は文言上カバーされておらず、将来の同種逸脱を予防する明示的要件が欠けている
+
+「源を絶つ」とは、`actor-core` の **production code（ソースコード）から `critical-section` クレートへの直接利用を撤去** すること。Cargo の `<dep>/<feature>` 構文制約により、`test-support = ["critical-section/std"]` を維持するためには `[dependencies]` の `critical-section` エントリ自体は完全削除できず **`optional = true` で残す** 必要がある（詳細は design.md Decision 6）。`portable-atomic` 経由の間接依存と `test-support` feature 自体の撤去は別 change で扱う。
+
+## What Changes
+
+- `tick_feed.rs` の `queue: critical_section::Mutex<RefCell<VecDeque<u32>>>` を `queue: SharedLock<VecDeque<u32>>` に置換し、driver は `DefaultMutex` で feature 切り替えに任せる
+- `tick_feed.rs` 内の `critical_section::with(|cs| ...)` を `SharedLock::with_lock(|q| ...)` に置換し、`RefCell` 二重ラップを除去
+- `TickFeed` 構造体の内部フィールド `queue` の型変更（フィールドは `pub` ではないため public API には影響しない）。`new`、`enqueue`、`enqueue_from_isr`、`drain_pending`、`snapshot` 等のメソッドシグネチャは不変
+- `actor-core/Cargo.toml:24` の `critical-section = { workspace = true, default-features = false }` を `critical-section = { workspace = true, default-features = false, optional = true }` に変更（optional 化）。これにより `actor-core` の通常ビルドでは引き込まれず、ソースコードから直接 use されることもない
+- `actor-core/Cargo.toml:19` の `test-support = ["critical-section/std"]` を `test-support = ["dep:critical-section", "critical-section/std"]` に変更。Cargo features 制約に対応しつつ impl provider 提供の機能性を維持する
+- `actor-lock-construction-governance` spec を拡張し、以下の 2 要件を追加する。これにより同種の逸脱を将来的に lint または review で検出可能にする
+  - **要件 A**: `actor-*` の production code は primitive lock crate（`critical-section`、`spin`、`parking_lot` 等）および `std::sync::Mutex` / `std::sync::RwLock` を直接 use / 構築してはならない（shared state は `SharedLock + DefaultMutex` を経由する）
+  - **要件 B**: `actor-*` の `Cargo.toml` は primitive lock crate を `[dependencies]` に **non-optional な直接依存** として宣言してはならない（推移的依存、または `optional = true` かつ feature で gated された impl provider 用エントリ経由でのみ表現する）
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `actor-lock-construction-governance`: 既存ガバナンス（backend concrete / fixed-family alias の直接構築禁止）に対し、以下 2 要件を追加する
+  - 要件 A: primitive lock crate および `std::sync::Mutex` / `std::sync::RwLock` の直接 use / 構築禁止（コードレベル）
+  - 要件 B: primitive lock crate の `[dependencies]` への non-optional 直接宣言禁止（依存管理レベル。`optional = true` かつ feature で gated された impl provider 用エントリは例外）
+
+## Impact
+
+### 影響を受けるコード
+- `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs`（実装置換）
+- `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs`（`enqueue_from_isr` 関連テストの動作確認のみ。`TickFeed` を直接構築している箇所があれば追従修正）
+- `modules/actor-core/Cargo.toml`（`critical-section` の optional 化、`test-support` feature の `dep:critical-section` 追加）
+- `openspec/specs/actor-lock-construction-governance/spec.md`（apply 時に 2 要件が merge される）
+
+### 影響を受けない範囲
+- `tick_feed.rs` の public API シグネチャ（`enqueue`、`enqueue_from_isr`、`drain_pending`、`snapshot`、`signal`、`handle`、`driver_active`、`new`、`set_resolution`）
+- `test-support` feature を有効化したときの impl provider 提供機能（実装は `dep:critical-section` 追加で内部表現が変わるが、外部から見た挙動は不変）
+- 他クレート（`fraktor-utils-core-rs`、`fraktor-actor-adaptor-std-rs`、`fraktor-cluster-*-rs`、`fraktor-remote-*-rs`、`fraktor-stream-*-rs`、`fraktor-persistence-*-rs`）
+
+### 依存関係
+- `actor-core` の通常ビルドから `critical-section` クレートへの依存が消える（optional 化により feature 無効時は引き込まれない）
+- `test-support` feature 有効時のみ `critical-section` クレートが直接依存として有効化される（impl provider 用）
+- 推移的依存としての `critical-section` は `portable-atomic` 経由で残る（今回は触らない）
+
+### リスク
+- **ISR セーフティ表面の変化**: `critical_section::Mutex` は割り込み禁止区間で動作する設計だが、`enqueue_from_isr` の caller を grep した結果、production caller は存在せず actor-core 内テストコード（`modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs:83-84`）のみが呼んでいる。よって ISR 安全性の実装上の意味は現状なし。詳細は design.md Decision 3 で評価
+- 既存 spec `actor-lock-construction-governance` への要件追加により、将来の同種違反を CI/lint で検出可能になるが、現存コードに新たな違反が見つかる可能性がある（修正は別 change で対応）

--- a/openspec/changes/drop-actor-core-critical-section-dep/specs/actor-lock-construction-governance/spec.md
+++ b/openspec/changes/drop-actor-core-critical-section-dep/specs/actor-lock-construction-governance/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: actor-* の production code は primitive lock crate を直接 use してはならない
+
+`actor-*` の production code は、`critical-section`、`spin`、`parking_lot` などの primitive lock crate、および `std::sync::Mutex` / `std::sync::RwLock` を、同期プリミティブを構築するために直接 import / 構築してはならない（MUST NOT）。同期プリミティブを必要とする shared state は、`utils-core` が提供する `SharedLock` / `SharedRwLock` 抽象と `DefaultMutex` / `DefaultRwLock` driver を通して構築されなければならない（MUST）。
+
+本 requirement は `compile-time-lock-backend` spec の `DefaultMutex` 利用要件、および本 spec 既存の「fixed-family lock construction 禁止」要件を補完する。本要件は primitive lock crate の利用境界（誰がどの primitive crate を直接 use してよいか）を明示する役割を持つ。
+
+primitive lock crate の直接 use が許可されるのは以下のみとする:
+
+- `utils-core` 内の backend 実装ファイル（`spin_sync_mutex.rs`、`std_sync_mutex.rs`、`checked_spin_sync_mutex.rs` など）
+- `utils-core` 内の driver / factory / shared wrapper 実装
+- テストコード（`#[cfg(test)]` module、`tests/` ディレクトリ、`benches/`）
+
+#### Scenario: actor-* の production file は primitive lock crate を直接 use しない
+
+- **WHEN** `actor-*` の production Rust file（`#[cfg(test)]` module、`tests/`、`benches/` 配下を除く）が同期プリミティブを必要とする shared state を構築する
+- **THEN** その file は `use critical_section::{...};`、`use spin::{...};`、`use parking_lot::{...};`、`use std::sync::Mutex;`、`use std::sync::RwLock;` のような primitive lock crate / module からの import を行わない
+- **AND** その file は `critical_section::Mutex::new(...)`、`critical_section::with(...)`、`spin::Mutex::new(...)`、`parking_lot::Mutex::new(...)`、`std::sync::Mutex::new(...)`、`std::sync::RwLock::new(...)` などの直接構築を行わない
+- **AND** その shared state は `SharedLock::new_with_driver::<DefaultMutex<_>>(...)` または `SharedRwLock::new_with_driver::<DefaultRwLock<_>>(...)` を通して構築される
+
+#### Scenario: backend 実装層と utils-core は例外として許可される
+
+- **WHEN** `utils-core` 内の backend 実装ファイル（例: `spin_sync_mutex.rs`、`std_sync_mutex.rs`、`checked_spin_sync_mutex.rs`）または driver / factory / shared wrapper 実装が primitive lock crate / `std::sync` を直接 use する
+- **THEN** その箇所は本 requirement の違反として扱わない
+- **AND** allow-list は `utils-core/src/core/sync/` 配下に閉じる
+
+### Requirement: actor-* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない
+
+`actor-*` クレートの `Cargo.toml` は、`critical-section`、`spin`、`parking_lot` などの primitive lock crate を `[dependencies]` に **non-optional な** 直接依存として宣言してはならない（MUST NOT）。これらの crate への依存は、`utils-core` を通した推移的依存として表現されなければならない（MUST）。
+
+ただし以下は例外として許可する:
+
+- `portable-atomic` のような low-level utility crate が引き込む推移的依存
+- `optional = true` で宣言され、かつ `[features]` の test 専用 feature（例: `test-support`）からのみ `dep:<name>` および `<name>/<feature>` 構文で有効化される impl provider 用エントリ。これは Cargo の `<dep>/<feature>` 構文制約を満たすために必要であり、shared state 構築用途には使われない（MUST 用途を制限）
+
+#### Scenario: actor-core の Cargo.toml は critical-section を non-optional な直接依存として持たない
+
+- **WHEN** `modules/actor-core/Cargo.toml` の `[dependencies]` セクションで `critical-section` エントリを検査する
+- **THEN** エントリが存在する場合、必ず `optional = true` を含む（non-optional な宣言は許容しない）
+- **AND** `optional = true` の `critical-section` エントリが存在する場合、`[features]` で必ず `dep:critical-section` を含む test 専用 feature（例: `test-support`）からのみ有効化される
+
+#### Scenario: actor-* の他クレートも同じ規約に従う
+
+- **WHEN** `fraktor-actor-adaptor-std-rs`、`fraktor-cluster-*-rs`、`fraktor-remote-*-rs`、`fraktor-stream-*-rs`、`fraktor-persistence-*-rs` の `Cargo.toml` を読む
+- **THEN** いずれも `critical-section`、`spin`、`parking_lot` を non-optional な `[dependencies]` 直接宣言として持たない
+- **AND** これらのクレートが同期プリミティブを必要とする場合は `fraktor-utils-core-rs` 経由で取得する

--- a/openspec/changes/drop-actor-core-critical-section-dep/tasks.md
+++ b/openspec/changes/drop-actor-core-critical-section-dep/tasks.md
@@ -1,0 +1,50 @@
+## 1. 事前調査
+
+- [x] 1.1 `tick_feed.rs` の単体テスト位置を確認する（`tick_driver/tests.rs:79-` に `enqueue_from_isr_preserves_order_and_metrics` を確認。加えて `tick_feed/tests.rs` も発見、内容は public API のみ使用）
+- [x] 1.2 `TickFeed` 構造体直接生成探索結果: `TickFeed { ... }` 直接生成は 0 件。`TickFeed::new(` は 8 箇所（system_state.rs:269, bootstrap.rs:53, tick_feed/tests.rs:13/28, tick_metrics_probe/tests.rs:14, tick_driver_bundle/tests.rs:10, scheduler_tick_executor/tests.rs:31, tick_driver/tests.rs:81）。すべて public API 経由のため追従修正不要
+- [x] 1.3 `actor-core` 全体で `critical_section` の他の参照箇所なし（`tick_feed.rs:11, :157, :169` のみ）
+- [x] 1.4 `enqueue_from_isr` caller は `tick_driver/tests.rs:83-84` のみ。production caller なし（design.md Decision 3 根拠維持）
+- [x] 1.5 `compile-time-lock-backend/spec.md` 確認済み。`DefaultMutex` 利用要求で本 change と整合
+- [x] 1.6 `actor-core/Cargo.toml` の `[dependencies]` 確認: **`spin = { workspace = true, ... }` が :36 で直接宣言されている**（本 change スコープ外、別 change で対応すべき hand-off 事項）。`parking_lot` は無し
+- [x] 1.7 `portable-atomic` features 確認結果: `critical-section, default, disable-fiq, fallback, float, force-amo, require-cas, s-mode, serde, std, unsafe-assume-privileged, unsafe-assume-single-core`。`critical-section/std` impl を有効化する代替経路は **存在しない**。本 change は主選択 X で進行
+
+## 2. tick_feed.rs の実装置換
+
+- [x] 2.1 `use critical_section::Mutex;` を削除した
+- [x] 2.2 `use core::cell::RefCell;` を削除した
+- [x] 2.3 `use fraktor_utils_core_rs::core::sync::{DefaultMutex, SharedLock};` を `ArcShared` import の隣に追加（`{ArcShared, DefaultMutex, SharedLock}` で alphabetical）
+- [x] 2.4 `queue: SharedLock<VecDeque<u32>>` に変更
+- [x] 2.5 `queue: SharedLock::new_with_driver::<DefaultMutex<_>>(queue)` に変更
+- [x] 2.6 `try_push` を `self.queue.with_lock(|queue| ...)` に置換
+- [x] 2.7 `pop_front` を `self.queue.with_lock(|queue| queue.pop_front())` に置換
+- [x] 2.8 `cargo fmt --check` で差分なし（追加修正不要）
+- [x] 2.9 `cargo build -p fraktor-actor-core-rs` 成功
+
+## 3. テスト追従
+
+- [x] 3.1 `tick_feed/tests.rs` は public API のみ使用で追従修正不要（task 1.1 で確認）
+- [x] 3.2 `cargo test -p fraktor-actor-core-rs --lib tick_driver` 24 passed
+- [x] 3.3 `cargo test -p fraktor-actor-core-rs --features test-support --tests --lib` 1846 passed, 3 ignored, 13 suites
+
+## 4. Cargo.toml クリーンアップ
+
+- [x] 4.1 `critical-section` を `optional = true` に変更
+- [x] 4.2 `test-support = ["dep:critical-section", "critical-section/std"]` に変更
+- [x] 4.3 `cargo build --no-default-features` 成功。`cargo tree --no-default-features --depth 1` で `critical-section` が direct dep に現れず、`portable-atomic v1.13.1` 経由の transitive のみ
+- [x] 4.4 `cargo build --features test-support` 成功、`invalid feature` エラーなし
+
+## 5. spec の整合確認
+
+- [x] 5.1 `openspec validate drop-actor-core-critical-section-dep --strict` valid
+- [x] 5.2 spec delta 視認: 2 要件（要件 A: primitive lock crate 直接 use 禁止、要件 B: Cargo.toml non-optional 直接依存禁止）が ADDED Requirements として merge 対象
+- [x] 5.3 Scenario の WHEN/THEN/AND は機械的検証可能な形（grep ベースの lint で実装可能な記述）
+
+## 6. 全体 CI 確認
+
+- [x] 6.1 `./scripts/ci-check.sh ai all` 成功（EXIT=0、全テスト pass、全 lint pass）
+- [x] 6.2 失敗なし
+- [ ] 6.3 ユーザー指示によりコミット保留（ユーザー判断後に実施）
+
+## 7. ドキュメント更新（必要なら）
+
+- [x] 7.1 `docs/plan/` に hand-off メモを作成: ① `test-support` 責務分離、② `portable-atomic` の `critical-section` feature 再評価、③ `enqueue_from_isr` API 名と実装意図の乖離、④ `actor-core/Cargo.toml:36` `spin` 直接依存の Requirement 2 違反


### PR DESCRIPTION
## 概要

`actor-core` の `tick_feed.rs` が唯一 `utils-core` 抽象を素通りして `critical_section::Mutex<RefCell<VecDeque<u32>>>` を直接 use していた箇所を、確立済みパターン `SharedLock + DefaultMutex` に置換する。

「源を絶つ」目標として、`actor-core` の production code から `critical-section` クレートへの直接利用を撤去した。

## 変更内容

### ソースコード
- `tick_feed.rs`: `critical_section::Mutex<RefCell<VecDeque<u32>>>` → `SharedLock<VecDeque<u32>>` + `DefaultMutex` driver
- `RefCell` 二重ラップを除去（コードが 1 段薄くなる）

### Cargo.toml
- `critical-section` → `optional = true` 化
- `test-support` feature → `["dep:critical-section", "critical-section/std"]`
- 完全削除しない理由: Cargo の `<dep>/<feature>` 構文制約により `[dependencies]` エントリ自体は必要

### Spec 拡張 (`actor-lock-construction-governance`)
- **要件 A**: `actor-*` の production code は primitive lock crate（`critical-section`、`spin`、`parking_lot` 等）および `std::sync::Mutex` / `RwLock` を直接 use / 構築してはならない
- **要件 B**: `actor-*` の `Cargo.toml` は primitive lock crate を non-optional な直接依存として宣言してはならない

## 検証結果

| チェック | 結果 |
|---------|------|
| `cargo build -p fraktor-actor-core-rs` | ✓ |
| `cargo build --no-default-features` | ✓ |
| `cargo build --features test-support` | ✓ (`invalid feature` エラーなし) |
| `cargo tree --no-default-features --depth 1` で `critical-section` が direct dep に出ない | ✓ (`portable-atomic` 経由 transitive のみ残る) |
| `cargo test --lib tick_driver` | 24 passed |
| `cargo test --features test-support --tests --lib` | 1846 passed, 3 ignored, 13 suites |
| `./scripts/ci-check.sh ai all` | EXIT=0 (全 pass) |

## スコープ外（hand-off 残課題）

`docs/plan/2026-04-21-actor-core-critical-section-followups.md` に記録:

1. `test-support` feature の責務分離（impl provider / テスト用 API / 内部 API 公開）
2. `portable-atomic` の `critical-section` feature 再評価
3. `enqueue_from_isr` API 名と実装意図の乖離（production caller なし）
4. **`actor-core/Cargo.toml:36` `spin` 直接依存が Requirement B 違反**（別 change で対応）
5. `[dev-dependencies]` の `critical-section` 直接宣言の整合確認

## 設計判断

詳細は `openspec/changes/drop-actor-core-critical-section-dep/design.md` を参照:

- Decision 3: ISR セーフティ要件を厳密に再評価しない（`enqueue_from_isr` の production caller が存在しないため）
- Decision 6: `critical-section` を `[dependencies]` から完全削除せず `optional = true` で残す（Cargo features 構文制約）

## 後方互換性

`TickFeed` の public API シグネチャは不変（`new`、`enqueue`、`enqueue_from_isr`、`drain_pending`、`snapshot` 等）。内部フィールド `queue` の型変更のみ（`pub` ではないため public API 影響なし）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes synchronization primitive used by `TickFeed` and adjusts Cargo feature/dependency wiring, which can subtly affect concurrency behavior and build configurations across targets.
> 
> **Overview**
> Removes `actor-core` production code’s direct use of `critical-section` by refactoring `tick_driver::tick_feed`’s internal queue from `critical_section::Mutex<RefCell<_>>` to `utils-core`’s `SharedLock<VecDeque<u32>>` with a `DefaultMutex` driver (keeping the public `TickFeed` API unchanged).
> 
> Updates `actor-core/Cargo.toml` so `critical-section` is `optional = true` and `test-support` explicitly enables it via `dep:critical-section` plus `critical-section/std`, reducing the default direct dependency edge.
> 
> Adds an OpenSpec change that extends `actor-lock-construction-governance` with new requirements forbidding primitive lock crates (and `std::sync` locks) in `actor-*` production code and forbidding non-optional direct primitive-lock dependencies in `Cargo.toml`, plus documentation/hand-off notes for follow-up items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 182fd9d165da5e80acaceee4a495611b3fe11afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 技術計画ドキュメントを追加し、フィーチャー依存関係と内部実装に関する技術課題をまとめました。

* **Refactor**
  * 内部の同期メカニズムを改善し、パフォーマンスと保守性を向上させました。

* **Chores**
  * 依存関係の宣言を最適化し、必要な場合のみ依存パッケージが読み込まれるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->