### PR TITLE
docs(actor-core): evaluate portable-atomic/critical-section need (step07)

### DIFF
--- a/docs/plan/2026-04-21-actor-core-critical-section-followups.md
+++ b/docs/plan/2026-04-21-actor-core-critical-section-followups.md
@@ -24,11 +24,21 @@
   - **完了** (`step05-hide-actor-core-internal-test-api`、2026-04-22): `Behavior::handle_*` (3)、`TypedActorContext::from_untyped`、`TickDriverBootstrap` 関連 (struct/method/re-export) を `pub(crate)` に縮小。dual-cfg pattern (`#[cfg(any(test, feature = "test-support"))] pub fn` + `#[cfg(not(...))] pub(crate) fn`) を全廃
 - feature 削除: **完了** (`step06-remove-actor-core-test-support-feature`、2026-04-22): `actor-core/Cargo.toml` から `test-support = []` 行と 8 個の `[[test]] required-features = ["test-support"]` を削除。下流 8 crate (`actor-adaptor-std`、`cluster-core`、`cluster-adaptor-std`、`persistence-core`、`remote-adaptor-std`、`stream-core`、`stream-adaptor-std`、`showcases/std`) の `Cargo.toml` から `fraktor-actor-core-rs/test-support` への参照も全廃。`actor-test-driver-placement` capability に検証 Scenario を追加し、再侵入を spec で機械的にブロック
 
-### 2. `portable-atomic` の `critical-section` feature 再評価
+### 2. `portable-atomic` の `critical-section` feature 再評価（解消済み）
 
-`actor-core/Cargo.toml:26` の `portable-atomic = { features = ["critical-section"] }` は組み込み 32-bit ターゲット向けの `AtomicU64` fallback として有効化されている。実際に組み込み 32-bit ターゲットでビルド・運用される実績があるか不明な場合は、std/64-bit 系のみ想定として `core::sync::atomic` への置換を検討する余地あり。
+**解消済み**: `step07-evaluate-portable-atomic-critical-section-need` change（2026-04-22）で評価完了。結論は **案 Y (現状維持)**。
 
-ただし、`actor-core` の他 16 ファイルで `portable_atomic` が使われており、影響範囲は広い。
+評価レポート: `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md`
+
+判定根拠:
+- CI が `thumbv8m.main-none-eabi` (32-bit ARMv8-M Mainline、Cortex-M33 等) で `actor-core` を check している (`scripts/ci-check.sh:1056`)
+- `thumbv8m.main` は AtomicU64 のハードウェアサポートを持たないため emulated atomic が必須
+- production code 内に `portable_atomic::AtomicU64` 利用が **8 ファイル** ある (test 除く)
+- 退役した瞬間に no-std CI ジョブが compile error で破綻する
+
+対応:
+- `actor-core/Cargo.toml:24` の `portable-atomic` 行に直前コメントで対象ターゲット (`thumbv8m.main`) と判定根拠 (8 ファイルの AtomicU64 利用) を記録、評価レポートへの参照を追加
+- step08 (`step08-retire-portable-atomic-critical-section`) は中止 (本評価で「退役不可」が確定したため)
 
 ### 3. `enqueue_from_isr` API 名と実装意図の乖離（解消済み）
 

--- a/docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md
+++ b/docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md
@@ -1,0 +1,153 @@
+# `portable-atomic/critical-section` feature 評価レポート
+
+調査 change: `step07-evaluate-portable-atomic-critical-section-need`
+作成日: 2026-04-22
+
+## サマリー
+
+`modules/actor-core/Cargo.toml:24` の以下の宣言を退役できるかを評価した:
+
+```toml
+portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }
+```
+
+**結論: 案 Y (現状維持) を強く推奨。**
+
+CI が `thumbv8m.main-none-eabi` (32-bit ARM Cortex-M33、ARMv8-M Mainline) で `actor-core` を `cargo check` しており、production code 内に `AtomicU64` の利用が **8 ファイル** ある。`thumbv8m.main` は 64-bit atomic のハードウェアサポートを持たないため、`portable-atomic/critical-section` による emulated atomic が必須。退役した瞬間に no-std CI ジョブが破綻する。
+
+## Phase 1: CI ターゲット棚卸し
+
+### 調査対象
+
+`.github/workflows/**.yml` および `scripts/ci-check.sh`。
+
+### 抽出結果
+
+| ターゲット triple | 利用箇所 | カテゴリ | AtomicU64 ハードサポート |
+|------------------|---------|---------|-----------------------|
+| ホスト (x86_64-unknown-linux-gnu / aarch64-apple-darwin など runner 依存) | `format`, `lint`, `test`, `docs`, `examples`, `no-std-host-*` | 64-bit | あり |
+| `thumbv8m.main-none-eabi` | `scripts/ci-check.sh:1056-1067` `run_no_std()` の `no-std-thumb-utils` / `no-std-thumb-core` | 32-bit ARMv8-M Mainline (Cortex-M33 等) | **なし** (emulation 必須) |
+
+### 補足: scripts/ci-check.sh:10 の THUMB_TARGETS 配列
+
+```bash
+THUMB_TARGETS=("thumbv6m-none-eabi" "thumbv8m.main-none-eabi")
+```
+
+- 両方とも 32-bit ARM、AtomicU64 ハードサポートなし
+- 実行 `run_no_std()` 内で使われているのは `thumbv8m.main-none-eabi` のみ (line 1056)
+- `thumbv6m-none-eabi` (Cortex-M0/M0+) は `run_embedded()` (line 1091〜) でコメントアウト中の future work
+- `THUMB_TARGETS` 配列が存在する事実自体が「組み込み 32-bit を想定対象に含めている」という方針表明
+
+### 結論 (Phase 1)
+
+CI が現役で組み込み 32-bit (`thumbv8m.main`) で `actor-core` を check しており、ターゲットは AtomicU64 のハードサポートを持たない。`portable-atomic/critical-section` の emulated atomic が **CI 通過のため必須**。
+
+## Phase 2: portable_atomic 利用 census
+
+### 抽出方法
+
+```bash
+rg -n 'use portable_atomic' modules/ --glob '*.rs' --glob '!**/tests.rs' --glob '!**/tests/*.rs'
+```
+
+production code (test ファイル除く) のみを対象。
+
+### actor-core 内 census
+
+| ファイル | symbol | 要求幅 | 代替候補 (`core::sync::atomic`) | 備考 |
+|---------|--------|-------|------------------------------|------|
+| `core/kernel/actor/actor_cell.rs:18` | `AtomicBool` | 1-bit | `core::sync::atomic::AtomicBool` (全ターゲット OK) | 32-bit 安全 |
+| `core/kernel/actor/actor_ref/base.rs:14` | `AtomicU64` | 64-bit | **代替不可** (32-bit ターゲットでは hardware なし) | thumbv8m で emulation 必須 |
+| `core/kernel/actor/fsm/machine.rs:8` | `AtomicU64` | 64-bit | **代替不可** | 同上 |
+| `core/kernel/actor/scheduler/tick_driver/tick_driver_trait.rs:6` | `AtomicU64` | 64-bit | **代替不可** | 同上 |
+| `core/kernel/actor/scheduler/tick_driver/tick_feed.rs:14` | `AtomicU64` | 64-bit | **代替不可** | 同上 |
+| `core/kernel/event/stream/actor_ref_subscriber.rs:6` | `AtomicU64` | 64-bit | **代替不可** | 同上 |
+| `core/kernel/routing/random_routing_logic.rs:6` | `AtomicU64` | 64-bit | **代替不可** | 同上 |
+| `core/kernel/system/state/system_state.rs:22` | `AtomicBool, AtomicU64` | 1-bit + 64-bit | AtomicBool は OK、`AtomicU64` 代替不可 | 同上 |
+| `core/typed/dsl/routing/group_router.rs:7` | `AtomicU64` | 64-bit | **代替不可** | 同上 |
+| `core/typed/dsl/routing/pool_router.rs:7` | `AtomicU64` | 64-bit | **代替不可** | 同上 |
+
+集計:
+- `AtomicU64` 利用ファイル数: **8 ファイル** (production)
+- `AtomicBool` のみのファイル数: 1 (`actor_cell.rs`)
+- `AtomicBool` + `AtomicU64`: 1 (`system_state.rs`)
+
+### stream-core 内 census
+
+| ファイル | symbol | 要求幅 | 代替候補 |
+|---------|--------|-------|---------|
+| `core/shape/port_id.rs:1` | `AtomicU64` | 64-bit | **代替不可** |
+| `core/impl/materialization/stream_handle_id.rs:1` | `AtomicU64` | 64-bit | **代替不可** |
+
+### utils-core 内 census
+
+| ファイル | symbol | 種別 |
+|---------|--------|------|
+| `core/sync/arc_shared.rs:13` | `portable_atomic_util::Arc` | `Arc` 代替 (atomic primitive ではない) |
+| `core/sync/weak_shared.rs:8` | `portable_atomic_util::Weak` | `Weak` 代替 (同上) |
+
+`portable_atomic_util` は `portable-atomic-util` クレート由来で、`portable-atomic/critical-section` feature とは別。`portable-atomic-util` が `portable-atomic` を依存として引き込み、その `portable-atomic` の `critical-section` feature 有効化要否は別途評価が必要だが、`utils-core` 経由で actor-core にも transitively つながっている。
+
+### 結論 (Phase 2)
+
+- production code 内の `AtomicU64` 利用は **少なくとも 10 ファイル** (actor-core 8 + stream-core 2)
+- いずれも 32-bit ARM (thumbv8m.main / thumbv6m) では hardware support なしで、`portable-atomic/critical-section` の emulated atomic 経由でのみビルド可能
+
+## Phase 3: 影響度評価
+
+Phase 1 と Phase 2 の結果から:
+
+- CI が `thumbv8m.main-none-eabi` を対象にしている → 組み込み 32-bit ターゲットが対象内
+- 利用箇所が 10 ファイルある → `AtomicU64` を必要とする箇所多数
+
+**ケース分類: B (維持必須)**
+
+`portable-atomic/critical-section` を退役すると:
+
+1. `cargo check -p fraktor-actor-core-rs --target thumbv8m.main-none-eabi` が compile error
+   - エラー例: `use portable_atomic::AtomicU64;` → portable-atomic の AtomicU64 が emulation なしでは 32-bit target で構築できない
+2. `scripts/ci-check.sh no-std` が fail
+3. CI ジョブ `Test (no_std)` が red
+
+退役は **不可**。
+
+## Phase 4: 利用実績調査
+
+ケース B (維持必須) が確定したため Phase 4 は **スキップ**。実利用報告の有無に関係なく、CI 自体が組み込み 32-bit 対応を要求している事実が決定的。
+
+## Decision Matrix
+
+| 選択肢 | 内容 | Pros | Cons | step08 で採るべき場合 |
+|--------|------|------|------|----------------------|
+| **X: 退役** | `portable-atomic/critical-section` feature を削除し、利用箇所を `core::sync::atomic` に置換 | 依存縮小、`critical-section` 推移依存解消 | **CI 即破綻** (no-std-thumb-core が compile error)、組み込み 32-bit 対応が損なわれる | 採用不可 (CI が組み込み対応を要求している現状では成立しない) |
+| **Y: 維持 ✓ (推奨)** | 現状維持。`portable-atomic/critical-section` feature を保持。Cargo.toml にコメントで根拠を残す | CI 通過、組み込み 32-bit 対応が維持される、step08 で扱う対象が消滅して Strategy B が論理的に閉じる | `critical-section` 推移依存が残る (が、これは組み込み対応の必然) | **本評価結果のケース B** |
+| **Z: 条件付き維持** | actor-core に feature flag (例: `embedded-atomic-fallback`) を追加し、`portable-atomic/critical-section` を opt-in 化 | std/64-bit 系のデフォルトで `critical-section` 依存が消える | feature 設計コスト、CI で opt-in を毎回指定する保守コスト、誤用 (opt-in 忘れ) で組み込み運用者が壊れる | 「std/64-bit デフォルトで critical-section 依存を完全に絶ちたい」という強い動機があり、かつ CI / utils 側でも整合できる場合のみ。本 change のスコープ外 |
+
+## Recommendation
+
+**案 Y (現状維持) を採用**。理由:
+
+1. CI が `thumbv8m.main-none-eabi` で `actor-core` を check している (scripts/ci-check.sh:1056)
+2. production code に `AtomicU64` 利用が 10 ファイル存在する
+3. 退役した瞬間に no-std CI が compile error で fail する
+4. `THUMB_TARGETS` 配列の存在 (scripts/ci-check.sh:10) が「組み込み 32-bit を想定対象に含む」という方針表明として機能している
+
+step08 (`step08-retire-portable-atomic-critical-section`) は **中止** すべき。中止理由: 本評価で「組み込み 32-bit 対応が CI 上必須であり、退役すると即破綻する」と確定したため。
+
+ただし、本評価で判明した「歴史的根拠が Cargo.toml に残っていない」状態は問題なので、以下の最小限の改善は本 change で実施:
+
+- `modules/actor-core/Cargo.toml:24` の `portable-atomic` 行に **直前コメント** で「`thumbv8m.main` 等の 32-bit 組み込みで `AtomicU64` を fallback 提供するため、`critical-section` feature が必須」と記録
+- 評価レポート (本ファイル) への参照を Cargo.toml コメント末尾に追記
+
+これにより:
+- 将来の contributor が「この feature は本当に必要か?」と疑問に思った際、本評価レポートを参照して結論を得られる
+- `actor-lock-construction-governance` capability の新規 Scenario「low-level utility crate の feature 指定は対象ターゲット / ユースケースが明示されている」を満たす状態になる
+
+## step08 へのハンドオフ
+
+step08 は **中止** (proposal の design 段階で「中止判断」を明記して archive、または proposal を archive に直接移動)。
+
+中止理由メモを step08 archive 時に proposal 末尾へ追記:
+
+> step07 評価により、`portable-atomic/critical-section` feature は CI 対象の `thumbv8m.main-none-eabi` で actor-core 内 AtomicU64 を構築するため必須と確認された (scripts/ci-check.sh:1056)。退役した場合 no-std CI ジョブが compile error で fail するため、本 change は中止する。詳細は `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md` を参照。

--- a/modules/actor-core/Cargo.toml
+++ b/modules/actor-core/Cargo.toml
@@ -21,6 +21,11 @@ alloc-metrics = []
 async-trait = { workspace = true }
 fraktor-utils-core-rs = { workspace = true, default-features = false, features = ["alloc", "unsize"] }
 heapless = { workspace = true, default-features = false, features = ["portable-atomic"] }
+# `critical-section` feature は `thumbv8m.main-none-eabi` 等の 32-bit ARM (Cortex-M)
+# ターゲットで `AtomicU64` を critical-section ベースで emulation するために必須。
+# CI が `thumbv8m.main` で actor-core を check しており (scripts/ci-check.sh:1056)、
+# production code 内で `portable_atomic::AtomicU64` を 8 ファイル使っている。
+# 詳細評価: docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md
 portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }
 portable-atomic-util = { workspace = true, default-features = false, features = ["alloc"] }
 cortex-m = { workspace = true, optional = true }

--- a/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/design.md
+++ b/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/design.md
@@ -1,0 +1,153 @@
+## Context
+
+`modules/actor-core/Cargo.toml:24` に以下が宣言されている:
+
+```toml
+portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }
+```
+
+`portable-atomic/critical-section` feature は、`AtomicU64` などの幅広 atomic を **ハードウェアサポートなしのターゲット** で fallback 提供するため `critical-section` ベースの emulated atomic を使う。これにより組み込み 32-bit (例: `thumbv6m-none-eabi`、`riscv32i-unknown-none-elf`) でも `AtomicU64` が使えるようになる。
+
+ただし以下が未確認:
+
+- fraktor-rs は実際に組み込み 32-bit ターゲットを CI / 配布対象にしているか
+- 利用者が組み込み環境で運用している実例があるか
+- `actor-core/src/` 内の `portable_atomic::Atomic*` 利用箇所はどの幅 (`U64` / `Usize` / `U32`) を要求しているか
+- 仮にすべて 32-bit 幅で済むなら、組み込み 32-bit ターゲットでも `core::sync::atomic` で代替可能 (= `portable-atomic` 自体不要 or `critical-section` feature 不要)
+
+`portable-atomic/critical-section` feature が **真に必要か否か** を本 change で評価し、step08 で実施する変更 (退役 / 維持 / 条件付き維持) を確定させる。本 change は **コードを一切変更しない調査 change**。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- fraktor-rs が CI / 配布対象としているターゲット集合を棚卸し
+- workspace 全体で `portable_atomic::Atomic*` が使われている箇所と要求幅を列挙
+- `core::sync::atomic` 代替可否を一次評価
+- 退役 / 維持 / 条件付き維持の意思決定マトリクスを作成
+- step08 で採るべきアクションを Recommendation として明示
+- 評価成果物を `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md` として残す
+
+**Non-Goals:**
+
+- コード変更 (`Cargo.toml` 修正、`core::sync::atomic` 置換は step08 のスコープ)
+- `portable-atomic` 本体依存の削除 (`portable-atomic` は `heapless` 等から推移的にも引き込まれるため、feature 指定だけが対象)
+- 組み込みクロスコンパイル実機検証 (CI 拡張やローカル `cargo build --target ...` 検証は step08)
+- step01〜step06 で扱った test-support / spin / critical-section 関連の再評価 (完了済み)
+
+## Investigation Methodology
+
+### Phase 1: ターゲット棚卸し (15 分目安)
+
+`.github/workflows/**.yml` を全数走査し、以下を抽出:
+
+- `cargo check / build / test` の `--target` オプションに登場するターゲット triple
+- `dtolnay/rust-toolchain` の `targets:` 入力
+- `cross` / `cargo-zigbuild` 等の言及
+- 組み込み系の言及 (`thumbv*`、`riscv32*`、`avr`、`xtensa`、`ARMv6-M` 等)
+
+成果: ターゲット triple のリストを `evaluation.md` に記録。AtomicU64 ハードサポート有無で分類:
+
+- 64-bit ターゲット (x86_64-*、aarch64-*) → ハードサポートあり
+- 32-bit ターゲットで AtomicU64 サポート (i686-pc-windows-* 等) → ハードサポートあり
+- 32-bit ターゲットで AtomicU64 emulation 必要 (thumbv6m、thumbv7m、riscv32i 等) → `portable-atomic/critical-section` 必要
+
+### Phase 2: 利用箇所の census (30 分目安)
+
+```bash
+rg -n 'portable_atomic::' modules/ --glob '*.rs'
+rg -n 'use portable_atomic' modules/ --glob '*.rs'
+```
+
+各ヒット箇所について以下を表で記録:
+
+| ファイル | symbol | 要求幅 | 代替候補 (`core::sync::atomic`) | 備考 |
+
+要求幅:
+
+- `AtomicU64` → 64-bit、emulation 対象
+- `AtomicUsize` → ターゲット幅依存 (32-bit ターゲットでは `core::sync::atomic::AtomicUsize` で十分)
+- `AtomicU32` / `AtomicI32` → 32-bit、すべてのターゲットで `core::sync::atomic` あり
+- `AtomicBool` / `AtomicPtr` → 全ターゲット OK
+
+代替候補列で「`core::sync::atomic::AtomicXX` で代替可能」「不可 (理由)」を判定。
+
+### Phase 3: 影響度評価 (10 分目安)
+
+Phase 1 と Phase 2 の結果から、`portable-atomic/critical-section` feature を退役した場合の影響を評価:
+
+- ケース A: すべての利用箇所が 32-bit 幅で済む → 退役可
+- ケース B: 1 箇所でも `AtomicU64` 利用があり、かつ 32-bit 組み込みターゲットが対象に含まれる → 維持必須
+- ケース C: `AtomicU64` 利用はあるが 32-bit 組み込みターゲットが対象外 → 条件付き維持 / 退役可 (将来需要の判断)
+
+### Phase 4: 利用実績調査 (任意、15 分目安)
+
+GitHub の issues / discussions / README / 配布先 (crates.io download targets) から、組み込みユーザの存在を確認:
+
+- `gh issue list --search "embedded"` 等
+- README / docs の embedded 言及
+- crates.io の download stats (ターゲット別は出ないが、量で組み込み比率を推測)
+
+「実利用報告ゼロ」なら退役寄り、「実利用報告あり」なら維持寄り。
+
+## Decision Matrix
+
+評価レポート末尾に以下のマトリクスを記載する:
+
+| 選択肢 | 内容 | Pros | Cons | step08 で採るべき場合 |
+|--------|------|------|------|----------------------|
+| **X: 退役** | `portable-atomic/critical-section` feature を削除し、必要なら利用箇所を `core::sync::atomic` に置換 | 依存縮小、`critical-section` 推移依存解消、組み込み非対象が明文化される | 将来 32-bit 組み込み対応時に再導入コスト発生 | ケース A (利用箇所がすべて 32-bit 幅で済む) または ケース C で組み込み非対象を確定 |
+| **Y: 維持** | 現状維持。`portable-atomic/critical-section` feature を保持 | 32-bit 組み込み運用が壊れない、将来的な拡張余地を保持 | `critical-section` 推移依存が残る、emulation コストが乗る | ケース B (32-bit 組み込みが対象、かつ `AtomicU64` 利用あり) |
+| **Z: 条件付き維持** | actor-core feature flag (例: `embedded-atomic-fallback`) で `portable-atomic/critical-section` を opt-in 化 | std/64-bit 系のデフォルト使用感を改善、組み込み利用者は opt-in | feature 設計コスト、誤用 (opt-in 忘れ) リスク | ケース C で「組み込み対応の意思はあるが現状非対象」 |
+
+各列の判定根拠を Phase 1〜4 の結果から導出。
+
+## Spec Delta Rationale
+
+本 change は **純粋な調査 change** (Non-Goals でコード変更を明示禁止) のため、spec delta は形式的な最小限にとどめる (proposal 案 C)。実質的な spec 変更は step08 で行う。
+
+最小限 delta として `actor-lock-construction-governance` capability の既存 Requirement「actor-* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない」に **Scenario を 1 件追加** する:
+
+- low-level utility crate (`portable-atomic` 等) の feature 指定は用途ターゲットが明示されなければならない
+- 評価レポート (`docs/plan/`) または Cargo.toml コメントで justification されている
+
+これにより「将来また同種の `features = [...]` を追加するとき、根拠を残す」というガードが spec で機械的に検証可能になる。
+
+## Output Artifacts
+
+- `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md`:
+  - Investigation summary (Phase 1〜4 の結果)
+  - Decision matrix (上記表)
+  - Recommendation (X / Y / Z のいずれか + 根拠)
+  - step08 へのハンドオフ (具体的なアクションリスト)
+- 上記レポートへの参照を `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 2 から追加
+
+## Risks / Trade-offs
+
+- **[Risk] 評価が表面的に終わり step08 判断を誤る**:
+  - Mitigation: Phase 2 (census) で全ヒット箇所を網羅的に列挙、要求幅を機械的に判定。曖昧な箇所は `[要確認]` マークを付けて step08 で再確認
+- **[Trade-off] Phase 4 (利用実績調査) はコストが見合わない可能性**:
+  - 受容: 「実績ゼロ → 退役」は弱い根拠。Phase 1〜3 で結論が出るならスキップ可。レポートに「Phase 4 はスキップ」と明記
+- **[Risk] `portable_atomic::AtomicU64` 利用が 1 箇所でもあると組み込み非対応を確定する判断が必要**:
+  - Mitigation: ケース C のための条件付き維持 (案 Z) を Decision Matrix に含める。step08 で詳細決定
+
+## Migration Plan
+
+調査 change のため migration なし。以下の順序で実施:
+
+1. **Phase 1**: CI ターゲット棚卸し → `.github/workflows/` を grep
+2. **Phase 2**: portable_atomic 利用 census → `rg portable_atomic`
+3. **Phase 3**: 代替可否評価 → 表を埋める
+4. **Phase 4** (任意): 利用実績調査
+5. **レポート執筆**: `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md`
+6. **Decision Matrix**: 上記表を埋める
+7. **Recommendation**: X / Y / Z を確定
+8. **Spec delta apply** (案 C minimal Scenario 追加)
+9. **Validate**: `openspec validate step07-... --strict`
+10. **docs/plan の hand-off メモ更新**: 残課題 2 に評価レポートへのリンクを追加
+11. **Commit / PR / merge / archive**
+
+## Open Questions
+
+- 評価結果が「ケース C: 条件付き維持」になった場合、step08 では feature flag 設計の追加コストが発生する。本 change の Recommendation では「X / Y / Z のいずれか + 設計概略」までに留め、詳細設計は step08 design.md で行う
+- step08 が「中止 (= 維持)」になった場合、本 change の Recommendation は「Y: 維持。理由は ... 」で完結し、step08 は archive 前に proposal で「中止判断」を明記して archive

--- a/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/proposal.md
+++ b/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-`modules/actor-core/Cargo.toml:25` の `portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }` は、組み込み 32-bit ターゲット（`armv7m` など `AtomicU64` 非対応プラットフォーム）向けの `AtomicU64` fallback を有効化する目的で `critical-section` feature を指定している。
+`modules/actor-core/Cargo.toml:24` の `portable-atomic = { workspace = true, default-features = false, features = ["critical-section"] }` は、組み込み 32-bit ターゲット（`armv7m` など `AtomicU64` 非対応プラットフォーム）向けの `AtomicU64` fallback を有効化する目的で `critical-section` feature を指定している。
 
 しかし以下が未確認のまま:
 - fraktor-rs が実際に組み込み 32-bit ターゲットでビルド・運用される実績はあるか
@@ -36,12 +36,7 @@ Strategy B の第 7 ステップ（評価）。step08 と合わせて `portable-
 - なし（調査 change であり、capability の新設は不要）
 
 ### Modified Capabilities
-- なし
-
-OpenSpec validation 要件を満たすため、design / specs フェーズで最低 1 件の delta を設計する。候補:
-- 案 A: 既存 `compile-time-lock-backend` に Scenario を追加（atomic backend の決定手順として）
-- 案 B: 新規 capability `actor-core-dependency-governance` を ADDED し、「低レベル依存の feature 指定は用途ターゲットが明示されなければならない」ルールを明文化
-- 案 C: 本 change は純粋な調査 change として spec delta を最小限にとどめ、step08 側で必要な spec 変更をまとめて行う
+- `actor-lock-construction-governance`: 既存 Requirement「actor-* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない」に MUST 節を追加し、low-level utility crate（`portable-atomic` 等）の feature 指定は対象ターゲット / ユースケースが Cargo.toml コメントまたは `docs/plan/` 評価レポートで明示されなければならない、というルールを明文化。Scenario「low-level utility crate の feature 指定は対象ターゲット / ユースケースが明示されている」を 1 件追加（案 C: 最小限）
 
 ## Impact
 

--- a/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/specs/actor-lock-construction-governance/spec.md
+++ b/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/specs/actor-lock-construction-governance/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: actor-* の Cargo.toml は primitive lock crate を non-optional な直接依存として宣言してはならない
+
+`actor-*` クレートの `Cargo.toml` は、`critical-section`、`spin`、`parking_lot` などの primitive lock crate を `[dependencies]` に直接依存として宣言してはならない（MUST NOT）。これらの crate への依存は、`utils-core` を通した推移的依存として表現されなければならない（MUST）。
+
+ただし以下は例外として許可する:
+
+- `portable-atomic` のような low-level utility crate が引き込む推移的依存
+- 各クレートの `[dev-dependencies]` に test/bench 用の impl provider 取得目的で記述される `critical-section = { features = ["std"] }` 等のエントリ（production 依存ではないため `[dependencies]` 直接宣言禁止には該当しない）
+- `showcases/std` のような実行バイナリ crate の `[dependencies]` における impl provider 取得目的の記述（バイナリ側が impl 選択責任を持つ標準作法に基づく）
+
+impl provider 取得は各バイナリが `[dev-dependencies]` または `[dependencies]` で直接宣言する形に統一する。
+
+加えて、`actor-*` クレートが low-level utility crate（`portable-atomic` 等）を直接依存として宣言する際に **特定 feature を指定する場合**、その feature 指定は単独で正当化されなければならない（MUST）。具体的には、Cargo.toml コメントまたは `docs/plan/` 配下の評価レポート（例: `docs/plan/YYYY-MM-DD-<topic>-evaluation.md`）への参照によって、その feature を有効化する **対象ターゲット** または **ユースケース** が明示されなければならない。「歴史的な理由でついている」状態の feature 指定を残してはならない（MUST NOT）。
+
+#### Scenario: actor-core の Cargo.toml は critical-section を `[dependencies]` 直接依存として持たない
+
+- **WHEN** `modules/actor-core/Cargo.toml` の `[dependencies]` セクションで `critical-section` エントリを検査する
+- **THEN** `critical-section` エントリは存在しない
+- **AND** `critical-section` への依存は `portable-atomic = { features = ["critical-section"] }` のような推移的経路でのみ表現される
+- **AND** `[dev-dependencies]` には `critical-section = { workspace = true, features = ["std"] }` が impl provider 取得目的で記述されてよい（actor-core 自身の `cargo test` で必要）
+
+#### Scenario: actor-core の Cargo.toml は spin を `[dependencies]` 直接依存として持たない
+
+- **WHEN** `modules/actor-core/Cargo.toml` の `[dependencies]` セクションで `spin` エントリを検査する
+- **THEN** `spin` エントリは存在しない
+- **AND** `spin` への依存は `fraktor-utils-core-rs` 経由の推移的経路でのみ表現される
+- **AND** `actor-core` の production code 内の write-once + lock-free read 用途（旧 `spin::Once<T>` 利用箇所）は `fraktor-utils-core-rs` が提供する `SyncOnce<T>` 抽象を通して構築される
+
+#### Scenario: actor-* の他クレートも同じ規約に従う
+
+- **WHEN** `fraktor-actor-adaptor-std-rs`、`fraktor-cluster-*-rs`、`fraktor-remote-*-rs`、`fraktor-stream-*-rs`、`fraktor-persistence-*-rs` の `Cargo.toml` を読む
+- **THEN** いずれも `critical-section`、`spin`、`parking_lot` を `[dependencies]` 直接宣言として持たない
+- **AND** これらのクレートが同期プリミティブを必要とする場合は `fraktor-utils-core-rs` 経由で取得する
+- **AND** test/bench で `critical-section` の `std` impl が必要な場合は `[dev-dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を直接記述する
+
+#### Scenario: 各バイナリは impl provider を直接宣言する
+
+- **WHEN** `actor-*` 配下のテスト（`[[test]]`）、bench、または `showcases/std` 等の実行バイナリ crate が `critical-section` の impl を必要とする
+- **THEN** 当該 crate は `[dev-dependencies]` または `[dependencies]` に `critical-section = { workspace = true, features = ["std"] }` を直接記述する
+- **AND** `actor-*` の library crate の feature flag（例: `test-support`）を経由した自動配給には依存しない
+
+#### Scenario: low-level utility crate の feature 指定は対象ターゲット / ユースケースが明示されている
+
+- **WHEN** `actor-*` クレートの `Cargo.toml` に `portable-atomic = { workspace = true, ..., features = [...] }` のような low-level utility crate の feature 指定が存在する
+- **THEN** その feature 指定の正当化が以下のいずれかで残されている:
+  - Cargo.toml の **直前または直後のコメント** で対象ターゲット (例: 「`thumbv6m-none-eabi` で `AtomicU64` を fallback 提供するため」) または用途 (例: 「`heapless` の portable-atomic 互換性確保のため」) が一文で説明されている
+  - `docs/plan/YYYY-MM-DD-<topic>-evaluation.md` の評価レポートへの参照がコメントに含まれている
+- **AND** 「歴史的な理由」「過去の change の名残」だけが理由で feature が残存している状態は許されない
+- **AND** 評価レポートが存在する場合は当該レポート内で「維持」の根拠 (該当ターゲット、該当 atomic 幅、代替不可の理由) が示されている

--- a/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/tasks.md
+++ b/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/tasks.md
@@ -1,0 +1,59 @@
+## 1. Phase 1 — CI ターゲット棚卸し
+
+- [ ] 1.1 `.github/workflows/` 配下の `**.yml` を全数走査し、`--target` / `targets:` / `cross` / `cargo-zigbuild` の言及を抽出
+- [ ] 1.2 抽出したターゲット triple を一覧化し、AtomicU64 ハードサポート有無で 3 分類 (64-bit / 32-bit hard / 32-bit emulation 必要)
+- [ ] 1.3 評価レポートに「Phase 1: CI ターゲット棚卸し」セクションとして記録
+
+## 2. Phase 2 — portable_atomic 利用 census
+
+- [ ] 2.1 `rg -n 'portable_atomic::' modules/ --glob '*.rs'` で全ヒット箇所を列挙
+- [ ] 2.2 `rg -n 'use portable_atomic' modules/ --glob '*.rs'` で import 形式の参照も列挙
+- [ ] 2.3 各ヒットを表化: `| ファイル | symbol | 要求幅 | 代替候補 (core::sync::atomic) | 備考 |`
+- [ ] 2.4 要求幅判定: `AtomicU64` / `AtomicUsize` / `AtomicU32` / `AtomicI32` / `AtomicBool` / `AtomicPtr` のどれか
+- [ ] 2.5 代替候補列に「`core::sync::atomic::AtomicXX` で代替可能」「不可 (理由)」を記入
+- [ ] 2.6 評価レポートに「Phase 2: 利用 census」セクションとして記録
+
+## 3. Phase 3 — 影響度評価
+
+- [ ] 3.1 Phase 1 + Phase 2 の結果から、`portable-atomic/critical-section` 退役時の影響をケース分類:
+  - ケース A: すべての利用箇所が 32-bit 幅で済む → 退役可
+  - ケース B: 1 箇所でも `AtomicU64` 利用があり、かつ 32-bit 組み込みターゲットが対象 → 維持必須
+  - ケース C: `AtomicU64` 利用はあるが 32-bit 組み込みターゲットが対象外 → 条件付き維持 / 退役可
+- [ ] 3.2 確定ケースを評価レポートに記録
+
+## 4. Phase 4 — 利用実績調査 (任意、結論に必要なら実施)
+
+- [ ] 4.1 GitHub issues / discussions で "embedded" / "no_std" 関連の言及を軽く確認 (`gh issue list --search ...`)
+- [ ] 4.2 README / docs で組み込み環境の言及を確認
+- [ ] 4.3 評価レポートに「Phase 4: 利用実績調査」セクションを追加 (スキップした場合は明記)
+
+## 5. Decision Matrix と Recommendation 作成
+
+- [ ] 5.1 評価レポートに Decision Matrix (X: 退役 / Y: 維持 / Z: 条件付き維持) を表として記載
+- [ ] 5.2 Phase 1〜3 (4) の結果から **Recommendation** (X / Y / Z のいずれか + 根拠) を執筆
+- [ ] 5.3 step08 で採るべきアクション (具体的な commit / Cargo.toml 修正候補など) を Recommendation セクションに列挙
+
+## 6. 評価レポート完成
+
+- [ ] 6.1 `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md` を完成 (Phase 1〜5 + Recommendation を含む)
+- [ ] 6.2 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 2 から本評価レポートへのリンクを追加
+- [ ] 6.3 step08 proposal を確認し、本評価レポートの Recommendation を反映 (中止判断含む)
+
+## 7. Spec delta apply
+
+- [ ] 7.1 `openspec/specs/actor-lock-construction-governance/spec.md` の MODIFIED Requirement を確認し、新規 Scenario「low-level utility crate の feature 指定は対象ターゲット / ユースケースが明示されている」を main spec に sync (本 change archive 時に実施)
+- [ ] 7.2 新規 Scenario が要求する justification (Cargo.toml コメント or 評価レポート参照) を `modules/actor-core/Cargo.toml` の `portable-atomic` 行に追加 (※ コード変更は本 change の Non-Goals に該当するが、Scenario 違反になるため最小限のコメント追加は本 change で行う)
+
+## 8. 全体検証
+
+- [ ] 8.1 `openspec validate step07-evaluate-portable-atomic-critical-section-need --strict` で artifact 整合確認
+- [ ] 8.2 `cargo test --workspace` (コード変更は Cargo.toml コメントのみのため pass する想定)
+- [ ] 8.3 `./scripts/ci-check.sh ai all` で全 CI 緑
+
+## 9. コミット・PR
+
+- [ ] 9.1 ブランチ作成: `step07-evaluate-portable-atomic-critical-section-need`
+- [ ] 9.2 論理単位での commit (artifacts / 評価レポート / Cargo.toml コメント / docs/plan 更新)
+- [ ] 9.3 push + PR 作成 (base: main、title prefix `docs(actor-core):` または `chore(actor-core):`)
+- [ ] 9.4 CI 全 pass + レビュー対応 + マージ
+- [ ] 9.5 archive (`/opsx:archive` または skill 経由)

--- a/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/tasks.md
+++ b/openspec/changes/step07-evaluate-portable-atomic-critical-section-need/tasks.md
@@ -1,54 +1,54 @@
 ## 1. Phase 1 — CI ターゲット棚卸し
 
-- [ ] 1.1 `.github/workflows/` 配下の `**.yml` を全数走査し、`--target` / `targets:` / `cross` / `cargo-zigbuild` の言及を抽出
-- [ ] 1.2 抽出したターゲット triple を一覧化し、AtomicU64 ハードサポート有無で 3 分類 (64-bit / 32-bit hard / 32-bit emulation 必要)
-- [ ] 1.3 評価レポートに「Phase 1: CI ターゲット棚卸し」セクションとして記録
+- [x] 1.1 `.github/workflows/` 配下の `**.yml` を全数走査し、`--target` / `targets:` / `cross` / `cargo-zigbuild` の言及を抽出
+- [x] 1.2 抽出したターゲット triple を一覧化し、AtomicU64 ハードサポート有無で 3 分類 (64-bit / 32-bit hard / 32-bit emulation 必要)
+- [x] 1.3 評価レポートに「Phase 1: CI ターゲット棚卸し」セクションとして記録
 
 ## 2. Phase 2 — portable_atomic 利用 census
 
-- [ ] 2.1 `rg -n 'portable_atomic::' modules/ --glob '*.rs'` で全ヒット箇所を列挙
-- [ ] 2.2 `rg -n 'use portable_atomic' modules/ --glob '*.rs'` で import 形式の参照も列挙
-- [ ] 2.3 各ヒットを表化: `| ファイル | symbol | 要求幅 | 代替候補 (core::sync::atomic) | 備考 |`
-- [ ] 2.4 要求幅判定: `AtomicU64` / `AtomicUsize` / `AtomicU32` / `AtomicI32` / `AtomicBool` / `AtomicPtr` のどれか
-- [ ] 2.5 代替候補列に「`core::sync::atomic::AtomicXX` で代替可能」「不可 (理由)」を記入
-- [ ] 2.6 評価レポートに「Phase 2: 利用 census」セクションとして記録
+- [x] 2.1 `rg -n 'portable_atomic::' modules/ --glob '*.rs'` で全ヒット箇所を列挙
+- [x] 2.2 `rg -n 'use portable_atomic' modules/ --glob '*.rs'` で import 形式の参照も列挙
+- [x] 2.3 各ヒットを表化: `| ファイル | symbol | 要求幅 | 代替候補 (core::sync::atomic) | 備考 |`
+- [x] 2.4 要求幅判定: `AtomicU64` / `AtomicUsize` / `AtomicU32` / `AtomicI32` / `AtomicBool` / `AtomicPtr` のどれか
+- [x] 2.5 代替候補列に「`core::sync::atomic::AtomicXX` で代替可能」「不可 (理由)」を記入
+- [x] 2.6 評価レポートに「Phase 2: 利用 census」セクションとして記録
 
 ## 3. Phase 3 — 影響度評価
 
-- [ ] 3.1 Phase 1 + Phase 2 の結果から、`portable-atomic/critical-section` 退役時の影響をケース分類:
+- [x] 3.1 Phase 1 + Phase 2 の結果から、`portable-atomic/critical-section` 退役時の影響をケース分類:
   - ケース A: すべての利用箇所が 32-bit 幅で済む → 退役可
   - ケース B: 1 箇所でも `AtomicU64` 利用があり、かつ 32-bit 組み込みターゲットが対象 → 維持必須
   - ケース C: `AtomicU64` 利用はあるが 32-bit 組み込みターゲットが対象外 → 条件付き維持 / 退役可
-- [ ] 3.2 確定ケースを評価レポートに記録
+- [x] 3.2 確定ケースを評価レポートに記録
 
 ## 4. Phase 4 — 利用実績調査 (任意、結論に必要なら実施)
 
-- [ ] 4.1 GitHub issues / discussions で "embedded" / "no_std" 関連の言及を軽く確認 (`gh issue list --search ...`)
-- [ ] 4.2 README / docs で組み込み環境の言及を確認
-- [ ] 4.3 評価レポートに「Phase 4: 利用実績調査」セクションを追加 (スキップした場合は明記)
+- [x] 4.1 GitHub issues / discussions で "embedded" / "no_std" 関連の言及を軽く確認 (`gh issue list --search ...`) — **スキップ** (Phase 3 でケース B 確定、結論に必要なし)
+- [x] 4.2 README / docs で組み込み環境の言及を確認 — **スキップ** (同上)
+- [x] 4.3 評価レポートに「Phase 4: 利用実績調査」セクションを追加 (スキップした場合は明記)
 
 ## 5. Decision Matrix と Recommendation 作成
 
-- [ ] 5.1 評価レポートに Decision Matrix (X: 退役 / Y: 維持 / Z: 条件付き維持) を表として記載
-- [ ] 5.2 Phase 1〜3 (4) の結果から **Recommendation** (X / Y / Z のいずれか + 根拠) を執筆
-- [ ] 5.3 step08 で採るべきアクション (具体的な commit / Cargo.toml 修正候補など) を Recommendation セクションに列挙
+- [x] 5.1 評価レポートに Decision Matrix (X: 退役 / Y: 維持 / Z: 条件付き維持) を表として記載
+- [x] 5.2 Phase 1〜3 (4) の結果から **Recommendation** (X / Y / Z のいずれか + 根拠) を執筆
+- [x] 5.3 step08 で採るべきアクション (具体的な commit / Cargo.toml 修正候補など) を Recommendation セクションに列挙
 
 ## 6. 評価レポート完成
 
-- [ ] 6.1 `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md` を完成 (Phase 1〜5 + Recommendation を含む)
-- [ ] 6.2 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 2 から本評価レポートへのリンクを追加
-- [ ] 6.3 step08 proposal を確認し、本評価レポートの Recommendation を反映 (中止判断含む)
+- [x] 6.1 `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md` を完成 (Phase 1〜5 + Recommendation を含む)
+- [x] 6.2 `docs/plan/2026-04-21-actor-core-critical-section-followups.md` 残課題 2 から本評価レポートへのリンクを追加
+- [x] 6.3 step08 proposal を確認し、本評価レポートの Recommendation を反映 (中止判断含む)
 
 ## 7. Spec delta apply
 
 - [ ] 7.1 `openspec/specs/actor-lock-construction-governance/spec.md` の MODIFIED Requirement を確認し、新規 Scenario「low-level utility crate の feature 指定は対象ターゲット / ユースケースが明示されている」を main spec に sync (本 change archive 時に実施)
-- [ ] 7.2 新規 Scenario が要求する justification (Cargo.toml コメント or 評価レポート参照) を `modules/actor-core/Cargo.toml` の `portable-atomic` 行に追加 (※ コード変更は本 change の Non-Goals に該当するが、Scenario 違反になるため最小限のコメント追加は本 change で行う)
+- [x] 7.2 新規 Scenario が要求する justification (Cargo.toml コメント or 評価レポート参照) を `modules/actor-core/Cargo.toml` の `portable-atomic` 行に追加 (※ コード変更は本 change の Non-Goals に該当するが、Scenario 違反になるため最小限のコメント追加は本 change で行う)
 
 ## 8. 全体検証
 
-- [ ] 8.1 `openspec validate step07-evaluate-portable-atomic-critical-section-need --strict` で artifact 整合確認
-- [ ] 8.2 `cargo test --workspace` (コード変更は Cargo.toml コメントのみのため pass する想定)
-- [ ] 8.3 `./scripts/ci-check.sh ai all` で全 CI 緑
+- [x] 8.1 `openspec validate step07-evaluate-portable-atomic-critical-section-need --strict` で artifact 整合確認
+- [x] 8.2 `cargo test --workspace` (コード変更は Cargo.toml コメントのみのため pass する想定)
+- [x] 8.3 `./scripts/ci-check.sh ai all` で全 CI 緑
 
 ## 9. コミット・PR
 

--- a/openspec/changes/step08-retire-portable-atomic-critical-section/proposal.md
+++ b/openspec/changes/step08-retire-portable-atomic-critical-section/proposal.md
@@ -1,6 +1,18 @@
 ## Why
 
-step07 の調査結果（`docs/plan/YYYY-MM-DD-portable-atomic-critical-section-evaluation.md`）で「`portable-atomic/critical-section` feature は不要」と結論されたら、本 change で実際に退役する。
+> **【中止】** step07 評価で「退役不可」が確定したため本 change は中止する。
+>
+> 中止理由 (2026-04-22): step07 (`step07-evaluate-portable-atomic-critical-section-need`) の評価レポート (`docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md`) により、以下が確定:
+> - CI が `thumbv8m.main-none-eabi` (32-bit ARM Cortex-M33) で `actor-core` を check している (`scripts/ci-check.sh:1056`)
+> - production code 内で `portable_atomic::AtomicU64` が **8 ファイル** 利用されている
+> - `thumbv8m.main` は AtomicU64 のハードウェアサポートを持たないため、`portable-atomic/critical-section` の emulated atomic が必須
+> - 退役した瞬間に no-std CI ジョブが compile error で fail する
+>
+> したがって本 change の本来の目的 (退役) は CI 上成立しない。本 change は **proposal のまま archive する** (実装フェーズに入らない)。
+>
+> 以下は中止前に書かれた本来の趣旨。記録のため残す:
+
+step07 の調査結果（`docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md`）で「`portable-atomic/critical-section` feature は不要」と結論されたら、本 change で実際に退役する。
 
 退役の意義:
 - `actor-core` が間接的に `critical-section` impl provider を要求する経路が消える（残課題が完全に閉じる）


### PR DESCRIPTION
## Summary

Strategy B step07: investigation change to evaluate whether `actor-core/Cargo.toml`'s `portable-atomic = { features = ["critical-section"] }` is still needed.

**Conclusion: maintain as-is (case Y).** `portable-atomic/critical-section` is required for actor-core to build under the 32-bit ARM target the CI exercises. step08 (retirement) is therefore cancelled.

## Findings

### Phase 1 — CI target audit
- `scripts/ci-check.sh:1056` runs `cargo check -p fraktor-actor-core-rs --target thumbv8m.main-none-eabi` (32-bit ARMv8-M Mainline / Cortex-M33)
- `thumbv8m.main` does NOT have hardware AtomicU64 → emulation required
- `THUMB_TARGETS` array (line 10) declares `thumbv6m-none-eabi` and `thumbv8m.main-none-eabi` as supported targets

### Phase 2 — `portable_atomic::AtomicU64` census
8 production files in actor-core use `portable_atomic::AtomicU64`:
- actor_ref/base.rs, fsm/machine.rs, tick_driver/{tick_driver_trait,tick_feed}.rs, event/stream/actor_ref_subscriber.rs, routing/{random_routing_logic,group_router,pool_router}.rs (typed dsl variant), system/state/system_state.rs

Plus 2 in stream-core (port_id.rs, stream_handle_id.rs).

`actor_cell.rs` uses only `AtomicBool` (32-bit safe).

### Phase 3 — case classification
**Case B (维持必須)**: 32-bit embedded target in CI + 10 `AtomicU64` files in production. Removing `portable-atomic/critical-section` would break `./scripts/ci-check.sh no-std` immediately.

### Recommendation
Maintain. Cancel step08.

## Changes

- **New**: `docs/plan/2026-04-22-portable-atomic-critical-section-evaluation.md` (full evaluation report with Phase 1〜3, Decision Matrix, Recommendation, step08 hand-off)
- **`modules/actor-core/Cargo.toml:24`**: add justification comment block directly above `portable-atomic` dep, referencing target (`thumbv8m.main`) + 8-file census + evaluation report path
- **`docs/plan/2026-04-21-actor-core-critical-section-followups.md`**: mark 残課題 2 resolved
- **`openspec/changes/step08-retire-portable-atomic-critical-section/proposal.md`**: prepend cancellation banner explaining rationale
- **Spec delta** (case C minimal): `actor-lock-construction-governance` capability gains a Scenario "low-level utility crate の feature 指定は対象ターゲット / ユースケースが明示されている" + a MUST clause to its existing Requirement on Cargo.toml feature governance. Full sync to main spec happens at archive time

## Verification

- `cargo test --workspace`: 4782 passed (Cargo.toml comment-only, no behavior change)
- `./scripts/ci-check.sh ai all`: exit 0
- `openspec validate step07-evaluate-portable-atomic-critical-section-need --strict`: pass

## OpenSpec Change

`openspec/changes/step07-evaluate-portable-atomic-critical-section-need/` (proposal/design/specs/tasks). Will be archived after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation/spec governance updates plus a Cargo.toml comment; no runtime code or dependency behavior changes, so risk is low aside from tightening future spec validation rules.
> 
> **Overview**
> Adds a step07 investigation report concluding `portable-atomic`’s `critical-section` feature must remain enabled to keep `actor-core` building under CI’s 32-bit embedded target, and updates the earlier follow-up plan to mark this item resolved.
> 
> Records the justification directly in `modules/actor-core/Cargo.toml` as a comment (target + `AtomicU64` usage + link to the report), updates OpenSpec governance to require such justifications for low-level dependency feature flags, and marks step08 (retirement) as **cancelled** in its proposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd451e17f393a7b4f0bf6a4f3382a3af6a996ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added evaluation report documenting the assessment of the `portable-atomic` critical-section feature requirement for 32-bit ARM embedded targets, including CI target audit results and production code usage analysis across the codebase.
* Updated planning documentation to mark the portable-atomic critical-section feature evaluation as resolved, with added justification comments in build configuration explaining the requirement for emulated 64-bit atomic operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->