### PR TITLE
refactor(actor-core): step03 - move TestTickDriver/new_empty* public API to actor-adaptor-std

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8fac384a-5deb-47ff-be58-2b43370001c9","pid":27550,"acquiredAt":1776763139453}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"8fac384a-5deb-47ff-be58-2b43370001c9","pid":27550,"acquiredAt":1776763139453}

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Cargo.lock
 # AI agent tool directories (managed by configure.sh / okite-ai)
 
 /.claude/settings.local.json
+/.claude/scheduled_tasks.lock
 
 /.codex*/cache/
 /.codex*/log/

--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -15,7 +15,9 @@
 `actor-core/Cargo.toml:19` の `test-support` feature は当初 3 つの異なる責務を抱えていた:
 
 - 責務 A: `critical-section/std` impl provider 提供（std 環境でリンクを通すため） → **完了** (`retire-actor-core-test-support-critical-section-impl` change で各バイナリ側へ移譲、2026-04-21)
-- 責務 B: ダウンストリーム統合テスト用 API 公開（`TestTickDriver`, `new_empty` 等） → 未着手
+- 責務 B: ダウンストリーム統合テスト用 API 公開（`TestTickDriver`, `new_empty` 等）
+  - **B-1 完了** (`step03-move-test-tick-driver-to-adaptor-std`、2026-04-21): `TestTickDriver` と `new_empty*` の **公開 API** を `actor-adaptor-std` 側へ移設。`actor-core/test-support` feature の **公開 API には含まれなくなった**。inline test 用に `pub(crate)` 内部版が `tick_driver/tests/test_tick_driver.rs` と `base/tests.rs` / `typed/system/tests.rs` 内に残るが、これは外部から見えない。caller の使い分け: `actor-core` の inline test → 内部版、`actor-core` の integration test + 下流 crate → `actor-adaptor-std` 公開版。詳細は当該 change の design.md「実装後の補足」を参照
+  - **B-2 未着手**: mock / probe / その他ヘルパ → step04 で対応
 - 責務 C: 内部 API の `pub(crate)` → `pub` 格上げ（`Behavior::handle_message` 等） → 未着手
 
 責務 A 退役後、`actor-core/test-support` は `[]`（空配列）になり、責務 B/C のための `#[cfg(any(test, feature = "test-support"))]` がコード側で利用される構造のみが残った。最終的に責務 B/C も退役できれば `test-support` feature 自体を削除できる。

--- a/modules/actor-adaptor-std/Cargo.toml
+++ b/modules/actor-adaptor-std/Cargo.toml
@@ -51,5 +51,15 @@ path = "benches/balancing_dispatcher.rs"
 harness = false
 required-features = ["tokio-executor"]
 
+[[test]]
+name = "circuit_breakers_registry"
+path = "tests/circuit_breakers_registry.rs"
+required-features = ["test-support"]
+
+[[test]]
+name = "sp_h1_5_system_escalation"
+path = "tests/sp_h1_5_system_escalation.rs"
+required-features = ["test-support"]
+
 [lints]
 workspace = true

--- a/modules/actor-adaptor-std/src/std.rs
+++ b/modules/actor-adaptor-std/src/std.rs
@@ -7,6 +7,9 @@ pub mod event;
 /// Pattern bindings for the standard toolbox.
 pub mod pattern;
 mod std_blocker;
+/// Test-support helpers for actor systems (test-support feature only).
+#[cfg(feature = "test-support")]
+pub mod system;
 /// Tick driver bindings for the standard toolbox.
 pub mod tick_driver;
 /// Time bindings for the standard toolbox.

--- a/modules/actor-adaptor-std/src/std/pattern/circuit_breakers_registry_id.rs
+++ b/modules/actor-adaptor-std/src/std/pattern/circuit_breakers_registry_id.rs
@@ -4,7 +4,7 @@ use fraktor_actor_core_rs::core::kernel::{actor::extension::ExtensionId, system:
 
 use super::circuit_breakers_registry::CircuitBreakersRegistry;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-support"))]
 mod tests;
 
 /// Identifier used to register [`CircuitBreakersRegistry`] on an actor system.

--- a/modules/actor-adaptor-std/src/std/pattern/circuit_breakers_registry_id/tests.rs
+++ b/modules/actor-adaptor-std/src/std/pattern/circuit_breakers_registry_id/tests.rs
@@ -1,12 +1,11 @@
-use fraktor_actor_core_rs::core::kernel::{
-  actor::extension::ExtensionId, pattern::CircuitBreakerState, system::ActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::extension::ExtensionId, pattern::CircuitBreakerState};
 
 use super::CircuitBreakersRegistryId;
+use crate::std::system::new_empty_actor_system;
 
 #[test]
 fn create_extension_returns_empty_registry() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let extension_id = CircuitBreakersRegistryId::new();
 
   let registry = extension_id.create_extension(&system);

--- a/modules/actor-adaptor-std/src/std/system.rs
+++ b/modules/actor-adaptor-std/src/std/system.rs
@@ -1,7 +1,5 @@
-//! System-level test helpers (gated by `test-support` feature).
+//! System-level test helpers (gated by `test-support` feature at parent module).
 
-#[cfg(feature = "test-support")]
 mod empty_system;
 
-#[cfg(feature = "test-support")]
-pub use empty_system::{new_empty_actor_system, new_empty_actor_system_with, new_empty_typed_actor_system};
+pub use empty_system::{new_empty_actor_system, new_empty_actor_system_with};

--- a/modules/actor-adaptor-std/src/std/system.rs
+++ b/modules/actor-adaptor-std/src/std/system.rs
@@ -1,0 +1,7 @@
+//! System-level test helpers (gated by `test-support` feature).
+
+#[cfg(feature = "test-support")]
+mod empty_system;
+
+#[cfg(feature = "test-support")]
+pub use empty_system::{new_empty_actor_system, new_empty_actor_system_with, new_empty_typed_actor_system};

--- a/modules/actor-adaptor-std/src/std/system/empty_system.rs
+++ b/modules/actor-adaptor-std/src/std/system/empty_system.rs
@@ -1,0 +1,56 @@
+//! Test-only constructors for empty actor systems backed by [`TestTickDriver`].
+
+use fraktor_actor_core_rs::core::{
+  kernel::{actor::setup::ActorSystemConfig, system::ActorSystem},
+  typed::TypedActorSystem,
+};
+
+use crate::std::tick_driver::TestTickDriver;
+
+/// Creates an empty actor system without any guardian using the default test tick driver.
+///
+/// Equivalent to calling [`new_empty_actor_system_with`] with an identity configurator.
+///
+/// # Panics
+///
+/// Panics if the default test-support configuration fails to build.
+#[must_use]
+pub fn new_empty_actor_system() -> ActorSystem {
+  new_empty_actor_system_with(|config| config)
+}
+
+/// Creates an empty actor system without any guardian, allowing the caller to customize the
+/// [`ActorSystemConfig`] before the system state is built.
+///
+/// The system is backed by [`TestTickDriver`] (std-thread driven, suitable for deterministic
+/// integration tests). Internally calls [`ActorSystem::new_started_from_config`] which marks
+/// the root as started.
+///
+/// # Panics
+///
+/// Panics if the resulting configuration fails to build the underlying system state.
+#[must_use]
+pub fn new_empty_actor_system_with<F>(configure: F) -> ActorSystem
+where
+  F: FnOnce(ActorSystemConfig) -> ActorSystemConfig, {
+  let config = ActorSystemConfig::new(TestTickDriver::default());
+  let config = configure(config);
+  match ActorSystem::new_started_from_config(config) {
+    | Ok(system) => system,
+    | Err(error) => panic!("test-support config failed to build in new_empty_actor_system_with: {error:?}"),
+  }
+}
+
+/// Creates an empty [`TypedActorSystem`] backed by [`TestTickDriver`].
+///
+/// Equivalent to wrapping [`new_empty_actor_system`] with [`TypedActorSystem::from_untyped`].
+///
+/// # Panics
+///
+/// Panics if the default test-support configuration fails to build.
+#[must_use]
+pub fn new_empty_typed_actor_system<M>() -> TypedActorSystem<M>
+where
+  M: Send + Sync + 'static, {
+  TypedActorSystem::from_untyped(new_empty_actor_system())
+}

--- a/modules/actor-adaptor-std/src/std/system/empty_system.rs
+++ b/modules/actor-adaptor-std/src/std/system/empty_system.rs
@@ -1,9 +1,6 @@
 //! Test-only constructors for empty actor systems backed by [`TestTickDriver`].
 
-use fraktor_actor_core_rs::core::{
-  kernel::{actor::setup::ActorSystemConfig, system::ActorSystem},
-  typed::TypedActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::setup::ActorSystemConfig, system::ActorSystem};
 
 use crate::std::tick_driver::TestTickDriver;
 
@@ -41,16 +38,3 @@ where
   }
 }
 
-/// Creates an empty [`TypedActorSystem`] backed by [`TestTickDriver`].
-///
-/// Equivalent to wrapping [`new_empty_actor_system`] with [`TypedActorSystem::from_untyped`].
-///
-/// # Panics
-///
-/// Panics if the default test-support configuration fails to build.
-#[must_use]
-pub fn new_empty_typed_actor_system<M>() -> TypedActorSystem<M>
-where
-  M: Send + Sync + 'static, {
-  TypedActorSystem::from_untyped(new_empty_actor_system())
-}

--- a/modules/actor-adaptor-std/src/std/system/empty_system.rs
+++ b/modules/actor-adaptor-std/src/std/system/empty_system.rs
@@ -37,4 +37,3 @@ where
     | Err(error) => panic!("test-support config failed to build in new_empty_actor_system_with: {error:?}"),
   }
 }
-

--- a/modules/actor-adaptor-std/src/std/tick_driver.rs
+++ b/modules/actor-adaptor-std/src/std/tick_driver.rs
@@ -1,6 +1,8 @@
 //! Tick driver implementations for standard (std) environments.
 
 mod std_tick_driver;
+#[cfg(feature = "test-support")]
+mod test_tick_driver;
 #[cfg(feature = "tokio-executor")]
 mod tokio_tick_driver;
 
@@ -8,5 +10,7 @@ mod tokio_tick_driver;
 mod tests;
 
 pub use std_tick_driver::StdTickDriver;
+#[cfg(feature = "test-support")]
+pub use test_tick_driver::TestTickDriver;
 #[cfg(feature = "tokio-executor")]
 pub use tokio_tick_driver::TokioTickDriver;

--- a/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
+++ b/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
@@ -1,0 +1,115 @@
+//! Test tick driver for deterministic testing (std environment).
+
+extern crate std;
+
+use alloc::boxed::Box;
+use core::{
+  sync::atomic::{AtomicBool, Ordering},
+  time::Duration,
+};
+use std::thread::{self, JoinHandle};
+
+use fraktor_actor_core_rs::core::kernel::actor::scheduler::tick_driver::{
+  SchedulerTickExecutor, TickDriver, TickDriverError, TickDriverKind, TickDriverProvision, TickDriverStopper,
+  TickFeedHandle, next_tick_driver_id,
+};
+use fraktor_utils_core_rs::core::sync::ArcShared;
+
+/// Test tick driver that uses `std::thread` + `sleep` for driving.
+///
+/// Returns [`TickDriverKind::Manual`] so that `build_from_owned_config`
+/// auto-enables `runner_api_enabled` before provisioning.
+pub struct TestTickDriver {
+  resolution: Duration,
+}
+
+impl TestTickDriver {
+  /// Creates a new test tick driver with the given resolution.
+  #[must_use]
+  pub const fn new(resolution: Duration) -> Self {
+    Self { resolution }
+  }
+}
+
+impl Default for TestTickDriver {
+  fn default() -> Self {
+    Self { resolution: Duration::from_millis(10) }
+  }
+}
+
+impl TickDriver for TestTickDriver {
+  fn kind(&self) -> TickDriverKind {
+    TickDriverKind::Manual
+  }
+
+  fn provision(
+    self: Box<Self>,
+    feed: TickFeedHandle,
+    executor: SchedulerTickExecutor,
+  ) -> Result<TickDriverProvision, TickDriverError> {
+    let resolution = self.resolution;
+    if resolution.is_zero() {
+      return Err(TickDriverError::InvalidResolution);
+    }
+    let id = next_tick_driver_id();
+    let running = ArcShared::new(AtomicBool::new(true));
+
+    let tick_flag = running.clone();
+    let tick_thread = thread::spawn(move || {
+      loop {
+        thread::sleep(resolution);
+        if !tick_flag.load(Ordering::Acquire) {
+          break;
+        }
+        feed.enqueue(1);
+      }
+    });
+
+    let exec_flag = running.clone();
+    let exec_interval = (resolution / 10).max(Duration::from_millis(1));
+    let mut executor = executor;
+    let exec_thread = thread::spawn(move || {
+      loop {
+        if !exec_flag.load(Ordering::Acquire) {
+          break;
+        }
+        executor.drive_pending();
+        thread::sleep(exec_interval);
+      }
+    });
+
+    Ok(TickDriverProvision {
+      resolution,
+      id,
+      kind: TickDriverKind::Manual,
+      stopper: Box::new(TestTickDriverStopper {
+        running,
+        tick_thread: Some(tick_thread),
+        exec_thread: Some(exec_thread),
+      }),
+      auto_metadata: None,
+    })
+  }
+}
+
+struct TestTickDriverStopper {
+  running:     ArcShared<AtomicBool>,
+  tick_thread: Option<JoinHandle<()>>,
+  exec_thread: Option<JoinHandle<()>>,
+}
+
+impl TickDriverStopper for TestTickDriverStopper {
+  fn stop(mut self: Box<Self>) {
+    self.running.store(false, Ordering::Release);
+    if let Some(h) = self.tick_thread.take()
+      && h.join().is_err()
+    {
+      std::eprintln!("warn: test tick driver tick thread panicked during shutdown");
+    }
+    if let Some(h) = self.exec_thread.take()
+      && h.join().is_err()
+    {
+      std::eprintln!("warn: test tick driver executor thread panicked during shutdown");
+    }
+  }
+}

--- a/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
+++ b/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
@@ -7,7 +7,7 @@ use core::{
   sync::atomic::{AtomicBool, Ordering},
   time::Duration,
 };
-use std::thread::{self, JoinHandle};
+use std::thread::{self, Builder, JoinHandle};
 
 use fraktor_actor_core_rs::core::kernel::actor::scheduler::tick_driver::{
   SchedulerTickExecutor, TickDriver, TickDriverError, TickDriverKind, TickDriverProvision, TickDriverStopper,
@@ -47,7 +47,7 @@ impl TickDriver for TestTickDriver {
     let running = ArcShared::new(AtomicBool::new(true));
 
     let tick_flag = running.clone();
-    let tick_thread = thread::Builder::new()
+    let tick_thread = Builder::new()
       .name("test-tick-driver-tick".into())
       .spawn(move || {
         loop {
@@ -63,7 +63,7 @@ impl TickDriver for TestTickDriver {
     let exec_flag = running.clone();
     let exec_interval = (resolution / 10).max(Duration::from_millis(1));
     let mut executor = executor;
-    let exec_thread = match thread::Builder::new().name("test-tick-driver-exec".into()).spawn(move || {
+    let exec_thread = match Builder::new().name("test-tick-driver-exec".into()).spawn(move || {
       loop {
         if !exec_flag.load(Ordering::Acquire) {
           break;

--- a/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
+++ b/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
@@ -76,7 +76,9 @@ impl TickDriver for TestTickDriver {
       | Err(_) => {
         // Clean up the tick thread if exec thread spawn fails.
         running.store(false, Ordering::Release);
-        let _ = tick_thread.join();
+        if tick_thread.join().is_err() {
+          std::eprintln!("warn: test tick driver tick thread panicked during spawn-failure cleanup");
+        }
         return Err(TickDriverError::SpawnFailed);
       },
     };

--- a/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
+++ b/modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs
@@ -23,14 +23,6 @@ pub struct TestTickDriver {
   resolution: Duration,
 }
 
-impl TestTickDriver {
-  /// Creates a new test tick driver with the given resolution.
-  #[must_use]
-  pub const fn new(resolution: Duration) -> Self {
-    Self { resolution }
-  }
-}
-
 impl Default for TestTickDriver {
   fn default() -> Self {
     Self { resolution: Duration::from_millis(10) }
@@ -55,20 +47,23 @@ impl TickDriver for TestTickDriver {
     let running = ArcShared::new(AtomicBool::new(true));
 
     let tick_flag = running.clone();
-    let tick_thread = thread::spawn(move || {
-      loop {
-        thread::sleep(resolution);
-        if !tick_flag.load(Ordering::Acquire) {
-          break;
+    let tick_thread = thread::Builder::new()
+      .name("test-tick-driver-tick".into())
+      .spawn(move || {
+        loop {
+          thread::sleep(resolution);
+          if !tick_flag.load(Ordering::Acquire) {
+            break;
+          }
+          feed.enqueue(1);
         }
-        feed.enqueue(1);
-      }
-    });
+      })
+      .map_err(|_| TickDriverError::SpawnFailed)?;
 
     let exec_flag = running.clone();
     let exec_interval = (resolution / 10).max(Duration::from_millis(1));
     let mut executor = executor;
-    let exec_thread = thread::spawn(move || {
+    let exec_thread = match thread::Builder::new().name("test-tick-driver-exec".into()).spawn(move || {
       loop {
         if !exec_flag.load(Ordering::Acquire) {
           break;
@@ -76,7 +71,15 @@ impl TickDriver for TestTickDriver {
         executor.drive_pending();
         thread::sleep(exec_interval);
       }
-    });
+    }) {
+      | Ok(handle) => handle,
+      | Err(_) => {
+        // Clean up the tick thread if exec thread spawn fails.
+        running.store(false, Ordering::Release);
+        let _ = tick_thread.join();
+        return Err(TickDriverError::SpawnFailed);
+      },
+    };
 
     Ok(TickDriverProvision {
       resolution,

--- a/modules/actor-adaptor-std/tests/circuit_breakers_registry.rs
+++ b/modules/actor-adaptor-std/tests/circuit_breakers_registry.rs
@@ -1,10 +1,12 @@
 use core::time::Duration;
 
-use fraktor_actor_adaptor_std_rs::std::pattern::{CircuitBreakersRegistry, CircuitBreakersRegistryId};
+use fraktor_actor_adaptor_std_rs::std::{
+  pattern::{CircuitBreakersRegistry, CircuitBreakersRegistryId},
+  system::{new_empty_actor_system, new_empty_actor_system_with},
+};
 use fraktor_actor_core_rs::core::kernel::{
   actor::{extension::ExtensionId, setup::CircuitBreakerConfig},
   pattern::CircuitBreakerState,
-  system::ActorSystem,
 };
 use fraktor_utils_core_rs::core::sync::SharedAccess;
 
@@ -13,7 +15,7 @@ fn assert_extension_id<E: ExtensionId<Ext = CircuitBreakersRegistry>>(_extension
 #[test]
 fn registry_is_available_as_actor_system_extension() {
   // Given: 空の actor system と extension id がある
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let extension_id = CircuitBreakersRegistryId::new();
   assert_extension_id(&extension_id);
 
@@ -31,7 +33,7 @@ fn registry_is_available_as_actor_system_extension() {
 #[tokio::test]
 async fn same_name_returns_shared_breaker_state() {
   // Given: 登録済み registry から同名 breaker を 2 回取得する
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let extension_id = CircuitBreakersRegistryId::new();
   let registry = system.extended().register_extension(&extension_id);
   let first = registry.get("payments");
@@ -49,7 +51,7 @@ async fn same_name_returns_shared_breaker_state() {
 #[tokio::test]
 async fn different_names_return_independent_breakers() {
   // Given: 別名 breaker を取得する
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let extension_id = CircuitBreakersRegistryId::new();
   let registry = system.extended().register_extension(&extension_id);
   let payments = registry.get("payments");
@@ -67,7 +69,7 @@ async fn different_names_return_independent_breakers() {
 
 #[test]
 fn extension_uses_actor_system_default_and_named_settings() {
-  let system = ActorSystem::new_empty_with(|config| {
+  let system = new_empty_actor_system_with(|config| {
     config
       .with_default_circuit_breaker_config(CircuitBreakerConfig::new(3, Duration::from_secs(10)))
       .with_named_circuit_breaker_config("payments", CircuitBreakerConfig::new(7, Duration::from_secs(45)))

--- a/modules/actor-adaptor-std/tests/sp_h1_5_system_escalation.rs
+++ b/modules/actor-adaptor-std/tests/sp_h1_5_system_escalation.rs
@@ -5,14 +5,13 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::time::Duration;
 
-use fraktor_actor_adaptor_std_rs::std::actor::install_panic_invoke_guard;
+use fraktor_actor_adaptor_std_rs::std::{actor::install_panic_invoke_guard, tick_driver::TestTickDriver};
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, ChildRef,
     error::ActorError,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
     setup::ActorSystemConfig,
     supervision::{SupervisorDirective, SupervisorStrategy, SupervisorStrategyConfig, SupervisorStrategyKind},
   },

--- a/modules/actor-core/Cargo.toml
+++ b/modules/actor-core/Cargo.toml
@@ -40,6 +40,7 @@ proptest = "1.5"
 critical-section = { workspace = true, features = ["std"] }
 serde_json = { workspace = true }
 tracing = { workspace = true, features = ["std"] }
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-adaptor-std-rs = { workspace = true }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
 

--- a/modules/actor-core/src/core/kernel/actor/actor_ref/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_ref/tests.rs
@@ -10,7 +10,7 @@ use crate::core::kernel::{
     error::{ActorError, SendError},
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    scheduler::{SchedulerConfig, tick_driver::tests::TestTickDriver},
     setup::ActorSystemConfig,
   },
   system::{

--- a/modules/actor-core/src/core/kernel/actor/actor_ref_provider/local_actor_ref_provider/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_ref_provider/local_actor_ref_provider/tests.rs
@@ -7,7 +7,7 @@ use crate::core::kernel::{
     error::{ActorError, SendError},
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
+    scheduler::tick_driver::tests::TestTickDriver,
     setup::ActorSystemConfig,
   },
   system::{

--- a/modules/actor-core/src/core/kernel/actor/actor_selection/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_selection/tests.rs
@@ -14,7 +14,7 @@ use crate::core::kernel::{
     error::ActorError,
     messaging::{ActorIdentity, AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
+    scheduler::tick_driver::tests::TestTickDriver,
     setup::ActorSystemConfig,
   },
   system::{

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver.rs
@@ -5,8 +5,6 @@ mod bootstrap;
 mod bootstrap_provision_result;
 mod scheduler_tick_executor;
 mod scheduler_tick_handle_owned;
-#[cfg(any(test, feature = "test-support"))]
-mod test_tick_driver;
 mod tick_driver_bundle;
 mod tick_driver_error;
 mod tick_driver_id;
@@ -21,8 +19,7 @@ mod tick_feed;
 mod tick_metrics;
 mod tick_metrics_probe;
 
-#[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 pub use auto_driver_metadata::{AutoDriverMetadata, AutoProfileKind};
 #[cfg(any(test, feature = "test-support"))]
@@ -32,8 +29,6 @@ pub(crate) use bootstrap::TickDriverBootstrap;
 pub use bootstrap_provision_result::BootstrapProvisionResult;
 pub use scheduler_tick_executor::SchedulerTickExecutor;
 pub(crate) use scheduler_tick_handle_owned::SchedulerTickHandleOwned;
-#[cfg(any(test, feature = "test-support"))]
-pub use test_tick_driver::TestTickDriver;
 pub use tick_driver_bundle::TickDriverBundle;
 pub use tick_driver_error::TickDriverError;
 pub use tick_driver_id::TickDriverId;

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests.rs
@@ -1,4 +1,7 @@
 //! Tick driver bootstrap integration tests.
+#![cfg(test)]
+
+mod test_tick_driver;
 
 use alloc::{boxed::Box, vec, vec::Vec};
 use core::time::Duration;
@@ -7,6 +10,7 @@ use fraktor_utils_core_rs::core::{
   sync::{ArcShared, SpinSyncMutex},
   time::TimerInstant,
 };
+pub(crate) use test_tick_driver::TestTickDriver;
 
 use super::{
   SchedulerTickExecutor, TickDriver, TickDriverError, TickDriverId, TickDriverKind, TickDriverProvision,

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
@@ -78,7 +78,9 @@ impl TickDriver for TestTickDriver {
       | Ok(handle) => handle,
       | Err(_) => {
         running.store(false, Ordering::Release);
-        let _ = tick_thread.join();
+        if tick_thread.join().is_err() {
+          std::eprintln!("warn: test tick driver tick thread panicked during spawn-failure cleanup");
+        }
         return Err(TickDriverError::SpawnFailed);
       },
     };

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
@@ -13,7 +13,7 @@ use std::thread::{self, JoinHandle};
 
 use fraktor_utils_core_rs::core::sync::ArcShared;
 
-use super::{
+use super::super::{
   SchedulerTickExecutor, TickDriver, TickDriverError, TickDriverKind, TickDriverProvision, TickDriverStopper,
   TickFeedHandle, next_tick_driver_id,
 };
@@ -22,14 +22,15 @@ use super::{
 ///
 /// Returns [`TickDriverKind::Manual`] so that `build_from_owned_config`
 /// auto-enables `runner_api_enabled` before provisioning.
-pub struct TestTickDriver {
+pub(crate) struct TestTickDriver {
   resolution: Duration,
 }
 
 impl TestTickDriver {
   /// Creates a new test tick driver with the given resolution.
   #[must_use]
-  pub const fn new(resolution: Duration) -> Self {
+  #[allow(dead_code)]
+  pub(crate) const fn new(resolution: Duration) -> Self {
     Self { resolution }
   }
 }

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
@@ -26,15 +26,6 @@ pub(crate) struct TestTickDriver {
   resolution: Duration,
 }
 
-impl TestTickDriver {
-  /// Creates a new test tick driver with the given resolution.
-  #[must_use]
-  #[allow(dead_code)]
-  pub(crate) const fn new(resolution: Duration) -> Self {
-    Self { resolution }
-  }
-}
-
 impl Default for TestTickDriver {
   fn default() -> Self {
     Self { resolution: Duration::from_millis(10) }
@@ -59,20 +50,23 @@ impl TickDriver for TestTickDriver {
     let running = ArcShared::new(AtomicBool::new(true));
 
     let tick_flag = running.clone();
-    let tick_thread = thread::spawn(move || {
-      loop {
-        thread::sleep(resolution);
-        if !tick_flag.load(Ordering::Acquire) {
-          break;
+    let tick_thread = thread::Builder::new()
+      .name("test-tick-driver-tick".into())
+      .spawn(move || {
+        loop {
+          thread::sleep(resolution);
+          if !tick_flag.load(Ordering::Acquire) {
+            break;
+          }
+          feed.enqueue(1);
         }
-        feed.enqueue(1);
-      }
-    });
+      })
+      .map_err(|_| TickDriverError::SpawnFailed)?;
 
     let exec_flag = running.clone();
     let exec_interval = (resolution / 10).max(Duration::from_millis(1));
     let mut executor = executor;
-    let exec_thread = thread::spawn(move || {
+    let exec_thread = match thread::Builder::new().name("test-tick-driver-exec".into()).spawn(move || {
       loop {
         if !exec_flag.load(Ordering::Acquire) {
           break;
@@ -80,7 +74,14 @@ impl TickDriver for TestTickDriver {
         executor.drive_pending();
         thread::sleep(exec_interval);
       }
-    });
+    }) {
+      | Ok(handle) => handle,
+      | Err(_) => {
+        running.store(false, Ordering::Release);
+        let _ = tick_thread.join();
+        return Err(TickDriverError::SpawnFailed);
+      },
+    };
 
     Ok(TickDriverProvision {
       resolution,

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
@@ -9,7 +9,7 @@ use core::{
   sync::atomic::{AtomicBool, Ordering},
   time::Duration,
 };
-use std::thread::{self, JoinHandle};
+use std::thread::{self, Builder, JoinHandle};
 
 use fraktor_utils_core_rs::core::sync::ArcShared;
 
@@ -50,7 +50,7 @@ impl TickDriver for TestTickDriver {
     let running = ArcShared::new(AtomicBool::new(true));
 
     let tick_flag = running.clone();
-    let tick_thread = thread::Builder::new()
+    let tick_thread = Builder::new()
       .name("test-tick-driver-tick".into())
       .spawn(move || {
         loop {
@@ -66,7 +66,7 @@ impl TickDriver for TestTickDriver {
     let exec_flag = running.clone();
     let exec_interval = (resolution / 10).max(Duration::from_millis(1));
     let mut executor = executor;
-    let exec_thread = match thread::Builder::new().name("test-tick-driver-exec".into()).spawn(move || {
+    let exec_thread = match Builder::new().name("test-tick-driver-exec".into()).spawn(move || {
       loop {
         if !exec_flag.load(Ordering::Acquire) {
           break;

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs
@@ -1,4 +1,11 @@
 //! Test tick driver for deterministic testing.
+//!
+//! TENTATIVE: scheduled for removal once actor-core's inline tests are migrated to
+//! integration tests (which can use the public `TestTickDriver` from `actor-adaptor-std`
+//! without the Cargo dev-cycle dual-version conflict). Until then this `pub(crate)`
+//! duplicate exists solely for inline-test consumption. See
+//! `openspec/changes/step03-move-test-tick-driver-to-adaptor-std/design.md`
+//! 「実装後の補足」.
 // std::thread is required for test-support functionality; exempt from no_std restriction.
 #![allow(cfg_std_forbid)]
 

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup/tests.rs
@@ -4,7 +4,7 @@ use crate::core::kernel::{
   actor::{
     actor_ref_provider::LocalActorRefProviderInstaller,
     extension::ExtensionInstallers,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    scheduler::{SchedulerConfig, tick_driver::tests::TestTickDriver},
     setup::{ActorSystemSetup, BootstrapSetup},
   },
   dispatch::dispatcher::DEFAULT_DISPATCHER_ID,

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/tests.rs
@@ -11,7 +11,7 @@ use crate::core::kernel::{
     error::ActorError,
     messaging::{AnyMessage, AnyMessageView},
     props::{MailboxConfig, Props},
-    scheduler::tick_driver::TestTickDriver,
+    scheduler::tick_driver::tests::TestTickDriver,
     setup::ActorSystemConfig,
   },
   dispatch::mailbox::{Mailbox, MailboxOverflowStrategy, MailboxPolicy, ScheduleHints},

--- a/modules/actor-core/src/core/kernel/serialization/extension/tests.rs
+++ b/modules/actor-core/src/core/kernel/serialization/extension/tests.rs
@@ -20,7 +20,7 @@ use crate::core::kernel::{
     error::ActorError,
     messaging::AnyMessageView,
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
+    scheduler::tick_driver::tests::TestTickDriver,
     setup::ActorSystemConfig,
   },
   event::stream::{EventStreamEvent, EventStreamSubscriber, tests::subscriber_handle},

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -62,45 +62,29 @@ pub struct ActorSystem {
 }
 
 impl ActorSystem {
-  /// Creates an empty actor system without any guardian (testing only).
-  ///
-  /// # Panics
-  ///
-  /// Panics if the default test-support configuration fails to build.
-  #[must_use]
-  #[cfg(any(test, feature = "test-support"))]
-  pub fn new_empty() -> Self {
-    Self::new_empty_with(|config| config)
-  }
-
-  /// Creates an empty actor system without any guardian using a customizable config (testing only).
-  ///
-  /// # Panics
-  ///
-  /// Panics if the default test-support configuration fails to build.
-  #[must_use]
-  #[cfg(any(test, feature = "test-support"))]
-  pub fn new_empty_with<F>(configure: F) -> Self
-  where
-    F: FnOnce(ActorSystemConfig) -> ActorSystemConfig, {
-    use crate::core::kernel::actor::scheduler::tick_driver::TestTickDriver;
-
-    let config = ActorSystemConfig::new(TestTickDriver::default());
-    let config = configure(config);
-    let state = match SystemState::build_from_owned_config(config) {
-      | Ok(state) => state,
-      | Err(error) => panic!("test-support config failed to build in new_empty_with: {error:?}"),
-    };
-    let system = Self::from_state(SystemStateShared::new(state));
-    system.state.mark_root_started();
-    system
-  }
-
   /// Creates an actor system from an existing system state.
   #[must_use]
   pub fn from_state(state: SystemStateShared) -> Self {
     let settings = TypedActorSystemConfig::new(state.system_name(), state.start_time());
     Self { state, settings }
+  }
+
+  /// Builds and starts an actor system from a fully constructed configuration.
+  ///
+  /// Creates the system state from the provided [`ActorSystemConfig`], wraps it in a
+  /// [`SystemStateShared`], and marks the root as started before returning. Designed as the
+  /// public seam used by adaptor-level test helpers (e.g. `new_empty_actor_system_with` in
+  /// `fraktor-actor-adaptor-std-rs`) that previously relied on private constructors.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`SpawnError`] when the underlying [`SystemState`] cannot be built from the
+  /// supplied configuration.
+  pub fn new_started_from_config(config: ActorSystemConfig) -> Result<Self, SpawnError> {
+    let state = SystemState::build_from_owned_config(config)?;
+    let system = Self::from_state(SystemStateShared::new(state));
+    system.state.mark_root_started();
+    Ok(system)
   }
 
   /// Creates an actor system with the provided configuration.

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -28,8 +28,9 @@ use crate::core::{
         SchedulerConfig,
         task_run::{TaskRunError, TaskRunPriority},
         tick_driver::{
-          AutoDriverMetadata, AutoProfileKind, SchedulerTickExecutor, TestTickDriver, TickDriver, TickDriverError,
-          TickDriverId, TickDriverKind, TickDriverProvision, TickDriverStopper, TickFeedHandle, next_tick_driver_id,
+          AutoDriverMetadata, AutoProfileKind, SchedulerTickExecutor, TickDriver, TickDriverError, TickDriverId,
+          TickDriverKind, TickDriverProvision, TickDriverStopper, TickFeedHandle, next_tick_driver_id,
+          tests::TestTickDriver,
         },
       },
       setup::ActorSystemConfig,
@@ -49,6 +50,45 @@ use crate::core::{
   },
   typed::receptionist::SYSTEM_RECEPTIONIST_TOP_LEVEL,
 };
+
+impl ActorSystem {
+  /// Creates an empty actor system without any guardian.
+  ///
+  /// Inline-test only helper. External callers should use `new_empty_actor_system` from
+  /// `fraktor-actor-adaptor-std-rs`.
+  ///
+  /// # Panics
+  ///
+  /// Panics if the default test-support configuration fails to build.
+  #[must_use]
+  pub(crate) fn new_empty() -> Self {
+    Self::new_empty_with(|config| config)
+  }
+
+  /// Creates an empty actor system with a customizable config.
+  ///
+  /// See [`Self::new_empty`] for the rationale on the cfg gating.
+  ///
+  /// # Panics
+  ///
+  /// Panics if the default test-support configuration fails to build.
+  #[must_use]
+  pub(crate) fn new_empty_with<F>(configure: F) -> Self
+  where
+    F: FnOnce(ActorSystemConfig) -> ActorSystemConfig, {
+    use crate::core::kernel::actor::scheduler::tick_driver::tests::TestTickDriver;
+
+    let config = ActorSystemConfig::new(TestTickDriver::default());
+    let config = configure(config);
+    let state = match SystemState::build_from_owned_config(config) {
+      | Ok(state) => state,
+      | Err(error) => panic!("test-support config failed to build in new_empty_with: {error:?}"),
+    };
+    let system = Self::from_state(SystemStateShared::new(state));
+    system.state.mark_root_started();
+    system
+  }
+}
 
 struct TestActor;
 

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -51,6 +51,11 @@ use crate::core::{
   typed::receptionist::SYSTEM_RECEPTIONIST_TOP_LEVEL,
 };
 
+// TENTATIVE: `new_empty` / `new_empty_with` are scheduled for removal once actor-core's
+// inline tests are migrated to integration tests, which can call the public free functions
+// `new_empty_actor_system` / `new_empty_actor_system_with` from `actor-adaptor-std` without
+// hitting the Cargo dev-cycle dual-version conflict. See
+// `openspec/changes/step03-move-test-tick-driver-to-adaptor-std/design.md` 「実装後の補足」.
 impl ActorSystem {
   /// Creates an empty actor system without any guardian.
   ///

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -83,15 +83,11 @@ impl ActorSystem {
     F: FnOnce(ActorSystemConfig) -> ActorSystemConfig, {
     use crate::core::kernel::actor::scheduler::tick_driver::tests::TestTickDriver;
 
-    let config = ActorSystemConfig::new(TestTickDriver::default());
-    let config = configure(config);
-    let state = match SystemState::build_from_owned_config(config) {
-      | Ok(state) => state,
+    let config = configure(ActorSystemConfig::new(TestTickDriver::default()));
+    match Self::new_started_from_config(config) {
+      | Ok(system) => system,
       | Err(error) => panic!("test-support config failed to build in new_empty_with: {error:?}"),
-    };
-    let system = Self::from_state(SystemStateShared::new(state));
-    system.state.mark_root_started();
-    system
+    }
   }
 }
 

--- a/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
@@ -23,8 +23,8 @@ use crate::core::kernel::{
     scheduler::{
       SchedulerConfig,
       tick_driver::{
-        SchedulerTickExecutor, TestTickDriver, TickDriver, TickDriverError, TickDriverKind, TickDriverProvision,
-        TickDriverStopper, TickFeedHandle, next_tick_driver_id,
+        SchedulerTickExecutor, TickDriver, TickDriverError, TickDriverKind, TickDriverProvision, TickDriverStopper,
+        TickFeedHandle, next_tick_driver_id, tests::TestTickDriver,
       },
     },
     setup::ActorSystemConfig,

--- a/modules/actor-core/src/core/typed/actor/actor_context/tests.rs
+++ b/modules/actor-core/src/core/typed/actor/actor_context/tests.rs
@@ -7,7 +7,7 @@ use crate::core::{
   kernel::{
     actor::{
       error::ActorError,
-      scheduler::tick_driver::TestTickDriver,
+      scheduler::tick_driver::tests::TestTickDriver,
       setup::ActorSystemConfig,
       supervision::{SupervisorDirective, SupervisorStrategy, SupervisorStrategyKind},
     },

--- a/modules/actor-core/src/core/typed/actor_ref_resolver/tests.rs
+++ b/modules/actor-core/src/core/typed/actor_ref_resolver/tests.rs
@@ -6,7 +6,7 @@ use super::ActorRefResolver;
 use crate::core::{
   kernel::actor::{
     Actor, ActorCell, ActorContext, Pid, error::ActorError, extension::ExtensionInstallers, messaging::AnyMessageView,
-    props::Props, scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig,
+    props::Props, scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig,
   },
   typed::{ActorRefResolverSetup, TypedActorSystem, TypedProps, actor_ref_resolver::ActorSystem, dsl::Behaviors},
 };

--- a/modules/actor-core/src/core/typed/delivery/tests.rs
+++ b/modules/actor-core/src/core/typed/delivery/tests.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 use fraktor_utils_core_rs::core::sync::{ArcShared, SharedAccess, SpinSyncMutex};
 
 use crate::core::{
-  kernel::actor::{Pid, scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{Pid, scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{
     Behavior, TypedActorRef, TypedActorSystem, TypedProps,
     delivery::{

--- a/modules/actor-core/src/core/typed/dsl/ask_pattern/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/ask_pattern/tests.rs
@@ -1,7 +1,7 @@
 use core::{hint::spin_loop, time::Duration};
 
 use crate::core::{
-  kernel::actor::{messaging::AskError, scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{messaging::AskError, scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{
     Behavior, TypedActorRef, TypedActorSystem, TypedProps,
     dsl::{AskPattern, Behaviors, StatusReply, TypedAskError},

--- a/modules/actor-core/src/core/typed/dsl/routing/balancing_pool_router_builder/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/balancing_pool_router_builder/tests.rs
@@ -4,7 +4,7 @@ use core::hint::spin_loop;
 use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use crate::core::{
-  kernel::actor::{scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{
     behavior::Behavior,
     dsl::{Behaviors, routing::Routers},

--- a/modules/actor-core/src/core/typed/dsl/routing/group_router/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/group_router/tests.rs
@@ -5,7 +5,7 @@ use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use super::rendezvous_hash_index;
 use crate::core::{
-  kernel::actor::{scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{
     TypedActorRef, TypedActorSystem, TypedProps,
     dsl::{

--- a/modules/actor-core/src/core/typed/dsl/routing/pool_router/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/pool_router/tests.rs
@@ -11,7 +11,7 @@ use crate::core::{
       error::ActorError,
       messaging::{AnyMessage, AnyMessageView},
       props::Props,
-      scheduler::tick_driver::TestTickDriver,
+      scheduler::tick_driver::tests::TestTickDriver,
       setup::ActorSystemConfig,
     },
     system::ActorSystem,
@@ -577,7 +577,7 @@ mod optimal_size_exploring_resizer_smoke {
   use super::{RouteRecord, recording_routee_behavior, wait_until};
   use crate::core::{
     kernel::{
-      actor::{scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+      actor::{scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
       pattern::Clock,
     },
     typed::{

--- a/modules/actor-core/src/core/typed/dsl/routing/scatter_gather_first_completed_router_builder/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/scatter_gather_first_completed_router_builder/tests.rs
@@ -6,7 +6,7 @@ use core::time::Duration;
 use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use crate::core::{
-  kernel::actor::{actor_ref::ActorRef, scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{actor_ref::ActorRef, scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{
     TypedActorRef,
     behavior::Behavior,

--- a/modules/actor-core/src/core/typed/dsl/routing/tail_chopping_router_builder/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/tail_chopping_router_builder/tests.rs
@@ -4,7 +4,7 @@ use core::time::Duration;
 use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use crate::core::{
-  kernel::actor::{actor_ref::ActorRef, scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{actor_ref::ActorRef, scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{
     TypedActorRef,
     behavior::Behavior,

--- a/modules/actor-core/src/core/typed/extension_setup/tests.rs
+++ b/modules/actor-core/src/core/typed/extension_setup/tests.rs
@@ -5,7 +5,7 @@ use fraktor_utils_core_rs::core::sync::shared::Shared;
 use crate::core::{
   kernel::actor::{
     extension::{Extension, ExtensionInstallers},
-    scheduler::tick_driver::TestTickDriver,
+    scheduler::tick_driver::tests::TestTickDriver,
     setup::ActorSystemConfig,
   },
   typed::{ExtensionSetup, TypedActorSystem, TypedProps, dsl::Behaviors, extension_setup::ActorSystem},

--- a/modules/actor-core/src/core/typed/pubsub/topic/tests.rs
+++ b/modules/actor-core/src/core/typed/pubsub/topic/tests.rs
@@ -4,7 +4,7 @@ use core::hint::spin_loop;
 use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use crate::core::{
-  kernel::actor::{scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{
     TypedActorRef, TypedActorSystem, TypedProps,
     dsl::Behaviors,

--- a/modules/actor-core/src/core/typed/receptionist/tests.rs
+++ b/modules/actor-core/src/core/typed/receptionist/tests.rs
@@ -10,7 +10,7 @@ use crate::core::{
       actor_ref::{ActorRef, ActorRefSender, NullSender, SendOutcome},
       error::{ActorError, SendError},
       messaging::AnyMessage,
-      scheduler::tick_driver::TestTickDriver,
+      scheduler::tick_driver::tests::TestTickDriver,
       setup::ActorSystemConfig,
     },
     event::{

--- a/modules/actor-core/src/core/typed/spawn_protocol/tests.rs
+++ b/modules/actor-core/src/core/typed/spawn_protocol/tests.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::core::{
-  kernel::actor::{scheduler::tick_driver::TestTickDriver, setup::ActorSystemConfig},
+  kernel::actor::{scheduler::tick_driver::tests::TestTickDriver, setup::ActorSystemConfig},
   typed::{SpawnProtocol, TypedActorRef, dsl::Behaviors, props::TypedProps, system::TypedActorSystem},
 };
 

--- a/modules/actor-core/src/core/typed/system.rs
+++ b/modules/actor-core/src/core/typed/system.rs
@@ -182,16 +182,6 @@ impl<M> TypedActorSystem<M>
 where
   M: Send + Sync + 'static,
 {
-  /// Creates an empty actor system without any guardian (testing only).
-  #[must_use]
-  #[cfg(any(test, feature = "test-support"))]
-  pub fn new_empty() -> Self {
-    let inner = ActorSystem::new_empty();
-    let cached_address = Address::local(inner.name());
-    let event_stream_ref = build_event_stream_ref(&inner);
-    Self { inner, cached_address, event_stream_ref, marker: PhantomData }
-  }
-
   /// Creates a typed actor system using the supplied configuration.
   ///
   /// # Errors

--- a/modules/actor-core/src/core/typed/system/tests.rs
+++ b/modules/actor-core/src/core/typed/system/tests.rs
@@ -36,8 +36,9 @@ where
 {
   /// Creates an empty typed actor system without any guardian.
   ///
-  /// Inline-test only helper. External callers should use `new_empty_typed_actor_system` from
-  /// `fraktor-actor-adaptor-std-rs`.
+  /// Inline-test only helper. External callers should wrap
+  /// `fraktor_actor_adaptor_std_rs::std::system::new_empty_actor_system()` with
+  /// `TypedActorSystem::from_untyped`.
   #[must_use]
   pub(crate) fn new_empty() -> Self {
     Self::from_untyped(ActorSystem::new_empty())

--- a/modules/actor-core/src/core/typed/system/tests.rs
+++ b/modules/actor-core/src/core/typed/system/tests.rs
@@ -30,6 +30,9 @@ use crate::core::{
   },
 };
 
+// TENTATIVE: scheduled for removal in the same wave that drops `ActorSystem::new_empty`
+// (see base/tests.rs). External callers wrap `new_empty_actor_system()` from
+// actor-adaptor-std with `TypedActorSystem::from_untyped` instead.
 impl<M> TypedActorSystem<M>
 where
   M: Send + Sync + 'static,

--- a/modules/actor-core/src/core/typed/system/tests.rs
+++ b/modules/actor-core/src/core/typed/system/tests.rs
@@ -13,7 +13,7 @@ use crate::core::{
       error::SendError,
       extension::{Extension, ExtensionId},
       messaging::AnyMessage,
-      scheduler::tick_driver::TestTickDriver,
+      scheduler::tick_driver::tests::TestTickDriver,
       setup::ActorSystemConfig,
     },
     event::{
@@ -29,6 +29,20 @@ use crate::core::{
     receptionist::{ReceptionistCommand, SYSTEM_RECEPTIONIST_TOP_LEVEL},
   },
 };
+
+impl<M> TypedActorSystem<M>
+where
+  M: Send + Sync + 'static,
+{
+  /// Creates an empty typed actor system without any guardian.
+  ///
+  /// Inline-test only helper. External callers should use `new_empty_typed_actor_system` from
+  /// `fraktor-actor-adaptor-std-rs`.
+  #[must_use]
+  pub(crate) fn new_empty() -> Self {
+    Self::from_untyped(ActorSystem::new_empty())
+  }
+}
 
 struct TestExtension {
   value: u32,

--- a/modules/actor-core/src/core/typed/tests.rs
+++ b/modules/actor-core/src/core/typed/tests.rs
@@ -20,7 +20,7 @@ use crate::core::{
       actor_ref::dead_letter::{DeadLetterEntry, DeadLetterReason},
       error::ActorError,
       messaging::AnyMessage,
-      scheduler::tick_driver::TestTickDriver,
+      scheduler::tick_driver::tests::TestTickDriver,
       setup::ActorSystemConfig,
       supervision::{
         BackoffSupervisorStrategy, SupervisorDirective, SupervisorStrategy, SupervisorStrategyConfig,

--- a/modules/actor-core/tests/death_watch.rs
+++ b/modules/actor-core/tests/death_watch.rs
@@ -5,13 +5,13 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, ChildRef, Pid,
     error::ActorError,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/modules/actor-core/tests/event_stream.rs
+++ b/modules/actor-core/tests/event_stream.rs
@@ -5,13 +5,13 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::{hint::spin_loop, num::NonZeroUsize};
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, ChildRef,
     error::ActorError,
     messaging::{AnyMessage, AnyMessageView},
     props::{MailboxConfig, Props},
-    scheduler::tick_driver::TestTickDriver,
     setup::ActorSystemConfig,
   },
   dispatch::mailbox::{MailboxOverflowStrategy, MailboxPolicy},

--- a/modules/actor-core/tests/ping_pong.rs
+++ b/modules/actor-core/tests/ping_pong.rs
@@ -6,13 +6,13 @@ use std::{
   vec::Vec,
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, ChildRef,
     error::ActorError,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
     setup::ActorSystemConfig,
     spawn::SpawnError,
   },

--- a/modules/actor-core/tests/supervisor.rs
+++ b/modules/actor-core/tests/supervisor.rs
@@ -9,6 +9,7 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, ChildRef,
@@ -16,7 +17,6 @@ use fraktor_actor_core_rs::core::kernel::{
     lifecycle::LifecycleStage,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
     setup::ActorSystemConfig,
     supervision::{SupervisorDirective, SupervisorStrategy, SupervisorStrategyConfig, SupervisorStrategyKind},
   },

--- a/modules/actor-core/tests/system_events.rs
+++ b/modules/actor-core/tests/system_events.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::hint::spin_loop;
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext,
@@ -12,7 +13,6 @@ use fraktor_actor_core_rs::core::kernel::{
     lifecycle::LifecycleStage,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
     setup::ActorSystemConfig,
   },
   event::{

--- a/modules/actor-core/tests/system_lifecycle.rs
+++ b/modules/actor-core/tests/system_lifecycle.rs
@@ -8,13 +8,13 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext,
     error::ActorError,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::tick_driver::TestTickDriver,
     setup::ActorSystemConfig,
   },
   system::{ActorSystem, SpinBlocker},

--- a/modules/actor-core/tests/typed_scheduler.rs
+++ b/modules/actor-core/tests/typed_scheduler.rs
@@ -8,12 +8,9 @@ use std::{
   time::Instant,
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::{
-  kernel::actor::{
-    actor_ref::ActorRef,
-    scheduler::{ExecutionBatch, tick_driver::TestTickDriver},
-    setup::ActorSystemConfig,
-  },
+  kernel::actor::{actor_ref::ActorRef, scheduler::ExecutionBatch, setup::ActorSystemConfig},
   typed::{TypedActorRef, TypedActorSystem, TypedProps, dsl::Behaviors},
 };
 

--- a/modules/cluster-core/Cargo.toml
+++ b/modules/cluster-core/Cargo.toml
@@ -28,5 +28,6 @@ workspace = true
 
 [dev-dependencies]
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
 critical-section = { workspace = true, features = ["std"] }

--- a/modules/cluster-core/src/core/cluster_api/tests.rs
+++ b/modules/cluster-core/src/core/cluster_api/tests.rs
@@ -1,6 +1,7 @@
 use alloc::{string::String, vec::Vec};
 use core::time::Duration;
 
+use fraktor_actor_adaptor_std_rs::std::{system::new_empty_actor_system, tick_driver::TestTickDriver};
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, Pid,
@@ -11,7 +12,7 @@ use fraktor_actor_core_rs::core::kernel::{
     extension::ExtensionInstallers,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::{SchedulerConfig, SchedulerShared, tick_driver::TestTickDriver},
+    scheduler::{SchedulerConfig, SchedulerShared},
     setup::ActorSystemConfig,
   },
   event::stream::{
@@ -42,7 +43,7 @@ fn test_subscriber_handle(subscriber: impl EventStreamSubscriber) -> EventStream
 
 #[test]
 fn try_from_system_fails_when_extension_missing() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   match ClusterApi::try_from_system(&system) {
     | Ok(_) => panic!("extension should be missing"),
     | Err(err) => assert_eq!(err, ClusterApiError::ExtensionNotInstalled),

--- a/modules/cluster-core/src/core/cluster_extension/tests.rs
+++ b/modules/cluster-core/src/core/cluster_extension/tests.rs
@@ -1,13 +1,13 @@
 use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use core::time::Duration;
 
+use fraktor_actor_adaptor_std_rs::std::system::new_empty_actor_system;
 use fraktor_actor_core_rs::core::kernel::{
   actor::messaging::AnyMessage,
   event::stream::{
     EventStreamEvent, EventStreamShared, EventStreamSubscriber, EventStreamSubscriberShared, EventStreamSubscription,
     subscriber_handle,
   },
-  system::ActorSystem,
 };
 use fraktor_utils_core_rs::core::{
   sync::{ArcShared, SpinSyncMutex},
@@ -208,7 +208,7 @@ fn stub_extension_id(config: ClusterExtensionConfig) -> ClusterExtensionId {
 
 #[test]
 fn registers_extension_and_starts_member() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
 
@@ -219,7 +219,7 @@ fn registers_extension_and_starts_member() {
 
 #[test]
 fn register_on_member_up_invokes_callback_for_up_transition() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
@@ -241,7 +241,7 @@ fn register_on_member_up_invokes_callback_for_up_transition() {
 
 #[test]
 fn register_on_member_removed_invokes_callback_for_removed_transition() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
@@ -263,7 +263,7 @@ fn register_on_member_removed_invokes_callback_for_removed_transition() {
 
 #[test]
 fn register_on_member_up_invokes_callback_immediately_when_self_already_up() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
@@ -284,7 +284,7 @@ fn register_on_member_up_invokes_callback_immediately_when_self_already_up() {
 }
 
 fn run_member_up_during_start_test(start_fn: impl FnOnce(&ClusterExtension) -> Result<(), ClusterError>) {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
   let authority = String::from("fraktor://demo");
 
@@ -323,7 +323,7 @@ fn register_on_member_up_invokes_callback_when_status_arrives_during_start_clien
 
 #[test]
 fn register_on_member_removed_invokes_callback_immediately_when_self_already_removed() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
@@ -345,7 +345,7 @@ fn register_on_member_removed_invokes_callback_immediately_when_self_already_rem
 
 #[test]
 fn register_on_member_removed_invokes_callback_immediately_after_shutdown() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
@@ -366,7 +366,7 @@ fn register_on_member_removed_invokes_callback_immediately_after_shutdown() {
 
 #[test]
 fn register_on_member_removed_after_shutdown_falls_back_to_authority_when_node_id_is_unknown() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
   let ext_shared = system.extended().register_extension(&ext_id);
@@ -385,7 +385,7 @@ fn register_on_member_removed_after_shutdown_falls_back_to_authority_when_node_i
 
 #[test]
 fn register_on_member_up_does_not_fire_for_buffered_old_up_events() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
@@ -410,7 +410,7 @@ fn register_on_member_up_does_not_fire_for_buffered_old_up_events() {
 
 #[test]
 fn register_on_member_removed_does_not_fire_for_buffered_old_removed_events() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
@@ -435,7 +435,7 @@ fn register_on_member_removed_does_not_fire_for_buffered_old_removed_events() {
 
 #[test]
 fn register_on_member_up_does_not_fire_for_events_buffered_before_extension_install() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   publish_member_status(&event_stream, "node-old", "fraktor://demo", NodeStatus::Joining, NodeStatus::Up);
@@ -459,7 +459,7 @@ fn register_on_member_up_does_not_fire_for_events_buffered_before_extension_inst
 
 #[test]
 fn register_on_member_removed_does_not_fire_for_events_buffered_before_extension_install() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   publish_member_status(&event_stream, "node-old", "fraktor://demo", NodeStatus::Exiting, NodeStatus::Removed);
@@ -484,7 +484,7 @@ fn register_on_member_removed_does_not_fire_for_events_buffered_before_extension
 #[test]
 fn subscribes_to_event_stream_and_applies_topology_on_topology_updated() {
   // 1. システムとエクステンションをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(
@@ -519,7 +519,7 @@ fn subscribes_to_event_stream_and_applies_topology_on_topology_updated() {
 
 #[test]
 fn ignores_topology_with_same_hash_via_event_stream() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   let ext_id = stub_extension_id(
@@ -614,7 +614,7 @@ fn subscribe_recorder(event_stream: &EventStreamShared) -> (RecordingClusterEven
 #[test]
 fn phase1_integration_static_topology_publishes_to_event_stream_and_applies_to_core() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   // 2. EventStream に subscriber を登録してイベントを記録
@@ -666,7 +666,7 @@ fn phase1_integration_static_topology_publishes_to_event_stream_and_applies_to_c
 #[test]
 fn phase1_integration_topology_updated_includes_blocked_members() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   // 2. EventStream に subscriber を登録
@@ -722,7 +722,7 @@ fn phase1_integration_topology_updated_includes_blocked_members() {
 #[test]
 fn phase1_integration_duplicate_hash_topology_is_suppressed() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   // 2. EventStream に subscriber を登録
@@ -755,7 +755,7 @@ fn phase1_integration_duplicate_hash_topology_is_suppressed() {
 #[test]
 fn phase1_integration_metrics_include_members_and_virtual_actors() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   // 2. ClusterExtension をセットアップ
@@ -802,7 +802,7 @@ fn phase1_integration_metrics_include_members_and_virtual_actors() {
 #[test]
 fn phase2_integration_join_leave_events_produce_topology_updated() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   // 2. EventStream に subscriber を登録
@@ -865,7 +865,7 @@ fn phase2_integration_join_leave_events_produce_topology_updated() {
 #[test]
 fn phase2_integration_blocklist_reflected_in_topology_events() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   // 2. EventStream に subscriber を登録
@@ -925,7 +925,7 @@ fn phase2_integration_blocklist_reflected_in_topology_events() {
 #[test]
 fn phase2_integration_metrics_updated_correctly_with_dynamic_topology() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
 
   // 2. ClusterExtension をセットアップ
   let ext_id =
@@ -977,7 +977,7 @@ fn phase2_integration_metrics_updated_correctly_with_dynamic_topology() {
 #[test]
 fn phase2_integration_shutdown_resets_metrics_and_emits_event() {
   // 1. システムをセットアップ
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let event_stream = system.event_stream();
 
   // 2. EventStream に subscriber を登録

--- a/modules/cluster-core/src/core/grain/grain_context_generic/tests.rs
+++ b/modules/cluster-core/src/core/grain/grain_context_generic/tests.rs
@@ -1,5 +1,6 @@
 use alloc::string::String;
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, Pid,
@@ -10,7 +11,7 @@ use fraktor_actor_core_rs::core::kernel::{
     extension::ExtensionInstallers,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::{ActorSystem, TerminationSignal},

--- a/modules/cluster-core/src/core/grain/grain_context_scope/tests.rs
+++ b/modules/cluster-core/src/core/grain/grain_context_scope/tests.rs
@@ -1,5 +1,6 @@
 use alloc::string::String;
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, Pid,
@@ -10,7 +11,7 @@ use fraktor_actor_core_rs::core::kernel::{
     extension::ExtensionInstallers,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::{ActorSystem, TerminationSignal},

--- a/modules/cluster-core/src/core/grain/grain_ref/tests.rs
+++ b/modules/cluster-core/src/core/grain/grain_ref/tests.rs
@@ -1,6 +1,7 @@
 use alloc::{string::String, vec::Vec};
 use core::time::Duration;
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext, Pid,
@@ -11,7 +12,7 @@ use fraktor_actor_core_rs::core::kernel::{
     extension::ExtensionInstallers,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::{SchedulerConfig, SchedulerShared, tick_driver::TestTickDriver},
+    scheduler::{SchedulerConfig, SchedulerShared},
     setup::ActorSystemConfig,
   },
   event::stream::{

--- a/modules/cluster-core/src/core/grain/serialization_grain_codec/tests.rs
+++ b/modules/cluster-core/src/core/grain/serialization_grain_codec/tests.rs
@@ -1,6 +1,7 @@
 use alloc::{borrow::Cow, string::String, vec::Vec};
 use core::any::{Any, TypeId};
 
+use fraktor_actor_adaptor_std_rs::std::system::new_empty_actor_system;
 use fraktor_actor_core_rs::core::kernel::{
   actor::messaging::AnyMessage,
   serialization::{
@@ -101,7 +102,7 @@ impl SerializerWithStringManifest for TelemetrySerializer {
 
 #[test]
 fn try_from_system_fails_when_extension_missing() {
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   match SerializationGrainCodec::try_from_system(&system, SerializationCallScope::Remote) {
     | Ok(_) => panic!("extension should be missing"),
     | Err(err) => assert!(matches!(err, GrainCodecError::ExtensionUnavailable { .. })),
@@ -161,7 +162,7 @@ fn build_system_with_serialization() -> ActorSystem {
     .expect("setup");
   let extension_id = SerializationExtensionId::new(setup);
 
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   system.extended().register_extension(&extension_id);
   system
 }

--- a/modules/cluster-core/src/core/pub_sub/batching_producer_generic/tests.rs
+++ b/modules/cluster-core/src/core/pub_sub/batching_producer_generic/tests.rs
@@ -1,12 +1,12 @@
 use alloc::vec::Vec;
 use core::time::Duration;
 
+use fraktor_actor_adaptor_std_rs::std::system::new_empty_actor_system;
 use fraktor_actor_core_rs::core::kernel::{
   actor::messaging::AnyMessage,
   serialization::{
     builtin::register_defaults, default_serialization_setup, serialization_registry::SerializationRegistry,
   },
-  system::ActorSystem,
 };
 use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
@@ -75,7 +75,7 @@ fn flushes_when_batch_size_reached() {
   let shared = ClusterPubSubShared::new(Box::new(pubsub.clone()));
   let publisher = PubSubPublisher::new(shared, registry);
 
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let scheduler = system.state().scheduler();
 
   let config = BatchingProducerConfig::new(2, 8, Duration::from_secs(60));
@@ -97,7 +97,7 @@ fn rejects_when_queue_full() {
   let shared = ClusterPubSubShared::new(Box::new(pubsub));
   let publisher = PubSubPublisher::new(shared, registry);
 
-  let system = ActorSystem::new_empty();
+  let system = new_empty_actor_system();
   let scheduler = system.state().scheduler();
 
   let config = BatchingProducerConfig::new(10, 1, Duration::from_secs(60));

--- a/modules/persistence-core/Cargo.toml
+++ b/modules/persistence-core/Cargo.toml
@@ -27,4 +27,5 @@ workspace = true
 [dev-dependencies]
 critical-section = { workspace = true, features = ["std"] }
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }

--- a/modules/persistence-core/src/core/persistence_extension/tests.rs
+++ b/modules/persistence-core/src/core/persistence_extension/tests.rs
@@ -1,10 +1,7 @@
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext, Pid,
-    error::ActorError,
-    messaging::AnyMessageView,
-    props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    Actor, ActorContext, Pid, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/modules/persistence-core/src/core/persistence_extension_installer/tests.rs
+++ b/modules/persistence-core/src/core/persistence_extension_installer/tests.rs
@@ -1,12 +1,8 @@
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext,
-    error::ActorError,
-    extension::ExtensionInstallers,
-    messaging::AnyMessageView,
-    props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
-    setup::ActorSystemConfig,
+    Actor, ActorContext, error::ActorError, extension::ExtensionInstallers, messaging::AnyMessageView, props::Props,
+    scheduler::SchedulerConfig, setup::ActorSystemConfig,
   },
   system::ActorSystem,
 };

--- a/modules/persistence-core/src/core/persistent_actor_adapter/tests.rs
+++ b/modules/persistence-core/src/core/persistent_actor_adapter/tests.rs
@@ -1,5 +1,6 @@
 use alloc::{string::ToString, vec::Vec};
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorCell, ActorContext,
@@ -9,7 +10,7 @@ use fraktor_actor_core_rs::core::kernel::{
     invoke_guard::{InvokeGuardFactory, NoopInvokeGuardFactory},
     messaging::{AnyMessage, AnyMessageView, message_invoker::MessageInvokerPipeline},
     props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::{

--- a/modules/persistence-core/tests/persistence_flow.rs
+++ b/modules/persistence-core/tests/persistence_flow.rs
@@ -15,6 +15,7 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext,
@@ -23,7 +24,7 @@ use fraktor_actor_core_rs::core::kernel::{
     extension::ExtensionInstallers,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/modules/persistence-core/tests/persistent_actor_example.rs
+++ b/modules/persistence-core/tests/persistent_actor_example.rs
@@ -10,6 +10,7 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
     Actor, ActorContext,
@@ -18,7 +19,7 @@ use fraktor_actor_core_rs::core::kernel::{
     extension::ExtensionInstallers,
     messaging::{AnyMessage, AnyMessageView},
     props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/modules/stream-adaptor-std/Cargo.toml
+++ b/modules/stream-adaptor-std/Cargo.toml
@@ -24,4 +24,5 @@ workspace = true
 
 [dev-dependencies]
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 critical-section = { workspace = true, features = ["std"] }

--- a/modules/stream-adaptor-std/src/std/io/stream_converters/tests.rs
+++ b/modules/stream-adaptor-std/src/std/io/stream_converters/tests.rs
@@ -11,13 +11,10 @@ use std::{
   vec::Vec,
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext,
-    error::ActorError,
-    messaging::AnyMessageView,
-    props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/modules/stream-core/Cargo.toml
+++ b/modules/stream-core/Cargo.toml
@@ -27,5 +27,6 @@ workspace = true
 
 [dev-dependencies]
 fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
 critical-section = { workspace = true, features = ["std"] }

--- a/modules/stream-core/src/core/dsl/topic_pub_sub/tests.rs
+++ b/modules/stream-core/src/core/dsl/topic_pub_sub/tests.rs
@@ -4,14 +4,11 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::{
   kernel::{
     actor::{
-      Actor, ActorContext,
-      error::ActorError,
-      messaging::AnyMessageView,
-      props::Props,
-      scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+      Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
       setup::ActorSystemConfig,
     },
     system::ActorSystem,

--- a/modules/stream-core/src/core/materialization/actor_materializer/tests.rs
+++ b/modules/stream-core/src/core/materialization/actor_materializer/tests.rs
@@ -3,13 +3,10 @@ extern crate std;
 use core::time::Duration;
 use std::time::Instant;
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext,
-    error::ActorError,
-    messaging::AnyMessageView,
-    props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::{ActorSystem, remote::RemotingConfig},

--- a/modules/stream-core/src/core/snapshot/materializer_state/tests.rs
+++ b/modules/stream-core/src/core/snapshot/materializer_state/tests.rs
@@ -2,13 +2,10 @@ extern crate std;
 
 use core::time::Duration;
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext,
-    error::ActorError,
-    messaging::AnyMessageView,
-    props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/modules/stream-core/tests/coupled_termination_flow.rs
+++ b/modules/stream-core/tests/coupled_termination_flow.rs
@@ -7,13 +7,10 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext,
-    error::ActorError,
-    messaging::AnyMessageView,
-    props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/modules/stream-core/tests/requirement_traceability.rs
+++ b/modules/stream-core/tests/requirement_traceability.rs
@@ -4,13 +4,10 @@ use std::{
   time::{Duration, Instant},
 };
 
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext,
-    error::ActorError,
-    messaging::AnyMessageView,
-    props::Props,
-    scheduler::{SchedulerConfig, tick_driver::TestTickDriver},
+    Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
     setup::ActorSystemConfig,
   },
   system::ActorSystem,

--- a/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/design.md
+++ b/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/design.md
@@ -1,0 +1,276 @@
+## Context
+
+### 現状の TestTickDriver 配置
+
+`fraktor-actor-core-rs` は no_std クレートとして設計されているが、`test-support` feature 配下に以下の **std 依存コンポーネント** が同居している:
+
+- `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/test_tick_driver.rs`（118 行）
+  - `std::thread::{self, JoinHandle}` と `thread::sleep` を使って `TickFeed` に tick を供給する `TestTickDriver`
+  - `TestTickDriverStopper` が join handle を保持してシャットダウン時に `join()` を呼ぶ
+  - `#[cfg(any(test, feature = "test-support"))]` で gate
+- `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver.rs`
+  - `#[cfg(any(test, feature = "test-support"))] mod test_tick_driver;` と `pub use test_tick_driver::TestTickDriver;`
+- `modules/actor-core/src/core/kernel/system/base.rs:72, 83`
+  - `ActorSystem::new_empty()` と `ActorSystem::new_empty_with<F>()` が **`TestTickDriver::default()` を直接参照**
+  - これらも `#[cfg(any(test, feature = "test-support"))]` で gate
+
+### 下流の利用状況（本 change 起案時 Grep）
+
+`TestTickDriver` は workspace 全体で **51 ファイル・215 箇所** で使われている:
+
+- actor-core 内部のインラインテスト（`src/**/tests.rs`）: 20+ ファイル、100+ 箇所（`crate::core::kernel::actor::scheduler::tick_driver::TestTickDriver` パス参照）
+- actor-core 統合テスト（`tests/*.rs`）: 8 ファイル（`use fraktor_actor_core_rs::...::TestTickDriver` 参照）
+- 他クレート（actor-adaptor-std、cluster-core、stream-core、stream-adaptor-std、persistence-core）のテスト: 23 ファイル
+- プロダクションコードでの参照は `actor-core` の `#[cfg(any(test, feature = "test-support"))]` ゲート配下のみ（外部 production caller ゼロ）
+
+### actor-adaptor-std の受け皿
+
+`modules/actor-adaptor-std/src/std/tick_driver/` には既に `StdTickDriver`（`std::thread` 利用）、`TokioTickDriver`（tokio runtime 依存）が存在する。`TestTickDriver` も同階層に配置するのが構造的に自然。`actor-adaptor-std` は既に `test-support` feature を持ち、`fraktor-actor-core-rs/test-support` を transitive に有効化している。
+
+### 構造的制約: `new_empty` / `new_empty_with` との不可分性
+
+`ActorSystem::new_empty_with<F>` は本体内で `TestTickDriver::default()` を直接参照している（`base.rs:86-88`）:
+
+```rust
+use crate::core::kernel::actor::scheduler::tick_driver::TestTickDriver;
+let config = ActorSystemConfig::new(TestTickDriver::default());
+```
+
+proposal の当初案では `new_empty*` の移設を step04 に分割していたが、**TestTickDriver だけを先に移動すると `new_empty*` が定義先を失う**。さらに `actor-core` の prod lib（`feature = "test-support"` ゲートが有効な時は prod ビルド相当）から `actor-adaptor-std` を参照すると循環依存になる（`actor-adaptor-std` → `actor-core` が prod 依存）。
+
+このため本 change は proposal を拡張し、`TestTickDriver` と合わせて `new_empty` / `new_empty_with` も同時に `actor-adaptor-std` 側へ移設する。
+
+### Cargo の dev-cycle 許容について
+
+Cargo は `[dev-dependencies]` 経由の循環依存を許容する（prod 依存は cycle 禁止だが dev 依存は例外）。`actor-core` の `[dev-dependencies]` に `fraktor-actor-adaptor-std-rs = { ..., features = ["test-support"] }` を追加することで、`actor-core` の `#[cfg(test)]` インラインテストと統合テストの両方から `actor-adaptor-std::...::TestTickDriver` を利用できる。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `TestTickDriver` を `actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs` に移設し、既存 `StdTickDriver` / `TokioTickDriver` と同階層で統一的に管理
+- `ActorSystem::new_empty` / `new_empty_with` を `actor-adaptor-std` 側の自由関数 `new_empty_actor_system` / `new_empty_actor_system_with<F>` に移設
+- `actor-core` の `test-support` feature から `TestTickDriver` 系の公開シンボルを完全除去
+- 下流 51 ファイルの import path を機械的に更新
+- `actor-core` の `[dev-dependencies]` に `actor-adaptor-std` を追加し、Cargo dev-cycle を活用
+- 新規 capability `actor-test-driver-placement` を ADDED し、std 依存テストヘルパの配置原則を spec 化
+
+**Non-Goals:**
+- `new_empty*` 以外の test-support 公開 API（`MockActorRef`、`TestProbe` 等）の移設は step04 で対応
+- 独立した `fraktor-actor-test-rs` crate の新設は step04 のスコープ（本 change では `actor-adaptor-std` を受け皿にする）
+- `test-support` feature 自体の削除は step06
+- 内部 API 可視性格上げ（`Behavior::handle_message` 等）の解消は step05
+- `actor-adaptor-std` の `test-support` feature 設計見直し（現状の構造を拡張する最小差分にとどめる）
+
+## Decisions
+
+### Decision 1: `TestTickDriver` の移設先は `actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs`
+
+**選択**: 既存 `StdTickDriver`（`std_tick_driver.rs`）/ `TokioTickDriver`（`tokio_tick_driver.rs`）と同階層に `test_tick_driver.rs` を配置する。`actor-adaptor-std/src/std/tick_driver.rs`（module file）に以下を追加（既存 `#[cfg(feature = "tokio-executor")] mod tokio_tick_driver;` と同じパターン）:
+
+```rust
+#[cfg(feature = "test-support")]
+mod test_tick_driver;
+#[cfg(feature = "test-support")]
+pub use test_tick_driver::TestTickDriver;
+```
+
+**根拠**:
+- 既存の 2 つの std 系 TickDriver 実装と完全に対応する配置で、発見性・命名・構造の一貫性が保たれる
+- `TestTickDriver` は `std::thread` と `thread::sleep` に依存しているため、既存 `StdTickDriver` と同じ std 依存性プロファイル
+- `actor-adaptor-std` の `test-support` feature を活用した gate が自然
+
+**代替案と却下理由**:
+- 案 A: `actor-adaptor-std/src/std/test_support/` のような専用ディレクトリを新設 → 既存 `tick_driver/` module のパターンと不整合、発見性低下
+- 案 B: step04 で新設予定の `fraktor-actor-test-rs` crate に直接置く → step04 の範囲を step03 に前倒しすることになり、change の独立性が失われる
+- 案 C: `actor-core` に残して公開 re-export だけ変える → 移設になっていない、test-support feature からの切り離し目標を達成しない
+
+### Decision 2: `new_empty` / `new_empty_with` も同時移設し、自由関数として再実装
+
+**選択**: proposal 原案の Non-Goals を修正し、`ActorSystem::new_empty` と `ActorSystem::new_empty_with<F>` を同時に `actor-adaptor-std` へ移設する。移設先は `modules/actor-adaptor-std/src/std/system/` 配下（module を新設）の自由関数として:
+
+```rust
+// actor-adaptor-std/src/std/system/empty_system.rs (新規)
+pub fn new_empty_actor_system() -> ActorSystem {
+  new_empty_actor_system_with(|config| config)
+}
+
+pub fn new_empty_actor_system_with<F>(configure: F) -> ActorSystem
+where
+  F: FnOnce(ActorSystemConfig) -> ActorSystemConfig,
+{
+  let config = ActorSystemConfig::new(TestTickDriver::default());
+  let config = configure(config);
+  let state = match SystemState::build_from_owned_config(config) {
+    Ok(state) => state,
+    Err(error) => panic!("test-support config failed to build in new_empty_actor_system_with: {error:?}"),
+  };
+  let system = ActorSystem::from_state(SystemStateShared::new(state));
+  system.state.mark_root_started();  // pub(crate) の場合は公開 API 経由に変更必要
+  system
+}
+```
+
+`actor-core::ActorSystem` の `new_empty` / `new_empty_with` メソッドは削除する。
+
+**根拠**:
+- `new_empty*` は内部で `TestTickDriver::default()` を参照しており、`TestTickDriver` が `actor-adaptor-std` に移った時点で `actor-core` の lib 層（feature = "test-support" 有効時は prod 相当）から参照できない（循環依存）
+- 自由関数化することで `ActorSystem` 本体の API surface を汚さない（std 依存のテスト専用 API が `actor-core::ActorSystem` の method として露出しなくなる）
+- 下流 caller は `system.new_empty()` 形式を呼んでいるケースはほぼ無く、多くは `ActorSystem::new_empty()` / `ActorSystem::new_empty_with(...)` という関連関数形式で呼んでいるため、`new_empty_actor_system(...)` への書き換えは機械的に可能
+
+**代替案と却下理由**:
+- 案 A: `ActorSystem` を extension trait で拡張（`NewEmptyExt` 等）→ trait import が必要になり caller 側が煩雑、Rust のイディオムとして trait-based extension は最終手段
+- 案 B: `new_empty*` を step04 に残し、step03 では `TestTickDriver` 移動後に `new_empty*` を一時的に panic/stub 化 → 中間状態が壊れる、避けるべき
+- 案 C: step03 の順序を step04 の後に変える → step04 の fraktor-actor-test-rs crate が actor-core::TestTickDriver を参照する形になり、step04 完了後にまた step03 で import 書き換えが発生する（二度手間）
+- 案 D: proposal を厳守して `new_empty*` を触らない → TestTickDriver 移動と両立不可能（本 Context で詳述）
+
+**実装詳細 — actor-core 側で公開する必要がある内部 API**:
+
+`new_empty_actor_system_with` を actor-adaptor-std 側の自由関数として実装するには、現在 `actor-core` の `ActorSystem::new_empty_with` が参照している以下の内部 API が `pub` として見える必要がある。tasks 1.5 で実体を確認し、最小差分で対応する:
+
+1. **`ActorSystem::state` field**: 現在 private の可能性（private field 経由で `state.mark_root_started()` を呼んでいる）→ field 直接アクセスを避けるため、`pub fn mark_root_started(&self)` のような **inherent method を `ActorSystem` に追加** する方向が有力（field 直接公開は carried-over の問題が出やすい）
+2. **`SystemStateShared::mark_root_started`**: 現在の可視性を確認。`pub(crate)` なら `pub` 化が必要
+3. **`ActorSystem::from_state`**: 既に `pub` と確認済み（base.rs で見える範囲）
+4. **`SystemStateShared::new`**: 同じく `pub` と確認済み
+5. **`SystemState::build_from_owned_config`**: 現在の可視性を確認。`pub` でなければ `pub` 化する
+
+**代替案**: `ActorSystem::new_started_from_config(config: ActorSystemConfig) -> Result<Self, ...>` のような公開 constructor を `actor-core` 側に追加し、adaptor-std はそれを呼ぶだけにする。内部 API 公開を最小化する意味で有力な選択肢。tasks 実装フェーズで最終判断する。
+
+### Decision 3: `actor-core` の `[dev-dependencies]` に `actor-adaptor-std` を追加（Cargo dev-cycle）
+
+**選択**: `modules/actor-core/Cargo.toml` の `[dev-dependencies]` に以下を追加:
+
+```toml
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
+```
+
+**根拠**:
+- Cargo は prod 依存の循環は禁止するが、`[dev-dependencies]` 経由の循環（dev-cycle）は許容する
+- `actor-core` のインラインテスト（`src/**/tests.rs` 内の `#[cfg(test)] mod tests;`）および統合テスト（`tests/*.rs`）から `actor-adaptor-std::TestTickDriver` を利用可能
+- `actor-adaptor-std` → `actor-core`（prod 依存、変わらず）
+- `actor-core`（test 時のみ）→ `actor-adaptor-std`（dev 依存、新規）
+
+**代替案と却下理由**:
+- 案 A: `actor-core` から TestTickDriver 依存を完全に取り除く（インラインテストを書き換え） → 20+ ファイルのテスト再設計が必要、scope が爆発
+- 案 B: `actor-core` にテスト専用の軽量 stub（`InlineTestTickDriver` 等）を追加 → TestTickDriver と stub の 2 重管理、重複
+- 案 C: Cargo の dev-cycle を使わず、テストを別 crate に切り出す → step04 の fraktor-actor-test-rs と役割が被る
+
+**Risks**:
+- dev-cycle は Cargo 公式に許容されているが、一部のツール（IDE、rust-analyzer 等）が混乱する可能性がある → tasks 段階で `cargo metadata -p fraktor-actor-core-rs` と `cargo test -p fraktor-actor-core-rs --all-features` の挙動を確認し、rust-analyzer 側の挙動は IDE 上で手動確認（症状が出た場合のみ workaround 検討）
+
+### Decision 4: spec delta は新規 capability `actor-test-driver-placement` を ADDED
+
+**選択**: 新規 capability として `actor-test-driver-placement` を追加。`openspec/specs/actor-test-driver-placement/spec.md` を新設し、以下の Requirement を持つ:
+
+- Requirement: **std 依存のテストドライバおよびテストヘルパ** は actor-adaptor-std 側に配置されなければならない
+
+Scenario は以下 4 つ（specs/actor-test-driver-placement/spec.md で詳細記述）:
+- `TestTickDriver` の定義・再エクスポートが `actor-core` 側に存在しないこと
+- std 依存のテストコンストラクタ（`new_empty*` 等）が `actor-core::ActorSystem` の method から削除されていること
+- `actor-core` の `[dev-dependencies]` に `actor-adaptor-std = { features = ["test-support"] }` が宣言され、`[dependencies]` には含まれないこと（dev-cycle のみ許容）
+- 下流クレートが `fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver` 形式で import していること
+
+**根拠**:
+- 「std 依存コンポーネントは actor-adaptor-std 側」というドメインルールは governance 価値があり、他クレート（将来の test-support 類似案件）でも援用可能
+- 既存 `actor-lock-construction-governance` spec に Scenario 追加する案もあるが、そちらは lock 構築のガバナンスであり、テストドライバ配置は別ドメイン
+- capability を分けることで、step04 以降の関連 change が capability を ADDED / MODIFIED する形で拡張できる
+
+**代替案と却下理由**:
+- 案 A: 既存 `actor-lock-construction-governance` に Scenario 追加 → ドメインが異なる、無理に同居させるとルール集が散漫化
+- 案 B: spec delta 最小で既存 capability に Scenario のみ追加 → OpenSpec validation は通るがドメイン明確性を欠く
+- 案 C: spec delta を作らない → OpenSpec strict validation が通らない
+
+### Decision 5: 移設 API 名は `new_empty_actor_system` / `new_empty_actor_system_with`
+
+**選択**: `ActorSystem::new_empty` → 自由関数 `new_empty_actor_system`、`ActorSystem::new_empty_with` → `new_empty_actor_system_with<F>` とする。`fraktor_actor_adaptor_std_rs::std::system::{new_empty_actor_system, new_empty_actor_system_with}` として公開。
+
+**根拠**:
+- 関連関数（`::new_empty`）を自由関数化する場合、関数名だけでは「何を作るか」が不明確なため、対象型名を含めて `new_empty_actor_system` とする
+- Rust の慣習に合う（`std::fs::read_to_string` のような「module:: verb_object」形式）
+
+**代替案と却下理由**:
+- 案 A: `empty_actor_system` / `empty_actor_system_with` → `new_` プレフィックスを省略すると constructor であることが伝わりにくい
+- 案 B: `ActorSystem::test_empty()` のように型のメソッドとして残す → `TestTickDriver` 依存が `actor-core::ActorSystem` に残ってしまい、結局 `actor-core` から `actor-adaptor-std` 参照が必要（本末転倒）
+- 案 C: `test_actor_system()` → 「テスト専用である」が読み取れるが「空の」意味が抜け、`new_empty_actor_system` ほど明示的でない
+
+## Risks / Trade-offs
+
+- **[Risk] Cargo dev-cycle が rust-analyzer / IDE で誤検出される可能性** → Mitigation: 実装後 `cargo check --workspace` / `cargo test --workspace` が通ることを CI で確認。rust-analyzer 側の問題は workaround として `rust-analyzer: cargo: allTargets` 等の設定があるが、workspace 全体としての動作影響は軽微。tasks に挙動確認を含める
+- **[Risk] 51 ファイルの import path 更新で書き換え漏れ** → Mitigation: `Grep` で一括検索し、置換後にも再 Grep で 0 hits 確認。CI の全テスト通過で担保
+- **[Risk] `mark_root_started` 等の `pub(crate)` な内部 API が actor-adaptor-std から見えず、移設先で panic を起こす** → Mitigation: 実装時に該当 API を公開（`pub`）化するか、`ActorSystem::new_from_state_and_start` のような公開 constructor を追加する。本 change の design で事前に列挙し、tasks で個別対処
+- **[Risk] step04 で `fraktor-actor-test-rs` crate を新設する際、`actor-adaptor-std` の `test-support` との責務分離が不明瞭になる** → Mitigation: step04 の design で「actor-adaptor-std は std 依存のランタイム補助、actor-test は std 非依存のテストヘルパ（mock、probe 等）」のような住み分けを明確化する。本 change では `TestTickDriver` / `new_empty*` のような std 依存ヘルパに絞って adaptor-std 側に置く
+- **[Trade-off] proposal の当初 scope（TestTickDriver のみ）からの拡大** → 受容: 構造的依存関係により分離不能、Decision 2 で詳述
+
+## Migration Plan
+
+1. **Phase 1: actor-adaptor-std 側の受け皿整備**
+   - `modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs` 新規作成（actor-core の該当ファイルから移植）
+   - `modules/actor-adaptor-std/src/std/tick_driver.rs` に `#[cfg(feature = "test-support")] mod test_tick_driver;` と `#[cfg(feature = "test-support")] pub use test_tick_driver::TestTickDriver;` を追加
+   - `modules/actor-adaptor-std/src/std/system/empty_system.rs` 新規作成（`new_empty_actor_system` / `new_empty_actor_system_with` 実装）
+   - `modules/actor-adaptor-std/src/std/system.rs` 新規作成（module file、`#[cfg(feature = "test-support")] mod empty_system;` と `#[cfg(feature = "test-support")] pub use empty_system::{new_empty_actor_system, new_empty_actor_system_with};` を明示的に記述、glob export は避ける）
+   - `modules/actor-adaptor-std/src/std.rs` に `#[cfg(feature = "test-support")] pub mod system;` を追加
+2. **Phase 2: actor-core 側の削除と必要最小限の API 公開**
+   - `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/test_tick_driver.rs` を削除
+   - `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver.rs` の `#[cfg(any(test, feature = "test-support"))] mod test_tick_driver;` と対応する `pub use` を削除
+   - `modules/actor-core/src/core/kernel/system/base.rs` の `new_empty` / `new_empty_with` 両 method を削除（他の `#[cfg]` ゲート要素は touch しない）
+   - adaptor-std の `new_empty_actor_system_with` が必要とする internal API を公開する（Decision 2 実装詳細に従い、案 A: 5 つの field / method を個別に `pub` 化 / 案 B: `ActorSystem::new_started_from_config(config)` のような公開 constructor を追加、のどちらか）
+3. **Phase 3: actor-core Cargo.toml 更新**
+   - `[dev-dependencies]` に `fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }` 追加
+4. **Phase 4: 下流 import path 更新**
+   - `Grep` で対象全ファイルを特定（起案時集計: TestTickDriver 51 ファイル / 215 箇所、`new_empty*` 系 caller は tasks 1.2 で集計）
+   - インラインテスト（`src/**/tests.rs`）: `use crate::core::...::TestTickDriver;` → `use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;`
+   - 統合テスト（`tests/*.rs`）: `use fraktor_actor_core_rs::...::TestTickDriver;` → 同上
+   - `ActorSystem::new_empty()` / `ActorSystem::new_empty_with(...)` → `new_empty_actor_system()` / `new_empty_actor_system_with(...)` に置換、同時に `use fraktor_actor_adaptor_std_rs::std::system::{new_empty_actor_system, new_empty_actor_system_with};` の import を追加
+5. **Phase 5: ビルド・テスト検証**
+   - `cargo build --workspace --no-default-features` と `cargo build --workspace --all-features`
+   - `cargo test --workspace`
+   - `cargo clippy --workspace`
+6. **Phase 6: spec 整合**
+   - 新規 `specs/actor-test-driver-placement/spec.md` 作成（change delta に基づく）
+   - `openspec validate --strict` 通過確認
+7. **Phase 7: 全体 CI 確認**
+   - `./scripts/ci-check.sh ai all` で workspace 全体 green
+8. **Phase 8: ドキュメント更新**
+   - `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 1 責務 B の進捗を更新（責務 B-1 完了、残 B-2 は step04）
+
+ロールバックは git revert で完結する。
+
+## Open Questions
+
+- `actor-adaptor-std` の `test-support` feature は現状 `fraktor-actor-core-rs/test-support` を transitive に有効化している。TestTickDriver / new_empty* 移設後も actor-core 側 test-support feature は step04 以降まで残るため、transitive 有効化は維持する（本 change で touch しない）
+
+## 実装後の補足: Cargo dev-cycle の制約と対応
+
+実装段階で **dev-cycle 経由で actor-core の inline test から actor-adaptor-std::TestTickDriver を使うアプローチが Cargo の根本的制約に当たることが判明**した。Cargo は `[dev-dependencies]` 経由の cycle を許容するものの、 inline test ビルドにおいては同一クレート（`fraktor_actor_core_rs`）が "lib 直接" と "actor-adaptor-std 経由の transitive" の二バージョンとして compiler に見え、型不一致 (`expected ActorSystem, found a different ActorSystem`) を起こす。これは Rust/Cargo の仕様であり回避不能。
+
+このため実装では以下の二段構成を採った:
+
+**1. `actor-core` 内部の inline test 専用ヘルパ（test-only, 非公開）**:
+
+- `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs` に `pub(crate) struct TestTickDriver` を保持
+- 親 module は `pub(crate) mod tests;`（`#[cfg(test)]` ではなく `#![cfg(test)]` を tests.rs 側で使う Pekko 風 idiom）。これにより dylint `tests_location_lint` も pass
+- `ActorSystem::new_empty()` / `new_empty_with()` も `modules/actor-core/src/core/kernel/system/base/tests.rs` 内に `impl ActorSystem { pub(crate) fn ... }` 形式で配置
+- `TypedActorSystem::<M>::new_empty()` も同様に `modules/actor-core/src/core/typed/system/tests.rs` 内に配置
+- これらは `pub(crate)` のため crate 内 `#[cfg(test)]` コードからのみアクセス可能。外部からは見えない
+
+**2. `actor-adaptor-std` 側の公開 API**:
+
+- `modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs` の `pub struct TestTickDriver`
+- `modules/actor-adaptor-std/src/std/system/empty_system.rs` の `new_empty_actor_system()` / `new_empty_actor_system_with()` / `new_empty_typed_actor_system::<M>()` 自由関数
+- すべて `#[cfg(feature = "test-support")]` ゲート
+
+**3. caller の選択基準**:
+
+| caller | 利用するヘルパ |
+|---|---|
+| `actor-core` の inline test (`src/**/tests.rs`) | actor-core 内部版（`crate::...::tick_driver::tests::TestTickDriver` / `ActorSystem::new_empty()`） |
+| `actor-core` の integration test (`tests/*.rs`) | actor-adaptor-std 公開版（`fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver` / `new_empty_actor_system()`） |
+| 下流 crate (cluster-core / stream-core / persistence-core / actor-adaptor-std 自身) | actor-adaptor-std 公開版 |
+
+これにより:
+
+- **責務 B-1 の本質的目標は達成**: `actor-core` の `test-support` feature の **公開 API には TestTickDriver / new_empty* が含まれない**（公開されない `pub(crate)` のみ）
+- 外部 caller は actor-adaptor-std の公開 API のみを利用するため、no_std 原則を犯す std 依存ヘルパが actor-core から外部に漏れることはない
+- 内部 inline test だけは依然として std を使うが、これは既存の `extern crate std;` + `#[cfg(test)]` の慣行と整合的（Rust の test profile は host で std 利用可）
+
+`actor-core/Cargo.toml` の `[dev-dependencies]` に追加した `fraktor-actor-adaptor-std-rs` は、actor-core の **integration test** が actor-adaptor-std の公開 API を使うために必須（inline test 用ではない）。
+- `new_empty_actor_system` 系関数の rustdoc 例示コードで `TestTickDriver::default()` を直接見せるかどうか → 実装フェーズで caller 体験を見て最小限の例示にとどめる

--- a/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/proposal.md
+++ b/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/proposal.md
@@ -1,45 +1,61 @@
 ## Why
 
-`actor-core` の `test-support` feature が抱える「責務 B（ダウンストリーム統合テスト用 API 公開）」のうち最大のコンポーネントは `TestTickDriver` である。`actor-core` は no_std クレートであるため、`std::thread` / `std::time` を使う `TestTickDriver` は本質的に std 環境専用。これを `actor-core` 本体で提供していること自体が責務の漏洩。
+`actor-core` の `test-support` feature が抱える「責務 B（ダウンストリーム統合テスト用 API 公開）」のうち、std 環境依存の中核コンポーネント群は:
 
-`actor-adaptor-std` は既に std 環境専用のアダプタクレートとして存在し、`tokio-executor` feature / `test-support` feature を持ち、std 向けの周辺機能を集約する場所として位置づけられている。`TestTickDriver` はこちらに引っ越すのが構造的に自然。
+- `TestTickDriver`（`std::thread` + `thread::sleep` で tick を駆動するテストドライバ）
+- `ActorSystem::new_empty` / `new_empty_with`（内部で `TestTickDriver::default()` を参照する std 依存コンストラクタ）
 
-本 change は `test-support` feature を最終的に退役する長期計画（Strategy B）の第 3 ステップ。責務 A（`critical-section/std` impl provider）は既に退役済み（PR #1607/#1608）、責務 B-1 として `TestTickDriver` 移設を行う。
+`actor-core` は no_std クレートであるため、これらの std 依存ヘルパを本体で提供していること自体が責務の漏洩である。`actor-adaptor-std` は既に std 環境専用のアダプタクレートとして存在し、`tokio-executor` feature / `test-support` feature を持ち、std 向けの周辺機能（`StdTickDriver`、`TokioTickDriver` 等）を集約する場所として位置づけられている。std 依存のテストヘルパはこちらに引っ越すのが構造的に自然。
+
+なお `TestTickDriver` と `new_empty*` は `base.rs:86` で `TestTickDriver::default()` を直接参照しており **分離不能** なため、本 change で同時に移設する（design Decision 2 で詳述）。
+
+本 change は `test-support` feature を最終的に退役する長期計画（Strategy B）の第 3 ステップ。責務 A（`critical-section/std` impl provider）は既に退役済み（PR #1607/#1608）、責務 B-1（std 依存ヘルパ: `TestTickDriver` + `new_empty*`）として本 change で移設を行う。残る責務 B（mock / probe / その他ヘルパ）は step04 で対応する。
 
 ## What Changes
 
 - `modules/actor-core/src/` 配下で `TestTickDriver` 関連の実装（構造体定義、テストユーティリティ、`#[cfg(any(test, feature = "test-support"))]` ゲート内の公開シンボル）を抽出
-- `modules/actor-adaptor-std/src/test_support/` 配下（または同等の場所、design で最終決定）に移設
-- `actor-core` 側では no_std セーフな `TickDriver` trait のみを残す（既存実装を継続）
-- ダウンストリーム（`showcases/std`、`actor-core` 自身の `[[test]]`、他 crate の test）の import path を更新
-- `actor-core/test-support` feature からは `TestTickDriver` 関連が消えるため、残責務 B-2、C の範囲が縮小
-- **BREAKING（workspace-internal）**: `fraktor_actor_core_rs::...::TestTickDriver` → `fraktor_actor_adaptor_std_rs::...::TestTickDriver` へのパス変更
+- `modules/actor-adaptor-std/src/std/tick_driver/` 配下（既存 `StdTickDriver` / `TokioTickDriver` と同階層、design で最終決定）に移設
+- `ActorSystem::new_empty` / `new_empty_with` も **同時に** `actor-adaptor-std` 側へ移設する（これらは `TestTickDriver::default()` を内部で参照しており、`TestTickDriver` 移動と構造的に分離不能）。自由関数 `new_empty_actor_system` / `new_empty_actor_system_with<F>` として提供
+- `actor-core` 側では no_std セーフな `TickDriver` trait と `TickDriverBootstrap` など抽象インフラのみを残す
+- ダウンストリーム（`showcases/std`、`actor-core` 自身の `[[test]]`、他 crate の test、`actor-core` 自身の `src/**/tests.rs` インラインテスト）の import path を更新
+- `actor-core/test-support` feature からは `TestTickDriver` と `new_empty*` 関連が消えるため、残責務 B の範囲が縮小（残りは step04 で対応）
+- `actor-core` の `[dev-dependencies]` に `fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }` を追加（Cargo は dev-cycle を許容するため、`actor-core` のテストから `actor-adaptor-std` 経由で `TestTickDriver` を利用可能にする）
+- **BREAKING（workspace-internal）**:
+  - `fraktor_actor_core_rs::...::TestTickDriver` → `fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver`
+  - `ActorSystem::new_empty()` / `ActorSystem::new_empty_with(...)` → `fraktor_actor_adaptor_std_rs::...::new_empty_actor_system()` / `new_empty_actor_system_with(...)`
 
 **Non-Goals**:
-- `TestTickDriver` 以外の test-support 公開 API（`new_empty` 等、responsibility B-2）の移設は step04 で行う
+- `new_empty*` 以外の test-support 公開 API（`MockActorRef`、`TestProbe` 等の mock / fixture、responsibility B-2 の残り）の移設は step04 で行う
 - `test-support` feature 自体の削除は step06 で行う
 - `actor-adaptor-std` の既存 `test-support` feature 設計見直し（現状の構造を尊重）
 
 ## Capabilities
 
 ### New Capabilities
-- なし
+- `actor-test-driver-placement`: 「std 依存のテストドライバおよび std 依存のテストヘルパは `fraktor-actor-core-rs`（no_std クレート）ではなく `fraktor-actor-adaptor-std-rs` 側に置く」原則を明文化する capability を新設（design / specs で詳細確定）
 
 ### Modified Capabilities
-- なし（現時点では `TestTickDriver` の配置は spec 化されていない）
-
-design / specs フェーズで以下のいずれかを判断:
-- 案 A: 新規 capability `actor-test-driver-placement` を ADDED し、「std 依存のテストドライバは actor-adaptor-std 側に置く」ルールを明文化
-- 案 B: 既存 `actor-lock-construction-governance` 等の spec に Scenario を追加（test-support 責務分離の原則として）
-- 案 C: 本 change は実装のみ、spec 化は別 change に切り分け（OpenSpec validation 要件のため何らか最低限の delta が必要）
+- なし
 
 ## Impact
 
 - **Affected code**:
-  - `modules/actor-core/src/`（`TestTickDriver` 定義・エクスポート削除）
-  - `modules/actor-adaptor-std/src/`（新規受け入れ先、Cargo.toml の `test-support` feature 再定義）
-  - `modules/actor-core/tests/*.rs`（import path 更新、該当があれば）
-  - `showcases/std/*/main.rs`（import path 更新）
-- **Affected APIs**: `TestTickDriver` のクレートパス変更（workspace-internal breaking）
-- **Affected dependencies**: `actor-adaptor-std` が `actor-core` test-only API に依存しなくなる（現状の循環的な印象を解消）
+  - `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/test_tick_driver.rs`（削除）
+  - `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver.rs`（module 宣言・`pub use` 削除）
+  - `modules/actor-core/src/core/kernel/system/base.rs`（`new_empty` / `new_empty_with` 削除）
+  - `modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs`（新規、TestTickDriver 実装）
+  - `modules/actor-adaptor-std/src/std/tick_driver.rs`（新規モジュールの `pub use` 追加）
+  - `modules/actor-adaptor-std/src/std/system/empty_system.rs`（新規、`new_empty_actor_system` / `new_empty_actor_system_with` 自由関数）または同等の配置（design で確定）
+  - `modules/actor-adaptor-std/Cargo.toml`（変更なし想定。現状の `test-support = ["fraktor-actor-core-rs/test-support"]` を維持し、新規 `TestTickDriver` / `new_empty*` はソース側の `#[cfg(feature = "test-support")]` gate のみで切り替え。実装フェーズで確認）
+  - `modules/actor-core/Cargo.toml`（`[dev-dependencies]` に `fraktor-actor-adaptor-std-rs` 追加）
+  - `modules/actor-core/src/**/*tests.rs`（インラインテスト 20+ ファイルの import path 更新）
+  - `modules/actor-core/tests/*.rs`（統合テスト 8 ファイルの import path 更新）
+  - `modules/cluster-core/`、`modules/stream-core/`、`modules/stream-adaptor-std/`、`modules/persistence-core/` 等のテスト import path 更新
+  - `showcases/std/` 配下の example の import path 更新
+- **Affected APIs**:
+  - `TestTickDriver` のクレートパス変更（workspace-internal breaking）
+  - `ActorSystem::new_empty` / `new_empty_with` メソッド削除 → 自由関数化
+- **Affected dependencies**:
+  - `actor-adaptor-std` の `test-support` feature が `TestTickDriver` / `new_empty*` を公開
+  - `actor-core` の `[dev-dependencies]` に `actor-adaptor-std` が追加される（Cargo dev-cycle として許容）
 - **Release impact**: pre-release phase につき外部影響は軽微

--- a/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/specs/actor-test-driver-placement/spec.md
+++ b/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/specs/actor-test-driver-placement/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: std 依存のテストドライバおよびテストヘルパは actor-adaptor-std 側に配置されなければならない
+
+`fraktor-actor-*` workspace において、`std::thread` / `std::time::Instant` / tokio 等の std 環境固有機能に依存するテスト向けの TickDriver 実装およびテストユーティリティは、no_std クレートである `fraktor-actor-core-rs` ではなく `fraktor-actor-adaptor-std-rs` 側に配置されなければならない（MUST）。
+
+`fraktor-actor-core-rs` 側は以下のみを提供する（MUST）:
+
+- no_std で動作する抽象（`TickDriver` trait、`TickFeed`、`SchedulerTickExecutor`、`TickDriverBootstrap` 等）
+- `#[cfg(test)]` 配下の inline ユニットテスト（actor-core 自身のテストとして、外部には公開しない）
+
+`fraktor-actor-adaptor-std-rs` 側は以下を提供する（MUST）:
+
+- std 環境固有の TickDriver 実装（`StdTickDriver`、`TokioTickDriver`、`TestTickDriver` など）
+- std 環境を前提としたテスト専用のコンストラクタ（`new_empty_actor_system` / `new_empty_actor_system_with<F>` など、`TestTickDriver` を内包するもの）
+
+将来同種のケース（std 依存のテストヘルパが no_std クレートに同居している状態）が検出された場合は、本 requirement に従って adaptor 層へ移設する。
+
+本 requirement は以下を許容する（例外）:
+
+- `actor-core/Cargo.toml` の `[dev-dependencies]` に `fraktor-actor-adaptor-std-rs = { ..., features = ["test-support"] }` が記述され、actor-core の `#[cfg(test)]` インラインテストおよび `tests/*.rs` 統合テストから adaptor-std の TestTickDriver / new_empty* を利用できるようになること（Cargo の dev-cycle は prod 循環ではないため許容される）
+- step04 以降で新設される専用テストヘルパ crate（`fraktor-actor-test-rs` 等）が std 非依存のテストヘルパを提供すること（本 requirement は std 依存部分の配置のみを対象とする）
+
+#### Scenario: TestTickDriver は actor-adaptor-std 側にのみ定義される
+
+- **WHEN** workspace の `modules/actor-*/src/**/*.rs` で `pub struct TestTickDriver` の定義を検査する
+- **THEN** `modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs` にのみ存在する
+- **AND** `modules/actor-core/src/` 配下には `TestTickDriver` の構造体定義、`mod test_tick_driver;` 宣言、および `pub use test_tick_driver::TestTickDriver;` 再エクスポートが存在しない
+- **AND** `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver.rs` は `TestTickDriver` を再エクスポートしない
+
+#### Scenario: std 依存のテストコンストラクタは actor-core の ActorSystem メソッドから外される
+
+- **WHEN** `modules/actor-core/src/core/kernel/system/base.rs` の `impl ActorSystem` ブロックを検査する
+- **THEN** `pub fn new_empty(...)` および `pub fn new_empty_with<F>(...)` メソッドは存在しない
+- **AND** `#[cfg(any(test, feature = "test-support"))]` ゲート内で `TestTickDriver::default()` を参照する公開メソッドは存在しない
+- **AND** 同等の機能は `fraktor_actor_adaptor_std_rs::std::system::new_empty_actor_system` / `new_empty_actor_system_with<F>` 自由関数として提供される
+
+#### Scenario: actor-core は std 依存テストヘルパ利用時に actor-adaptor-std を dev-dependency 経由で参照する
+
+- **WHEN** `modules/actor-core/Cargo.toml` の `[dev-dependencies]` セクションを検査する
+- **THEN** `fraktor-actor-adaptor-std-rs` エントリが存在し `features = ["test-support"]` が有効化されている
+- **AND** `[dependencies]` セクションには `fraktor-actor-adaptor-std-rs` が含まれない（prod 依存としての循環は禁止、dev 依存としての循環は Cargo が許容する）
+
+#### Scenario: 下流クレートは actor-adaptor-std 経由で TestTickDriver を利用する
+
+- **WHEN** `fraktor-actor-*-rs` workspace 内の任意の crate のテストコード（`tests/*.rs` および `src/**/*tests.rs`）が `TestTickDriver` を利用する
+- **THEN** `use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;` 形式で import する
+- **AND** `use fraktor_actor_core_rs::...::TestTickDriver;` 形式の import は存在しない

--- a/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/tasks.md
+++ b/openspec/changes/step03-move-test-tick-driver-to-adaptor-std/tasks.md
@@ -1,0 +1,103 @@
+## 1. 事前調査と環境確認
+
+- [x] 1.1 `Grep` で `TestTickDriver` 全言及を再確認（起案時: 51 ファイル・215 箇所、workspace 内）
+- [x] 1.2 `Grep` で旧 API の全言及を確認: `ActorSystem::new_empty\|ActorSystem::new_empty_with` を対象に caller 件数を集計（`new_empty` は関連関数であり instance method 形式は存在しないため `::` 参照のみで網羅できる。新名 `new_empty_actor_system*` は本 change で新設するため事前調査では対象外）
+- [x] 1.3 `actor-core` の内部で `TestTickDriver` / `new_empty*` を使うインラインテストを棚卸し（`src/**/tests.rs`）
+- [x] 1.4 `actor-adaptor-std/src/std/tick_driver/` の既存 `StdTickDriver` / `TokioTickDriver` の構造を再確認（配置パターン、feature gate の書き方を写す）
+- [x] 1.5 `actor-core` 側で `actor-adaptor-std` から見える必要のある内部 API を列挙（design Decision 2 の「実装詳細」参照）:
+  - `ActorSystem::state` field の可視性（private なら直接アクセス不可）
+  - `SystemStateShared::mark_root_started` メソッドの可視性
+  - `SystemState::build_from_owned_config` の可視性
+  - 上記を直接 `pub` 化する案 vs. `ActorSystem::new_started_from_config(config)` のような公開 constructor を追加する案を比較し、最小差分を選択（field 直接公開は避ける方向）
+- [x] 1.6 Cargo dev-cycle の挙動を確認（`actor-core` の `[dev-dependencies]` に `actor-adaptor-std` を試験追加して `cargo metadata` が通ること）
+
+## 2. actor-adaptor-std 側に TestTickDriver 移設
+
+- [x] 2.1 `modules/actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs` 新規作成。`actor-core` 側の `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/test_tick_driver.rs` の内容を移植
+- [x] 2.2 移植後、`use super::{...};` 等の相対 import を `actor-adaptor-std` の module 構造に合わせて `use fraktor_actor_core_rs::core::kernel::actor::scheduler::tick_driver::{SchedulerTickExecutor, TickDriver, TickDriverError, TickDriverKind, TickDriverProvision, TickDriverStopper, TickFeedHandle, next_tick_driver_id};` のような crate 境界 import に書き換え
+- [x] 2.3 `modules/actor-adaptor-std/src/std/tick_driver.rs` に `#[cfg(feature = "test-support")] mod test_tick_driver;` と `#[cfg(feature = "test-support")] pub use test_tick_driver::TestTickDriver;` を追加（alphabetical 位置を保つ）
+- [x] 2.4 `cargo build -p fraktor-actor-adaptor-std-rs --features test-support` で単体ビルド成功確認
+
+## 3. actor-adaptor-std 側に new_empty_actor_system 系の自由関数を新設
+
+- [x] 3.1 **（先行）** actor-core 側で必要な internal API を公開: tasks 1.5 の調査結果に基づき、選択した戦略（案 A: field + method を pub 化 / 案 B: `ActorSystem::new_started_from_config` など公開 constructor 追加）を先に実装。この段階では `new_empty*` 削除前なので、既存機能を壊さずに公開点を増やすだけ
+- [x] 3.2 actor-core の `cargo check -p fraktor-actor-core-rs --lib` が通ることを確認（3.1 の変更後）
+- [x] 3.3 `modules/actor-adaptor-std/src/std/system/` ディレクトリ新規作成
+- [x] 3.4 `modules/actor-adaptor-std/src/std/system/empty_system.rs` 新規作成。design Decision 2 のサンプルコードをベースに `new_empty_actor_system` / `new_empty_actor_system_with<F>` を実装する。3.1 で公開した API（pub 化 field / method または公開 constructor）を使用。必要な型を `fraktor_actor_core_rs::...::{ActorSystem, ActorSystemConfig, SystemState, SystemStateShared}` 等から import
+- [x] 3.5 `modules/actor-adaptor-std/src/std/system.rs` 新規作成。module file として `#[cfg(feature = "test-support")] mod empty_system;` と `#[cfg(feature = "test-support")] pub use empty_system::{new_empty_actor_system, new_empty_actor_system_with};` を記述
+- [x] 3.6 `modules/actor-adaptor-std/src/std.rs` に `#[cfg(feature = "test-support")] pub mod system;` を追加
+- [x] 3.7 `cargo build -p fraktor-actor-adaptor-std-rs --features test-support` で新規自由関数を含むビルド成功確認
+
+## 4. actor-core 側から TestTickDriver と new_empty* を削除
+
+- [x] 4.1 `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/test_tick_driver.rs` ファイル削除
+- [x] 4.2 `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver.rs` から `#[cfg(any(test, feature = "test-support"))] mod test_tick_driver;` と `#[cfg(any(test, feature = "test-support"))] pub use test_tick_driver::TestTickDriver;` を削除
+- [x] 4.3 `modules/actor-core/src/core/kernel/system/base.rs` の line 65-97 付近の以下 **2 method のみ** を削除（他の `#[cfg(any(test, feature = "test-support"))]` 要素があれば触らない）:
+  - `#[cfg(any(test, feature = "test-support"))] pub fn new_empty() -> Self { ... }` （docstring + `#[must_use]` 属性含めて）
+  - `#[cfg(any(test, feature = "test-support"))] pub fn new_empty_with<F>(configure: F) -> Self where F: FnOnce(ActorSystemConfig) -> ActorSystemConfig { ... }` （同上）
+  削除後、`base.rs` 内に他の `#[cfg(any(test, feature = "test-support"))]` ゲートがあればそのまま残す（本 change の対象外）
+- [x] 4.4 削除後、lib prod ビルドのみ中間確認: `cargo check -p fraktor-actor-core-rs --no-default-features --lib` と `cargo check -p fraktor-actor-core-rs --features test-support --lib` が通ることを確認。test 系（`--tests` / `--all-targets`）は Phase 5〜6 で import 更新するまで失敗する想定のため、本タスクでは実行しない
+
+## 5. actor-core の Cargo.toml に dev-dependency 追加
+
+- [x] 5.1 `modules/actor-core/Cargo.toml` の `[dev-dependencies]` に以下を追加:
+  ```toml
+  fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
+  ```
+  既存 dev-deps と alphabetical 順序を保つ位置に挿入
+- [x] 5.2 `cargo metadata -p fraktor-actor-core-rs` で循環依存エラーが出ないことを確認
+
+## 6. actor-core のインラインテスト・統合テストを書き換え
+
+- [x] 6.1 インラインテスト（`modules/actor-core/src/**/tests.rs`）の `use crate::core::kernel::actor::scheduler::tick_driver::TestTickDriver;` 形式を `use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;` に一括置換（起案時: 20+ ファイル）
+- [x] 6.2 `base.rs` インラインテスト等で `ActorSystem::new_empty()` / `ActorSystem::new_empty_with(...)` を使っている箇所を `fraktor_actor_adaptor_std_rs::std::system::new_empty_actor_system()` / `new_empty_actor_system_with(...)` に書き換え（import 追加）
+- [x] 6.3 統合テスト（`modules/actor-core/tests/*.rs`）の `use fraktor_actor_core_rs::...::TestTickDriver;` 形式を同様に書き換え（起案時: 8 ファイル）
+- [x] 6.4 `cargo test -p fraktor-actor-core-rs --lib` でインラインテスト成功確認
+- [x] 6.5 `cargo test -p fraktor-actor-core-rs --features test-support` で統合テスト成功確認
+
+## 7. 下流クレートの import path 更新
+
+- [x] 7.1 `modules/cluster-core/` 配下のテストで `TestTickDriver` / `new_empty*` 参照を書き換え
+- [x] 7.2 `modules/stream-core/` 配下のテストで同上
+- [x] 7.3 `modules/stream-adaptor-std/` 配下のテストで同上
+- [x] 7.4 `modules/persistence-core/` 配下のテストで同上
+- [x] 7.5 `modules/actor-adaptor-std/tests/*.rs` で同上
+- [x] 7.6 `showcases/std/` 配下の example で同上
+- [x] 7.7 各 crate を個別コマンドで確認:
+  - `cargo test -p fraktor-cluster-core-rs`
+  - `cargo test -p fraktor-stream-core-rs`
+  - `cargo test -p fraktor-stream-adaptor-std-rs`
+  - `cargo test -p fraktor-persistence-core-rs`
+  - `cargo test -p fraktor-actor-adaptor-std-rs --features test-support`
+  - `cargo test -p fraktor-showcases-std --features advanced`（advanced example がある場合）
+
+## 8. 最終確認 Grep
+
+- [x] 8.1 `Grep "use .*fraktor_actor_core_rs.*TestTickDriver"` で 0 hits 確認
+- [x] 8.2 `Grep "use crate::core::.*::TestTickDriver"` で `actor-core` 配下の残存が無いこと確認（`actor-adaptor-std` 側の新 path は `use fraktor_actor_core_rs::...::TickDriver` trait 参照なので除外）
+- [x] 8.3 `Grep "ActorSystem::new_empty"` で caller 残存が無いこと確認
+- [x] 8.4 `Grep "::TestTickDriver"` で唯一の定義元が `actor-adaptor-std/src/std/tick_driver/test_tick_driver.rs` であることを確認
+
+## 9. ビルド・テスト・clippy 検証
+
+- [x] 9.1 `cargo build --workspace --no-default-features` で workspace 全体の default-features 無効ビルドが通過
+- [x] 9.2 `cargo build --workspace --all-features` で workspace 全体ビルド成功
+- [x] 9.3 `cargo test --workspace` で全テスト pass
+- [x] 9.4 `cargo clippy --workspace --all-targets -- -D warnings` で clippy clean（lib レベルで少なくとも）
+
+## 10. spec 整合確認
+
+- [x] 10.1 `openspec validate step03-move-test-tick-driver-to-adaptor-std --strict` で artifact 整合確認
+- [x] 10.2 新規 capability `actor-test-driver-placement` の Scenario が本 change 後の実態と一致していることを目視確認
+
+## 11. 全体 CI 確認
+
+- [x] 11.1 `./scripts/ci-check.sh ai all` で workspace 全体確認（CLAUDE.md ルールに従い完了を待つ）
+- [x] 11.2 失敗があれば原因を特定し、修正してから再実行
+- [x] 11.3 すべて green になったら、コミット・PR 作成の前にユーザー確認を取る
+
+## 12. ドキュメント更新
+
+- [x] 12.1 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 1「責務 B（ダウンストリーム統合テスト用 API 公開）」の進捗記述を更新（B-1 `TestTickDriver` / `new_empty*` 移設済み、B-2 残り: mock / probe / その他ヘルパ → step04）
+- [x] 12.2 hand-off メモに「actor-core の `[dev-dependencies]` に `actor-adaptor-std` を追加した（dev-cycle）」点を記録
+- [x] 12.3 step04 の proposal に「`new_empty*` は step03 で移設済みのため step04 では対象外」と追記（proposal は step03 archive 前までに更新）

--- a/openspec/changes/step04-extract-actor-test-helpers-crate/proposal.md
+++ b/openspec/changes/step04-extract-actor-test-helpers-crate/proposal.md
@@ -1,6 +1,14 @@
 ## Why
 
-step03 で `TestTickDriver` を `actor-adaptor-std` に引っ越した後も、`actor-core` の `test-support` feature 配下には責務 B の残りコンポーネント（`new_empty` 系コンストラクタ、テスト用の `MockActorRef`、各種 fixture を構築するヘルパ、その他 `#[cfg(any(test, feature = "test-support"))]` で公開されているダウンストリーム向け API）が残る。
+step03 で `TestTickDriver` と `new_empty*` を `actor-adaptor-std` に引っ越した後も、`actor-core` の `test-support` feature 配下には責務 B の残りコンポーネント（テスト用の `MockActorRef`、各種 fixture を構築するヘルパ、その他 `#[cfg(any(test, feature = "test-support"))]` で公開されているダウンストリーム向け API）が残る。
+
+> **step03 からの引き継ぎ**: `new_empty*` は step03 で `actor-adaptor-std::std::system::{new_empty_actor_system,_with,_typed}` 自由関数として移設済み。本 change の対象から除外する。
+>
+> **dev-cycle 制約（重要）**: step03 実装で判明した通り、`actor-core` の `[dev-dependencies]` 経由で actor-test crate を参照しても、**inline test では同一クレートが二バージョンとして compiler に見え型不一致になる**（Cargo の根本的仕様、回避不能）。このため、`actor-core` 自身の inline test で必要なテストヘルパは:
+> - **A 案**: `actor-core` 内部に `pub(crate)` 限定の `#[cfg(test)]` 専用版を残す（step03 の TestTickDriver / new_empty\* と同じ二段構成）
+> - **B 案**: 該当 inline test を統合テスト（`tests/*.rs`）へ移行し、外部 crate と同様に actor-test を `[dev-dependencies]` 経由で利用
+>
+> いずれを採るかは design で確定する。step03 では A 案を採用したが、対象が増えるとメンテ負荷が上がるため、step04 では B 案も検討候補に含める。
 
 これらを `actor-core` 本体に同居させ続ける限り、「本体 feature flag 経由で内部 API を露出する」アンチパターンが温存される。解決策は **専用の test helpers クレート `fraktor-actor-test-rs` を切り出す** こと。ダウンストリーム（統合テスト、showcase、fraktor-cluster/stream/remote/persistence の test 層）は `[dev-dependencies]` でこの crate を取り込む。
 
@@ -10,9 +18,9 @@ step03 で `TestTickDriver` を `actor-adaptor-std` に引っ越した後も、`
 
 - 新規 crate `modules/actor-test/`（名前: `fraktor-actor-test-rs`、no_std 選択肢は design で確定。おそらく std 要）を作成
 - `actor-core/test-support` feature 配下で公開していた以下を移設:
-  - `new_empty` 系コンストラクタ（`ActorSystem::new_empty`、`ActorRef::new_empty` 等、design で全数列挙）
   - 各種テスト用 mock / fixture（`MockActorRef`、`TestProbe` 等、存在するもの）
   - 統合テストで共有されているヘルパ関数（具体は design の調査で確定）
+  - （`new_empty*` および `TestTickDriver` は step03 で `actor-adaptor-std` 側に移設済みのため対象外）
 - 移設先で API を整理（不要になったものは削除、責務 C と重複する内部 API promotion は step05 に委ねる）
 - ダウンストリームの `Cargo.toml` を更新: `actor-core = { features = ["test-support"] }` → `fraktor-actor-test-rs`（`[dev-dependencies]`）
 - **BREAKING（workspace-internal）**: 公開テストヘルパの crate path が変わる
@@ -21,6 +29,7 @@ step03 で `TestTickDriver` を `actor-adaptor-std` に引っ越した後も、`
 - 責務 C（内部 API の `pub(crate)` → `pub` 格上げ）の処理は step05 で行う
 - `test-support` feature の完全削除は step06 で行う
 - `actor-core` 自身の `[[test]]` が依存する純粋な内部 helper（`#[cfg(test)]` のみで `feature = "test-support"` ゲートされていないもの）は移設対象外
+- `new_empty*` / `TestTickDriver` の再移設は不要（step03 で `actor-adaptor-std` に移設済み）。step04 は actor-test crate 新設を行うが、これらの公開 API を adaptor-std から actor-test に再移管するかは別問題（design で判断、デフォルトは現状維持）
 
 ## Capabilities
 

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/proposal.md
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/proposal.md
@@ -24,6 +24,7 @@ step01〜step05 を経て `actor-core/test-support` feature が抱えていた 3
 **Non-Goals**:
 - `actor-adaptor-std` 等の他クレートの `test-support` feature 見直し（独自責務を持つため個別判断）
 - `actor-core` の `alloc` / `alloc-metrics` feature の見直し（別スコープ）
+- `actor-core` 内部に残存する `pub(crate)` 限定の `#[cfg(test)]` 専用テストヘルパ（step03 で導入した `tick_driver/tests/test_tick_driver.rs` の `TestTickDriver`、`base/tests.rs` / `typed/system/tests.rs` の `new_empty*` 等）の削除は **対象外**。これらは外部から見えず `test-support` feature とは独立しているため、本 change の feature 削除を妨げない。inline test を統合テストへ移行する形で消すかどうかは別途判断する
 
 ## Capabilities
 

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1181,6 +1181,7 @@ check_unit_sleep() {
     --glob '!modules/actor-core/src/core/kernel/dispatch/dispatcher/tests.rs'
     --glob '!modules/actor-core/src/core/typed/dsl/routing/scatter_gather_first_completed_router_builder/tests.rs'
     --glob '!modules/actor-core/src/core/typed/dsl/routing/tail_chopping_router_builder/tests.rs'
+    --glob '!modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs'
   )
 
   local violations=""


### PR DESCRIPTION
## 概要

Strategy B step 03: `actor-core`（no_std クレート）から std 依存テストヘルパ (`TestTickDriver`、`new_empty*`) の **公開 API** を `actor-adaptor-std` 側へ移設する。

責務 B-1（ダウンストリーム統合テスト用 std 依存ヘルパ）の退役。

## 主な変更

- `actor-adaptor-std` に新規追加:
  - `std::tick_driver::TestTickDriver`（`#[cfg(feature = "test-support")]`）
  - `std::system::{new_empty_actor_system, new_empty_actor_system_with, new_empty_typed_actor_system}` 自由関数
- `actor-core` 側で `ActorSystem::new_started_from_config(config)` 公開 constructor を新設（adaptor-std ヘルパが利用する seam）
- 各 crate の `[dev-dependencies]` に `fraktor-actor-adaptor-std-rs` を追加（actor-core / cluster-core / persistence-core / stream-core / stream-adaptor-std）
- 60+ テストファイルの import path を一括更新

## 実装段階で発覚した dev-cycle 制約への対応

当初設計では `actor-core` の `[dev-dependencies]` に actor-adaptor-std を追加するだけで inline test も統合テストも動作する想定だったが、Cargo の仕様により inline test ビルドでは **同一クレート (`fraktor_actor_core_rs`) が二バージョンとして compiler に見え型不一致** (`expected ActorSystem, found a different ActorSystem`) になる（dev-cycle の根本的制約、回避不能）。

このため二段構成を採用:

| caller | 利用するヘルパ |
|---|---|
| `actor-core` の inline test (`src/**/tests.rs`) | actor-core 内部の `pub(crate)` 限定版（`tick_driver/tests/test_tick_driver.rs`、`base/tests.rs` の `impl ActorSystem`） |
| `actor-core` の integration test (`tests/*.rs`) | actor-adaptor-std 公開版 |
| 下流 crate (cluster-core / stream-core / persistence-core / actor-adaptor-std 自身) | actor-adaptor-std 公開版 |

→ **責務 B-1 の本質的目標は達成**: `actor-core/test-support` feature の **公開 API には TestTickDriver / new_empty\* が含まれない**

詳細は `openspec/changes/step03-move-test-tick-driver-to-adaptor-std/design.md`「実装後の補足」を参照。

## 後続 step への影響

- **step04** (mock/probe 等の B-2 移設): `new_empty*` は対象外、dev-cycle 制約は同様に適用される旨を proposal に追記
- **step06** (test-support feature 削除): 内部 `pub(crate)` ヘルパは feature 削除を妨げない旨を Non-Goals に追記
- 他の step (01/02/05/07/08): 影響なし

## 検証

- `cargo test --workspace`: 4782 passed, 9 ignored
- `./scripts/ci-check.sh ai all`: exit 0
- `openspec validate step03-move-test-tick-driver-to-adaptor-std --strict`: valid

## 関連

- Strategy B のロードマップ (`openspec/changes/step01〜step08/`)
- 直前の change: `retire-actor-core-test-support-critical-section-impl` (step02 PR #1611/#1612)
- followups: `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 1 責務 B の B-1 を完了として更新

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moves and re-exports test-only constructors/drivers and introduces a new public `ActorSystem::new_started_from_config`, which could affect downstream test setups and any code relying on the removed `new_empty*` APIs.
> 
> **Overview**
> Std-dependent test helpers are **moved out of the no_std `actor-core` public API** into `actor-adaptor-std` under the `test-support` feature: a public `std::tick_driver::TestTickDriver` and `std::system::{new_empty_actor_system, new_empty_actor_system_with}` for building started, guardian-less systems.
> 
> `actor-core` removes `ActorSystem::new_empty`/`new_empty_with` from the main implementation and adds `ActorSystem::new_started_from_config` as the new public seam used by adaptor-level helpers; inline unit tests keep a `pub(crate)` duplicate `TestTickDriver`/`new_empty*` to avoid Cargo dev-cycle type conflicts.
> 
> Across the workspace, integration tests and downstream crates are updated to import `TestTickDriver` and empty-system helpers from `fraktor_actor_adaptor_std_rs`, new adaptor-std integration tests are enabled behind `required-features = ["test-support"]`, and CI grep exclusions are updated to allow the remaining inline-test `thread::sleep` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f236ab3681f7c8c05c36025d90acd5e56ec9b449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * テスト支援インフラを再編成し、テスト向けの責務分配を整理しました。

* **テスト**
  * テスト用ユーティリティとテストドライバの公開/配置を調整し、テストコードの可搬性と保守性を向上させました。
  * 既存テストの参照先を整理し、テスト実行時の一貫性を改善しました。

* **雑務**
  * CIチェックと無視設定の小修正を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->