### PR TITLE
step02: align enqueue_from_isr with implementation (remove the misleading API)

### DIFF
--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -26,14 +26,15 @@
 
 ただし、`actor-core` の他 16 ファイルで `portable_atomic` が使われており、影響範囲は広い。
 
-### 3. `enqueue_from_isr` API 名と実装意図の乖離
+### 3. `enqueue_from_isr` API 名と実装意図の乖離（解消済み）
 
-`tick_feed.rs:88` の `pub fn enqueue_from_isr(&self, ticks: u32)` は API 名から ISR セーフティを示唆するが、実装は `try_push` を呼ぶだけで `enqueue` と完全に同じパス。本 change の起案時調査で production caller が存在しない（`tick_driver/tests.rs:83-84` のテストのみ）ことが判明した。
+**解消済み**: `step02-align-enqueue-from-isr-implementation` change（2026-04-21）で選択肢 A（`enqueue_from_isr` 削除 → `enqueue` 一本化）を採用して対応完了。
 
-選択肢:
-- A: `enqueue_from_isr` を削除し、`enqueue` に一本化
-- B: ISR 専用の backend を `DefaultMutex` の feature variant（例: `irq-locks`）として追加し、`enqueue_from_isr` の実装を分岐
-- C: API 名を維持し、ドキュメントで「実装上は `enqueue` と同じ」を明記
+対応内容:
+- `TickFeed::enqueue_from_isr` public API を削除
+- `tick_driver/tests.rs` の test 関数 `enqueue_from_isr_preserves_order_and_metrics` を `enqueue_tracks_driver_active_and_drop_metrics` にリネーム（既存 `tick_feed/tests.rs::enqueue_wakes_signal_and_preserves_order` とユニーク検証点を区別する命名）
+- `actor-lock-construction-governance` spec に「ISR セーフに見せかけながら中身が通常ロック」の public API を禁止する Scenario を追加
+- 将来 ISR セーフ経路が真に必要になった場合は、`DefaultMutex` の ISR セーフ feature variant（例: `irq-locks`）を伴う形で **新規 API として** 設計する方針（名前だけ先行した API を温存する方向は選ばない）
 
 ### 4. `actor-core/Cargo.toml:35` `spin` 直接依存の Requirement 2 違反（解消済み）
 

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs
@@ -76,12 +76,12 @@ impl TickDriver for InlineTestDriver {
 }
 
 #[test]
-fn enqueue_from_isr_preserves_order_and_metrics() {
+fn enqueue_tracks_driver_active_and_drop_metrics() {
   let signal = TickExecutorSignal::new();
   let feed = TickFeed::new(Duration::from_millis(1), 1, signal.clone());
 
-  feed.enqueue_from_isr(1);
-  feed.enqueue_from_isr(1);
+  feed.enqueue(1);
+  feed.enqueue(1);
 
   let mut drained = Vec::new();
   feed.drain_pending(|ticks| drained.push(ticks));

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs
@@ -82,15 +82,6 @@ impl TickFeed {
     self.finalize_enqueue(pushed, ticks);
   }
 
-  /// Enqueues ticks from interrupt context.
-  pub fn enqueue_from_isr(&self, ticks: u32) {
-    if ticks == 0 {
-      return;
-    }
-    let pushed = self.try_push(ticks);
-    self.finalize_enqueue(pushed, ticks);
-  }
-
   /// Drains buffered ticks, invoking the provided closure for each batch.
   pub(crate) fn drain_pending<F>(&self, mut consumer: F)
   where

--- a/openspec/changes/step02-align-enqueue-from-isr-implementation/tasks.md
+++ b/openspec/changes/step02-align-enqueue-from-isr-implementation/tasks.md
@@ -1,49 +1,49 @@
 ## 1. 事前調査と確認
 
-- [ ] 1.1 `modules/actor-core/src` 全体で `enqueue_from_isr` の残存言及を再 Grep（起案時は `tick_feed.rs:86` の定義 + `tests.rs:83-84` の呼び出し 2 箇所のみ想定）
-- [ ] 1.2 workspace 全体（`modules/` 配下の `src/` と `benches/`、`showcases/`、`scripts/`、`.github/`）で `enqueue_from_isr` を Grep し、production caller / CI allowlist が存在しないことを最終確認。workspace 直下には `benches/` ディレクトリは無いため対象外
-- [ ] 1.3 `tick_feed.rs` の `enqueue` と `enqueue_from_isr` の実装が依然同一であることを目視確認（前回調査から差分が入っていないか）
-- [ ] 1.4 `tests.rs:79-96` の `enqueue_from_isr_preserves_order_and_metrics` テストの期待値が `enqueue` 呼び出しでも同じ結果になることを確認（容量 1 → 2 回 push で 1 dropped、`driver_active` 立ち上がり、`signal.arm()` 通知）
+- [x] 1.1 `modules/actor-core/src` 全体で `enqueue_from_isr` の残存言及を再 Grep（起案時は `tick_feed.rs:86` の定義 + `tests.rs:83-84` の呼び出し 2 箇所のみ想定）
+- [x] 1.2 workspace 全体（`modules/` 配下の `src/` と `benches/`、`showcases/`、`scripts/`、`.github/`）で `enqueue_from_isr` を Grep し、production caller / CI allowlist が存在しないことを最終確認。workspace 直下には `benches/` ディレクトリは無いため対象外
+- [x] 1.3 `tick_feed.rs` の `enqueue` と `enqueue_from_isr` の実装が依然同一であることを目視確認（前回調査から差分が入っていないか）
+- [x] 1.4 `tests.rs:79-96` の `enqueue_from_isr_preserves_order_and_metrics` テストの期待値が `enqueue` 呼び出しでも同じ結果になることを確認（容量 1 → 2 回 push で 1 dropped、`driver_active` 立ち上がり、`signal.arm()` 通知）
 
 ## 2. tick_feed.rs からの API 削除
 
-- [ ] 2.1 `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs` の `pub fn enqueue_from_isr(&self, ticks: u32) { ... }` method（line 85-92 付近、docstring 含む）を削除
-- [ ] 2.2 削除後、`enqueue` method が残り tick 受付 API として唯一の public 経路になっていることを確認
-- [ ] 2.3 `cargo fmt -p fraktor-actor-core-rs` で format 整形
+- [x] 2.1 `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_feed.rs` の `pub fn enqueue_from_isr(&self, ticks: u32) { ... }` method（line 85-92 付近、docstring 含む）を削除
+- [x] 2.2 削除後、`enqueue` method が残り tick 受付 API として唯一の public 経路になっていることを確認
+- [x] 2.3 `cargo fmt -p fraktor-actor-core-rs` で format 整形
 
 ## 3. テストの更新
 
-- [ ] 3.1 `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs` の test 関数名 `enqueue_from_isr_preserves_order_and_metrics` を `enqueue_tracks_driver_active_and_drop_metrics` にリネーム（design Decision 3 通り、既存 `tick_feed/tests.rs::enqueue_wakes_signal_and_preserves_order` と役割を区別する命名）
-- [ ] 3.2 同関数内の `feed.enqueue_from_isr(1);` 呼び出し 2 箇所を `feed.enqueue(1);` に置換
-- [ ] 3.3 テスト本体の assertion（`drained`, `driver_active`, `metrics.enqueued_total()`, `metrics.dropped_total()`, `signal.arm()`）が変更不要であることを確認
-- [ ] 3.4 その他の test 関数が `enqueue_from_isr` を間接参照していないか再 Grep
+- [x] 3.1 `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs` の test 関数名 `enqueue_from_isr_preserves_order_and_metrics` を `enqueue_tracks_driver_active_and_drop_metrics` にリネーム（design Decision 3 通り、既存 `tick_feed/tests.rs::enqueue_wakes_signal_and_preserves_order` と役割を区別する命名）
+- [x] 3.2 同関数内の `feed.enqueue_from_isr(1);` 呼び出し 2 箇所を `feed.enqueue(1);` に置換
+- [x] 3.3 テスト本体の assertion（`drained`, `driver_active`, `metrics.enqueued_total()`, `metrics.dropped_total()`, `signal.arm()`）が変更不要であることを確認
+- [x] 3.4 その他の test 関数が `enqueue_from_isr` を間接参照していないか再 Grep
 
 ## 4. 残存言及の整理
 
-- [ ] 4.1 `modules/actor-core/` 配下の docstring / コメント / ドキュメントで `enqueue_from_isr` 言及が残っていないか最終 Grep（削除対象 API は本 change で完全消去）
-- [ ] 4.2 CI allowlist / `.github/workflows/**.yml` / `scripts/*.sh` に `enqueue_from_isr` を指定する test filter が無いことを Grep で最終確認（tasks 1.2 の補足）
-- [ ] 4.3 `docs/` 配下で `enqueue_from_isr` に言及する箇所があれば、履歴的文脈（hand-off メモ / archive 済み change）以外は更新 or 削除判断
+- [x] 4.1 `modules/actor-core/` 配下の docstring / コメント / ドキュメントで `enqueue_from_isr` 言及が残っていないか最終 Grep（削除対象 API は本 change で完全消去）
+- [x] 4.2 CI allowlist / `.github/workflows/**.yml` / `scripts/*.sh` に `enqueue_from_isr` を指定する test filter が無いことを Grep で最終確認（tasks 1.2 の補足）
+- [x] 4.3 `docs/` 配下で `enqueue_from_isr` に言及する箇所があれば、履歴的文脈（hand-off メモ / archive 済み change）以外は更新 or 削除判断
 
 ## 5. ビルド・テスト検証
 
-- [ ] 5.1 `cargo build -p fraktor-actor-core-rs --no-default-features` で no_std ビルド成功を確認
-- [ ] 5.2 `cargo build -p fraktor-actor-core-rs --features test-support` で test-support ビルド成功を確認
-- [ ] 5.3 `cargo test -p fraktor-actor-core-rs --lib` で lib テスト成功（リネーム後のテスト含む）
-- [ ] 5.4 `cargo test -p fraktor-actor-core-rs --features test-support` で統合テスト成功
-- [ ] 5.5 `cargo clippy -p fraktor-actor-core-rs --lib` で clippy clean を確認
+- [x] 5.1 `cargo build -p fraktor-actor-core-rs --no-default-features` で no_std ビルド成功を確認
+- [x] 5.2 `cargo build -p fraktor-actor-core-rs --features test-support` で test-support ビルド成功を確認
+- [x] 5.3 `cargo test -p fraktor-actor-core-rs --lib` で lib テスト成功（リネーム後のテスト含む）
+- [x] 5.4 `cargo test -p fraktor-actor-core-rs --features test-support` で統合テスト成功
+- [x] 5.5 `cargo clippy -p fraktor-actor-core-rs --lib` で clippy clean を確認
 
 ## 6. spec 整合確認
 
-- [ ] 6.1 `openspec validate step02-align-enqueue-from-isr-implementation --strict` を実行し artifact 整合を確認
-- [ ] 6.2 追加した Scenario「actor-\* は ISR セーフに見せかけた通常ロック API を公開しない」が本 change 後の状態（`enqueue_from_isr` 削除済み）と一致していることを目視確認
+- [x] 6.1 `openspec validate step02-align-enqueue-from-isr-implementation --strict` を実行し artifact 整合を確認
+- [x] 6.2 追加した Scenario「actor-\* は ISR セーフに見せかけた通常ロック API を公開しない」が本 change 後の状態（`enqueue_from_isr` 削除済み）と一致していることを目視確認
 
 ## 7. 全体 CI 確認
 
-- [ ] 7.1 `./scripts/ci-check.sh ai all` を実行しエラーがないことを確認（CLAUDE.md ルールに従い完了を待つ）
-- [ ] 7.2 失敗があれば原因を特定し、修正してから再実行する
-- [ ] 7.3 すべて green になったら、コミット・PR 作成の前にユーザー確認を取る
+- [x] 7.1 `./scripts/ci-check.sh ai all` を実行しエラーがないことを確認（CLAUDE.md ルールに従い完了を待つ）
+- [x] 7.2 失敗があれば原因を特定し、修正してから再実行する
+- [x] 7.3 すべて green になったら、コミット・PR 作成の前にユーザー確認を取る
 
 ## 8. ドキュメント更新
 
-- [ ] 8.1 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 3（`enqueue_from_isr` API 名と実装意図の乖離）を「解消済み（選択肢 A で削除一本化、step02 で対応）」に更新
-- [ ] 8.2 hand-off メモに「将来 ISR セーフ経路が必要になった場合は、`DefaultMutex` の ISR セーフ feature variant と合わせて新規 API として設計する」方針を追記
+- [x] 8.1 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` の残課題 3（`enqueue_from_isr` API 名と実装意図の乖離）を「解消済み（選択肢 A で削除一本化、step02 で対応）」に更新
+- [x] 8.2 hand-off メモに「将来 ISR セーフ経路が必要になった場合は、`DefaultMutex` の ISR セーフ feature variant と合わせて新規 API として設計する」方針を追記


### PR DESCRIPTION
## Summary

`TickFeed::enqueue_from_isr` は API 名から ISR（割り込みハンドラ）セーフな経路を示唆していたが、実装は通常の `enqueue` と完全に同一で、内部で `SharedLock::with_lock` を経由していた。名前だけが嘘をついている状態で、新規 integrator が ISR から呼び出す誤用を招くリスクがあったため、選択肢 A（削除して `enqueue` に一本化）を採用する。

関連 change: `step02-align-enqueue-from-isr-implementation`（design/specs/tasks は 2026-04-22 に main にマージ済み）。本 PR で対応する実装を追加する。

## Changes

### actor-core
- `tick_feed.rs` から `pub fn enqueue_from_isr(&self, ticks: u32)` を削除
- `tick_driver/tests.rs` のテスト関数を `enqueue_from_isr_preserves_order_and_metrics` → `enqueue_tracks_driver_active_and_drop_metrics` にリネーム
  - 既存 `tick_feed/tests.rs::enqueue_wakes_signal_and_preserves_order` とユニーク検証点（`driver_active` 立ち上がり、`enqueued_total`/`dropped_total` 同時検証、`signal.arm` セマンティクス）を区別する命名
- `feed.enqueue_from_isr(1)` 呼び出し 2 箇所を `feed.enqueue(1)` に置換

### docs / openspec
- `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 3 を解消済みに更新、将来 ISR セーフ経路が真に必要になった場合の方針も明記
- `openspec/changes/step02-align-enqueue-from-isr-implementation/tasks.md` 全 26 タスクを完了マーク

## Verification

- `cargo build -p fraktor-actor-core-rs --no-default-features`: OK
- `cargo build -p fraktor-actor-core-rs --features test-support`: OK
- `cargo test -p fraktor-actor-core-rs --lib`: 1772 passed（リネーム後のテスト含む）
- `cargo clippy -p fraktor-actor-core-rs --lib`: clean
- `openspec validate step02-align-enqueue-from-isr-implementation --strict`: valid
- `./scripts/ci-check.sh ai all`: EXIT=0

## Breaking changes

workspace-internal のみ。production caller は起案時・実装時の Grep で workspace 全体に存在しないことを確認済み。pre-release phase につき外部影響は軽微。

## Related

- 先行 PR: #1609（step01: eliminate actor-core spin direct dep）、#1610（archive step01）
- 次: step03 以降は未着手。step02 のスコープで完結

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused, misleading public method and updates a single integration test accordingly; primary risk is any untracked downstream code still calling `enqueue_from_isr`.
> 
> **Overview**
> Eliminates the misleading `TickFeed::enqueue_from_isr` public API and relies solely on `enqueue` for tick submission.
> 
> Updates the tick driver integration test to call `enqueue` (and renames the test for clearer intent), and marks the follow-up item as completed in the hand-off plan/spec tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 044dc660ffb6a412d9ce84f2cde205b91cc1fff7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->