### PR TITLE
refactor(actor-core): retire test-support critical-section impl provider

### DIFF
--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -12,13 +12,13 @@
 
 ### 1. `test-support` feature の責務分離
 
-`actor-core/Cargo.toml:19` の `test-support` feature は現状 3 つの異なる責務を抱えている:
+`actor-core/Cargo.toml:19` の `test-support` feature は当初 3 つの異なる責務を抱えていた:
 
-- 責務 A: `critical-section/std` impl provider 提供（std 環境でリンクを通すため）
-- 責務 B: ダウンストリーム統合テスト用 API 公開（`TestTickDriver`, `new_empty` 等）
-- 責務 C: 内部 API の `pub(crate)` → `pub` 格上げ（`Behavior::handle_message` 等）
+- 責務 A: `critical-section/std` impl provider 提供（std 環境でリンクを通すため） → **完了** (`retire-actor-core-test-support-critical-section-impl` change で各バイナリ側へ移譲、2026-04-21)
+- 責務 B: ダウンストリーム統合テスト用 API 公開（`TestTickDriver`, `new_empty` 等） → 未着手
+- 責務 C: 内部 API の `pub(crate)` → `pub` 格上げ（`Behavior::handle_message` 等） → 未着手
 
-`showcases/std` が `test-support` を `[dependencies]` で常時有効化している事実が、責務の混乱を示している。本来は `std-impl` / `test-support` / `internal-api` のような分離を検討すべき。
+責務 A 退役後、`actor-core/test-support` は `[]`（空配列）になり、責務 B/C のための `#[cfg(any(test, feature = "test-support"))]` がコード側で利用される構造のみが残った。最終的に責務 B/C も退役できれば `test-support` feature 自体を削除できる。
 
 ### 2. `portable-atomic` の `critical-section` feature 再評価
 

--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -45,9 +45,9 @@
 - `utils-core` の `SpinSyncMutex` / `SpinSyncRwLock` 抽象に置き換え可能か検証
 - 置き換え不能なケースがあれば、そのケースだけ allow-list 化
 
-### 5. `dev-dependencies` の `critical-section` 直接宣言
+### 5. `dev-dependencies` の `critical-section` 直接宣言（解消済み）
 
-`actor-core/Cargo.toml:42` で `critical-section = { workspace = true, features = ["std"] }` が `[dev-dependencies]` に直接宣言されている。これは `actor-core` 自身の `cargo test` 実行時に std impl provider を提供するため。本 change で `[dependencies]` 側を `optional = true` に変更したので、`[dev-dependencies]` 側は `optional` の有無に関わらず常に有効化される。整合性を取るなら `[dev-dependencies]` 宣言を削除し、`test-support` feature 経由のみで impl 提供することも可能（要検証）。
+`retire-actor-core-test-support-critical-section-impl` change（2026-04-21）により、impl provider 供給は各バイナリ（tests/benches/showcases）の責務に統一された。`actor-core/Cargo.toml` の `[dependencies]` から `critical-section` は完全削除済み。`[dev-dependencies]` に残る `critical-section = { workspace = true, features = ["std"] }` は、`actor-core` 自身の `cargo test` が impl を必要とするため引き続き必要（除去しない）。
 
 ## 参照
 

--- a/modules/actor-core/Cargo.toml
+++ b/modules/actor-core/Cargo.toml
@@ -16,12 +16,11 @@ autoexamples = false
 default = []
 alloc = []
 alloc-metrics = []
-test-support = ["dep:critical-section", "critical-section/std"]
+test-support = []
 
 [dependencies]
 async-trait = { workspace = true }
 fraktor-utils-core-rs = { workspace = true, default-features = false, features = ["alloc", "unsize"] }
-critical-section = { workspace = true, default-features = false, optional = true }
 heapless = { workspace = true, default-features = false, features = ["portable-atomic"] }
 portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }
 portable-atomic-util = { workspace = true, default-features = false, features = ["alloc"] }

--- a/modules/cluster-adaptor-std/Cargo.toml
+++ b/modules/cluster-adaptor-std/Cargo.toml
@@ -37,5 +37,6 @@ fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["tokio-executor", "test-support"] }
 fraktor-cluster-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
+critical-section = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net", "sync", "io-util"] }
 anyhow = { workspace = true }

--- a/modules/cluster-core/Cargo.toml
+++ b/modules/cluster-core/Cargo.toml
@@ -29,3 +29,4 @@ workspace = true
 [dev-dependencies]
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
+critical-section = { workspace = true, features = ["std"] }

--- a/modules/remote-adaptor-std/Cargo.toml
+++ b/modules/remote-adaptor-std/Cargo.toml
@@ -31,7 +31,6 @@ tracing = { workspace = true, features = ["std"] }
 workspace = true
 
 [dev-dependencies]
-fraktor-remote-core-rs = { workspace = true }
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["tokio-executor", "test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }

--- a/modules/remote-adaptor-std/Cargo.toml
+++ b/modules/remote-adaptor-std/Cargo.toml
@@ -14,10 +14,7 @@ autoexamples = false
 
 [features]
 default = []
-test-support = [
-  "fraktor-remote-core-rs/test-support",
-  "fraktor-actor-core-rs/test-support",
-]
+test-support = ["fraktor-actor-core-rs/test-support"]
 
 [dependencies]
 fraktor-remote-core-rs = { workspace = true }
@@ -34,9 +31,10 @@ tracing = { workspace = true, features = ["std"] }
 workspace = true
 
 [dev-dependencies]
-fraktor-remote-core-rs = { workspace = true, features = ["test-support"] }
+fraktor-remote-core-rs = { workspace = true }
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["tokio-executor", "test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
+critical-section = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "net", "sync", "io-util", "test-util"] }
 anyhow = { workspace = true }

--- a/modules/remote-core/Cargo.toml
+++ b/modules/remote-core/Cargo.toml
@@ -14,7 +14,6 @@ autoexamples = false
 
 [features]
 default = []
-test-support = []
 
 [dependencies]
 fraktor-actor-core-rs = { workspace = true }

--- a/modules/stream-adaptor-std/Cargo.toml
+++ b/modules/stream-adaptor-std/Cargo.toml
@@ -24,3 +24,4 @@ workspace = true
 
 [dev-dependencies]
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+critical-section = { workspace = true, features = ["std"] }

--- a/modules/stream-core/Cargo.toml
+++ b/modules/stream-core/Cargo.toml
@@ -28,3 +28,4 @@ workspace = true
 [dev-dependencies]
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
+critical-section = { workspace = true, features = ["std"] }

--- a/openspec/changes/retire-actor-core-test-support-critical-section-impl/.openspec.yaml
+++ b/openspec/changes/retire-actor-core-test-support-critical-section-impl/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/retire-actor-core-test-support-critical-section-impl/design.md
+++ b/openspec/changes/retire-actor-core-test-support-critical-section-impl/design.md
@@ -1,0 +1,134 @@
+## Context
+
+`actor-core/test-support` feature は前回 change（`drop-actor-core-critical-section-dep`、PR #1605/#1606）以前から、`critical-section/std` impl provider をダウンストリームに自動配給する役割（責務 A）を担ってきた。前回 change で Cargo features 構文制約に対応するため `test-support = ["dep:critical-section", "critical-section/std"]` 形式に整理されたが、責務 A 自体は `actor-core` に残ったままだった。
+
+`critical-section` クレートの本来の作法では、ライブラリは依存を宣言するのみで impl 選択はバイナリ（test バイナリ、showcase バイナリ等）の責任とされる。本 change は `actor-core` が責務 A を抱え続ける理由がないこと（前回 change で tick_feed.rs から直接 use が消え、impl 選択の機能性のみが残っている）を踏まえ、責務 A を **本来の所在地（バイナリ側）に移譲** する。
+
+実態調査（前回 change の hand-off メモおよび本 change の追加調査）により以下が判明:
+
+- `modules/actor-adaptor-std/Cargo.toml:37-38` および `modules/persistence-core/Cargo.toml:28-29` は **既に dev-deps で `critical-section = { features = ["std"] }` を直接記述済み**。これは `actor-adaptor-std/Cargo.toml:30-36` のコメントによれば「integration tests と benches のシンボル解決失敗を防ぐため」の意図的な二重宣言。本 change で `actor-core/test-support` から impl provider 関連が消えれば、二重宣言は単純な「自前で取得」に整理される
+- 他 5 クレート（cluster-core、cluster-adaptor-std、remote-adaptor-std、stream-core、stream-adaptor-std）は `actor-core/test-support` 経由のみで impl provider を取得
+- `showcases/std/Cargo.toml:9-10, 19-20` は `[dependencies]` で `actor-core/test-support` および他 3 クレートの `test-support` を有効化
+- `remote-core/Cargo.toml:17` の `test-support = []` は完全に空、利用箇所なし
+- `actor-core/Cargo.toml:51-86` の 8 個の `[[test]]` ブロックは `required-features = ["test-support"]`。本 change では `test-support` feature 自体は残すため影響なし
+
+## Goals / Non-Goals
+
+**Goals:**
+- `actor-core` から `critical-section` クレートへの **direct dependency edge を完全削除** する（`optional = true` 含めて Cargo.toml の `[dependencies]` から消す）
+- `test-support` feature を `[]` に簡略化し、impl provider 関連責務を撤去する
+- 各バイナリ単位（test/bench/showcase）で `critical-section = { features = ["std"] }` を `[dev-dependencies]` または `[dependencies]` に直接記述する形に統一する
+- `actor-lock-construction-governance` Requirement B の例外条項を削除し、規約をシンプル化する
+- 全 9 クレートのビルド・テストが従来どおり通る
+
+**Non-Goals:**
+- `test-support` feature 自体の完全退役（責務 B/C のため残す）
+- 責務 B（`TestTickDriver`、`new_empty` 等の API 公開）の分離・移動
+- 責務 C（内部 API の `pub` 格上げ）の分離
+- `portable-atomic/critical-section` feature の撤去
+- `utils-core/Cargo.toml:26` の `critical-section` 直接依存の見直し（utils-core は backend 実装層として例外許可）
+- `actor-core/Cargo.toml:36` の `spin` 直接依存の撤去
+
+## Decisions
+
+### Decision 1: 責務 A を完全に各バイナリ側に移譲する
+
+**選択**: `actor-core/test-support` から `critical-section/std` 関連を完全削除し、各バイナリが自前で `critical-section = { features = ["std"] }` を宣言する。
+
+**根拠**:
+- `critical-section` クレートの標準作法（ライブラリは依存宣言のみ、impl 選択はバイナリ側）に準拠する
+- `actor-adaptor-std`・`persistence-core` で意図的に行われていた二重宣言（context 参照）が「単純な自前取得」に整理される
+- `test-support` feature の名称と機能が一致するようになる（impl provider 提供は名前から類推されない責務だった）
+
+**代替案と却下理由**:
+- 案 A: 専用 feature `std-impl` を新設して責務 A を切り出す → feature 数が増え、ダウンストリームが「`test-support` か `std-impl` か」を判断する必要が出る。標準作法に従えば feature 自体が不要
+- 案 B: `actor-core` の `test-support` に責務 A を残し続ける → 現状維持。`test-support` の責務混在が解消しない
+
+### Decision 2: `actor-core/Cargo.toml` から `critical-section` を完全削除する
+
+**選択**: `actor-core/Cargo.toml:24` の `critical-section = { workspace = true, default-features = false, optional = true }` 行を完全に削除する。
+
+**根拠**:
+- 責務 A 撤去後、`actor-core` 自身が `critical-section` を直接依存する理由が完全に消える
+- `[dev-dependencies]` の `critical-section = { workspace = true, features = ["std"] }`（:42）は維持（actor-core 自身の `cargo test` で必要）
+- ソースコードからの use は前回 change で既に消えている
+- `portable-atomic` 経由の transitive 依存は引き続き存在するが、これは `[dependencies]` 直接宣言ではない
+
+**代替案と却下理由**:
+- 案 A: `optional = true` のまま残す → 利用されない依存宣言を残すのは死に依存。Requirement B の規約簡素化の意義も失われる
+
+### Decision 3: 各バイナリ側の修正方針は「最小追加・既存非破壊」
+
+**選択**: ダウンストリームクレートの修正は以下に統一する:
+
+1. `[dev-dependencies]`（または `[dependencies]`）に `critical-section = { workspace = true, features = ["std"] }` を 1 行追加
+2. 既存の `fraktor-actor-core-rs = { features = ["test-support"] }` 等の記述は維持（責務 B/C のため引き続き必要）
+3. `actor-adaptor-std` と `persistence-core` は既に直接記述済みのため変更不要
+
+**根拠**:
+- `test-support` feature 自体の退役は別 change のため、`test-support` 利用箇所はそのまま
+- 各クレートで responsibility A の取得経路を明示することで「誰が impl provider を要求しているか」が明確になる
+- 1 行追加で済む最小変更
+
+**代替案と却下理由**:
+- 案 A: workspace ルートの `Cargo.toml` の `[workspace.dependencies]` に `critical-section = { features = ["std"] }` をデフォルト有効化として宣言 → workspace 全体に影響、no_std 利用者にも `std` feature が誤って入る危険
+
+### Decision 4: `actor-lock-construction-governance` Requirement B の例外条項を削除する
+
+**選択**: 前回 change で追加した「`optional = true` かつ feature gated な impl provider 用エントリは例外」の例外条項を MODIFIED Requirements で削除する。
+
+**根拠**:
+- 本 change で例外を発動する箇所（`actor-core` の `critical-section` optional 宣言）が消える
+- 例外を残すと「将来再び optional 宣言を作る余地」を spec として認めることになり、本 change の方針（バイナリ側責任）に反する
+- spec はシンプルに「`actor-*` の `Cargo.toml` は primitive lock crate を `[dependencies]` に直接宣言してはならない（推移的依存のみ許可）」と整理する
+
+**代替案と却下理由**:
+- 案 A: 例外条項を残しつつ「現時点で発動箇所なし」と注記 → 将来の逸脱の余地を残す。シンプル化の意義が損なわれる
+
+### Decision 5: `remote-core` の幽霊定義を削除する
+
+**選択**: `modules/remote-core/Cargo.toml:17` の `test-support = []` を削除する。
+
+**根拠**:
+- 完全に空、`remote-core/src` 内に `cfg(any(test, feature = "test-support"))` は 0 件（前回 change の調査で確認済み）
+- 以前は `remote-adaptor-std` の dev-deps 記述のためだけに存在していたが、本 change で `remote-adaptor-std` 側の `fraktor-remote-core-rs/test-support` 記述も整理可能（test-support 自体は責務 B/C のため残るが、remote-core には責務 B/C が無いため不要）
+
+**代替案と却下理由**:
+- 案 A: 幽霊定義を残す → 死に feature 定義を spec / コードに残す意味なし
+
+### Decision 6: showcases/std は `[dependencies]` に直接記述する
+
+**選択**: `showcases/std/Cargo.toml` の `[dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を追加する（`[dev-dependencies]` ではなく）。
+
+**根拠**:
+- `showcases/std` は実行バイナリとして `cargo run` されるため、`[dependencies]` で常時必要
+- 既に `actor-core/test-support` を `[dependencies]` で常時有効化していた事実と整合（前回 change の調査で「test-support の常時有効化が命名と実態の乖離」と指摘した部分が、本修正で正される）
+
+**代替案と却下理由**:
+- 案 A: `showcases/std` を crate 構造変更し、impl provider 取得を別経路にする → 過剰
+
+## Risks / Trade-offs
+
+- **[Risk] 各クレートの `critical-section/std` 追加忘れ** → Mitigation: tasks フェーズで対象 5 クレート + showcase を網羅的に修正、各クレートで `cargo test` または `cargo build` を確認
+- **[Risk] `[[test]] required-features = ["test-support"]` の挙動変化** → Mitigation: `actor-core/Cargo.toml` の `test-support = []` 化後も、test-support 有効化時に `[dev-dependencies]` の `critical-section/std` が引き込まれるため、actor-core 自身のテストは従来どおり動く（Decision 2 で言及）
+- **[Risk] 移行漏れによる no_std ターゲットへの影響** → Mitigation: `actor-core` の `[dependencies]` から `critical-section` を完全削除しても no_std ターゲットには元々 `critical-section/std` は無関係。ダウンストリームの dev-deps 経由は test/bench でのみ有効化されるため no_std ビルドに影響なし
+- **[Trade-off] ダウンストリームに 1 行のボイラープレートが増える** → 受容: 標準作法に従う代償として妥当。長期的には feature 構造のシンプル化メリットが上回る
+- **[Trade-off] `test-support` feature が中途半端な状態（責務 B/C のみ）になる** → 受容: 責務 B/C の退役は別 change でスケジュール済み。本 change は段階的退役の第 1 ステップ
+
+## Migration Plan
+
+本 change はビルド設定変更が主体であり、ダウンストリーム移行手順は不要。
+
+1. **Phase 1**: ダウンストリーム 5 クレートの dev-dependencies に `critical-section = { features = ["std"] }` 追加
+2. **Phase 2**: `showcases/std/Cargo.toml` の `[dependencies]` に `critical-section = { features = ["std"] }` 追加
+3. **Phase 3**: 各クレートで `cargo test` / `cargo build` 確認
+4. **Phase 4**: `actor-core/Cargo.toml` の `test-support = []` 化、`[dependencies]` から `critical-section` 削除
+5. **Phase 5**: `remote-core/Cargo.toml:17` の幽霊定義削除（連動して `remote-adaptor-std` の test-support 配列も整理）
+6. **Phase 6**: `openspec validate --strict` で artifact 整合確認（spec delta は本 change の `specs/actor-lock-construction-governance/spec.md` に記述済み、`openspec apply` 時に main spec へ自動 merge）
+7. **Phase 7**: `./scripts/ci-check.sh ai all` 実行確認
+
+ロールバックは git revert で完結する（外部状態への影響なし）。
+
+## Open Questions
+
+- なし（必要な設計判断は本 design で確定済み）

--- a/openspec/changes/retire-actor-core-test-support-critical-section-impl/proposal.md
+++ b/openspec/changes/retire-actor-core-test-support-critical-section-impl/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+直前 merge された change `drop-actor-core-critical-section-dep`（PR #1605, #1606）で `tick_feed.rs` の直接 use を撤去し `actor-core/Cargo.toml` の `critical-section` を `optional = true` 化したが、`actor-core/test-support` feature には依然として **3 責務（A: impl provider 提供 / B: テスト用 API 公開 / C: 内部 API の `pub` 格上げ）** が混在している。
+
+本 change は **責務 A の退役** を目的とする。`critical-section` クレートの本来の作法（ライブラリは依存宣言のみ、impl 選択はバイナリ側の責任）に従い、各バイナリ単位（test/bench/showcase）が `critical-section = { features = ["std"] }` を直接書く形に移行する。これにより `test-support` feature 自体は責務 B/C のみを抱える状態となり、最終的な feature 退役（別 change）への足場ができる。
+
+## What Changes
+
+- **BREAKING（ワークスペース内ダウンストリーム + 同パターン外部利用者）**: `actor-core/test-support` 経由で `critical-section/std` impl が自動配給されなくなる。fraktor-rs ワークスペース内の 5 クレート + showcase で `critical-section = { features = ["std"] }` の追加宣言が必要。fraktor-rs を library として使う外部利用者（`actor-core/test-support` を有効化していたケース）も同様の追加宣言が必要（ただし fraktor-rs はリリース前開発フェーズのため実質影響は workspace 内に限定）
+- `actor-core/Cargo.toml:19` の `test-support = ["dep:critical-section", "critical-section/std"]` を `test-support = []` に変更
+- `actor-core/Cargo.toml:24` の `critical-section = { workspace = true, default-features = false, optional = true }` を完全削除
+- 各ダウンストリームクレートの修正は design Decision 3 を参照（最小追加・既存非破壊）
+- `remote-core/Cargo.toml:17` の幽霊定義 `test-support = []` を削除
+- `actor-lock-construction-governance` spec の Requirement B（前回 change で追加）の例外条項「`optional = true` かつ feature gated な impl provider 用エントリ」を MODIFIED で削除（本 change で例外発動箇所が消えるため）
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `actor-lock-construction-governance`: Requirement B の例外条項を削除する MODIFIED。`optional + feature gated impl provider` の例外を撤去し、`actor-*` の `Cargo.toml` は「primitive lock crate を `[dependencies]` に直接宣言してはならない（推移的依存のみ許可）」というシンプルな規約に整理する
+
+## Impact
+
+### 影響を受けるコード
+
+- `modules/actor-core/Cargo.toml`: `test-support` から impl 関連削除、`[dependencies]` の `critical-section` 完全削除
+- `modules/cluster-core/Cargo.toml`: dev-deps に `critical-section/std` 追加
+- `modules/cluster-adaptor-std/Cargo.toml`: dev-deps に `critical-section/std` 追加
+- `modules/remote-adaptor-std/Cargo.toml`: dev-deps に `critical-section/std` 追加
+- `modules/stream-core/Cargo.toml`: dev-deps に `critical-section/std` 追加
+- `modules/stream-adaptor-std/Cargo.toml`: dev-deps に `critical-section/std` 追加
+- `modules/remote-core/Cargo.toml:17`: 幽霊定義削除
+- `showcases/std/Cargo.toml`: `[dependencies]` に `critical-section/std` 追加
+- `openspec/specs/actor-lock-construction-governance/spec.md`: Requirement B の例外条項を MODIFIED で削除
+
+### 影響を受けない範囲
+
+- `modules/actor-adaptor-std/Cargo.toml`: 既に dev-deps で `critical-section = { features = ["std"] }` 直接記述済み（`:38`）
+- `modules/persistence-core/Cargo.toml`: 既に dev-deps で `critical-section = { features = ["std"] }` 直接記述済み（`:28`）
+- `modules/actor-core/Cargo.toml` の `[dev-dependencies]` の `critical-section = { workspace = true, features = ["std"] }`（`:42`）: actor-core 自身のテスト用、維持
+- `actor-core/Cargo.toml` の 8 個の `required-features = ["test-support"]` integration test 設定: `test-support` feature 自体は維持されるため不変
+- `tick_feed.rs` の `SharedLock + DefaultMutex` 実装（前回 change で完成）
+- `utils-core/Cargo.toml` の `critical-section` 直接依存: `utils-core` は backend 実装層であり Requirement A/B の例外として許可される（actor-* ではない）
+
+### 依存関係
+
+- `actor-core` の `[dependencies]` から `critical-section` クレートが完全に消える（`portable-atomic` 経由 transitive のみ残る）
+- 各バイナリ（test/bench/showcase）が impl provider 選択の責任を持つ標準的構造になる
+
+### リスク
+
+- **dev-dependencies 経由の test 動作確認**: 各クレートで `cargo test` が通ることを確認
+- **showcase の動作確認**: `showcases/std` の実行が通ること
+- **移行漏れ**: ダウンストリーム 5 クレート + showcase の修正で 1 つでも漏れると、対象クレートの `cargo test` または `cargo build` が `undefined reference to _critical_section_1_0_acquire` でリンク失敗する
+- **責務 B/C は依然 `test-support` feature に残る**: 本 change のスコープは A のみ。`test-support` feature 自体の退役は別 change
+
+### 後続 change（hand-off）
+
+- 責務 B（`TestTickDriver`、`new_empty` 等の API 公開）の `actor-adaptor-std` への移動 / 専用 crate 切り出し
+- 責務 C（内部 API の `pub` 格上げ）の `test-helpers` crate 化または `#[doc(hidden)]` 化
+- 責務 B/C 完全退役後、`test-support` feature 自体の削除

--- a/openspec/changes/retire-actor-core-test-support-critical-section-impl/specs/actor-lock-construction-governance/spec.md
+++ b/openspec/changes/retire-actor-core-test-support-critical-section-impl/specs/actor-lock-construction-governance/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: actor-* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない
+
+`actor-*` クレートの `Cargo.toml` は、`critical-section`、`spin`、`parking_lot` などの primitive lock crate を `[dependencies]` に直接依存として宣言してはならない（MUST NOT）。これらの crate への依存は、`utils-core` を通した推移的依存として表現されなければならない（MUST）。
+
+ただし以下は例外として許可する:
+
+- `portable-atomic` のような low-level utility crate が引き込む推移的依存
+- 各クレートの `[dev-dependencies]` に test/bench 用の impl provider 取得目的で記述される `critical-section = { features = ["std"] }` 等のエントリ（production 依存ではないため `[dependencies]` 直接宣言禁止には該当しない）
+- `showcases/std` のような実行バイナリ crate の `[dependencies]` における impl provider 取得目的の記述（バイナリ側が impl 選択責任を持つ標準作法に基づく）
+
+impl provider 取得は各バイナリが `[dev-dependencies]` または `[dependencies]` で直接宣言する形に統一する。
+
+#### Scenario: actor-core の Cargo.toml は critical-section を `[dependencies]` 直接依存として持たない
+
+- **WHEN** `modules/actor-core/Cargo.toml` の `[dependencies]` セクションで `critical-section` エントリを検査する
+- **THEN** `critical-section` エントリは存在しない
+- **AND** `critical-section` への依存は `portable-atomic = { features = ["critical-section"] }` のような推移的経路でのみ表現される
+- **AND** `[dev-dependencies]` には `critical-section = { workspace = true, features = ["std"] }` が impl provider 取得目的で記述されてよい（actor-core 自身の `cargo test` で必要）
+
+#### Scenario: actor-* の他クレートも同じ規約に従う
+
+- **WHEN** `fraktor-actor-adaptor-std-rs`、`fraktor-cluster-*-rs`、`fraktor-remote-*-rs`、`fraktor-stream-*-rs`、`fraktor-persistence-*-rs` の `Cargo.toml` を読む
+- **THEN** いずれも `critical-section`、`spin`、`parking_lot` を `[dependencies]` 直接宣言として持たない
+- **AND** これらのクレートが同期プリミティブを必要とする場合は `fraktor-utils-core-rs` 経由で取得する
+- **AND** test/bench で `critical-section` の `std` impl が必要な場合は `[dev-dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を直接記述する
+
+#### Scenario: 各バイナリは impl provider を直接宣言する
+
+- **WHEN** `actor-*` 配下のテスト（`[[test]]`）、bench、または `showcases/std` 等の実行バイナリ crate が `critical-section` の impl を必要とする
+- **THEN** 当該 crate は `[dev-dependencies]` または `[dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を直接記述する
+- **AND** `actor-*` の library crate の feature flag（例: `test-support`）を経由した自動配給には依存しない

--- a/openspec/changes/retire-actor-core-test-support-critical-section-impl/tasks.md
+++ b/openspec/changes/retire-actor-core-test-support-critical-section-impl/tasks.md
@@ -1,0 +1,55 @@
+## 1. 事前調査と確認
+
+- [x] 1.1 各クレート `[dev-dependencies]` 確認完了: `actor-adaptor-std:38`/`persistence-core:28` は `critical-section` 直接記述あり、`cluster-core:30`/`cluster-adaptor-std:36-39`/`remote-adaptor-std:37-40`/`stream-core:29`/`stream-adaptor-std:26` は `actor-core/test-support` 経由のみ
+- [x] 1.2 `showcases/std/Cargo.toml:9-10, 19-20` で 4 クレートの `test-support` 有効化を確認
+- [x] 1.3 `remote-core` の test-support 空定義の参照は `remote-adaptor-std/Cargo.toml:18, :37` のみ
+- [x] 1.4 `actor-core/Cargo.toml:51-86` の 8 integration test の `required-features = ["test-support"]` は `test-support` feature 自体が残るため動作不変
+
+## 2. ダウンストリームクレートの dev-dependencies 修正
+
+- [x] 2.1 `cluster-core/Cargo.toml` の `[dev-dependencies]` に `critical-section = { workspace = true, features = ["std"] }` 追加
+- [x] 2.2 `cluster-adaptor-std/Cargo.toml` の `[dev-dependencies]` に追加
+- [x] 2.3 `remote-adaptor-std/Cargo.toml` の `[dev-dependencies]` に追加
+- [x] 2.4 `stream-core/Cargo.toml` の `[dev-dependencies]` に追加
+- [x] 2.5 `stream-adaptor-std/Cargo.toml` の `[dev-dependencies]` に追加
+- [x] 2.6 `actor-adaptor-std`、`persistence-core` は既に直接記述済みのため変更不要を確認
+
+## 3. showcases/std の修正
+
+- [x] 3.1 `showcases/std/Cargo.toml` の `[dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を追加
+
+## 4. 中間ビルド検証（actor-core 修正前）
+
+- [x] 4.1 5 ダウンストリームクレートで `cargo build` 成功（cluster-core/cluster-adaptor-std/remote-adaptor-std/stream-core/stream-adaptor-std）
+- [x] 4.2 `cargo build` 全ターゲット成功
+
+## 5. actor-core の整理
+
+- [x] 5.1 `actor-core/Cargo.toml` の `test-support` を `[]` に変更（impl 関連削除）
+- [x] 5.2 `actor-core/Cargo.toml` の `[dependencies]` から `critical-section` 行を完全削除
+- [x] 5.3 `[dev-dependencies]` の `critical-section` は維持
+- [x] 5.4 `cargo build -p fraktor-actor-core-rs --no-default-features` 成功
+- [x] 5.5 `cargo test -p fraktor-actor-core-rs --features test-support` 成功（CI 全 pass で確認）
+- [x] 5.6 `cargo tree --no-default-features --depth 1` で `critical-section` direct dep に出現せず（`portable-atomic v1.13.1` 経由 transitive のみ、dev-deps に `critical-section v1.2.0`）
+
+## 6. remote-core の整理
+
+- [x] 6.1 `remote-core/Cargo.toml` の `test-support = []` 行削除
+- [x] 6.2 `remote-adaptor-std/Cargo.toml` の `test-support` 配列から `fraktor-remote-core-rs/test-support` 削除
+- [x] 6.3 `remote-adaptor-std/Cargo.toml` の `fraktor-remote-core-rs` features 削除
+- [x] 6.4 `cargo build` 成功
+
+## 7. spec の整合確認
+
+- [x] 7.1 `openspec validate retire-actor-core-test-support-critical-section-impl --strict` valid
+- [x] 7.2 spec delta 視認確認、apply 時に既存 Requirement が MODIFIED 内容で置換される形
+
+## 8. 全体 CI 確認
+
+- [x] 8.1 `./scripts/ci-check.sh ai all` 成功（EXIT=0、全 pass）
+- [x] 8.2 失敗なし
+- [ ] 8.3 ユーザー指示によりコミット・PR 作成へ進行
+
+## 9. ドキュメント更新
+
+- [x] 9.1 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 更新（責務 A 部分退役完了を記録）

--- a/showcases/std/Cargo.toml
+++ b/showcases/std/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["std-locks"] }
+critical-section = { workspace = true, features = ["std"] }
 fraktor-stream-core-rs = { workspace = true }
 serde_json = { workspace = true }
 bincode = { workspace = true, features = ["alloc", "serde"] }


### PR DESCRIPTION
## 概要

直前 merge された #1605/#1606（`drop-actor-core-critical-section-dep`）に続き、`actor-core/test-support` feature から `critical-section/std` impl provider 提供責任（責務 A）を撤去し、各バイナリ（test/bench/showcase）が自前で impl を宣言する形に移行する。

`critical-section` クレートの標準作法（ライブラリは依存宣言のみ、impl 選択はバイナリ側の責任）に準拠。

## 変更内容

### `actor-core/Cargo.toml`
- `test-support = ["dep:critical-section", "critical-section/std"]` → `test-support = []`
- `[dependencies]` から `critical-section = { ..., optional = true }` 行を完全削除
- `[dev-dependencies]` の `critical-section = { ..., features = ["std"] }` は維持（actor-core 自身の `cargo test` 用）

### ダウンストリーム 5 クレート（`[dev-dependencies]` に追加）
- `cluster-core`、`cluster-adaptor-std`、`remote-adaptor-std`、`stream-core`、`stream-adaptor-std`

### `showcases/std/Cargo.toml`
- `[dependencies]` に `critical-section = { features = ["std"] }` 追加（実行バイナリのため）

### `remote-core/Cargo.toml`
- 幽霊定義 `test-support = []` を削除
- `remote-adaptor-std` 側の `fraktor-remote-core-rs/test-support` 参照もクリーンアップ

### Spec MODIFIED (`actor-lock-construction-governance`)
- Requirement B の例外条項から「`optional = true` + feature gated impl provider」を削除
- `[dev-dependencies]` / 実行バイナリの `[dependencies]` 直接記述を許可する例外を明示
- impl provider 取得は各バイナリの責任へ統一

## 検証結果

| チェック | 結果 |
|---------|------|
| `cargo build -p fraktor-actor-core-rs --no-default-features` | ✓ |
| `cargo build --features test-support` | ✓ (`invalid feature` エラーなし) |
| `cargo tree --no-default-features --depth 1` | ✓ (`critical-section` 消失) |
| `./scripts/ci-check.sh ai all` | EXIT=0 (全 pass) |

## スコープ外（hand-off 更新）

`docs/plan/2026-04-21-actor-core-critical-section-followups.md` を更新:

- ✅ **責務 A**: `critical-section/std` impl provider 提供 → 退役完了（本 PR）
- 責務 B: `TestTickDriver`、`new_empty` 等の API 公開 → 未着手
- 責務 C: 内部 API の `pub(crate)` → `pub` 格上げ → 未着手

責務 B/C の退役後、`test-support` feature 自体を削除する段階に進める。

## 設計判断

詳細は `openspec/changes/retire-actor-core-test-support-critical-section-impl/design.md` を参照。6 つの Decision:

1. 責務 A を各バイナリに移譲（標準作法準拠）
2. `critical-section` を `[dependencies]` から完全削除
3. 各バイナリ修正は最小追加・既存非破壊
4. spec 例外条項を MODIFIED で削除
5. `remote-core` の幽霊定義削除
6. `showcases/std` は `[dependencies]` に直接記述（実行バイナリのため）

## 後方互換性

`test-support` feature 自体は維持されるため、feature を有効化するダウンストリームコードは影響なし。ただし impl provider の自動配給が消えるため、workspace 内 5 クレート + showcase で `critical-section/std` の明示宣言を追加した。

外部利用者で `actor-core/test-support` 経由 impl 取得を期待していた場合は、`critical-section = { features = ["std"] }` の追加宣言が必要（fraktor-rs はリリース前開発フェーズのため実質影響は workspace 内に限定）。

## 関連

- 前 PR: #1605（実装本体）、#1606（archive）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily dependency/feature wiring, but it is *behaviorally breaking* for any downstream that implicitly relied on `actor-core/test-support` to link `critical-section/std`, and missed updates will fail at link time in tests/benches/showcases.
> 
> **Overview**
> Removes `critical-section/std` impl-provider auto-wiring from `fraktor-actor-core-rs`: `test-support` is now empty (`[]`) and `critical-section` is deleted from `[dependencies]` (kept only as a `[dev-dependencies]` requirement for `actor-core`’s own tests).
> 
> To keep tests/benches and the std showcase linking, downstream crates that relied on the transitive impl now explicitly add `critical-section = { features = ["std"] }` (cluster/remote/stream std crates), `remote-adaptor-std` drops the unused `remote-core/test-support` feature linkage, and `showcases/std` adds `critical-section` as a normal dependency. The `actor-lock-construction-governance` spec is updated to reflect the stricter “no primitive lock crates in `[dependencies]`” rule while explicitly allowing impl providers in `[dev-dependencies]`/binary `[dependencies]`, and the follow-up plan doc is updated to mark this responsibility retired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c5eaf2274b9d312647cf2d0de8ce150ad9a935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * テスト機能の責務を明確化し、各モジュール間での役割分担を整理しました。
  * 一部モジュールの内部依存関係を再編成し、開発環境における構成を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->