### PR TITLE
step01: eliminate actor-core spin direct dependency

### DIFF
--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -35,15 +35,18 @@
 - B: ISR 専用の backend を `DefaultMutex` の feature variant（例: `irq-locks`）として追加し、`enqueue_from_isr` の実装を分岐
 - C: API 名を維持し、ドキュメントで「実装上は `enqueue` と同じ」を明記
 
-### 4. `actor-core/Cargo.toml:36` `spin` 直接依存の Requirement 2 違反
+### 4. `actor-core/Cargo.toml:35` `spin` 直接依存の Requirement 2 違反（解消済み）
 
-本 change で追加した `actor-lock-construction-governance` Requirement 2「`actor-*` の `Cargo.toml` は primitive lock crate を non-optional な直接依存として宣言してはならない」に対し、`actor-core/Cargo.toml:36` の `spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "once"] }` が違反している。
+**解消済み**: `step01-eliminate-actor-core-spin-direct-dep` change（2026-04-21）で対応完了。
 
-本 change のスコープは `critical-section` のみだったため、`spin` 直接依存の解消は別 change として対応する必要がある。検討事項:
+対応内容:
+- `utils-core` に Once 系の 3 段構造（`OnceDriver<T>` trait、`SpinOnce<T>` backend、`SyncOnce<T>` 公開抽象）を新設（既存 `LockDriver` / `SpinSyncMutex` / `SharedLock` パターンと相似形）
+- `actor-core` の `spin::Once` 利用 2 箇所（`coordinated_shutdown.rs`、`mailbox/base.rs`）を `SyncOnce` に置換
+- `actor-core/Cargo.toml` から `spin` 直接依存行を完全削除
+- `actor-core/clippy.toml` の `disallowed-types` に `spin::Once` を追加（safety net 強化）
+- `actor-lock-construction-governance` spec に `spin` 固有 Scenario を追加して検査カバレッジを拡張
 
-- `spin` の利用箇所を `actor-core` 内で grep
-- `utils-core` の `SpinSyncMutex` / `SpinSyncRwLock` 抽象に置き換え可能か検証
-- 置き換え不能なケースがあれば、そのケースだけ allow-list 化
+他 actor-\* クレート（`cluster-*`、`remote-*`、`stream-*`、`persistence-*`、`actor-adaptor-std`）の `spin` 直接依存調査は本 change のスコープ外。必要があれば同じ方針で別 change として対応する。
 
 ### 5. `dev-dependencies` の `critical-section` 直接宣言（解消済み）
 

--- a/modules/actor-core/Cargo.toml
+++ b/modules/actor-core/Cargo.toml
@@ -32,7 +32,6 @@ erased-serde = { workspace = true }
 bincode = { workspace = true }
 futures = { workspace = true, features = ["alloc"] }
 tracing = { workspace = true, default-features = false }
-spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "once"] }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/modules/actor-core/clippy.toml
+++ b/modules/actor-core/clippy.toml
@@ -7,4 +7,5 @@ disallowed-types = [
   { path = "std::sync::Mutex", reason = "Use SpinSyncMutex within production code", replacement = "fraktor_utils_core_rs::core::sync::SpinSyncMutex" },
   { path = "spin::Mutex", reason = "Use SpinSyncMutex within production code", replacement = "fraktor_utils_core_rs::core::sync::SpinSyncMutex" },
   { path = "spin::RwLock", reason = "Use SpinSyncRwLock within production code", replacement = "fraktor_utils_core_rs::core::sync::SpinSyncRwLock" },
+  { path = "spin::Once", reason = "Use SyncOnce within production code", replacement = "fraktor_utils_core_rs::core::sync::SyncOnce" },
 ]

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs
@@ -6,8 +6,7 @@ mod tests;
 use alloc::{boxed::Box, collections::VecDeque, string::String};
 use core::{num::NonZeroUsize, time::Duration};
 
-use fraktor_utils_core_rs::core::sync::{SharedAccess, WeakShared};
-use spin::Once;
+use fraktor_utils_core_rs::core::sync::{SharedAccess, SyncOnce, WeakShared};
 
 use super::{
   CloseRequestOutcome, DequeMessageQueue, MailboxScheduleState, RunFinishOutcome, ScheduleHints, SystemQueue,
@@ -49,15 +48,15 @@ pub struct Mailbox {
   state:           MailboxScheduleState,
   /// Write-once instrumentation hooks. Set once via
   /// [`set_instrumentation`](Self::set_instrumentation), read lock-free thereafter via
-  /// `spin::Once::get()`.
-  instrumentation: Once<MailboxInstrumentation>,
+  /// `SyncOnce::get()`.
+  instrumentation: SyncOnce<MailboxInstrumentation>,
   cleanup_policy:  MailboxCleanupPolicy,
   /// Write-once message invoker. Set once via [`install_invoker`](Self::install_invoker),
-  /// read lock-free thereafter via `spin::Once::get()`.
-  invoker:         Once<MessageInvokerShared>,
+  /// read lock-free thereafter via `SyncOnce::get()`.
+  invoker:         SyncOnce<MessageInvokerShared>,
   /// Write-once weak handle to the owning actor cell. Set by [`Mailbox::with_actor`]
   /// or [`install_actor`](Self::install_actor), read lock-free thereafter.
-  actor:           Once<WeakShared<ActorCell>>,
+  actor:           SyncOnce<WeakShared<ActorCell>>,
 }
 
 unsafe impl Send for Mailbox {}
@@ -127,10 +126,10 @@ impl Mailbox {
       user: queue,
       put_lock: shared_set.put_lock(),
       state: MailboxScheduleState::new(),
-      instrumentation: Once::new(),
+      instrumentation: SyncOnce::new(),
       cleanup_policy: MailboxCleanupPolicy::DrainToDeadLetters,
-      invoker: Once::new(),
-      actor: Once::new(),
+      invoker: SyncOnce::new(),
+      actor: SyncOnce::new(),
     }
   }
 
@@ -159,10 +158,10 @@ impl Mailbox {
       user: queue,
       put_lock: shared_set.put_lock(),
       state: MailboxScheduleState::new(),
-      instrumentation: Once::new(),
+      instrumentation: SyncOnce::new(),
       cleanup_policy: MailboxCleanupPolicy::LeaveSharedQueue,
-      invoker: Once::new(),
-      actor: Once::new(),
+      invoker: SyncOnce::new(),
+      actor: SyncOnce::new(),
     }
   }
 
@@ -197,11 +196,11 @@ impl Mailbox {
       user: queue,
       put_lock: shared_set.put_lock(),
       state: MailboxScheduleState::new(),
-      instrumentation: Once::new(),
+      instrumentation: SyncOnce::new(),
       cleanup_policy: MailboxCleanupPolicy::DrainToDeadLetters,
-      invoker: Once::new(),
+      invoker: SyncOnce::new(),
       actor: {
-        let once = Once::new();
+        let once = SyncOnce::new();
         once.call_once(|| actor);
         once
       },

--- a/modules/actor-core/src/core/kernel/system/coordinated_shutdown.rs
+++ b/modules/actor-core/src/core/kernel/system/coordinated_shutdown.rs
@@ -16,11 +16,10 @@ use core::{
 };
 
 use fraktor_utils_core_rs::core::{
-  sync::{ArcShared, DefaultMutex, SharedAccess, SharedLock},
+  sync::{ArcShared, DefaultMutex, SharedAccess, SharedLock, SyncOnce},
   timing::delay::DelayProvider,
 };
 use futures::future::{Either, join_all, poll_fn, select};
-use spin::Once;
 
 use super::{coordinated_shutdown_error::CoordinatedShutdownError, coordinated_shutdown_id::CoordinatedShutdownId};
 use crate::core::kernel::{
@@ -70,7 +69,7 @@ pub struct CoordinatedShutdown {
   tasks:          SharedLock<BTreeMap<String, Vec<ShutdownTask>>>,
   run_started:    AtomicBool,
   run_done:       AtomicBool,
-  reason:         Once<CoordinatedShutdownReason>,
+  reason:         SyncOnce<CoordinatedShutdownReason>,
   delay_provider: Option<SharedLock<Box<dyn DelayProvider>>>,
 }
 
@@ -214,7 +213,7 @@ impl CoordinatedShutdown {
       tasks: SharedLock::new_with_driver::<DefaultMutex<_>>(BTreeMap::new()),
       run_started: AtomicBool::new(false),
       run_done: AtomicBool::new(false),
-      reason: Once::new(),
+      reason: SyncOnce::new(),
       delay_provider: delay_provider.map(SharedLock::new_with_driver::<DefaultMutex<_>>),
     })
   }

--- a/modules/actor-core/src/core/kernel/system/shared_factory/mailbox_shared_set.rs
+++ b/modules/actor-core/src/core/kernel/system/shared_factory/mailbox_shared_set.rs
@@ -8,7 +8,7 @@ use fraktor_utils_core_rs::core::sync::{DefaultMutex, SharedLock};
 /// The former `invoker` / `actor` / `instrumentation` fields were write-once
 /// and are now stored directly in
 /// [`Mailbox`](crate::core::kernel::dispatch::mailbox::Mailbox) as
-/// `spin::Once<T>` for lock-free reads on the hot path.
+/// `SyncOnce<T>` for lock-free reads on the hot path.
 #[derive(Clone)]
 pub struct MailboxSharedSet {
   put_lock: MailboxLocked<()>,

--- a/modules/utils-core/Cargo.toml
+++ b/modules/utils-core/Cargo.toml
@@ -24,7 +24,7 @@ unsize = []
 [dependencies]
 async-trait = { workspace = true }
 critical-section = { workspace = true, default-features = false, optional = false }
-spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "rwlock", "portable_atomic"] }
+spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "rwlock", "once", "portable_atomic"] }
 portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }
 cortex-m = { workspace = true, optional = true }
 portable-atomic-util = { version = "0.2", default-features = false, features = ["alloc"] }

--- a/modules/utils-core/clippy.toml
+++ b/modules/utils-core/clippy.toml
@@ -7,4 +7,5 @@ disallowed-types = [
   { path = "std::sync::Mutex", reason = "Use SpinSyncMutex within production code", replacement = "fraktor_utils_core_rs::core::sync::SpinSyncMutex" },
   { path = "spin::Mutex", reason = "Use SpinSyncMutex within production code", replacement = "fraktor_utils_core_rs::core::sync::SpinSyncMutex" },
   { path = "spin::RwLock", reason = "Use SpinSyncRwLock within production code", replacement = "fraktor_utils_core_rs::core::sync::SpinSyncRwLock" },
+  { path = "spin::Once", reason = "Use SpinOnce within production code", replacement = "fraktor_utils_core_rs::core::sync::SpinOnce" },
 ]

--- a/modules/utils-core/src/core/sync.rs
+++ b/modules/utils-core/src/core/sync.rs
@@ -22,6 +22,7 @@ mod checked_spin_sync_mutex_guard;
 mod checked_spin_sync_rwlock;
 mod lock_driver;
 mod lock_driver_factory;
+mod once_driver;
 mod rw_lock_driver_factory;
 mod rwlock_driver;
 pub mod shared;
@@ -29,6 +30,9 @@ mod shared_access;
 mod shared_error;
 mod shared_lock;
 mod shared_rw_lock;
+/// Spin-based write-once cell wrapper acting as the `spin` backend for `OnceDriver`.
+#[allow(clippy::disallowed_types)]
+mod spin_once;
 mod spin_sync_factory;
 /// Spin-based mutex wrapper used as the canonical sync primitive.
 #[allow(clippy::disallowed_types)]
@@ -47,6 +51,7 @@ mod std_sync_mutex;
 #[cfg(feature = "std-locks")]
 #[allow(clippy::disallowed_types, cfg_std_forbid)]
 mod std_sync_rwlock;
+mod sync_once;
 #[allow(clippy::disallowed_types)]
 mod weak_shared;
 mod weak_shared_lock;
@@ -65,12 +70,14 @@ pub use checked_spin_sync_mutex_guard::CheckedSpinSyncMutexGuard;
 pub use checked_spin_sync_rwlock::CheckedSpinSyncRwLock;
 pub use lock_driver::LockDriver;
 pub use lock_driver_factory::LockDriverFactory;
+pub use once_driver::OnceDriver;
 pub use rw_lock_driver_factory::RwLockDriverFactory;
 pub use rwlock_driver::RwLockDriver;
 pub use shared_access::SharedAccess;
 pub use shared_error::SharedError;
 pub use shared_lock::SharedLock;
 pub use shared_rw_lock::SharedRwLock;
+pub use spin_once::SpinOnce;
 pub use spin_sync_factory::SpinSyncFactory;
 pub use spin_sync_mutex::SpinSyncMutex;
 pub use spin_sync_rwlock::SpinSyncRwLock;
@@ -79,6 +86,7 @@ pub use spin_sync_rwlock_factory::SpinSyncRwLockFactory;
 pub use std_sync_mutex::StdSyncMutex;
 #[cfg(feature = "std-locks")]
 pub use std_sync_rwlock::StdSyncRwLock;
+pub use sync_once::SyncOnce;
 pub use weak_shared::WeakShared;
 pub use weak_shared_lock::WeakSharedLock;
 pub use weak_shared_rw_lock::WeakSharedRwLock;

--- a/modules/utils-core/src/core/sync/once_driver.rs
+++ b/modules/utils-core/src/core/sync/once_driver.rs
@@ -1,0 +1,18 @@
+/// Runtime-selectable write-once cell driver contract.
+///
+/// Mirrors the shape of [`crate::core::sync::LockDriver`] / [`crate::core::sync::RwLockDriver`] so
+/// callers can swap the concrete backend (e.g. `SpinOnce`, a future `StdOnce`) through the
+/// shared abstraction without coupling to a primitive crate.
+pub trait OnceDriver<T>: Sized {
+  /// Creates a fresh, uninitialized driver instance.
+  fn new() -> Self;
+
+  /// Initializes the cell exactly once and returns a reference to the stored value.
+  fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T;
+
+  /// Returns the stored value if it has been initialized, otherwise `None`.
+  fn get(&self) -> Option<&T>;
+
+  /// Returns whether the cell has been initialized.
+  fn is_completed(&self) -> bool;
+}

--- a/modules/utils-core/src/core/sync/spin_once.rs
+++ b/modules/utils-core/src/core/sync/spin_once.rs
@@ -1,0 +1,63 @@
+#[cfg(test)]
+mod tests;
+
+use spin::Once;
+
+use crate::core::sync::OnceDriver;
+
+/// Thin wrapper around [`spin::Once`], acting as the `spin` backend for the `OnceDriver`
+/// abstraction. This is the sole place inside `utils-core` that uses `spin::Once` directly;
+/// upstream callers must route through [`crate::core::sync::SyncOnce`].
+pub struct SpinOnce<T>(Once<T>);
+
+unsafe impl<T: Send> Send for SpinOnce<T> {}
+unsafe impl<T: Send + Sync> Sync for SpinOnce<T> {}
+
+impl<T> SpinOnce<T> {
+  /// Creates a new, uninitialized `SpinOnce`.
+  #[must_use]
+  pub const fn new() -> Self {
+    Self(Once::new())
+  }
+
+  /// Initializes the cell exactly once and returns a reference to the stored value.
+  pub fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T {
+    self.0.call_once(f)
+  }
+
+  /// Returns the stored value if it has been initialized.
+  #[must_use]
+  pub fn get(&self) -> Option<&T> {
+    self.0.get()
+  }
+
+  /// Returns whether the cell has been initialized.
+  #[must_use]
+  pub fn is_completed(&self) -> bool {
+    self.0.is_completed()
+  }
+}
+
+impl<T> Default for SpinOnce<T> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<T> OnceDriver<T> for SpinOnce<T> {
+  fn new() -> Self {
+    Self::new()
+  }
+
+  fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T {
+    self.call_once(f)
+  }
+
+  fn get(&self) -> Option<&T> {
+    self.get()
+  }
+
+  fn is_completed(&self) -> bool {
+    self.is_completed()
+  }
+}

--- a/modules/utils-core/src/core/sync/spin_once/tests.rs
+++ b/modules/utils-core/src/core/sync/spin_once/tests.rs
@@ -1,0 +1,55 @@
+use super::SpinOnce;
+use crate::core::sync::OnceDriver;
+
+#[test]
+fn test_spin_once_new_is_uncompleted() {
+  let once: SpinOnce<i32> = SpinOnce::new();
+  assert!(!once.is_completed());
+  assert!(once.get().is_none());
+}
+
+#[test]
+fn test_spin_once_call_once_initializes_value() {
+  let once = SpinOnce::new();
+  let value = once.call_once(|| 42);
+  assert_eq!(*value, 42);
+  assert!(once.is_completed());
+  assert_eq!(once.get(), Some(&42));
+}
+
+#[test]
+fn test_spin_once_call_once_runs_only_once() {
+  let once = SpinOnce::new();
+  let first = *once.call_once(|| 10);
+  let second = *once.call_once(|| 99);
+  assert_eq!(first, 10);
+  assert_eq!(second, 10);
+  assert_eq!(once.get(), Some(&10));
+}
+
+#[test]
+fn test_spin_once_get_before_init_is_none() {
+  let once: SpinOnce<&str> = SpinOnce::new();
+  assert!(once.get().is_none());
+  let _ = once.call_once(|| "value");
+  assert_eq!(once.get(), Some(&"value"));
+}
+
+#[test]
+fn test_spin_once_const_new() {
+  static ONCE: SpinOnce<i32> = SpinOnce::new();
+  let value = ONCE.call_once(|| 7);
+  assert_eq!(*value, 7);
+  assert!(ONCE.is_completed());
+}
+
+#[test]
+fn test_spin_once_driver_trait() {
+  let once: SpinOnce<u8> = <SpinOnce<u8> as OnceDriver<u8>>::new();
+  assert!(!OnceDriver::is_completed(&once));
+  assert_eq!(OnceDriver::get(&once), None);
+  let value = OnceDriver::call_once(&once, || 5u8);
+  assert_eq!(*value, 5);
+  assert!(OnceDriver::is_completed(&once));
+  assert_eq!(OnceDriver::get(&once), Some(&5));
+}

--- a/modules/utils-core/src/core/sync/sync_once.rs
+++ b/modules/utils-core/src/core/sync/sync_once.rs
@@ -60,3 +60,21 @@ impl<T> Default for SyncOnce<T, SpinOnce<T>> {
     Self::new()
   }
 }
+
+impl<T, D: OnceDriver<T>> OnceDriver<T> for SyncOnce<T, D> {
+  fn new() -> Self {
+    Self::with_driver()
+  }
+
+  fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T {
+    self.call_once(f)
+  }
+
+  fn get(&self) -> Option<&T> {
+    self.get()
+  }
+
+  fn is_completed(&self) -> bool {
+    self.is_completed()
+  }
+}

--- a/modules/utils-core/src/core/sync/sync_once.rs
+++ b/modules/utils-core/src/core/sync/sync_once.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod tests;
+
+use crate::core::sync::SpinOnce;
+
+/// Public write-once cell abstraction that upstream crates (e.g. `actor-*`) depend on.
+///
+/// Mirrors the `LockDriver` → `SpinSyncMutex` → `SharedLock` layering: `SyncOnce` is the public
+/// abstraction, while the concrete backend lives in `SpinOnce` so that the primitive `spin` crate
+/// stays confined to `utils-core`.
+///
+/// Unlike `SharedLock`, `SyncOnce` does not wrap an `ArcShared` layer. Once-cells are written once
+/// and then read without synchronization, so the extra shared-ownership layer provides no benefit
+/// for the typical usage pattern. Callers that need shared ownership can wrap `SyncOnce` inside
+/// their own `ArcShared<SyncOnce<T>>`.
+pub struct SyncOnce<T> {
+  inner: SpinOnce<T>,
+}
+
+impl<T> SyncOnce<T> {
+  /// Creates a new, uninitialized `SyncOnce`.
+  #[must_use]
+  pub const fn new() -> Self {
+    Self { inner: SpinOnce::new() }
+  }
+
+  /// Initializes the cell exactly once and returns a reference to the stored value.
+  pub fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T {
+    self.inner.call_once(f)
+  }
+
+  /// Returns the stored value if it has been initialized.
+  #[must_use]
+  pub fn get(&self) -> Option<&T> {
+    self.inner.get()
+  }
+
+  /// Returns whether the cell has been initialized.
+  #[must_use]
+  pub fn is_completed(&self) -> bool {
+    self.inner.is_completed()
+  }
+}
+
+impl<T> Default for SyncOnce<T> {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/modules/utils-core/src/core/sync/sync_once.rs
+++ b/modules/utils-core/src/core/sync/sync_once.rs
@@ -1,27 +1,40 @@
 #[cfg(test)]
 mod tests;
 
-use crate::core::sync::SpinOnce;
+use core::marker::PhantomData;
+
+use crate::core::sync::{OnceDriver, SpinOnce};
 
 /// Public write-once cell abstraction that upstream crates (e.g. `actor-*`) depend on.
 ///
 /// Mirrors the `LockDriver` → `SpinSyncMutex` → `SharedLock` layering: `SyncOnce` is the public
-/// abstraction, while the concrete backend lives in `SpinOnce` so that the primitive `spin` crate
-/// stays confined to `utils-core`.
+/// abstraction, while the concrete backend lives in a type implementing [`OnceDriver`] so that
+/// the primitive `spin` crate stays confined to `utils-core`. `SpinOnce` is the default backend
+/// today; future backends (e.g. a `StdOnce` built on `std::sync::OnceLock`, or a `DebugOnce`
+/// with instrumentation) can plug in through the same `OnceDriver` contract.
 ///
 /// Unlike `SharedLock`, `SyncOnce` does not wrap an `ArcShared` layer. Once-cells are written once
 /// and then read without synchronization, so the extra shared-ownership layer provides no benefit
 /// for the typical usage pattern. Callers that need shared ownership can wrap `SyncOnce` inside
 /// their own `ArcShared<SyncOnce<T>>`.
-pub struct SyncOnce<T> {
-  inner: SpinOnce<T>,
+pub struct SyncOnce<T, D: OnceDriver<T> = SpinOnce<T>> {
+  inner: D,
+  _pd:   PhantomData<fn() -> T>,
 }
 
-impl<T> SyncOnce<T> {
-  /// Creates a new, uninitialized `SyncOnce`.
+impl<T> SyncOnce<T, SpinOnce<T>> {
+  /// Creates a new, uninitialized `SyncOnce` using the default [`SpinOnce`] backend.
   #[must_use]
   pub const fn new() -> Self {
-    Self { inner: SpinOnce::new() }
+    Self { inner: SpinOnce::new(), _pd: PhantomData }
+  }
+}
+
+impl<T, D: OnceDriver<T>> SyncOnce<T, D> {
+  /// Creates a `SyncOnce` backed by an explicit driver implementation.
+  #[must_use]
+  pub fn with_driver() -> Self {
+    Self { inner: D::new(), _pd: PhantomData }
   }
 
   /// Initializes the cell exactly once and returns a reference to the stored value.
@@ -42,7 +55,7 @@ impl<T> SyncOnce<T> {
   }
 }
 
-impl<T> Default for SyncOnce<T> {
+impl<T> Default for SyncOnce<T, SpinOnce<T>> {
   fn default() -> Self {
     Self::new()
   }

--- a/modules/utils-core/src/core/sync/sync_once/tests.rs
+++ b/modules/utils-core/src/core/sync/sync_once/tests.rs
@@ -40,3 +40,14 @@ fn test_sync_once_const_new() {
   assert_eq!(*value, "ready");
   assert_eq!(ONCE.get(), Some(&"ready"));
 }
+
+#[test]
+fn test_sync_once_with_explicit_driver() {
+  use crate::core::sync::SpinOnce;
+  let once: SyncOnce<i32, SpinOnce<i32>> = SyncOnce::with_driver();
+  assert!(!once.is_completed());
+  let value = once.call_once(|| 21);
+  assert_eq!(*value, 21);
+  assert!(once.is_completed());
+  assert_eq!(once.get(), Some(&21));
+}

--- a/modules/utils-core/src/core/sync/sync_once/tests.rs
+++ b/modules/utils-core/src/core/sync/sync_once/tests.rs
@@ -1,0 +1,42 @@
+use super::SyncOnce;
+
+#[test]
+fn test_sync_once_new_is_uncompleted() {
+  let once: SyncOnce<i32> = SyncOnce::new();
+  assert!(!once.is_completed());
+  assert!(once.get().is_none());
+}
+
+#[test]
+fn test_sync_once_call_once_initializes_value() {
+  let once = SyncOnce::new();
+  let value = once.call_once(|| 100);
+  assert_eq!(*value, 100);
+  assert!(once.is_completed());
+  assert_eq!(once.get(), Some(&100));
+}
+
+#[test]
+fn test_sync_once_call_once_runs_only_once() {
+  let once = SyncOnce::new();
+  let first = *once.call_once(|| 1);
+  let second = *once.call_once(|| 2);
+  assert_eq!(first, 1);
+  assert_eq!(second, 1);
+}
+
+#[test]
+fn test_sync_once_default_matches_new() {
+  let once: SyncOnce<u32> = SyncOnce::default();
+  assert!(!once.is_completed());
+  let value = once.call_once(|| 9);
+  assert_eq!(*value, 9);
+}
+
+#[test]
+fn test_sync_once_const_new() {
+  static ONCE: SyncOnce<&str> = SyncOnce::new();
+  let value = ONCE.call_once(|| "ready");
+  assert_eq!(*value, "ready");
+  assert_eq!(ONCE.get(), Some(&"ready"));
+}

--- a/modules/utils-core/src/core/sync/sync_once/tests.rs
+++ b/modules/utils-core/src/core/sync/sync_once/tests.rs
@@ -51,3 +51,25 @@ fn test_sync_once_with_explicit_driver() {
   assert!(once.is_completed());
   assert_eq!(once.get(), Some(&21));
 }
+
+#[test]
+fn test_sync_once_implements_once_driver() {
+  use crate::core::sync::OnceDriver;
+  let once: SyncOnce<u8> = <SyncOnce<u8> as OnceDriver<u8>>::new();
+  assert!(!OnceDriver::is_completed(&once));
+  assert_eq!(OnceDriver::get(&once), None);
+  let value = OnceDriver::call_once(&once, || 3u8);
+  assert_eq!(*value, 3);
+  assert!(OnceDriver::is_completed(&once));
+  assert_eq!(OnceDriver::get(&once), Some(&3));
+}
+
+#[test]
+fn test_sync_once_nested_as_driver() {
+  use crate::core::sync::SpinOnce;
+  // SyncOnce<T> 自身が OnceDriver<T> を実装するため、SyncOnce の backend として SyncOnce を渡せる
+  let outer: SyncOnce<i32, SyncOnce<i32, SpinOnce<i32>>> = SyncOnce::with_driver();
+  let value = outer.call_once(|| 7);
+  assert_eq!(*value, 7);
+  assert!(outer.is_completed());
+}

--- a/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/.openspec.yaml
+++ b/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/design.md
+++ b/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/design.md
@@ -1,0 +1,167 @@
+## Context
+
+`actor-core` 内での `spin` クレート直接利用は実態調査の結果 **`spin::Once<T>` の利用 2 ファイル のみ**:
+
+- `modules/actor-core/src/core/kernel/system/coordinated_shutdown.rs:23`: `use spin::Once;`
+- `modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs:10`: `use spin::Once;`、3 フィールドで `Once<T>` を使用（`instrumentation`、`invoker`、`actor`）
+
+利用パターンは **write-once + lock-free read**: 一度だけ初期化し、その後はロックなしで読み出す。`spin::Once` は no_std 環境でこのセマンティクスを提供する標準的な選択。
+
+`actor-core/Cargo.toml:35` の `spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "once"] }` の features には `"mutex"` と `"spin_mutex"` が含まれているが、ソースコードでの利用は `"once"` のみ。features 指定が実態に対して過剰。
+
+`utils-core` には現在 `Once<T>` 相当の抽象が存在しない:
+- `SpinSyncMutex<T>`、`SpinSyncRwLock<T>`、`SharedLock<T>`、`SharedRwLock<T>` はあり
+- `Once<T>` または `OnceLock<T>` 相当はなし
+
+`std::sync::OnceLock<T>` は Rust 1.70+ stable だが std 限定。`actor-core` は no_std クレート。`core::sync::atomic::Once` のような構造は core にも存在しない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `actor-core` の production code から `spin` クレート直接 use を撤去
+- `actor-core/Cargo.toml` から `spin` 直接依存を完全削除
+- `utils-core` に Once 系の 3 段構造を新設し、既存の `LockDriver` / `SpinSyncMutex` / `SharedLock` パターンと相似形にする:
+  - driver trait `OnceDriver<T>`
+  - backend 実装 `SpinOnce<T>`（`spin::Once<T>` の thin wrapper）
+  - 公開抽象 `SyncOnce<T>`（actor-\* の依存先、`spin::Once<T>` 相当の write-once + lock-free read セマンティクスを no_std 対応で提供）
+- `actor-lock-construction-governance` spec への準拠状態を回復し、spin 固有 Scenario を追加して検査カバレッジを広げる
+- 既存の機能性・パフォーマンス（lock-free read）を維持
+
+**Non-Goals:**
+- 他 actor-* クレート（cluster-\*, remote-\*, stream-\*, persistence-\*, actor-adaptor-std 等）の `spin` 直接依存調査・撤去（hand-off、必要なら別 change）
+- `utils-core` 内の `spin` 利用見直し（backend 実装層として spec 例外で許可、本 change 対象外）
+- `Once` 以外の `spin` 抽象（`Mutex`、`RwLock`、`Lazy` 等）の `utils-core` への追加（YAGNI、現在 `actor-core` では使われていない）
+- `DefaultOnce<T>` のような feature 切替による driver 選択機構の導入（将来拡張用、本 change では `SyncOnce<T>` が常に `SpinOnce<T>` を保持する単段構成）
+
+（補足）`actor-core/Cargo.toml` の `[dev-dependencies]` 側には `spin` 直接依存は存在しないことを起案時に確認済みであり、tasks 1.2 で最終再確認するのみ。Non-Goal ではない。
+
+## Decisions
+
+### Decision 1: 既存の `LockDriver` / `SpinSyncMutex` / `SharedLock` パターンに倣った 3 段構造を `utils-core` に新設する
+
+**選択**: `utils-core` に以下の 3 要素を追加し、既存の同期プリミティブ抽象と対応関係を持たせる:
+
+| 層 | Once 系（新設） | Mutex 系（既存） | Rwlock 系（既存） | 責務 |
+|---|---|---|---|---|
+| driver trait | `OnceDriver<T>` | `LockDriver<T>` | `RwLockDriver<T>` | backend 契約 |
+| backend 実装 | `SpinOnce<T>` | `SpinSyncMutex<T>` | `SpinSyncRwLock<T>` | `spin` クレートを直接使う唯一の場所 |
+| 公開抽象 | `SyncOnce<T>` | `SharedLock<T>` | `SharedRwLock<T>` | actor-* などの上位層が依存する先 |
+
+`actor-core` は `SpinOnce`（backend 実装）ではなく `SyncOnce`（抽象）に依存する。これにより `actor-lock-construction-governance` Requirement の「actor-\* は primitive lock crate を直接 use しない」原則を atomic once 系まで一貫して適用できる。
+
+**根拠**:
+- 既存パターン（`LockDriver`/`SpinSyncMutex`/`SharedLock`）と完全に対応関係を持つため、命名・配置・責務が一意に定まる
+- spec `actor-lock-construction-governance` の例外条項「`utils-core` 内の backend 実装層は primitive lock crate 直接 use を許可」が `SpinOnce` にも自然に適用される
+- `actor-core` から `spin` への direct edge が消える
+- 将来 std 環境向けに `StdOnce<T>`（`std::sync::OnceLock<T>` backend）を追加したくなっても、driver trait が既にあるので `DefaultOnce<T>` の feature 切替で差し替え可能（ただし本 change では追加しない）
+
+**代替案と却下理由**:
+- 案 A: `actor-core` で `spin::Once` を別パターンに置換（例: `SharedLock<Option<T>>`）→ lock-free read セマンティクスが失われ、ホットパス（`mailbox/base.rs` の `instrumentation`/`invoker`/`actor`）で毎回ロック取得が発生し性能劣化。不採用
+- 案 B: `actor-core` で `spin::Once` を許容例外として spec に追加 → 自分で作った規約に例外を追加するのは「割れ窓」化、本 change の趣旨と反する
+- 案 C: `utils-core` に単一型（`SyncOnce<T>` のみで内部が `spin::Once`）だけ追加 → mutex / rwlock との対応関係が崩れ、将来 backend を切り替える余地も closed になる。既存の 3 段構造と揃える方が拡張余地・責務分離の両面で優位
+- 案 D: `core::sync::atomic` ベースで独自 Once 実装 → `spin::Once` を再発明する手間、unsafe レビューコスト大、既存の堅牢な実装をラップする方が安全
+
+### Decision 2: `SpinOnce<T>` の内部は `spin::Once<T>` の thin wrapper とする
+
+**選択**: `SpinOnce<T>` は `spin::Once<T>` を内部に保持する薄いラッパーとして `utils-core/src/core/sync/spin_once.rs` に配置する。`SpinSyncMutex<T>` と同様の構造。
+
+**根拠**:
+- `spin::Once` は no_std 対応で実装が成熟
+- 独自実装は `AtomicBool` + `UnsafeCell<MaybeUninit<T>>` の組み合わせで unsafe 多用、レビューコスト大
+- 性能特性（lock-free read）を完全維持
+- 既存の `SpinSyncMutex` / `SpinSyncRwLock` が `spin::Mutex` / `spin::RwLock` のラップである構造と一貫
+
+**代替案と却下理由**:
+- 案 A: 独自実装 → 不採用理由は上記
+- 案 B: `portable-atomic-util::OnceLock` を内部で使う → 依存経路が複雑化、`portable-atomic-util` に該当 API があるかの確認コストも本 change の範囲を超える
+
+### Decision 3: `OnceDriver<T>` trait と API 形状
+
+**選択**: driver trait は以下の最小契約を定める。
+
+```rust
+pub trait OnceDriver<T>: Sized {
+  fn new() -> Self;
+  fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T;
+  fn get(&self) -> Option<&T>;
+  fn is_completed(&self) -> bool;
+}
+```
+
+`SpinOnce<T>: OnceDriver<T>` を実装する。`SyncOnce<T>` は `OnceDriver<T>` trait object に直接依存せず、`LockDriver` / `SharedLock` と同様に `SyncOnceBackend` のような crate-internal trait を介して `ArcShared<dyn SyncOnceBackend<T>>` を保持する形も考えられるが、Once は 1 度書いたら読むだけなので「共有」自体が不要なケースが多い。そのため **`SyncOnce<T>` は直接 `SpinOnce<T>`（あるいは feature で選ばれた driver）を保持する単段構成とし、`ArcShared` 層を介さない** 設計を採用する。
+
+**本 change の具体化**:
+- `SyncOnce<T>` の内部型は `SpinOnce<T>` を直接保持する構造にする（`DefaultMutex` のような feature 切替は本 change では導入しない。将来拡張時に追加）
+- 公開 API は `OnceDriver<T>` trait と同じく `new` / `call_once` / `get` / `is_completed` を `SyncOnce<T>` の inherent method として提供
+
+```rust
+impl<T> SyncOnce<T> {
+  pub const fn new() -> Self;
+  pub fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T;
+  pub fn get(&self) -> Option<&T>;
+  pub fn is_completed(&self) -> bool;
+}
+```
+
+`actor-core` 側の置換は `use spin::Once;` → `use fraktor_utils_core_rs::core::sync::SyncOnce;`、および型名 `Once<T>` → `SyncOnce<T>` の機械的変更で済む。
+
+**根拠**:
+- `spin::Once<T>` の主要 API と互換にすることで置換コストを最小化
+- driver trait を別途用意しておけば、将来 `StdOnce`（`std::sync::OnceLock` backend）や `DebugOnce`（instrumentation 付き）を追加する余地が残る
+- `ArcShared` 層を入れないことで `SharedLock` より軽量（Once は mutation しないため shared 不要、`&SyncOnce<T>` を各所に渡すだけで十分）
+
+**代替案と却下理由**:
+- 案 A: `SyncOnce<T>` も `SharedLock` と同じく `ArcShared<dyn SyncOnceBackend<T>>` を持つ → Once の利用パターンでは shared 所有の必要がなく、実質 overhead のみ増える。不採用
+- 案 B: `OnceCell` 風の `get_or_init` API 中心 → 現利用箇所（`spin::Once::call_once`）と API 形状が異なり置換コスト増。YAGNI
+
+### Decision 4: spec には spin 固有 Scenario を MODIFIED で追加
+
+**選択**: `actor-lock-construction-governance` spec の Requirement「actor-\* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない」に、`spin` 固有の Scenario を MODIFIED で追加する。
+
+**根拠**:
+- 既存 Requirement は本文で `critical-section、spin、parking_lot` を列挙しているが、Scenario は `critical-section` のみを検査する形になっていた
+- 本 change で `spin` 直接依存を撤去するため、同じ形式で `spin` 用 Scenario を追加しておけば spec の検査カバレッジと本 change の成果が 1:1 に対応する
+- `SyncOnce<T>` が `utils-core` 側の正式な write-once + lock-free read 抽象であることを Scenario レベルで明示できる
+- OpenSpec 運用上、change には最低 1 つの delta が必須（validation 要件）。スコープ内で自然な delta として spin Scenario が最適
+
+**代替案と却下理由**:
+- 案 A: spec を変更せず本 change は実装のみとする → OpenSpec strict validation に違反（delta が 1 つも無い change は reject される）。また、将来他 actor-* crate で spin 直接依存が再発した場合に Scenario で捕捉できない
+- 案 B: 新規 Requirement として ADDED する → 既存 Requirement が既に本文で spin を対象としており、重複する。Scenario 追加が最小差分
+
+### Decision 5: `spin` 直接依存行の完全削除と clippy safety net 追加
+
+**選択**: `actor-core/Cargo.toml:35` の `spin = { ..., features = ["mutex", "spin_mutex", "once"] }` 行を **完全削除** する。さらに `actor-core/clippy.toml` の `disallowed-types` に `spin::Once` エントリを追加する（`replacement = "fraktor_utils_core_rs::core::sync::SyncOnce"`）。
+
+**根拠**:
+- `spin` 自体への依存が消えるため `features` 指定も全て不要（部分削減ではなく行ごと削除が最小差分）
+- 仮に他箇所で `spin::Once` 以外の利用があっても、本 change の調査範囲（`use spin::` および `spin::` の grep）で発見されていない。tasks フェーズの `cargo build` で実証
+- `clippy.toml` の `disallowed-types` には既に `spin::Mutex` / `spin::RwLock` エントリがある。`spin::Once` も同列に追加しておくことで、将来 `spin` を transitive にでも再導入した場合に、`SyncOnce` ではなく `spin::Once` を直接使う書き方を lint が捕捉できる（safety net の二重化）
+
+## Risks / Trade-offs
+
+- **[Risk] `SyncOnce` の `Send`/`Sync` トレート境界** → Mitigation: `spin::Once<T>` が `T: Send + Sync` で `Send + Sync` を実装するのと同じ制約を継承。`actor-core` 側の `Once<MailboxInstrumentation>`、`Once<MessageInvokerShared>`、`Once<WeakShared<ActorCell>>` はすべて `Send + Sync` を満たす型なので問題なし
+- **[Risk] `SpinOnce::new()` / `SyncOnce::new()` を `const fn` にできるか** → Mitigation: `spin::Once::new()` は `const fn` なので、`SpinOnce::new()` も `const fn { Self(spin::Once::new()) }` で実現可能。`SyncOnce::new()` も同じく `const fn { Self { inner: SpinOnce::new() } }` で連鎖的に `const fn` を維持できる
+- **[Risk] `actor-core` の他箇所で実は `spin` を別途利用している可能性** → Mitigation: tasks 1.1 で `Grep` 全数調査、`Cargo.toml` の `spin` 直接依存削除後に `cargo build` で compile 時エラーとして検出（依存経路が消えると `use spin::*` は unresolved import になる）
+- **[Trade-off] `utils-core` の依存に `spin` が引き続き必要** → 受容: spec 例外として `utils-core` の backend 実装層は許可されている。本 change の趣旨は「`actor-core` 単位での違反解消」
+
+## Migration Plan
+
+本 change はライブラリ内部実装の置換であり、ダウンストリーム移行手順は不要。
+
+1. **Phase 1a**: `utils-core` に `OnceDriver<T>` trait を新設（`once_driver.rs`）
+2. **Phase 1b**: `utils-core` に `SpinOnce<T>` backend 実装を新設（`spin_once.rs`、`OnceDriver<T>` を impl）
+3. **Phase 1c**: `utils-core` に `SyncOnce<T>` 公開抽象を新設（`sync_once.rs`、`SpinOnce<T>` を内部保持）
+4. **Phase 2a**: `actor-core` の `spin::Once` 利用 2 ファイル（`coordinated_shutdown.rs`、`mailbox/base.rs`）を `SyncOnce` に置換
+5. **Phase 2b**: `actor-core` 内の docstring 残存言及（`mailbox_shared_set.rs` 等）を `SyncOnce` に置換
+6. **Phase 3**: 個別ビルド確認（`cargo build -p fraktor-actor-core-rs`、`cargo test -p fraktor-actor-core-rs --features test-support`）
+7. **Phase 4a**: `actor-core/Cargo.toml` から `spin` 直接依存削除
+8. **Phase 4b**: `actor-core/clippy.toml` の `disallowed-types` に `spin::Once` を追加（safety net 強化、将来の再発防止）
+9. **Phase 5**: `cargo tree -p fraktor-actor-core-rs --no-default-features --depth 1` で `spin` が消えたことを確認
+10. **Phase 6**: `./scripts/ci-check.sh ai all` で workspace 全体確認
+11. **Phase 7**: `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 4 を「解消済み」に更新
+
+ロールバックは git revert で完結する。
+
+## Open Questions
+
+- なし（必要な設計判断は本 design で確定済み）

--- a/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/proposal.md
+++ b/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+直前 archive された change `retire-actor-core-test-support-critical-section-impl`（PR #1607/#1608）で `actor-lock-construction-governance` spec の Requirement「`actor-*` の `Cargo.toml` は primitive lock crate を non-optional な直接依存として宣言してはならない」を確立した。しかし `actor-core/Cargo.toml:35` に `spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "once"] }` が残っており、これは **本 spec の自分自身による違反** 状態。
+
+実態調査により、`actor-core/src` 内での `spin` クレート直接利用は **`spin::Once` の 2 箇所のみ**（`coordinated_shutdown.rs:23`、`mailbox/base.rs:10`）。`spin::Mutex` の利用はなく、`Cargo.toml` の features 指定（`"mutex", "spin_mutex"`）は実態に対して過剰。
+
+「自分で追加したガバナンスに自分で違反している」状態を解消し、ガバナンス完全準拠状態にする。
+
+## What Changes
+
+既存の `LockDriver` / `SpinSyncMutex` / `SharedLock` 3 段構造と相似形になるよう、`utils-core` 側に同じ責務分離の 3 要素を追加する:
+
+| 層 | Once 系（本 change 新設） | Mutex 系（既存） |
+|---|---|---|
+| driver trait | `OnceDriver<T>` | `LockDriver<T>` |
+| backend 実装 | `SpinOnce<T>`（`spin::Once<T>` を直接使う唯一の場所） | `SpinSyncMutex<T>` |
+| 公開抽象 | `SyncOnce<T>`（actor-\* が依存する先） | `SharedLock<T>` |
+
+- **新 trait**: `utils-core` に `OnceDriver<T>` trait を追加（`new`/`call_once`/`get`/`is_completed`）
+- **新 backend 実装**: `utils-core` に `SpinOnce<T>` を追加（`spin::Once<T>` の thin wrapper、`OnceDriver<T>` を impl）
+- **新公開抽象**: `utils-core` に `SyncOnce<T>` を追加（`SpinOnce<T>` を内部保持する単段構成、write-once + lock-free read セマンティクスを維持）
+- **置換**: `actor-core` の `spin::Once` 利用 2 箇所を `SyncOnce` に置換
+  - `modules/actor-core/src/core/kernel/system/coordinated_shutdown.rs:23`
+  - `modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs:10`（`instrumentation`, `invoker`, `actor` の 3 フィールド）
+- **依存削除**: `modules/actor-core/Cargo.toml:35` から `spin = { workspace = true, ... }` 行を完全削除
+- **spec 更新**: `actor-lock-construction-governance` の既存 Requirement に spin 固有 Scenario を MODIFIED で追加（validation 要件を兼ねる）
+- **ドキュメント更新**: `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 4 を「解消済み」に更新
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `actor-lock-construction-governance`: 既存 Requirement「actor-\* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない」に **spin 固有 Scenario を追加**（Scenario 数が従来の `critical-section` 検査のみ → `spin` 検査も含む形に拡張）。Requirement 本文（文言）は変更しない。
+
+## Impact
+
+### 影響を受けるコード
+
+- `modules/utils-core/src/core/sync/once_driver.rs`（新規ファイル、`OnceDriver<T>` trait 定義）
+- `modules/utils-core/src/core/sync/spin_once.rs`（新規ファイル、`SpinOnce<T>` backend 実装）
+- `modules/utils-core/src/core/sync/sync_once.rs`（新規ファイル、`SyncOnce<T>` 公開抽象）
+- `modules/utils-core/src/core/sync.rs`（`OnceDriver` / `SpinOnce` / `SyncOnce` の `pub use` 追加）
+- `modules/actor-core/src/core/kernel/system/coordinated_shutdown.rs`（`spin::Once` → `SyncOnce` 置換）
+- `modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs`（同、および docstring 内の `spin::Once::get()` 言及 2 箇所を更新）
+- `modules/actor-core/src/core/kernel/system/shared_factory/mailbox_shared_set.rs`（docstring 内の `spin::Once<T>` 言及を `SyncOnce<T>` に更新）
+- `modules/actor-core/Cargo.toml`（`spin` 直接依存削除）
+- `modules/actor-core/clippy.toml`（`disallowed-types` に `spin::Once` を追加し safety net を強化）
+- `docs/plan/2026-04-21-actor-core-critical-section-followups.md`（残課題 4 を解消済みに更新）
+
+### 影響を受けない範囲
+
+- `actor-core` の他のソースコード（`spin::Once` の置換に伴う public API 変更なし）
+- `utils-core` 内の `spin` 利用（backend 実装層として spec 例外、`spin_sync_mutex.rs` 等）
+- 他 actor-* クレート（cluster-*, remote-*, stream-*, persistence-*）の `Cargo.toml`（本 change 対象外、別途 hand-off で確認）
+- `actor-core` の `[dev-dependencies]` の `critical-section`（前 change で確定済み）
+
+### 依存関係
+
+- `actor-core` から `spin` クレートへの直接依存が完全に消える（`utils-core` 経由の transitive で `spin` は `utils-core` のみが利用）
+- workspace 全体での `spin` 利用ポリシー: `utils-core` のみで使用、actor-* は `utils-core` 抽象経由
+
+### リスク
+
+- **`SyncOnce<T>` の API 設計**: `spin::Once<T>` の API（`call_once`、`get` 等）と互換性を持たせる必要。design.md で詳細設計
+- **パフォーマンス影響**: `spin::Once` の lock-free read セマンティクスを `SyncOnce` でも維持する必要。内部実装は `spin::Once` のラップが最も安全（性能影響なし）
+- **`actor-core/Cargo.toml` の features 指定**: 現在 `["mutex", "spin_mutex", "once"]` だが、削除すれば全 feature 不要
+
+### 後続 change（hand-off）
+
+- 他 actor-* クレートの `Cargo.toml` で `spin` 直接依存がないか調査（必要なら別 change）
+- `actor-core/Cargo.toml` の `[dev-dependencies]` には `spin` 直接依存は無いことを起案時に確認済み（残作業なし）

--- a/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/specs/actor-lock-construction-governance/spec.md
+++ b/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/specs/actor-lock-construction-governance/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: actor-* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない
+
+`actor-*` クレートの `Cargo.toml` は、`critical-section`、`spin`、`parking_lot` などの primitive lock crate を `[dependencies]` に直接依存として宣言してはならない（MUST NOT）。これらの crate への依存は、`utils-core` を通した推移的依存として表現されなければならない（MUST）。
+
+ただし以下は例外として許可する:
+
+- `portable-atomic` のような low-level utility crate が引き込む推移的依存
+- 各クレートの `[dev-dependencies]` に test/bench 用の impl provider 取得目的で記述される `critical-section = { features = ["std"] }` 等のエントリ（production 依存ではないため `[dependencies]` 直接宣言禁止には該当しない）
+- `showcases/std` のような実行バイナリ crate の `[dependencies]` における impl provider 取得目的の記述（バイナリ側が impl 選択責任を持つ標準作法に基づく）
+
+impl provider 取得は各バイナリが `[dev-dependencies]` または `[dependencies]` で直接宣言する形に統一する。
+
+#### Scenario: actor-core の Cargo.toml は critical-section を `[dependencies]` 直接依存として持たない
+
+- **WHEN** `modules/actor-core/Cargo.toml` の `[dependencies]` セクションで `critical-section` エントリを検査する
+- **THEN** `critical-section` エントリは存在しない
+- **AND** `critical-section` への依存は `portable-atomic = { features = ["critical-section"] }` のような推移的経路でのみ表現される
+- **AND** `[dev-dependencies]` には `critical-section = { workspace = true, features = ["std"] }` が impl provider 取得目的で記述されてよい（actor-core 自身の `cargo test` で必要）
+
+#### Scenario: actor-core の Cargo.toml は spin を `[dependencies]` 直接依存として持たない
+
+- **WHEN** `modules/actor-core/Cargo.toml` の `[dependencies]` セクションで `spin` エントリを検査する
+- **THEN** `spin` エントリは存在しない
+- **AND** `spin` への依存は `fraktor-utils-core-rs` 経由の推移的経路でのみ表現される
+- **AND** `actor-core` の production code 内の write-once + lock-free read 用途（旧 `spin::Once<T>` 利用箇所）は `fraktor-utils-core-rs` が提供する `SyncOnce<T>` 抽象を通して構築される
+
+#### Scenario: actor-* の他クレートも同じ規約に従う
+
+- **WHEN** `fraktor-actor-adaptor-std-rs`、`fraktor-cluster-*-rs`、`fraktor-remote-*-rs`、`fraktor-stream-*-rs`、`fraktor-persistence-*-rs` の `Cargo.toml` を読む
+- **THEN** いずれも `critical-section`、`spin`、`parking_lot` を `[dependencies]` 直接宣言として持たない
+- **AND** これらのクレートが同期プリミティブを必要とする場合は `fraktor-utils-core-rs` 経由で取得する
+- **AND** test/bench で `critical-section` の `std` impl が必要な場合は `[dev-dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を直接記述する
+
+#### Scenario: 各バイナリは impl provider を直接宣言する
+
+- **WHEN** `actor-*` 配下のテスト（`[[test]]`）、bench、または `showcases/std` 等の実行バイナリ crate が `critical-section` の impl を必要とする
+- **THEN** 当該 crate は `[dev-dependencies]` または `[dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を直接記述する
+- **AND** `actor-*` の library crate の feature flag（例: `test-support`）を経由した自動配給には依存しない

--- a/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/tasks.md
+++ b/openspec/changes/step01-eliminate-actor-core-spin-direct-dep/tasks.md
@@ -1,0 +1,68 @@
+## 1. 事前調査と確認
+
+- [x] 1.1 `actor-core/src` 全体で `spin` 直接利用箇所を再 Grep（`use spin::` および `spin::`）。起案時調査では `coordinated_shutdown.rs:23` と `mailbox/base.rs:10` の `Once` のみ。実装直前に再確認
+- [x] 1.2 `actor-core/Cargo.toml` の `[dependencies]` および `[dev-dependencies]` の `spin` 利用を確認（`:35` の `spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "once"] }`、`[dev-dependencies]` 側には `spin` が無いことを再確認）
+- [x] 1.3 `utils-core/src/core/sync/` の既存構成（`lock_driver.rs`、`spin_sync_mutex.rs`、`shared_lock.rs` 等）を再確認し、`once_driver.rs` / `spin_once.rs` / `sync_once.rs` の配置（design Decision 1〜3 で確定済み）と `pub use` 経路を確認
+- [x] 1.4 `spin::Once<T>` の正確な API（`call_once`、`get`、`is_completed` 等）を `spin` crate ドキュメントで確認
+
+## 2. utils-core への OnceDriver trait + SpinOnce backend 新設
+
+- [x] 2.1 `modules/utils-core/src/core/sync/once_driver.rs` を新規作成。`OnceDriver<T>` trait を `LockDriver<T>` / `RwLockDriver<T>` と同じ形式で定義（`new`/`call_once`/`get`/`is_completed` を要求）
+- [x] 2.2 `modules/utils-core/src/core/sync/spin_once.rs` を新規作成。`SpinOnce<T>` 構造体を `spin::Once<T>` の thin wrapper として実装（`SpinSyncMutex<T>` と同じ形式、ファイル先頭の `mod tests;` 宣言と `unsafe impl Send`/`Sync` 含む）
+- [x] 2.3 `SpinOnce<T>: OnceDriver<T>` を実装。`Send`/`Sync` 制約も `SpinSyncMutex` に合わせる（`T: Send + Sync` で `SpinOnce<T>: Send + Sync`）
+- [x] 2.4 `spin_once.rs` に `#[cfg(test)] mod tests;` を添え、`call_once` の 1 度だけ実行、`get` の None → Some(...) 遷移、`is_completed` の状態遷移を単体テスト
+- [x] 2.5 `modules/utils-core/src/core/sync.rs` に既存パターン（`mod` private + `pub use` 公開）に従って alphabetical 順序で挿入: `mod once_driver;`（`mod lock_driver_factory;` の後）、`#[allow(clippy::disallowed_types)] mod spin_once;`（`mod spin_sync_rwlock_factory;` の後、`spin_sync_mutex` と同じ allow 属性必須）、`pub use once_driver::OnceDriver;` および `pub use spin_once::SpinOnce;` を `pub use` ブロックの alphabetical 位置に追加
+
+## 3. utils-core への SyncOnce abstraction 新設
+
+- [x] 3.1 `modules/utils-core/src/core/sync/sync_once.rs` を新規作成。`SyncOnce<T>` 構造体を `SpinOnce<T>` を内部保持する形で定義（design Decision 3 通り、`ArcShared` 層は挟まない単段構成）
+- [x] 3.2 公開 API: `const fn new() -> Self`、`call_once<F>(...)`、`get(...)`、`is_completed(...)`
+- [x] 3.3 `SyncOnce<T>: Send + Sync` bound を `SpinOnce<T>` と同じ制約で継承
+- [x] 3.4 `modules/utils-core/src/core/sync.rs` に既存パターンに従って `mod sync_once;`（alphabetical 位置: `mod std_sync_rwlock;` の後、`mod weak_shared;` の前）と `pub use sync_once::SyncOnce;` を `pub use` ブロックの alphabetical 位置に追加（`SyncOnce` は `spin::Once` を直接使わないため `#[allow(clippy::disallowed_types)]` は不要）
+- [x] 3.5 `sync_once.rs` に `#[cfg(test)] mod tests;` を添え、`SyncOnce` 経由でも `call_once`/`get`/`is_completed` が期待動作することを確認
+- [x] 3.6 `cargo build -p fraktor-utils-core-rs` で utils-core のビルド成功を確認
+- [x] 3.7 `cargo test -p fraktor-utils-core-rs` で新規テスト含む全テスト pass を確認
+
+## 4. actor-core の置換
+
+- [x] 4.1 `modules/actor-core/src/core/kernel/system/coordinated_shutdown.rs:23` の `use spin::Once;` を `use fraktor_utils_core_rs::core::sync::SyncOnce;` に置換
+- [x] 4.2 `coordinated_shutdown.rs` 内の `Once<...>` 型参照と利用を `SyncOnce<...>` に置換
+- [x] 4.3 `modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs:10` の `use spin::Once;` を `use fraktor_utils_core_rs::core::sync::SyncOnce;` に置換
+- [x] 4.4 `mailbox/base.rs` の 3 フィールド `instrumentation`、`invoker`、`actor` の型を `Once<T>` → `SyncOnce<T>` に置換
+- [x] 4.5 `mailbox/base.rs` 内のドキュメントコメント（`spin::Once::get()` 言及 2 箇所、line 52 / 56）を `SyncOnce::get()` に修正
+- [x] 4.6 `modules/actor-core/src/core/kernel/system/shared_factory/mailbox_shared_set.rs:11` のドキュメントコメント `spin::Once<T>` 言及も `SyncOnce<T>` に置換
+- [x] 4.7 `modules/actor-core/` 全体のコメント / docstring / `use spin::` で残存する言及を最終 Grep で確認（漏れがあれば追加置換）
+- [x] 4.8 `cargo fmt -p fraktor-actor-core-rs --check` で format 整合性を確認
+- [x] 4.9 `cargo build -p fraktor-actor-core-rs` でビルド成功を確認
+
+## 5. actor-core の spin 直接依存削除と clippy safety net 強化
+
+- [x] 5.1 `modules/actor-core/Cargo.toml:35` の `spin = { workspace = true, default-features = false, features = ["mutex", "spin_mutex", "once"] }` 行を完全削除
+- [x] 5.2 `modules/actor-core/clippy.toml` の `disallowed-types` に `spin::Once` エントリを追加（既存の `spin::Mutex` / `spin::RwLock` 同様の形式、`replacement = "fraktor_utils_core_rs::core::sync::SyncOnce"`）— safety net として将来の再発防止
+- [x] 5.3 `cargo build -p fraktor-actor-core-rs --no-default-features` で no_std ビルド成功を確認
+- [x] 5.4 `cargo build -p fraktor-actor-core-rs --features test-support` でビルド成功を確認
+- [x] 5.5 `cargo tree -p fraktor-actor-core-rs --no-default-features --depth 1` で `spin` が direct dep に出現しないことを確認（utils-core 経由の transitive のみ残る）
+- [x] 5.6 `cargo clippy -p fraktor-actor-core-rs --all-targets -- -D warnings` で新 clippy ルールと整合することを確認
+
+## 6. テスト確認
+
+- [x] 6.1 `cargo test -p fraktor-utils-core-rs` で utils-core テスト成功（新規 SpinOnce / SyncOnce テスト含む）
+- [x] 6.2 `cargo test -p fraktor-actor-core-rs --lib` で actor-core lib テスト成功
+- [x] 6.3 `cargo test -p fraktor-actor-core-rs --features test-support` で test-support 経由テスト成功
+- [x] 6.4 `mailbox/base.rs` の `instrumentation`/`invoker`/`actor` 関連の動作テスト（既存 `mailbox/tests.rs` 等）が引き続き pass
+
+## 7. 全体 CI 確認
+
+- [x] 7.1 `./scripts/ci-check.sh ai all` を実行し、エラーがないことを確認（CLAUDE.md ルールに従い完了を待つ）
+- [x] 7.2 失敗があれば原因を特定し、修正してから再実行する
+- [x] 7.3 すべて green になったら、コミット・PR 作成の前にユーザー確認を取る
+
+## 8. spec 整合確認
+
+- [x] 8.1 `openspec validate step01-eliminate-actor-core-spin-direct-dep --strict` を実行し、artifact 整合を確認
+- [x] 8.2 `SyncOnce` 経由の利用が spec delta（spin 固有 Scenario）と一致しているかを目視確認
+
+## 9. ドキュメント更新
+
+- [x] 9.1 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 4（`actor-core/Cargo.toml:35` `spin` 直接依存）を「解消済み」に更新
+- [x] 9.2 hand-off メモに「他 actor-* クレートの `spin` 直接依存も同様の方針で別 change で対応」を追記（任意）

--- a/openspec/changes/step02-align-enqueue-from-isr-implementation/.openspec.yaml
+++ b/openspec/changes/step02-align-enqueue-from-isr-implementation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step02-align-enqueue-from-isr-implementation/proposal.md
+++ b/openspec/changes/step02-align-enqueue-from-isr-implementation/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs:88` の `pub fn enqueue_from_isr(&self, ticks: u32)` は API 名から ISR（割り込みハンドラ）セーフティを示唆するが、実装は `try_push` を呼ぶだけで通常の `enqueue` と完全に同じパスを通る。production caller は存在せず、利用箇所は `tick_driver/tests.rs:83-84` のテストのみ。
+
+「名前が実装意図から乖離している」状態は、将来の読者や新規 integrator を誤解させる。特に embedded 系で ISR セーフな API を期待して採用された場合、実装は通常のロックを取る `SharedLock` 経由であり、期待を満たさない可能性がある。本残課題は `drop-actor-core-critical-section-dep` change の hand-off メモ（`docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 3）として記録されている。
+
+## What Changes
+
+本 change は上記残課題の選択肢 A〜C のうち、**選択肢 A（`enqueue_from_isr` を削除し `enqueue` に一本化）** を採用する（詳細根拠は design フェーズで確定）。
+
+- **BREAKING（workspace-internal）**: `TickFeed::enqueue_from_isr(&self, ticks: u32)` public API を削除
+- `tick_driver/tests.rs:83-84` の `enqueue_from_isr` 呼び出しを `enqueue` に置換
+- 他の caller が workspace 内で存在しないことを `Grep` で全数確認（ゼロ件である想定）
+- `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 3 を「解消済み」に更新
+
+**Non-Goals**:
+- 選択肢 B（ISR 専用 backend を `DefaultMutex` の feature variant として追加）の追求（YAGNI。実需要が顕在化してから対応）
+- 選択肢 C（API 名維持 + ドキュメント注記）の追求（実装乖離を温存するため却下）
+- `tick_feed.rs` の他部分（`SharedLock` 利用パターン、`peek`/`drain` API）の見直し
+
+## Capabilities
+
+### New Capabilities
+- なし
+
+### Modified Capabilities
+- なし（`actor-lock-construction-governance` および `compile-time-lock-backend` spec は本 change の影響を受けない。`TickFeed` の public API は spec 化されていない workspace-internal の実装詳細）
+
+ただし OpenSpec validation 要件により最低 1 件の delta が必要なため、design / specs フェーズで適切な capability（例: `actor-runtime-public-api-hygiene` のような新規 capability、または既存 spec への Scenario 追加）を設計する。スコープが大きくなる場合は本 change を「実装のみ」にとどめ、capability spec 化は別 change として切り分けることを検討する。
+
+## Impact
+
+- **Affected code**:
+  - `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs`（public API 削除）
+  - `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs`（呼び出し箇所差し替え）
+- **Affected dependencies**: なし
+- **Affected systems**: `actor-core` 外部に露出する危険性のある紛らわしい API が消える（API surface の健全化）
+- **Release impact**: pre-release phase につき外部影響は軽微。`fraktor-actor-core-rs` の minor bump で十分

--- a/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/.openspec.yaml
+++ b/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/proposal.md
+++ b/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+`actor-core` の `test-support` feature が抱える「責務 B（ダウンストリーム統合テスト用 API 公開）」のうち最大のコンポーネントは `TestTickDriver` である。`actor-core` は no_std クレートであるため、`std::thread` / `std::time` を使う `TestTickDriver` は本質的に std 環境専用。これを `actor-core` 本体で提供していること自体が責務の漏洩。
+
+`actor-adaptor-std` は既に std 環境専用のアダプタクレートとして存在し、`tokio-executor` feature / `test-support` feature を持ち、std 向けの周辺機能を集約する場所として位置づけられている。`TestTickDriver` はこちらに引っ越すのが構造的に自然。
+
+本 change は `test-support` feature を最終的に退役する長期計画（Strategy B）の第 3 ステップ。責務 A（`critical-section/std` impl provider）は既に退役済み（PR #1607/#1608）、責務 B-1 として `TestTickDriver` 移設を行う。
+
+## What Changes
+
+- `modules/actor-core/src/` 配下で `TestTickDriver` 関連の実装（構造体定義、テストユーティリティ、`#[cfg(any(test, feature = "test-support"))]` ゲート内の公開シンボル）を抽出
+- `modules/actor-adaptor-std/src/test_support/` 配下（または同等の場所、design で最終決定）に移設
+- `actor-core` 側では no_std セーフな `TickDriver` trait のみを残す（既存実装を継続）
+- ダウンストリーム（`showcases/std`、`actor-core` 自身の `[[test]]`、他 crate の test）の import path を更新
+- `actor-core/test-support` feature からは `TestTickDriver` 関連が消えるため、残責務 B-2、C の範囲が縮小
+- **BREAKING（workspace-internal）**: `fraktor_actor_core_rs::...::TestTickDriver` → `fraktor_actor_adaptor_std_rs::...::TestTickDriver` へのパス変更
+
+**Non-Goals**:
+- `TestTickDriver` 以外の test-support 公開 API（`new_empty` 等、responsibility B-2）の移設は step04 で行う
+- `test-support` feature 自体の削除は step06 で行う
+- `actor-adaptor-std` の既存 `test-support` feature 設計見直し（現状の構造を尊重）
+
+## Capabilities
+
+### New Capabilities
+- なし
+
+### Modified Capabilities
+- なし（現時点では `TestTickDriver` の配置は spec 化されていない）
+
+design / specs フェーズで以下のいずれかを判断:
+- 案 A: 新規 capability `actor-test-driver-placement` を ADDED し、「std 依存のテストドライバは actor-adaptor-std 側に置く」ルールを明文化
+- 案 B: 既存 `actor-lock-construction-governance` 等の spec に Scenario を追加（test-support 責務分離の原則として）
+- 案 C: 本 change は実装のみ、spec 化は別 change に切り分け（OpenSpec validation 要件のため何らか最低限の delta が必要）
+
+## Impact
+
+- **Affected code**:
+  - `modules/actor-core/src/`（`TestTickDriver` 定義・エクスポート削除）
+  - `modules/actor-adaptor-std/src/`（新規受け入れ先、Cargo.toml の `test-support` feature 再定義）
+  - `modules/actor-core/tests/*.rs`（import path 更新、該当があれば）
+  - `showcases/std/*/main.rs`（import path 更新）
+- **Affected APIs**: `TestTickDriver` のクレートパス変更（workspace-internal breaking）
+- **Affected dependencies**: `actor-adaptor-std` が `actor-core` test-only API に依存しなくなる（現状の循環的な印象を解消）
+- **Release impact**: pre-release phase につき外部影響は軽微

--- a/openspec/changes/step04-extract-actor-test-helpers-crate/.openspec.yaml
+++ b/openspec/changes/step04-extract-actor-test-helpers-crate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step04-extract-actor-test-helpers-crate/proposal.md
+++ b/openspec/changes/step04-extract-actor-test-helpers-crate/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+step03 で `TestTickDriver` を `actor-adaptor-std` に引っ越した後も、`actor-core` の `test-support` feature 配下には責務 B の残りコンポーネント（`new_empty` 系コンストラクタ、テスト用の `MockActorRef`、各種 fixture を構築するヘルパ、その他 `#[cfg(any(test, feature = "test-support"))]` で公開されているダウンストリーム向け API）が残る。
+
+これらを `actor-core` 本体に同居させ続ける限り、「本体 feature flag 経由で内部 API を露出する」アンチパターンが温存される。解決策は **専用の test helpers クレート `fraktor-actor-test-rs` を切り出す** こと。ダウンストリーム（統合テスト、showcase、fraktor-cluster/stream/remote/persistence の test 層）は `[dev-dependencies]` でこの crate を取り込む。
+
+本 change は Strategy B の第 4 ステップ（責務 B-2）。`test-support` feature の体積を大幅に減らし、step05（責務 C 処理）と step06（feature 削除）の地ならしになる。
+
+## What Changes
+
+- 新規 crate `modules/actor-test/`（名前: `fraktor-actor-test-rs`、no_std 選択肢は design で確定。おそらく std 要）を作成
+- `actor-core/test-support` feature 配下で公開していた以下を移設:
+  - `new_empty` 系コンストラクタ（`ActorSystem::new_empty`、`ActorRef::new_empty` 等、design で全数列挙）
+  - 各種テスト用 mock / fixture（`MockActorRef`、`TestProbe` 等、存在するもの）
+  - 統合テストで共有されているヘルパ関数（具体は design の調査で確定）
+- 移設先で API を整理（不要になったものは削除、責務 C と重複する内部 API promotion は step05 に委ねる）
+- ダウンストリームの `Cargo.toml` を更新: `actor-core = { features = ["test-support"] }` → `fraktor-actor-test-rs`（`[dev-dependencies]`）
+- **BREAKING（workspace-internal）**: 公開テストヘルパの crate path が変わる
+
+**Non-Goals**:
+- 責務 C（内部 API の `pub(crate)` → `pub` 格上げ）の処理は step05 で行う
+- `test-support` feature の完全削除は step06 で行う
+- `actor-core` 自身の `[[test]]` が依存する純粋な内部 helper（`#[cfg(test)]` のみで `feature = "test-support"` ゲートされていないもの）は移設対象外
+
+## Capabilities
+
+### New Capabilities
+- なし（新規 crate の API surface そのものは capability spec 化しない想定。design で再検討し、必要なら `actor-test-helpers-api` のような capability を ADDED として導入）
+
+### Modified Capabilities
+- なし
+
+OpenSpec validation 要件を満たすため、design / specs フェーズで最低 1 件の delta を設計する。候補:
+- 案 A: 新規 capability `actor-test-helpers-placement` を ADDED し、「ダウンストリーム向けテストヘルパは専用 crate に置く」ルールを明文化
+- 案 B: `actor-lock-construction-governance` に Scenario を追加（test-support feature 経由で内部 API を露出しない原則として）
+
+## Impact
+
+- **Affected code**:
+  - 新規: `modules/actor-test/src/**`、`modules/actor-test/Cargo.toml`
+  - 既存: `modules/actor-core/src/` の `#[cfg(any(test, feature = "test-support"))]` ゲートの一部削除
+  - ダウンストリーム: `modules/cluster-*`、`modules/remote-*`、`modules/stream-*`、`modules/persistence-*`、`showcases/std` の `[dev-dependencies]`
+- **Affected APIs**: テストヘルパの crate path 変更（workspace-internal breaking）
+- **Affected dependencies**: 新規 crate が `fraktor-actor-core-rs` に依存（逆方向の循環は発生しない）
+- **Release impact**: pre-release phase につき外部影響は軽微。ただし新規 crate publish の検討が必要（docs.rs 向け、または publish = false で workspace-internal のみ）

--- a/openspec/changes/step05-hide-actor-core-internal-test-api/.openspec.yaml
+++ b/openspec/changes/step05-hide-actor-core-internal-test-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step05-hide-actor-core-internal-test-api/proposal.md
+++ b/openspec/changes/step05-hide-actor-core-internal-test-api/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+`actor-core/test-support` feature の責務 C は「内部 API の `pub(crate)` → `pub` 格上げ」である。具体的には `Behavior::handle_message`、`ActorCell::receive` のような、本来 crate 内部に閉じたい API が、ダウンストリームのテスト（`fraktor-cluster-*`、`fraktor-remote-*` の統合テスト等）のために `#[cfg(any(test, feature = "test-support"))]` ゲート内で `pub` になっている。
+
+step04 で `fraktor-actor-test-rs` crate を切り出した後、この責務 C を解消する戦略は 3 つ:
+
+- **A. 内部 API を本当に公開する** → Rust の `pub` は crate 境界で切れるため、ダウンストリームから必要なら正規の public API として設計し直す
+- **B. `fraktor-actor-test-rs` 経由で安全に露出する** → `actor-test` crate 内で薄いファサード関数を提供し、internal API を呼び出す（`actor-core` 側は `pub(crate)` に戻せる）
+- **C. テスト設計自体を見直す** → 本当に internal API を叩く必要があるのか再評価。多くの場合は public API（`ActorRef::tell` 等）でカバーできる
+
+本 change は Strategy B の第 5 ステップ（責務 C 処理）。ケースごとに A/B/C のいずれを採るかを design で判断し、ほぼすべての `#[cfg(any(test, feature = "test-support"))]` による `pub` 格上げを排除する。
+
+## What Changes
+
+- `actor-core` 配下で `#[cfg(any(test, feature = "test-support"))]` により可視性を拡大している全箇所を棚卸し（Grep で全数収集）
+- 各箇所について A/B/C のいずれかの戦略を割り当て（design 段階で決定）
+- 割り当てに従いリファクタ:
+  - A: 正規 public API として docs / 型シグネチャを整備
+  - B: `actor-test` crate 側にファサード関数を追加し、`actor-core` 側は `pub(crate)` に戻す
+  - C: ダウンストリームのテストを public API 経由に書き換え、`actor-core` 側の unrealistic な露出を削除
+- `actor-core/src/` から `#[cfg(any(test, feature = "test-support"))]` で可視性拡大している箇所が 0 件になるのを目標にする（純粋な `#[cfg(test)]` は保持）
+- **BREAKING（workspace-internal）**: 一部 API のパス・シグネチャ・可視性が変わる（ダウンストリームテストの修正が必要）
+
+**Non-Goals**:
+- `test-support` feature 自体の削除は step06 で行う（本 change 完了後は feature が空 `[]` または限りなく空に近づく想定）
+- `actor-core` の public API surface の再設計（責務 C 解消で露出する必要のある API のみ整備）
+
+## Capabilities
+
+### New Capabilities
+- なし
+
+### Modified Capabilities
+- なし
+
+OpenSpec validation 要件を満たすため、design / specs フェーズで最低 1 件の delta を設計する。候補:
+- 案 A: 新規 capability `actor-core-api-visibility-governance` を ADDED し、「feature flag 経由で内部 API の可視性を拡大してはならない」ルールを明文化
+- 案 B: `actor-lock-construction-governance` に同趣旨の Scenario を追加
+
+## Impact
+
+- **Affected code**:
+  - `modules/actor-core/src/**` の各所（`#[cfg(any(test, feature = "test-support"))]` 削除と可視性戻し）
+  - `modules/actor-test/src/**`（ファサード関数追加、戦略 B 採用箇所）
+  - ダウンストリームのテスト（`modules/cluster-*/tests/`、`modules/remote-*/tests/` 等）の書き換え
+- **Affected APIs**: workspace-internal な API シグネチャ・可視性変更
+- **Affected dependencies**: なし（crate 依存構造は step04 で確定した形を維持）
+- **Release impact**: pre-release phase につき外部影響は軽微

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/.openspec.yaml
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/proposal.md
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+step01〜step05 を経て `actor-core/test-support` feature が抱えていた 3 責務（A: critical-section/std impl provider、B: ダウンストリーム統合テスト用 API、C: 内部 API 可視性拡大）はすべて退役済みの状態になる想定。`actor-core/Cargo.toml:19` の `test-support = []` は空の名前空間として残ったまま、何の意味も持たない。
+
+この空 feature は歴史的理由で残されているに過ぎず、残しておくと:
+- 「何か意味があるのでは」と誤解した新規 contributor が再利用しようとする
+- `actor-core` の `[[test]]` で `required-features = ["test-support"]` が書かれ続ける（現在 8 箇所）
+- ダウンストリームの `Cargo.toml` で `features = ["test-support"]` が残り続け、いつか壊れる
+
+最終ステップとして feature 自体を削除し、`actor-core` の feature surface を整理する。本 change は Strategy B の第 6 ステップであり、test-support 関連タスクの打ち止め。
+
+## What Changes
+
+- `modules/actor-core/Cargo.toml`:
+  - `[features]` セクションから `test-support = []` 行を削除
+  - `[[test]]` セクション群（8 箇所）の `required-features = ["test-support"]` 行を削除
+- ダウンストリームの `Cargo.toml`:
+  - `fraktor-actor-core-rs = { ..., features = ["test-support"] }` の `features = ["test-support"]` 指定を全削除
+  - 対象: `modules/cluster-*`、`modules/remote-*`、`modules/stream-*`、`modules/persistence-*`、`showcases/std` の `[dependencies]` および `[dev-dependencies]`
+- `actor-core/src/` 内で `feature = "test-support"` を参照する `#[cfg(...)]` が残っていれば削除（step05 で 0 件になっている想定だが検証する）
+- `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 1 を「解消済み」に更新
+- **BREAKING（workspace-internal、ほぼ影響なし）**: 存在しない feature の指定が `Cargo.toml` に残っていても pre-release phase では検出されやすい
+
+**Non-Goals**:
+- `actor-adaptor-std` 等の他クレートの `test-support` feature 見直し（独自責務を持つため個別判断）
+- `actor-core` の `alloc` / `alloc-metrics` feature の見直し（別スコープ）
+
+## Capabilities
+
+### New Capabilities
+- なし
+
+### Modified Capabilities
+- なし
+
+OpenSpec validation 要件を満たすため、design / specs フェーズで最低 1 件の delta を設計する。候補:
+- 案 A: step04 / step05 で導入した capability（`actor-test-helpers-placement` / `actor-core-api-visibility-governance` 等）に Scenario を追加し、「`actor-core` には `test-support` feature が存在しない」を検査項目化
+- 案 B: 既存 `actor-lock-construction-governance` に Scenario を追加
+
+## Impact
+
+- **Affected code**:
+  - `modules/actor-core/Cargo.toml`（feature 削除、`[[test]]` required-features 削除）
+  - 全ダウンストリーム crate の `Cargo.toml`
+- **Affected APIs**: なし（既に step03-05 で移設・再設計済み）
+- **Affected dependencies**: なし
+- **Release impact**: pre-release phase につき外部影響は軽微。`fraktor-actor-core-rs` の feature surface が縮小する

--- a/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/.openspec.yaml
+++ b/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/proposal.md
+++ b/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+`modules/actor-core/Cargo.toml:25` の `portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }` は、組み込み 32-bit ターゲット（`armv7m` など `AtomicU64` 非対応プラットフォーム）向けの `AtomicU64` fallback を有効化する目的で `critical-section` feature を指定している。
+
+しかし以下が未確認のまま:
+- fraktor-rs が実際に組み込み 32-bit ターゲットでビルド・運用される実績はあるか
+- ある場合、どのターゲット（thumbv6m、thumbv7m、riscv32i 等）が対象か
+- ない場合、`core::sync::atomic::AtomicU64` で十分ではないか
+
+本 change は判断材料の収集・評価のみを行い、step08（実際の退役）の是非を確定する **調査 change**。実装フェーズで得られた結論に基づいて step08 に進むか、逆に step08 を中止して方針転換する。
+
+Strategy B の第 7 ステップ（評価）。step08 と合わせて `portable-atomic/critical-section` 依存の処遇を決める。
+
+## What Changes
+
+本 change は実装を伴わない評価 change である。以下を生成物として残す:
+
+- **Investigation report**（`docs/plan/` 配下に配置、`.takt/` ではない）:
+  - fraktor-rs の CI 対象ターゲット棚卸し（`.github/workflows/**.yml` を調査）
+  - `modules/actor-core/src/` および workspace 全体で `portable_atomic::AtomicU64` が使われている箇所を列挙
+  - 各利用箇所が要求する整数幅の特定（`AtomicU64` なのか `AtomicUsize` なのか、`AtomicU32` で十分か）
+  - `core::sync::atomic` で代替可能かの一次評価
+  - 組み込み系 contributor の実利用報告があるか（GitHub issues / discussions を軽く調査）
+- **Decision matrix**（`docs/plan/` 配下）:
+  - 選択肢 X（`portable-atomic/critical-section` 退役）、Y（維持）、Z（条件付き維持: feature flag で切替）のトレードオフ比較
+- **Recommendation**: step08 で採るべきアクションを明示
+
+**Non-Goals**:
+- コード変更は一切行わない（`Cargo.toml` の修正、`core::sync::atomic` への置換は step08 のスコープ）
+- `portable-atomic` 本体依存の削除（`portable-atomic` は `heapless` 等からも使われているため、feature 指定の再評価のみを対象とする）
+- 組み込み系の実ビルド検証（CI 外でのクロスコンパイル実行は step08 のスコープ）
+
+## Capabilities
+
+### New Capabilities
+- なし（調査 change であり、capability の新設は不要）
+
+### Modified Capabilities
+- なし
+
+OpenSpec validation 要件を満たすため、design / specs フェーズで最低 1 件の delta を設計する。候補:
+- 案 A: 既存 `compile-time-lock-backend` に Scenario を追加（atomic backend の決定手順として）
+- 案 B: 新規 capability `actor-core-dependency-governance` を ADDED し、「低レベル依存の feature 指定は用途ターゲットが明示されなければならない」ルールを明文化
+- 案 C: 本 change は純粋な調査 change として spec delta を最小限にとどめ、step08 側で必要な spec 変更をまとめて行う
+
+## Impact
+
+- **Affected code**: なし（ドキュメント生成のみ）
+- **Affected APIs**: なし
+- **Affected dependencies**: なし
+- **Release impact**: なし
+- **Output artifacts**:
+  - `docs/plan/YYYY-MM-DD-portable-atomic-critical-section-evaluation.md`（investigation report + decision matrix）

--- a/openspec/changes/step08-retire-portable-atomic-critical-section/.openspec.yaml
+++ b/openspec/changes/step08-retire-portable-atomic-critical-section/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/step08-retire-portable-atomic-critical-section/proposal.md
+++ b/openspec/changes/step08-retire-portable-atomic-critical-section/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+step07 の調査結果（`docs/plan/YYYY-MM-DD-portable-atomic-critical-section-evaluation.md`）で「`portable-atomic/critical-section` feature は不要」と結論されたら、本 change で実際に退役する。
+
+退役の意義:
+- `actor-core` が間接的に `critical-section` impl provider を要求する経路が消える（残課題が完全に閉じる）
+- 依存グラフが簡素化される（`portable-atomic` の internal config が `critical-section` 不要に倒れる）
+- step01〜step06 で確立した「`actor-core` は同期プリミティブ供給責任を持たない」原則が atomic 層にも徹底される
+
+step07 で「維持すべし」となった場合、本 change は **中止または縮小** する。実装フェーズに入る前に design 段階で結論を再確認する。
+
+Strategy B の最終ステップ（第 8 ステップ）。これで `actor-core` 周辺の同期プリミティブ依存に関する整理計画が完了する。
+
+## What Changes
+
+step07 の結論が「退役」だった場合のみ実施する変更:
+
+- `modules/actor-core/Cargo.toml:25` の `portable-atomic = { ..., features = ["critical-section"] }` から `"critical-section"` を削除
+  - 完全に不要なら `default-features = false` のみに整理
+  - 一部ターゲットで必要なら、`actor-core` の feature flag（例: `portable-atomic-critical-section`）に optional 化して条件付き有効化
+- `modules/actor-core/src/` で `AtomicU64`（または該当する atomic 型）の利用箇所を `core::sync::atomic` 由来に置換可能か再検証し、置換
+- 組み込み系の主要ターゲット（step07 で特定したもの）でクロスコンパイル検証（CI に追加できるかも検討）
+- `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 2 を「解消済み」または「方針転換により取り下げ」に更新
+- workspace の `cargo tree -e features` 等で `critical-section` impl provider 要求経路が完全に消えることを確認
+- **BREAKING（workspace-internal）**: 組み込み 32-bit ターゲット向けビルドの構成が変わる可能性（feature 名・`Cargo.toml` 指定）
+
+**Non-Goals**:
+- step07 で「維持」と結論されたら本 change は中止（`design.md` で「中止判断」を明記して archive、または `proposal.md` 段階で削除）
+- `heapless` 側の `portable-atomic` feature 指定見直し（別スコープ）
+
+## Capabilities
+
+### New Capabilities
+- なし
+
+### Modified Capabilities
+- なし
+
+OpenSpec validation 要件を満たすため、design / specs フェーズで最低 1 件の delta を設計する。候補:
+- 案 A: `actor-lock-construction-governance` Requirement「actor-\* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない」の例外条項（`portable-atomic` のような low-level utility crate が引き込む推移的依存）を縮小・削除する MODIFIED
+- 案 B: 既存 `compile-time-lock-backend` に「atomic backend は core::sync::atomic を第一選択とする」原則を Scenario として追加
+
+## Impact
+
+- **Affected code**:
+  - `modules/actor-core/Cargo.toml`（feature 指定整理）
+  - `modules/actor-core/src/` で `portable_atomic::AtomicU64` 等を使っている 16 ファイル相当（step07 調査範囲）
+- **Affected APIs**: なし（atomic 型は内部実装詳細）
+- **Affected dependencies**: `portable-atomic/critical-section` feature が無効化される
+- **Release impact**:
+  - 組み込み 32-bit ターゲット利用者が現れた場合の互換性は要評価（pre-release phase につき影響軽微）
+  - workspace 全体で `critical-section` impl provider 要求が actor-core 側からは完全に消える


### PR DESCRIPTION
## Summary

`actor-lock-construction-governance` spec の Requirement「`actor-*` の `Cargo.toml` は primitive lock crate を non-optional な直接依存として宣言してはならない」に違反していた `actor-core/Cargo.toml` の `spin` 直接依存を撤去する。

直前の archive change `retire-actor-core-test-support-critical-section-impl` (PR #1607) で確立した上記 governance に対し、actor-core 自身が違反している状態を解消する。

## Changes

既存の `LockDriver` / `SpinSyncMutex` / `SharedLock` 3 段構造と相似形になるよう、`utils-core` 側に Once 系の同形構造を新設:

| 層 | Once 系（本 PR 新設） | Mutex 系（既存） |
|---|---|---|
| driver trait | `OnceDriver<T>` | `LockDriver<T>` |
| backend 実装 | `SpinOnce<T>`（`spin::Once<T>` の thin wrapper） | `SpinSyncMutex<T>` |
| 公開抽象 | `SyncOnce<T>`（actor-* の依存先） | `SharedLock<T>` |

### utils-core
- `OnceDriver<T>` trait を新設（`new`/`call_once`/`get`/`is_completed`）
- `SpinOnce<T>` を新設（`spin::Once` 唯一の利用点）
- `SyncOnce<T>` を新設（`SpinOnce<T>` を内部保持する単段構成、`ArcShared` は挟まない）
- `Cargo.toml` の `spin` features に `"once"` を追加

### actor-core
- `coordinated_shutdown.rs`、`mailbox/base.rs` の `spin::Once` 利用を `SyncOnce` に置換
- `mailbox_shared_set.rs` docstring の `spin::Once<T>` 言及更新
- `Cargo.toml` から `spin = { ... }` 行を完全削除
- `clippy.toml` の `disallowed-types` に `spin::Once` を追加（safety net 強化、既存の `spin::Mutex` / `spin::RwLock` と同列）

### spec / docs
- `actor-lock-construction-governance` spec に `spin` 固有 Scenario を追加（検査カバレッジを `critical-section` 単独 → `spin` も含む形に拡張）
- `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 4 を解消済みに更新

## Verification

- `cargo build -p fraktor-actor-core-rs --no-default-features`: OK（no_std）
- `cargo test -p fraktor-actor-core-rs --features test-support`: 1852 passed
- `cargo tree -p fraktor-actor-core-rs --no-default-features --depth 1`: `spin` が direct dep から消失、`utils-core` 経由の transitive のみ残存
- `./scripts/ci-check.sh ai all`: EXIT=0
- `openspec validate step01-eliminate-actor-core-spin-direct-dep --strict`: valid

## Related

- 元 spec: `openspec/specs/actor-lock-construction-governance/spec.md`
- 直前 PR: #1607 (retire test-support critical-section impl provider)
- 後続: step02〜step08 の proposal も同 PR で追加（actor-core sync primitive cleanup の長期計画）

## Breaking changes

workspace-internal のみ。pre-release phase につき外部影響は軽微。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core concurrency initialization paths (`Mailbox`/`CoordinatedShutdown`) by swapping the underlying once primitive, which could surface subtle thread-safety or no_std behavior differences despite being a thin wrapper with tests.
> 
> **Overview**
> Removes `actor-core`'s direct dependency on the primitive lock crate `spin` by replacing its remaining `spin::Once` usages with a new `utils-core` abstraction.
> 
> `utils-core` now provides a write-once, lock-free-read stack (`OnceDriver`, `SpinOnce`, `SyncOnce`) with unit tests, and `actor-core` migrates `Mailbox` and `CoordinatedShutdown` to `SyncOnce`, deletes the `spin` entry from `actor-core/Cargo.toml`, and adds clippy bans for `spin::Once` to prevent regressions. The governance spec/docs are updated to explicitly assert `actor-core` has no direct `spin` dependency (and note the follow-up item as resolved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0603a2802cdc5c302b882812859e8dd0de2dbc9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 内部同期プリミティブを最適化し、ホットパスでのロックフリー読み取りを実現しました。
  * 書き込み一度限りのセルの新しい抽象化を導入しました。

* **Documentation**
  * 実装計画を更新し、最近の変更を反映しました。

* **Tests**
  * 新しい同期プリミティブの動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->