### PR TITLE
chore(actor-core): remove test-support feature (step06)

### DIFF
--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -10,9 +10,11 @@
 
 ## 残課題
 
-### 1. `test-support` feature の責務分離
+### 1. `test-support` feature の責務分離（解消済み）
 
-`actor-core/Cargo.toml:19` の `test-support` feature は当初 3 つの異なる責務を抱えていた:
+**解消済み**: `step06-remove-actor-core-test-support-feature` change（2026-04-22）で feature 定義そのものを削除し、責務 A〜C + feature 削除すべて完了。
+
+`actor-core/test-support` feature は当初 3 つの異なる責務を抱えていた:
 
 - 責務 A: `critical-section/std` impl provider 提供（std 環境でリンクを通すため） → **完了** (`retire-actor-core-test-support-critical-section-impl` change で各バイナリ側へ移譲、2026-04-21)
 - 責務 B: ダウンストリーム統合テスト用 API 公開（`TestTickDriver`, `new_empty` 等）
@@ -20,8 +22,7 @@
   - **B-2 完了** (`step05-hide-actor-core-internal-test-api`、2026-04-22): step04 (CLOSED) で当初想定していた mock/probe 等の test fixture は実在せず、`feature = "test-support"` 公開シンボル (`ActorRef::new_with_builtin_lock`、`SchedulerRunner::manual`、`state::booting_state`/`running_state` 等) はすべて actor-core 内部 inline test のみが caller と判明。step05 で全 11 シンボルを `pub(crate)` 化して feature ゲートを削除した
 - 責務 C: 内部 API の `pub(crate)` → `pub` 格上げ（`Behavior::handle_message` 等）
   - **完了** (`step05-hide-actor-core-internal-test-api`、2026-04-22): `Behavior::handle_*` (3)、`TypedActorContext::from_untyped`、`TickDriverBootstrap` 関連 (struct/method/re-export) を `pub(crate)` に縮小。dual-cfg pattern (`#[cfg(any(test, feature = "test-support"))] pub fn` + `#[cfg(not(...))] pub(crate) fn`) を全廃
-
-責務 A〜C すべて退役。`actor-core/test-support` feature は **空 (`[]`)** になり、`actor-core/src/` 配下の `feature = "test-support"` 参照は **0 件**。残すは feature 定義そのものの削除（step06 で対応）。
+- feature 削除: **完了** (`step06-remove-actor-core-test-support-feature`、2026-04-22): `actor-core/Cargo.toml` から `test-support = []` 行と 8 個の `[[test]] required-features = ["test-support"]` を削除。下流 8 crate (`actor-adaptor-std`、`cluster-core`、`cluster-adaptor-std`、`persistence-core`、`remote-adaptor-std`、`stream-core`、`stream-adaptor-std`、`showcases/std`) の `Cargo.toml` から `fraktor-actor-core-rs/test-support` への参照も全廃。`actor-test-driver-placement` capability に検証 Scenario を追加し、再侵入を spec で機械的にブロック
 
 ### 2. `portable-atomic` の `critical-section` feature 再評価
 

--- a/modules/actor-adaptor-std/Cargo.toml
+++ b/modules/actor-adaptor-std/Cargo.toml
@@ -14,7 +14,7 @@ autoexamples = false
 
 [features]
 default = []
-test-support = ["fraktor-actor-core-rs/test-support"]
+test-support = []
 tokio-executor = ["dep:tokio"]
 
 [dependencies]
@@ -27,14 +27,6 @@ tracing = { workspace = true, features = ["std"] }
 [dev-dependencies]
 criterion = { workspace = true }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
-# Override the prod dep to pull in `test-support` (which transitively enables
-# `critical-section/std`) so the lib's `#[cfg(any(test, feature = "test-support"))]`
-# items are visible to integration tests and benches in this crate. Without
-# this override, `cargo test --features tokio-executor` and
-# `cargo bench --features tokio-executor` fail to link / resolve symbols
-# because the bench / test binaries do not pick up the `std` impl of
-# `critical-section`.
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 critical-section = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "test-util"] }
 serde_json = { workspace = true }

--- a/modules/actor-core/Cargo.toml
+++ b/modules/actor-core/Cargo.toml
@@ -16,7 +16,6 @@ autoexamples = false
 default = []
 alloc = []
 alloc-metrics = []
-test-support = []
 
 [dependencies]
 async-trait = { workspace = true }
@@ -47,42 +46,34 @@ fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
 [[test]]
 name = "actor_path_e2e"
 path = "tests/actor_path_e2e.rs"
-required-features = ["test-support"]
 
 [[test]]
 name = "death_watch"
 path = "tests/death_watch.rs"
-required-features = ["test-support"]
 
 [[test]]
 name = "event_stream"
 path = "tests/event_stream.rs"
-required-features = ["test-support"]
 
 [[test]]
 name = "ping_pong"
 path = "tests/ping_pong.rs"
-required-features = ["test-support"]
 
 [[test]]
 name = "supervisor"
 path = "tests/supervisor.rs"
-required-features = ["test-support"]
 
 [[test]]
 name = "system_events"
 path = "tests/system_events.rs"
-required-features = ["test-support"]
 
 [[test]]
 name = "system_lifecycle"
 path = "tests/system_lifecycle.rs"
-required-features = ["test-support"]
 
 [[test]]
 name = "typed_scheduler"
 path = "tests/typed_scheduler.rs"
-required-features = ["test-support"]
 
 [lints]
 workspace = true

--- a/modules/cluster-adaptor-std/Cargo.toml
+++ b/modules/cluster-adaptor-std/Cargo.toml
@@ -15,7 +15,7 @@ autoexamples = false
 [features]
 default = []
 aws-ecs = ["dep:aws-sdk-ecs", "dep:aws-config"]
-test-support = ["fraktor-cluster-core-rs/test-support", "fraktor-actor-core-rs/test-support"]
+test-support = ["fraktor-cluster-core-rs/test-support"]
 
 [dependencies]
 fraktor-cluster-core-rs = { workspace = true }
@@ -33,7 +33,6 @@ tokio = { workspace = true, features = ["rt", "sync", "time", "net", "macros"] }
 workspace = true
 
 [dev-dependencies]
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["tokio-executor", "test-support"] }
 fraktor-cluster-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }

--- a/modules/cluster-core/Cargo.toml
+++ b/modules/cluster-core/Cargo.toml
@@ -14,7 +14,7 @@ autoexamples = false
 
 [features]
 default = []
-test-support = ["fraktor-actor-core-rs/test-support"]
+test-support = []
 
 [dependencies]
 fraktor-actor-core-rs = { workspace = true }
@@ -27,7 +27,6 @@ tracing = { workspace = true }
 workspace = true
 
 [dev-dependencies]
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
 critical-section = { workspace = true, features = ["std"] }

--- a/modules/persistence-core/Cargo.toml
+++ b/modules/persistence-core/Cargo.toml
@@ -26,6 +26,5 @@ workspace = true
 
 [dev-dependencies]
 critical-section = { workspace = true, features = ["std"] }
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }

--- a/modules/remote-adaptor-std/Cargo.toml
+++ b/modules/remote-adaptor-std/Cargo.toml
@@ -14,7 +14,7 @@ autoexamples = false
 
 [features]
 default = []
-test-support = ["fraktor-actor-core-rs/test-support"]
+test-support = []
 
 [dependencies]
 fraktor-remote-core-rs = { workspace = true }
@@ -31,7 +31,6 @@ tracing = { workspace = true, features = ["std"] }
 workspace = true
 
 [dev-dependencies]
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["tokio-executor", "test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
 critical-section = { workspace = true, features = ["std"] }

--- a/modules/stream-adaptor-std/Cargo.toml
+++ b/modules/stream-adaptor-std/Cargo.toml
@@ -23,6 +23,5 @@ fraktor-stream-core-rs = { workspace = true }
 workspace = true
 
 [dev-dependencies]
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 critical-section = { workspace = true, features = ["std"] }

--- a/modules/stream-core/Cargo.toml
+++ b/modules/stream-core/Cargo.toml
@@ -26,7 +26,6 @@ miniz_oxide = { version = "0.9", optional = true, default-features = false, feat
 workspace = true
 
 [dev-dependencies]
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
 critical-section = { workspace = true, features = ["std"] }

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/design.md
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/design.md
@@ -1,0 +1,158 @@
+## Context
+
+step03〜step05 を経て `actor-core/test-support` feature は **完全に空 (`[]`)** になり、`actor-core/src/` 配下に `feature = "test-support"` を参照する `#[cfg(...)]` は **0 件** になった (step05 完了状態)。本 change は最終ステップとして、空のままになっている feature 定義そのものと、各クレートに残る関連参照を機械的に削除する。
+
+### 全数棚卸し (step06 開始時点)
+
+| カテゴリ | 場所 | 件数 | 内容 |
+|---|---|---|---|
+| ① actor-core feature 定義 | `modules/actor-core/Cargo.toml:19` | 1 | `test-support = []` |
+| ② actor-core `[[test]] required-features` | `modules/actor-core/Cargo.toml` | 8 | `required-features = ["test-support"]` × 8 セクション |
+| ③ actor-core dev-dep adaptor-std features | `modules/actor-core/Cargo.toml:43` | 1 | `fraktor-actor-adaptor-std-rs = { ..., features = ["test-support"] }` (これは actor-adaptor-std の test-support を有効化、step06 後も残る) |
+| ④ 下流 crate の test-support feature 定義（actor-core 経由 forward） | actor-adaptor-std (line 17)、cluster-core (17)、cluster-adaptor-std (18)、remote-adaptor-std (17) | 4 | `["fraktor-actor-core-rs/test-support"]` を含む定義 |
+| ⑤ 下流 dev-dep の `actor-core features=["test-support"]` | 8 ファイル | 8 | actor-adaptor-std (37)、cluster-core (30)、cluster-adaptor-std (36)、persistence-core (29)、remote-adaptor-std (34)、stream-core (29)、stream-adaptor-std (26)、showcases/std (9) |
+| ⑥ actor-core/src の `feature = "test-support"` 参照 | `modules/actor-core/src/**/*.rs` | 0 | step05 完了済み |
+
+### 重要な制約
+
+- **actor-adaptor-std/test-support feature は残す**: actor-adaptor-std の `test-support` feature は `TestTickDriver`、`new_empty_actor_system*` の **公開ゲート** として使われている (step03 で確立)。actor-core/test-support とは独立した責務を持つため、本 change では actor-adaptor-std/test-support を削除しない。ただし `["fraktor-actor-core-rs/test-support"]` の forward 部分は撤去する（actor-core 側で消えるため）
+- **同様に cluster-core/test-support、remote-adaptor-std/test-support、cluster-adaptor-std/test-support も残す**: それぞれ独自の用途を持つ可能性がある（caller を本 change では再評価しない）
+- **dev-dep `fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }` の取り扱い**: feature 削除後、`fraktor-actor-core-rs = { workspace = true }` 単独になる。これは prod dep (各 crate の `[dependencies]`) と完全に同じ宣言になり redundant。Cargo は許容するが警告/混乱の元なので **dev-dep 行ごと削除**するのが望ましい (Decision 3)
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `modules/actor-core/Cargo.toml` から `test-support` feature 定義と関連 `required-features` を全廃
+- 全下流 crate の `Cargo.toml` から `fraktor-actor-core-rs/test-support` への参照を全廃
+- 下流 crate の dev-dep が prod dep と同等になった場合、redundant な dev-dep 行を削除
+- workspace 全体ビルドおよびテストが、feature 削除前と同じ pass 率を維持
+- `actor-test-driver-placement` capability に「`actor-core` には `test-support` feature が存在しない」を検証する Scenario を追加 (MODIFIED)
+
+**Non-Goals:**
+
+- `actor-adaptor-std/test-support`、`cluster-core/test-support`、`cluster-adaptor-std/test-support`、`remote-adaptor-std/test-support` feature の削除や見直し（独自責務、別 change）
+- `actor-core` の `alloc` / `alloc-metrics` feature の見直し（別スコープ）
+- `actor-core` 内部に残存する `pub(crate)` 限定の test-only ヘルパ (step03 dev-cycle workaround 由来) の削除（別 change）
+- portable-atomic 関連の整理 (step07 / step08 で扱う)
+
+## Decisions
+
+### Decision 1: actor-core/Cargo.toml の機械的削除
+
+```toml
+# Before (lines 15-19)
+[features]
+default = []
+alloc = []
+alloc-metrics = []
+test-support = []
+
+# After
+[features]
+default = []
+alloc = []
+alloc-metrics = []
+```
+
+`[[test]]` セクション 8 個の `required-features = ["test-support"]` 行を削除（行のみ削除、`[[test]]` 本体は残す）。
+
+### Decision 2: 下流 crate の test-support feature 定義の更新
+
+actor-core/test-support を forward していた 4 件:
+
+- `actor-adaptor-std/Cargo.toml:17` `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- `cluster-core/Cargo.toml:17` `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- `cluster-adaptor-std/Cargo.toml:18` `test-support = ["fraktor-cluster-core-rs/test-support", "fraktor-actor-core-rs/test-support"]` → `test-support = ["fraktor-cluster-core-rs/test-support"]`
+- `remote-adaptor-std/Cargo.toml:17` `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+
+cluster-core / remote-adaptor-std / actor-adaptor-std の test-support feature が空 `[]` になっても、独自の用途 (capability gate 等) があれば feature 自体は維持する (本 change スコープ外)。
+
+### Decision 3: 下流 dev-dep `actor-core features=["test-support"]` の取り扱い
+
+各 crate Cargo.toml の dev-dep 行:
+
+```toml
+fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+```
+
+から `features = ["test-support"]` を削除すると `{ workspace = true }` になる。これは同一 crate の `[dependencies]` セクション（prod dep）と完全一致するため **dev-dep 行ごと削除する**。
+
+例外: `showcases/std/Cargo.toml:9` は `[dependencies]` (prod) に書かれているため、行ごと削除ではなく `features = ["test-support"]` のみ削除する:
+
+```toml
+# Before
+fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+# After
+fraktor-actor-core-rs = { workspace = true }
+```
+
+### Decision 4: actor-core の dev-dep `actor-adaptor-std features=["test-support"]` は残す
+
+`modules/actor-core/Cargo.toml:43` の以下は **そのまま残す**:
+
+```toml
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
+```
+
+これは actor-adaptor-std の test-support feature を有効化するもので、actor-adaptor-std 側の `TestTickDriver`、`new_empty_actor_system*` を actor-core の integration test (`tests/*.rs`) で利用するために必須。step03 で確立した dev-cycle 経路。
+
+### Decision 5: spec delta は MODIFIED でカバー
+
+提案で挙げた 2 案のうち **案 A** (既存 capability に Scenario 追加) を採用。
+
+`actor-test-driver-placement` capability の Requirement「actor-core では feature ゲート経由で内部 API の可視性を拡大してはならない」(step05 で追加) に Scenario を追加 (MODIFIED):
+
+- `actor-core/Cargo.toml` の `[features]` セクションに `test-support` が存在しないことを検証
+- 全下流 crate の actor-core dev-dep に `features = ["test-support"]` が含まれないことを検証
+
+これにより「step06 後に test-support 関連参照が残らない」というルールが spec で機械的に検査可能になる。
+
+## Risks / Trade-offs
+
+- **[Risk] 下流 crate の dev-dep 行削除で別の隠れた依存が壊れる**:
+  - Mitigation: 各 crate を `cargo test` で個別検証する。redundant 削除前後でテスト結果に差が出ないことを確認
+- **[Risk] actor-adaptor-std / cluster-core / remote-adaptor-std の test-support 定義を空 `[]` にした後、別の forward が必要になる**:
+  - Mitigation: 本 change は最小差分。空にした後で問題が出れば該当 crate 側で個別対応
+- **[Trade-off] actor-adaptor-std 等の test-support feature 自体を残すか削除するかの判断**:
+  - 受容: 本 change は actor-core/test-support のみがスコープ。他クレートの feature 整理は独立した責務なので将来の change で扱う
+- **[Risk] `[[test]] required-features` 削除後、実体は同じだが Cargo の解釈が変わる**:
+  - 確認: required-features 削除しても、その test は常に build/run される（feature 不要のため）。step05 後 actor-core/test-support が `[]` だったので required-features があってもなくても挙動は同じ
+- **[Risk] `cargo test --workspace --features test-support` のような呼び出しが CI/ローカルで使われている**:
+  - Mitigation: 削除後は「unknown feature `test-support` for actor-core」エラーになるため、検出は容易。既知の呼び出し箇所 (`scripts/ci-check.sh` 等) を grep で確認
+
+## Migration Plan
+
+1. **Phase 1: 下流 crate の参照削除** (順序依存なし)
+   - 8 ファイルから dev-dep `fraktor-actor-core-rs = { ..., features = ["test-support"] }` 削除（Decision 3）
+   - 4 ファイルから `test-support` feature 定義の forward を削除（Decision 2）
+   - 各 crate ごとに `cargo test -p <crate>` で pass 確認
+2. **Phase 2: actor-core 本体の削除**
+   - `modules/actor-core/Cargo.toml` の `test-support = []` 行を削除
+   - 8 個の `[[test]] required-features = ["test-support"]` 行を削除
+   - `cargo test -p fraktor-actor-core-rs` で pass 確認
+3. **Phase 3: workspace 全体検証**
+   - `cargo test --workspace` 全 pass
+   - `cargo build --workspace --no-default-features` pass
+   - `cargo build --workspace --all-features` pass
+   - `Grep "test-support" modules/actor-core/Cargo.toml` で 0 件
+   - `Grep 'fraktor-actor-core-rs.*test-support' modules/ showcases/` で 0 件
+   - `./scripts/ci-check.sh dylint` pass
+   - `./scripts/ci-check.sh ai all` pass
+4. **Phase 4: spec delta 適用**
+   - `actor-test-driver-placement` capability に MODIFIED で Scenario 追加
+   - `openspec validate --strict` pass
+5. **Phase 5: ドキュメント更新**
+   - `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 1 全体を「解消済み」に更新（責務 A/B/C/feature 削除すべて完了）
+6. **Phase 6: コミット + PR**
+   - 論理単位での commit (Phase 1 を crate ごとに分けるか、一括にするかは判断)
+   - PR 作成 → レビュー → マージ
+7. **Phase 7: archive**
+
+ロールバックは git revert で完結する。
+
+## Open Questions
+
+- 下流 crate (actor-adaptor-std / cluster-core / cluster-adaptor-std / remote-adaptor-std) の test-support feature が空 `[]` になった場合、それ自体を削除するかは別 change で再評価する。本 change ではスコープ外として残す
+- showcases/std の `fraktor-actor-core-rs` を `[dependencies]` に持つ設計が妥当かは別問題。本 change では `features = ["test-support"]` のみ除去
+- step07 (portable-atomic 評価) との順序は独立。step06 マージ後、step07 に進める

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/proposal.md
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/proposal.md
@@ -32,11 +32,10 @@ step01〜step05 を経て `actor-core/test-support` feature が抱えていた 3
 - なし
 
 ### Modified Capabilities
-- なし
-
-OpenSpec validation 要件を満たすため、design / specs フェーズで最低 1 件の delta を設計する。候補:
-- 案 A: step04 / step05 で導入した capability（`actor-test-helpers-placement` / `actor-core-api-visibility-governance` 等）に Scenario を追加し、「`actor-core` には `test-support` feature が存在しない」を検査項目化
-- 案 B: 既存 `actor-lock-construction-governance` に Scenario を追加
+- `actor-test-driver-placement`: step05 で追加した Requirement「actor-core では feature ゲート経由で内部 API の可視性を拡大してはならない」に Scenario を 2 件追加
+  - actor-core/Cargo.toml に `test-support` feature 定義が存在しないことを検証
+  - 全下流 crate の Cargo.toml が actor-core の存在しない `test-support` feature を要求していないことを検証
+  - 同 Requirement 本文も MUST NOT 節を追加し、「feature 自体が存在してはならない」「下流が存在しない feature を要求してはならない」を明文化
 
 ## Impact
 

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/specs/actor-test-driver-placement/spec.md
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/specs/actor-test-driver-placement/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: actor-core では feature ゲート経由で内部 API の可視性を拡大してはならない
+
+`fraktor-actor-core-rs` の本体ソース (`modules/actor-core/src/**/*.rs`) では、`#[cfg(any(test, feature = "test-support"))]` のような **`feature = "test-support"` を含む cfg ゲート** を使って `pub(crate)` 以下の内部 API を `pub` に格上げしてはならない（MUST NOT）。
+
+加えて、本 capability では **`fraktor-actor-core-rs` クレート自身が `test-support` feature を提供してはならない** (MUST NOT)。`actor-core/Cargo.toml` の `[features]` セクションに `test-support` の定義が存在してはならず、関連する `[[test]] required-features = ["test-support"]` も含まれてはならない。同様に、ダウンストリームクレートの `Cargo.toml` で `fraktor-actor-core-rs = { ..., features = ["test-support"] }` のように **存在しない feature を要求してはならない** (MUST NOT)。
+
+許容される使い方は以下のみ:
+
+- 純粋な `#[cfg(test)]`（`feature = "test-support"` を含まない）による test-only コード分離
+- `<module>/tests.rs` (file-level `#![cfg(test)]`) 配下に test fixture や test 用の inherent method を置くこと
+- `pub(crate)` のままの内部 API（feature ゲートを伴わない）
+
+「ダウンストリームのテストから internal API を叩きたい」という需要が現れた場合は、以下のいずれかで対応する（feature ゲート経由の visibility 拡大は禁止）:
+
+- 当該 API を正規 public API として設計し、`pub` で公開する（docs / 型シグネチャを整備）
+- ダウンストリームのテストを public API 経由 (`ActorRef::tell` 等) に書き換える
+- `actor-adaptor-std` 等の adaptor crate にファサード関数を追加し、ダウンストリームはそれを経由する
+
+#### Scenario: actor-core src 配下に test-support ゲート経由の visibility 拡大が存在しない
+
+- **WHEN** `Grep "feature = \"test-support\"" modules/actor-core/src/` を実行する
+- **THEN** ヒット件数が 0 件である
+- **AND** `#[cfg(any(test, feature = "test-support"))]` 形式の attribute を本体 (`src/**/*.rs`) に持つ箇所が存在しない
+
+#### Scenario: 内部 API の dual-visibility パターンが残存しない
+
+- **WHEN** `modules/actor-core/src/` 配下の任意のファイルを検査する
+- **THEN** 同一シンボルに対して以下のような dual-cfg pattern が存在しない:
+  ```rust
+  #[cfg(any(test, feature = "test-support"))]
+  pub fn foo(...) { ... }
+  #[cfg(not(any(test, feature = "test-support")))]
+  pub(crate) fn foo(...) { ... }
+  ```
+- **AND** 該当シンボルは単一の `pub(crate)` 定義に統一されている
+
+#### Scenario: `pub(crate)` 内部 API が常に存在する (test/test-support 限定の存在切替を行わない)
+
+- **WHEN** `pub(crate)` 可視性を持つ内部 API のシンボルを検査する
+- **THEN** `#[cfg(any(test, feature = "test-support"))]` で「test/test-support ビルド時のみ存在する」という存在切替を行っていない
+- **AND** production caller (intra-crate) があるシンボルは常に存在し、ゲートで隠さない
+
+#### Scenario: actor-core/Cargo.toml に test-support feature が存在しない
+
+- **WHEN** `modules/actor-core/Cargo.toml` を検査する
+- **THEN** `[features]` セクションに `test-support` の定義が存在しない
+- **AND** `[[test]]` セクション群に `required-features = ["test-support"]` を含む行が 0 件
+- **AND** 任意の `Grep "test-support" modules/actor-core/Cargo.toml` のヒットは、actor-adaptor-std を dev-dep として有効化する `fraktor-actor-adaptor-std-rs = { ..., features = ["test-support"] }` のみに限られる（actor-adaptor-std 側の独立 feature への参照）
+
+#### Scenario: ダウンストリーム crate が actor-core の存在しない test-support feature を要求しない
+
+- **WHEN** workspace 内の任意の `Cargo.toml` (`modules/**/Cargo.toml`、`showcases/**/Cargo.toml`) を検査する
+- **THEN** `fraktor-actor-core-rs = { ..., features = [..., "test-support", ...] }` の形で actor-core の `test-support` を要求している行が存在しない
+- **AND** 同様に他 crate の `test-support` feature 定義 (`test-support = [...]`) において `"fraktor-actor-core-rs/test-support"` を forward する記述が存在しない

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/tasks.md
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/tasks.md
@@ -1,58 +1,58 @@
 ## 1. 事前確認
 
-- [ ] 1.1 ベースライン記録: `cargo test --workspace` および `cargo test --workspace --features test-support` 両方 pass を確認
-- [ ] 1.2 `Grep "feature = \"test-support\"" modules/actor-core/src/` で 0 件であることを確認 (step05 完了状態の検証)
-- [ ] 1.3 `Grep 'fraktor-actor-core-rs.*test-support' --include='Cargo.toml' modules/ showcases/` で全 8 ファイル列挙し、design.md の表と一致することを確認
+- [x] 1.1 ベースライン記録: `cargo test --workspace` および `cargo test --workspace --features test-support` 両方 pass を確認
+- [x] 1.2 `Grep "feature = \"test-support\"" modules/actor-core/src/` で 0 件であることを確認 (step05 完了状態の検証)
+- [x] 1.3 `Grep 'fraktor-actor-core-rs.*test-support' --include='Cargo.toml' modules/ showcases/` で全 8 ファイル列挙し、design.md の表と一致することを確認
 
 ## 2. Phase 1 — 下流 dev-dep の `actor-core features=["test-support"]` 削除 (8 ファイル)
 
 > redundant な dev-dep 行ごと削除する (Decision 3)。例外: `showcases/std/Cargo.toml` は `[dependencies]` のため行は残し `features = ["test-support"]` のみ削除。
 
-- [ ] 2.1 `modules/actor-adaptor-std/Cargo.toml`: dev-dep `fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }` 行ごと削除（前後の説明コメントも整合させる）
-- [ ] 2.2 `modules/cluster-core/Cargo.toml`: dev-dep 行ごと削除
-- [ ] 2.3 `modules/cluster-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
-- [ ] 2.4 `modules/persistence-core/Cargo.toml`: dev-dep 行ごと削除
-- [ ] 2.5 `modules/remote-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
-- [ ] 2.6 `modules/stream-core/Cargo.toml`: dev-dep 行ごと削除
-- [ ] 2.7 `modules/stream-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
-- [ ] 2.8 `showcases/std/Cargo.toml`: prod dep の `features = ["test-support"]` のみ削除（行は残す）
-- [ ] 2.9 各 crate ごとに `cargo test -p <crate>` で pass 確認
+- [x] 2.1 `modules/actor-adaptor-std/Cargo.toml`: dev-dep `fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }` 行ごと削除（前後の説明コメントも整合させる）
+- [x] 2.2 `modules/cluster-core/Cargo.toml`: dev-dep 行ごと削除
+- [x] 2.3 `modules/cluster-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
+- [x] 2.4 `modules/persistence-core/Cargo.toml`: dev-dep 行ごと削除
+- [x] 2.5 `modules/remote-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
+- [x] 2.6 `modules/stream-core/Cargo.toml`: dev-dep 行ごと削除
+- [x] 2.7 `modules/stream-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
+- [x] 2.8 `showcases/std/Cargo.toml`: prod dep の `features = ["test-support"]` のみ削除（行は残す）
+- [x] 2.9 各 crate ごとに `cargo test -p <crate>` で pass 確認
 
 ## 3. Phase 2 — 下流 crate の `test-support` feature 定義 forward 削除 (4 ファイル)
 
 > Decision 2 に従い、`"fraktor-actor-core-rs/test-support"` の forward を削除する。feature 自体は残す。
 
-- [ ] 3.1 `modules/actor-adaptor-std/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
-- [ ] 3.2 `modules/cluster-core/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
-- [ ] 3.3 `modules/cluster-adaptor-std/Cargo.toml:18`: `test-support = ["fraktor-cluster-core-rs/test-support", "fraktor-actor-core-rs/test-support"]` → `test-support = ["fraktor-cluster-core-rs/test-support"]`
-- [ ] 3.4 `modules/remote-adaptor-std/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
-- [ ] 3.5 `cargo test --workspace` で pass 確認 (この段階で actor-core 側はまだ `test-support = []` を持つので動く)
+- [x] 3.1 `modules/actor-adaptor-std/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- [x] 3.2 `modules/cluster-core/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- [x] 3.3 `modules/cluster-adaptor-std/Cargo.toml:18`: `test-support = ["fraktor-cluster-core-rs/test-support", "fraktor-actor-core-rs/test-support"]` → `test-support = ["fraktor-cluster-core-rs/test-support"]`
+- [x] 3.4 `modules/remote-adaptor-std/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- [x] 3.5 `cargo test --workspace` で pass 確認 (この段階で actor-core 側はまだ `test-support = []` を持つので動く)
 
 ## 4. Phase 3 — actor-core 本体から削除
 
-- [ ] 4.1 `modules/actor-core/Cargo.toml:19` の `test-support = []` 行を削除
-- [ ] 4.2 同 Cargo.toml 内の 8 個の `[[test]] required-features = ["test-support"]` 行を削除（`[[test]]` 本体は残す）
-- [ ] 4.3 `cargo test -p fraktor-actor-core-rs` で pass 確認
-- [ ] 4.4 `cargo test --workspace` で pass 確認
+- [x] 4.1 `modules/actor-core/Cargo.toml:19` の `test-support = []` 行を削除
+- [x] 4.2 同 Cargo.toml 内の 8 個の `[[test]] required-features = ["test-support"]` 行を削除（`[[test]]` 本体は残す）
+- [x] 4.3 `cargo test -p fraktor-actor-core-rs` で pass 確認
+- [x] 4.4 `cargo test --workspace` で pass 確認
 
 ## 5. Phase 4 — 全体検証
 
-- [ ] 5.1 `Grep "^test-support" modules/actor-core/Cargo.toml` で 0 件確認
-- [ ] 5.2 `Grep 'required-features.*test-support' modules/actor-core/Cargo.toml` で 0 件確認
-- [ ] 5.3 `Grep 'fraktor-actor-core-rs.*features.*test-support' --include='Cargo.toml' modules/ showcases/` で 0 件確認
-- [ ] 5.4 `Grep '"fraktor-actor-core-rs/test-support"' --include='Cargo.toml' modules/ showcases/` で 0 件確認
-- [ ] 5.5 `cargo build --workspace --no-default-features` で pass 確認
-- [ ] 5.6 `cargo build --workspace --all-features` で pass 確認 (actor-core/test-support がないので `--all-features` が actor-core に余分な feature を要求しないことを確認)
-- [ ] 5.7 `cargo test --workspace` で pass 確認
-- [ ] 5.8 `cargo test --workspace --features test-support` (もし誰かがこのコマンドを使った場合) は **エラーになる想定** — 確認のみ。これは期待動作
-- [ ] 5.9 `./scripts/ci-check.sh dylint` で lint pass
-- [ ] 5.10 `./scripts/ci-check.sh ai all` で全 CI 緑
+- [x] 5.1 `Grep "^test-support" modules/actor-core/Cargo.toml` で 0 件確認
+- [x] 5.2 `Grep 'required-features.*test-support' modules/actor-core/Cargo.toml` で 0 件確認
+- [x] 5.3 `Grep 'fraktor-actor-core-rs.*features.*test-support' --include='Cargo.toml' modules/ showcases/` で 0 件確認
+- [x] 5.4 `Grep '"fraktor-actor-core-rs/test-support"' --include='Cargo.toml' modules/ showcases/` で 0 件確認
+- [x] 5.5 `cargo build --workspace --no-default-features` で pass 確認
+- [x] 5.6 `cargo build --workspace --all-features` で pass 確認 (actor-core/test-support がないので `--all-features` が actor-core に余分な feature を要求しないことを確認)
+- [x] 5.7 `cargo test --workspace` で pass 確認
+- [x] 5.8 `cargo test -p fraktor-actor-core-rs --features test-support` は **エラーになる想定** (`the package 'fraktor-actor-core-rs' does not contain this feature: test-support`) — 確認のみ。これは期待動作。なお `cargo test --workspace --features test-support` は他 crate (actor-adaptor-std, cluster-core, cluster-adaptor-std, remote-adaptor-std) に空の `test-support` feature が残るため通る
+- [x] 5.9 `./scripts/ci-check.sh dylint` で lint pass
+- [x] 5.10 `./scripts/ci-check.sh ai all` で全 CI 緑
 
 ## 6. spec / docs 整合
 
-- [ ] 6.1 `openspec validate step06-remove-actor-core-test-support-feature --strict` で artifact 整合確認
-- [ ] 6.2 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 1 全体を「解消済み」に更新（責務 A/B/C + feature 削除すべて完了）
-- [ ] 6.3 step07 / step08 proposal の前提が変わらないことを確認（test-support 関連の言及があれば「解消済み」へ）
+- [x] 6.1 `openspec validate step06-remove-actor-core-test-support-feature --strict` で artifact 整合確認
+- [x] 6.2 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 1 全体を「解消済み」に更新（責務 A/B/C + feature 削除すべて完了）
+- [x] 6.3 step07 / step08 proposal の前提が変わらないことを確認（test-support 関連の言及があれば「解消済み」へ）
 
 ## 7. コミット・PR
 

--- a/openspec/changes/step06-remove-actor-core-test-support-feature/tasks.md
+++ b/openspec/changes/step06-remove-actor-core-test-support-feature/tasks.md
@@ -1,0 +1,65 @@
+## 1. 事前確認
+
+- [ ] 1.1 ベースライン記録: `cargo test --workspace` および `cargo test --workspace --features test-support` 両方 pass を確認
+- [ ] 1.2 `Grep "feature = \"test-support\"" modules/actor-core/src/` で 0 件であることを確認 (step05 完了状態の検証)
+- [ ] 1.3 `Grep 'fraktor-actor-core-rs.*test-support' --include='Cargo.toml' modules/ showcases/` で全 8 ファイル列挙し、design.md の表と一致することを確認
+
+## 2. Phase 1 — 下流 dev-dep の `actor-core features=["test-support"]` 削除 (8 ファイル)
+
+> redundant な dev-dep 行ごと削除する (Decision 3)。例外: `showcases/std/Cargo.toml` は `[dependencies]` のため行は残し `features = ["test-support"]` のみ削除。
+
+- [ ] 2.1 `modules/actor-adaptor-std/Cargo.toml`: dev-dep `fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }` 行ごと削除（前後の説明コメントも整合させる）
+- [ ] 2.2 `modules/cluster-core/Cargo.toml`: dev-dep 行ごと削除
+- [ ] 2.3 `modules/cluster-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
+- [ ] 2.4 `modules/persistence-core/Cargo.toml`: dev-dep 行ごと削除
+- [ ] 2.5 `modules/remote-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
+- [ ] 2.6 `modules/stream-core/Cargo.toml`: dev-dep 行ごと削除
+- [ ] 2.7 `modules/stream-adaptor-std/Cargo.toml`: dev-dep 行ごと削除
+- [ ] 2.8 `showcases/std/Cargo.toml`: prod dep の `features = ["test-support"]` のみ削除（行は残す）
+- [ ] 2.9 各 crate ごとに `cargo test -p <crate>` で pass 確認
+
+## 3. Phase 2 — 下流 crate の `test-support` feature 定義 forward 削除 (4 ファイル)
+
+> Decision 2 に従い、`"fraktor-actor-core-rs/test-support"` の forward を削除する。feature 自体は残す。
+
+- [ ] 3.1 `modules/actor-adaptor-std/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- [ ] 3.2 `modules/cluster-core/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- [ ] 3.3 `modules/cluster-adaptor-std/Cargo.toml:18`: `test-support = ["fraktor-cluster-core-rs/test-support", "fraktor-actor-core-rs/test-support"]` → `test-support = ["fraktor-cluster-core-rs/test-support"]`
+- [ ] 3.4 `modules/remote-adaptor-std/Cargo.toml:17`: `test-support = ["fraktor-actor-core-rs/test-support"]` → `test-support = []`
+- [ ] 3.5 `cargo test --workspace` で pass 確認 (この段階で actor-core 側はまだ `test-support = []` を持つので動く)
+
+## 4. Phase 3 — actor-core 本体から削除
+
+- [ ] 4.1 `modules/actor-core/Cargo.toml:19` の `test-support = []` 行を削除
+- [ ] 4.2 同 Cargo.toml 内の 8 個の `[[test]] required-features = ["test-support"]` 行を削除（`[[test]]` 本体は残す）
+- [ ] 4.3 `cargo test -p fraktor-actor-core-rs` で pass 確認
+- [ ] 4.4 `cargo test --workspace` で pass 確認
+
+## 5. Phase 4 — 全体検証
+
+- [ ] 5.1 `Grep "^test-support" modules/actor-core/Cargo.toml` で 0 件確認
+- [ ] 5.2 `Grep 'required-features.*test-support' modules/actor-core/Cargo.toml` で 0 件確認
+- [ ] 5.3 `Grep 'fraktor-actor-core-rs.*features.*test-support' --include='Cargo.toml' modules/ showcases/` で 0 件確認
+- [ ] 5.4 `Grep '"fraktor-actor-core-rs/test-support"' --include='Cargo.toml' modules/ showcases/` で 0 件確認
+- [ ] 5.5 `cargo build --workspace --no-default-features` で pass 確認
+- [ ] 5.6 `cargo build --workspace --all-features` で pass 確認 (actor-core/test-support がないので `--all-features` が actor-core に余分な feature を要求しないことを確認)
+- [ ] 5.7 `cargo test --workspace` で pass 確認
+- [ ] 5.8 `cargo test --workspace --features test-support` (もし誰かがこのコマンドを使った場合) は **エラーになる想定** — 確認のみ。これは期待動作
+- [ ] 5.9 `./scripts/ci-check.sh dylint` で lint pass
+- [ ] 5.10 `./scripts/ci-check.sh ai all` で全 CI 緑
+
+## 6. spec / docs 整合
+
+- [ ] 6.1 `openspec validate step06-remove-actor-core-test-support-feature --strict` で artifact 整合確認
+- [ ] 6.2 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 1 全体を「解消済み」に更新（責務 A/B/C + feature 削除すべて完了）
+- [ ] 6.3 step07 / step08 proposal の前提が変わらないことを確認（test-support 関連の言及があれば「解消済み」へ）
+
+## 7. コミット・PR
+
+> 本 change は **artifacts PR** (proposal/design/specs/tasks のみ) と **implementation PR** (本セクション) を分けて運用するか、変更が小さいため同一 PR で進めるかは判断する。design.md / spec の delta が小さいため同一 PR でも可。
+
+- [ ] 7.1 ブランチ作成: `step06-remove-actor-core-test-support-feature` (artifacts と impl を同 PR にする場合) または artifacts と `-impl` を分ける
+- [ ] 7.2 論理単位での commit (Phase 1 を crate ごとに分けるか、一括にするかは判断)
+- [ ] 7.3 push + PR 作成（base: main、title prefix `chore(actor-core):` または `refactor(actor-core):`）
+- [ ] 7.4 CI 全 pass + レビュー対応 + マージ
+- [ ] 7.5 archive (`/opsx:archive` または skill 経由)

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1220,8 +1220,8 @@ check_unit_sleep() {
 }
 
 run_actor_path_e2e() {
-  log_step "cargo +${DEFAULT_TOOLCHAIN} test -p fraktor-actor-core-rs --test actor_path_e2e --features test-support -- --nocapture"
-  run_cargo test -p fraktor-actor-core-rs --test actor_path_e2e --features test-support -- --nocapture || return 1
+  log_step "cargo +${DEFAULT_TOOLCHAIN} test -p fraktor-actor-core-rs --test actor_path_e2e -- --nocapture"
+  run_cargo test -p fraktor-actor-core-rs --test actor_path_e2e -- --nocapture || return 1
 }
 
 run_examples() {

--- a/showcases/std/Cargo.toml
+++ b/showcases/std/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 # 基本依存（全 example 共通）
-fraktor-actor-core-rs = { workspace = true, features = ["test-support"] }
+fraktor-actor-core-rs = { workspace = true }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-core-rs = { workspace = true, features = ["std-locks"] }
 critical-section = { workspace = true, features = ["std"] }


### PR DESCRIPTION
## Summary

Strategy B step06: drop the now-empty \`actor-core/test-support\` feature and all references in downstream Cargo.toml files. Final cleanup of the test-support feature retirement series (step01-step06).

## Background

After step01-step05, \`actor-core/test-support\` had become an empty (\`[]\`) feature with no remaining cfg references in \`actor-core/src/\`:

- Responsibility A (critical-section/std impl provider): retired in \`retire-actor-core-test-support-critical-section-impl\`
- Responsibility B (downstream test API): retired in step03 (publishers moved to actor-adaptor-std) + step05 (B-2 residue \`pub(crate)\`-ized)
- Responsibility C (internal API visibility expansion): retired in step05 (dual-cfg pattern eliminated)

Keeping the empty feature was a stale name with no behavior. This change removes the definition + all downstream references.

## Changes

**actor-core/Cargo.toml:**
- Drop \`test-support = []\` from \`[features]\`
- Drop 8 \`required-features = [\"test-support\"]\` lines from \`[[test]]\` sections (\`[[test]]\` bodies retained)

**Downstream crates (4 with forwards, 7 with redundant dev-deps, 1 with prod-dep):**
- Drop \`fraktor-actor-core-rs/test-support\` forward in 4 \`test-support\` feature definitions (actor-adaptor-std, cluster-core, cluster-adaptor-std, remote-adaptor-std). Their \`test-support\` features remain as empty \`[]\` (independent responsibility, out of scope)
- Drop redundant dev-deps \`fraktor-actor-core-rs = { workspace = true, features = [\"test-support\"] }\` in 7 crates (becomes identical to prod dep after feature removal)
- showcases/std (prod dep): drop \`features = [\"test-support\"]\` only (line retained)

**Docs / Spec:**
- \`docs/plan/2026-04-21-actor-core-critical-section-followups.md\`: mark 残課題 1 entirely resolved
- \`actor-test-driver-placement\` capability: add 2 Scenarios verifying actor-core/Cargo.toml has no test-support feature definition + downstream Cargo.toml does not reference the (non-existent) actor-core/test-support feature

## Verification

- \`cargo test --workspace\`: 4782 passed, 9 ignored (matches baseline)
- \`cargo build --workspace --no-default-features\`: pass
- \`cargo build -p fraktor-actor-core-rs --all-features\`: pass
- \`cargo test -p fraktor-actor-core-rs --features test-support\`: error as expected (\`the package 'fraktor-actor-core-rs' does not contain this feature: test-support\`)
- \`./scripts/ci-check.sh ai all\`: exit 0
- \`openspec validate step06-remove-actor-core-test-support-feature --strict\`: pass

## OpenSpec Change

\`openspec/changes/step06-remove-actor-core-test-support-feature/\` (proposal/design/specs/tasks). Will be archived after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the `fraktor-actor-core-rs` `test-support` feature and rewires multiple crates/CI to stop requesting it, which can break any remaining consumers that still pass `--features test-support` for actor-core or forward it transitively.
> 
> **Overview**
> Fully retires the now-empty `fraktor-actor-core-rs/test-support` feature by deleting its definition from `modules/actor-core/Cargo.toml` and removing the eight `[[test]] required-features = ["test-support"]` gates so actor-core integration tests always run.
> 
> Updates downstream crates and showcases to stop forwarding or enabling the removed feature (dropping redundant dev-deps and changing `test-support` feature definitions to no longer include `"fraktor-actor-core-rs/test-support"`), and adjusts `scripts/ci-check.sh` to run `actor_path_e2e` without `--features test-support`. Documentation and OpenSpec artifacts are updated to mark the follow-up as resolved and to add spec scenarios that mechanically forbid reintroducing `actor-core` `test-support` references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76633761b43807752167c3804efde654d80b470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * テストインフラストラクチャの依存関係を整理しました。複数のモジュールで不要なテスト機能の参照を削除し、ビルドプロセスを最適化しました。

* **Documentation**
  * テスト機能の整理完了状況をドキュメントに反映しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->