### PR TITLE
feat(actor-core): close default pre_restart deferred gap in sync dispatch (Pekko parity)

### DIFF
--- a/modules/actor-core/src/core/kernel/actor/actor_cell.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_cell.rs
@@ -1199,6 +1199,11 @@ impl ActorCell {
       // child mailbox work to queue up instead. Production dispatchers already
       // enter the trampoline when `mailbox.run` is scheduled on a worker
       // thread, so this wrap is effectively a no-op there.
+      // 範囲制限: この guard が保護するのは親と同一の `ExecutorShared`（=同一 dispatcher）
+      // 配下の child のみ。`with_dispatcher_id` で別 dispatcher を割り当てた child の
+      // `send_system_message` → その dispatcher 側の `system_dispatch` は親とは別の
+      // trampoline を通るため、guard の外で実行され得る。クロス dispatcher 下の
+      // 再入防止は各 dispatcher 側の CAS ベース drain-owner 選択が担う。
       let dispatcher = self.new_dispatcher_shared();
       let pre_restart_result =
         dispatcher.run_with_drive_guard(|| self.actor.with_write(|actor| actor.pre_restart(&mut ctx, cause)));

--- a/modules/actor-core/src/core/kernel/actor/actor_cell.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_cell.rs
@@ -1187,7 +1187,22 @@ impl ActorCell {
     {
       let mut ctx = self.make_context();
       ctx.cancel_receive_timeout();
-      self.actor.with_write(|actor| actor.pre_restart(&mut ctx, cause))?;
+      // Pekko parity under sync dispatch: default `pre_restart` invokes
+      // `stop_all_children`, which sends `SystemMessage::Stop` to each child.
+      // When the outer invocation is driven via `ActorCellInvoker::system_invoke`
+      // (e.g. test direct calls) the executor's `running` flag is not yet held,
+      // so the first nested `execute` for the child mailbox would claim the
+      // drain-owner slot and drain on the same thread — reentering into the
+      // parent before `set_children_termination_reason(Recreation)` runs.
+      // `run_with_drive_guard` claims the slot via the existing
+      // `ExecutorShared` trampoline for the duration of `pre_restart`, forcing
+      // child mailbox work to queue up instead. Production dispatchers already
+      // enter the trampoline when `mailbox.run` is scheduled on a worker
+      // thread, so this wrap is effectively a no-op there.
+      let dispatcher = self.new_dispatcher_shared();
+      let pre_restart_result =
+        dispatcher.run_with_drive_guard(|| self.actor.with_write(|actor| actor.pre_restart(&mut ctx, cause)));
+      pre_restart_result?;
       ctx.clear_sender();
     }
 

--- a/modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs
@@ -1547,13 +1547,21 @@ fn al_h1_t1_default_pre_restart_calls_post_stop_and_default_post_restart_calls_p
 }
 
 #[test]
-#[ignore = "synchronous test dispatcher: stop_all_children は child を即座に停止させ children_state を Empty に遷移させるため、set_children_termination_reason(Recreation) が false を返し finish_recreate が即時 fall-through する。deferred 経路は AC-H4 T2/T3 (override pre_restart) で検証済みのため ignore。"]
 fn al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate() {
   // AL-H1: 既定 pre_restart は stop_all_children を呼ぶことで子を terminate
   // キューに乗せた後、自身の post_stop を呼ぶ。childrenRefs は live child を
   // 残したまま Terminating(Recreation) へ遷移するため finishRecreate は遅延され、
   // 子が handle_terminated されるタイミングで post_restart (= 既定の pre_start
   // 委譲) が走る。
+  //
+  // Sync-dispatch parity は `ActorCell::fault_recreate` が `pre_restart` を
+  // `MessageDispatcherShared::run_with_drive_guard` でラップすることで成立する。
+  // guard が `ExecutorShared::running` を事前に claim するため、
+  // `stop_all_children` が child へ発行する `SystemMessage::Stop` は既存
+  // trampoline の pending に積まれるだけで parent の呼び出しスタック上では
+  // drain されない。後続の `parent.handle_death_watch_notification(child)` が
+  // `remove_child_and_get_state_change` で `Recreation(cause)` を観測し
+  // `finish_recreate` を起動する。
   let state = ActorSystem::new_empty().state();
   let log = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let parent_props = Props::from_fn({
@@ -1570,8 +1578,11 @@ fn al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate() {
   state.register_cell(child.clone());
   parent.register_child(child.pid());
   // AC-H5 pre-wiring: spawn_with_parent 自動配線と同等の supervision watch を
-  // 手動登録する。
-  parent.register_watching(child.pid());
+  // 手動登録する。`register_supervision_watching` で `WatchKind::Supervision` を
+  // 使うことで、既定 `pre_restart` の `stop_all_children` が呼ぶ
+  // `unregister_watching`（User kind のみ除去）の影響を受けず、後続の
+  // `handle_death_watch_notification` が `watching_contains_pid` で通過する。
+  parent.register_supervision_watching(child.pid());
 
   let mut parent_invoker = ActorCellInvoker { cell: parent.downgrade() };
   parent_invoker.system_invoke(SystemMessage::Create).expect("parent create");
@@ -1606,6 +1617,86 @@ fn al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate() {
   assert!(parent.children().is_empty(), "AL-H1: finishRecreate 後は children() は空");
   assert!(!parent.mailbox().is_suspended(), "AL-H1: finishRecreate 完了後は mailbox を resume");
   assert!(parent.children_state_is_normal(), "AL-H1: finishRecreate 後は ChildrenContainer が Normal に戻る");
+}
+
+#[test]
+fn al_h1_t2_default_pre_restart_with_multiple_children_defers_finish_recreate_until_last() {
+  // AL-H1: child が 2 件以上ある場合、最後の child の
+  // `handle_death_watch_notification` が届くまで `finish_recreate` が起動しない
+  // ことを確認する。中間の child DWN では `remove_child_and_get_state_change` が
+  // `None` を返し（container が Terminating に留まり to_die が非空のまま）、
+  // 最後の child DWN で初めて `Some(Recreation(cause))` → `finish_recreate` が起動する。
+  let state = ActorSystem::new_empty().state();
+  let log = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let parent_props = Props::from_fn({
+    let log = log.clone();
+    move || LifecycleRecorderActor::new(log.clone())
+  });
+  let parent = ActorCell::create(state.clone(), Pid::new(813, 0), None, "al-h1-t2-multi".to_string(), &parent_props)
+    .expect("create parent");
+  let child_a_props = Props::from_fn(|| ProbeActor);
+  let child_a = ActorCell::create(
+    state.clone(),
+    Pid::new(814, 0),
+    Some(parent.pid()),
+    "al-h1-t2-multi-child-a".to_string(),
+    &child_a_props,
+  )
+  .expect("create child_a");
+  let child_b_props = Props::from_fn(|| ProbeActor);
+  let child_b = ActorCell::create(
+    state.clone(),
+    Pid::new(815, 0),
+    Some(parent.pid()),
+    "al-h1-t2-multi-child-b".to_string(),
+    &child_b_props,
+  )
+  .expect("create child_b");
+  state.register_cell(parent.clone());
+  state.register_cell(child_a.clone());
+  state.register_cell(child_b.clone());
+  parent.register_child(child_a.pid());
+  parent.register_child(child_b.pid());
+  // 両 child を supervision watch に登録（User kind だと stop_all_children で除去される）
+  parent.register_supervision_watching(child_a.pid());
+  parent.register_supervision_watching(child_b.pid());
+
+  let mut parent_invoker = ActorCellInvoker { cell: parent.downgrade() };
+  parent_invoker.system_invoke(SystemMessage::Create).expect("parent create");
+  assert_eq!(log.lock().clone(), vec!["pre_start"]);
+
+  parent.mailbox().suspend();
+  let cause = ActorErrorReason::new("al-h1-t2-multi-cause");
+  parent_invoker.system_invoke(SystemMessage::Recreate(cause)).expect("recreate");
+
+  // Recreate 直後: children が 2 件残り、Terminating(Recreation) で待機中。
+  assert_eq!(parent.children().len(), 2, "両 child が children_state の to_die に残存");
+  assert!(parent.children_state_is_terminating(), "子 stop 待ちで Terminating(Recreation)");
+  let mid_snapshot = log.lock().clone();
+  assert_eq!(mid_snapshot, vec!["pre_start", "post_stop"], "post_restart は最後の child 終了まで遅延");
+
+  // child_a の DWN → まだ child_b が to_die に残るので finish_recreate は起動しない
+  parent.handle_death_watch_notification(child_a.pid()).expect("handle_death_watch_notification A");
+  assert!(parent.children_state_is_terminating(), "child_a 除去後も to_die に child_b が残存するので Terminating 継続");
+  assert_eq!(parent.children().len(), 1, "child_a のみ children_state から除去される");
+  let after_a_snapshot = log.lock().clone();
+  assert_eq!(
+    after_a_snapshot,
+    vec!["pre_start", "post_stop"],
+    "child_a の DWN 処理中に finish_recreate は起動しない（中間 state_change=None）"
+  );
+
+  // child_b の DWN → 最後の child なので finish_recreate が起動し post_restart → pre_start
+  parent.handle_death_watch_notification(child_b.pid()).expect("handle_death_watch_notification B");
+  let final_snapshot = log.lock().clone();
+  assert_eq!(
+    final_snapshot,
+    vec!["pre_start", "post_stop", "pre_start"],
+    "最後の child_b DWN で finish_recreate → 既定 post_restart → pre_start が走る"
+  );
+  assert!(parent.children_state_is_normal(), "finish_recreate 後に Normal/Empty へ戻る");
+  assert!(parent.children().is_empty(), "finish_recreate 後 children は空");
+  assert!(!parent.mailbox().is_suspended(), "finish_recreate 後 mailbox を resume");
 }
 
 #[test]

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher.rs
@@ -9,6 +9,7 @@ mod dispatcher_core;
 mod dispatcher_sender;
 mod dispatchers;
 mod dispatchers_error;
+mod drive_guard_token;
 mod execute_error;
 mod executor;
 mod executor_factory;

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/drive_guard_token.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/drive_guard_token.rs
@@ -1,0 +1,65 @@
+//! RAII token for an [`ExecutorShared`] drain-owner claim.
+//!
+//! See [`ExecutorShared::enter_drive_guard`](super::ExecutorShared::enter_drive_guard)
+//! for the acquisition path. This token exists purely so the release path is
+//! bound to `Drop`; there is no public `exit_drive_guard` method.
+
+#[cfg(test)]
+mod tests;
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use fraktor_utils_core_rs::core::sync::ArcShared;
+
+/// RAII handle that releases an [`ExecutorShared`] drain-owner claim when
+/// dropped.
+///
+/// The token is produced by
+/// [`ExecutorShared::enter_drive_guard`](super::ExecutorShared::enter_drive_guard).
+/// If the CAS succeeded, `claimed` is `true` and `Drop` stores `false` back
+/// into `running`, allowing the next caller to become the drain owner. If the
+/// CAS failed — another drain owner was already active — `claimed` is `false`
+/// and `Drop` is a no-op so the outer owner keeps running the drain loop.
+///
+/// This type must be kept alive for the full guarded region; dropping it
+/// immediately (`let _ = executor.enter_drive_guard()`) would release the
+/// claim before any guarded work runs, defeating the purpose of the guard.
+/// The `#[must_use]` attribute promotes such misuse into a compile-time
+/// warning (which project-wide lint settings elevate to an error).
+///
+/// # Tail drain is intentionally **not** performed in `Drop`
+///
+/// Tasks queued into `trampoline.pending` while the guard was held remain
+/// there after the token drops. A subsequent
+/// [`ExecutorShared::execute`](super::ExecutorShared::execute) call naturally
+/// picks them up via the existing CAS-based drain-owner selection. Performing
+/// a synchronous tail drain inside `Drop` would defeat the entire point of
+/// the guard (child mailboxes would run on the caller's stack again — the
+/// very reentrance this mechanism exists to prevent), so that path is
+/// forbidden here.
+#[must_use = "DriveGuardToken must be held for the full guarded region; \
+              drop it at the end of the scope where `enter_drive_guard` was called"]
+pub(crate) struct DriveGuardToken {
+  claimed: bool,
+  running: ArcShared<AtomicBool>,
+}
+
+impl DriveGuardToken {
+  /// Creates a token with the given claim outcome. Only
+  /// [`ExecutorShared::enter_drive_guard`](super::ExecutorShared::enter_drive_guard)
+  /// constructs tokens; callers outside this crate cannot fabricate one because
+  /// both the struct and its constructor are `pub(crate)`.
+  pub(crate) const fn new(claimed: bool, running: ArcShared<AtomicBool>) -> Self {
+    Self { claimed, running }
+  }
+}
+
+impl Drop for DriveGuardToken {
+  fn drop(&mut self) {
+    if self.claimed {
+      // MUST NOT: tail drain the trampoline pending queue here — see the
+      // type-level doc comment above. Only releasing the claim is allowed.
+      self.running.store(false, Ordering::Release);
+    }
+  }
+}

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/drive_guard_token.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/drive_guard_token.rs
@@ -57,8 +57,8 @@ impl DriveGuardToken {
 impl Drop for DriveGuardToken {
   fn drop(&mut self) {
     if self.claimed {
-      // MUST NOT: tail drain the trampoline pending queue here — see the
-      // type-level doc comment above. Only releasing the claim is allowed.
+      // 禁止事項: ここでトランポリンの pending キューを末尾消費してはならない
+      // （上の型レベルドキュメント参照）。許可されるのはクレームの解放のみ。
       self.running.store(false, Ordering::Release);
     }
   }

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/drive_guard_token/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/drive_guard_token/tests.rs
@@ -1,0 +1,34 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use fraktor_utils_core_rs::core::sync::ArcShared;
+
+use super::DriveGuardToken;
+
+/// Test-only extension exposing the `claimed` field without widening
+/// production visibility.
+impl DriveGuardToken {
+  pub(crate) fn claimed(&self) -> bool {
+    self.claimed
+  }
+}
+
+#[test]
+fn drop_stores_false_when_claimed() {
+  let running = ArcShared::new(AtomicBool::new(true));
+  {
+    let token = DriveGuardToken::new(true, running.clone());
+    assert!(token.claimed());
+    assert!(running.load(Ordering::Acquire));
+  }
+  assert!(!running.load(Ordering::Acquire), "drop must release running when claimed=true");
+}
+
+#[test]
+fn drop_is_noop_when_not_claimed() {
+  let running = ArcShared::new(AtomicBool::new(true));
+  {
+    let token = DriveGuardToken::new(false, running.clone());
+    assert!(!token.claimed());
+  }
+  assert!(running.load(Ordering::Acquire), "drop must not touch running when claimed=false");
+}

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs
@@ -30,6 +30,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use fraktor_utils_core_rs::core::sync::{ArcShared, DefaultMutex, SharedAccess, SharedLock};
 
 use super::{
+  drive_guard_token::DriveGuardToken,
   execute_error::ExecuteError,
   executor::Executor,
   trampoline_state::{QueuedTask, TrampolineState},
@@ -136,6 +137,34 @@ impl ExecutorShared {
       | Some(err) => Err(err),
       | None => Ok(()),
     }
+  }
+
+  /// Claims the drain-owner slot on this shared executor so that subsequent
+  /// [`execute`](Self::execute) calls made while the returned
+  /// [`DriveGuardToken`] is alive simply enqueue into the trampoline and
+  /// return without draining.
+  ///
+  /// If another drain owner is already active, the CAS fails and the returned
+  /// token reports `claimed = false`; its `Drop` is then a no-op so the outer
+  /// owner keeps running the drain loop. This contention handling is the
+  /// reason nested guards and production multi-thread access are safe without
+  /// additional synchronisation.
+  ///
+  /// Pairs with the token's `Drop` implementation. There is intentionally no
+  /// public `exit_drive_guard` method: release only happens through `Drop`, so
+  /// the type system prevents release-forgotten / double-release bugs.
+  ///
+  /// # Use case
+  ///
+  /// `ActorCell::fault_recreate` wraps the `pre_restart` call with this guard
+  /// (via [`MessageDispatcherShared::run_with_drive_guard`](super::MessageDispatcherShared::run_with_drive_guard))
+  /// so that default `pre_restart`'s `stop_all_children` does not trigger
+  /// same-thread reentrancy into child mailboxes when the invocation is
+  /// driven from outside the normal `execute` path (e.g. test direct
+  /// `system_invoke` calls).
+  pub(crate) fn enter_drive_guard(&self) -> DriveGuardToken {
+    let claimed = self.running.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire).is_ok();
+    DriveGuardToken::new(claimed, self.running.clone())
   }
 
   /// Shuts the inner executor down.

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared/tests.rs
@@ -73,3 +73,78 @@ fn clone_shares_inner_state() {
   cloned.execute(Box::new(|| {}), 0).expect("execute should succeed");
   assert_eq!(count.load(Ordering::SeqCst), 2);
 }
+
+#[test]
+fn enter_drive_guard_claims_running_slot_via_cas() {
+  let count = Arc::new(AtomicUsize::new(0));
+  let shared = ExecutorShared::new(Box::new(CountingExecutor { count: Arc::clone(&count) }), TrampolineState::new());
+
+  let token = shared.enter_drive_guard();
+  assert!(token.claimed(), "first enter should claim the running slot");
+}
+
+#[test]
+fn enter_drive_guard_is_no_op_when_already_claimed() {
+  let count = Arc::new(AtomicUsize::new(0));
+  let shared = ExecutorShared::new(Box::new(CountingExecutor { count: Arc::clone(&count) }), TrampolineState::new());
+
+  let outer = shared.enter_drive_guard();
+  assert!(outer.claimed());
+  let inner = shared.enter_drive_guard();
+  assert!(!inner.claimed(), "nested enter must not re-claim the running slot");
+
+  drop(inner);
+  // outer still holds the claim — no new claim possible yet
+  let concurrent = shared.enter_drive_guard();
+  assert!(!concurrent.claimed(), "outer guard still owns the running slot after inner dropped");
+}
+
+#[test]
+fn drive_guard_token_release_allows_subsequent_claim() {
+  let count = Arc::new(AtomicUsize::new(0));
+  let shared = ExecutorShared::new(Box::new(CountingExecutor { count: Arc::clone(&count) }), TrampolineState::new());
+
+  {
+    let token = shared.enter_drive_guard();
+    assert!(token.claimed());
+  }
+  // previous token dropped → running slot is free
+  let retry = shared.enter_drive_guard();
+  assert!(retry.claimed(), "running slot should be reclaimable after the first token drops");
+}
+
+#[test]
+fn execute_inside_drive_guard_enqueues_without_calling_inner() {
+  let count = Arc::new(AtomicUsize::new(0));
+  let shared = ExecutorShared::new(Box::new(CountingExecutor { count: Arc::clone(&count) }), TrampolineState::new());
+
+  let token = shared.enter_drive_guard();
+  assert!(token.claimed());
+
+  // Submit a task while the guard holds running=true. The task should queue
+  // into the trampoline but NOT reach the inner executor yet.
+  shared.execute(Box::new(|| {}), 0).expect("execute should succeed");
+  assert_eq!(count.load(Ordering::SeqCst), 0, "inner.execute must not run while the guard is held");
+
+  // Dropping the token releases running=false but does NOT tail-drain. The
+  // task stays in the trampoline queue until the next external execute.
+  drop(token);
+  assert_eq!(count.load(Ordering::SeqCst), 0, "DriveGuardToken::drop must not tail-drain the trampoline");
+
+  // The next external execute picks up both the leftover task and the new one.
+  shared.execute(Box::new(|| {}), 0).expect("execute should succeed");
+  assert_eq!(count.load(Ordering::SeqCst), 2, "pending task + new task should both drain");
+}
+
+#[test]
+fn execute_without_drive_guard_drains_as_before() {
+  let count = Arc::new(AtomicUsize::new(0));
+  let shared = ExecutorShared::new(Box::new(CountingExecutor { count: Arc::clone(&count) }), TrampolineState::new());
+
+  // Baseline: without ever calling enter_drive_guard, execute behaves
+  // exactly like before — each call drains the task.
+  shared.execute(Box::new(|| {}), 0).expect("execute should succeed");
+  assert_eq!(count.load(Ordering::SeqCst), 1);
+  shared.execute(Box::new(|| {}), 0).expect("execute should succeed");
+  assert_eq!(count.load(Ordering::SeqCst), 2);
+}

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared.rs
@@ -84,6 +84,37 @@ impl MessageDispatcherShared {
     self.with_read(|inner| inner.executor())
   }
 
+  /// Runs `f` on the calling thread while the underlying `ExecutorShared`
+  /// has its drain-owner slot claimed.
+  ///
+  /// Any nested `execute` calls triggered by `f` — typically through
+  /// `register_for_execution` from a `send_system_message` inside an actor
+  /// invocation — will observe `running = true` and enqueue into the
+  /// `ExecutorShared` trampoline instead of draining synchronously on the
+  /// current stack.
+  ///
+  /// Pending tasks accumulated during the guarded window are **not** drained
+  /// on exit — they remain in the trampoline queue and are picked up by the
+  /// next external `execute` call that wins the drain-owner CAS. This matches
+  /// Pekko async dispatcher semantics where actor invocation exit does not
+  /// implicitly flush other actors' mailboxes.
+  ///
+  /// The guard's enter/release pair is managed via RAII on the
+  /// [`DriveGuardToken`](super::DriveGuardToken) returned by
+  /// [`ExecutorShared::enter_drive_guard`](super::ExecutorShared::enter_drive_guard);
+  /// even if `f` panics, the token is still dropped during unwind so the
+  /// drain-owner slot is always released.
+  ///
+  /// Visibility is `pub(crate)`; `fault_recreate` is the sole caller within
+  /// actor-core.
+  pub(crate) fn run_with_drive_guard<F, R>(&self, f: F) -> R
+  where
+    F: FnOnce() -> R, {
+    let executor = self.executor();
+    let _token = executor.enter_drive_guard();
+    f()
+  }
+
   /// Returns a pre-built shared mailbox if the inner dispatcher requires one.
   ///
   /// Delegates to

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared/tests.rs
@@ -5,6 +5,7 @@ use core::{
   time::Duration,
 };
 use std::{
+  panic::{AssertUnwindSafe, catch_unwind},
   sync::{
     Mutex as StdMutex,
     mpsc::{self, Receiver, Sender},
@@ -233,4 +234,53 @@ fn detach_running_mailbox_returns_before_runner_finalizes() {
   detach_handle.join().expect("detach thread should complete");
   assert_eq!(seen.load(Ordering::SeqCst), 1, "runner finalizer must suppress the second queued user message");
   assert_eq!(mailbox.user_len(), 0, "runner finalizer should clean remaining queued user messages");
+}
+
+#[test]
+fn run_with_drive_guard_runs_f_and_defers_nested_execute() {
+  let submits = Arc::new(AtomicUsize::new(0));
+  let executor =
+    ExecutorShared::new(Box::new(CountingExecutor { submits: Arc::clone(&submits) }), TrampolineState::new());
+  let executor_for_nested = executor.clone();
+  let settings = DispatcherConfig::with_defaults("drive-guard");
+  let dispatcher = DefaultDispatcher::new(&settings, executor);
+  let shared = MessageDispatcherShared::new(Box::new(dispatcher));
+
+  let observed = Arc::new(AtomicUsize::new(0));
+  let observed_inside = Arc::clone(&observed);
+  let result = shared.run_with_drive_guard(|| {
+    observed_inside.store(1, Ordering::SeqCst);
+    // Nested execute through the same ExecutorShared — while the guard is
+    // held the task must queue into the trampoline, not reach the inner
+    // executor. `submits` tracks inner executor calls; it should stay at 0.
+    executor_for_nested.execute(Box::new(|| {}), 0).expect("nested execute should succeed");
+    assert_eq!(submits.load(Ordering::SeqCst), 0, "inner.execute must not run while the guard is held");
+    42
+  });
+  assert_eq!(result, 42, "run_with_drive_guard must return f()'s value");
+  assert_eq!(observed.load(Ordering::SeqCst), 1, "f() must have run");
+  assert_eq!(submits.load(Ordering::SeqCst), 0, "DriveGuardToken::drop must not tail-drain the trampoline");
+}
+
+#[test]
+fn run_with_drive_guard_releases_guard_even_when_f_panics() {
+  let submits = Arc::new(AtomicUsize::new(0));
+  let executor =
+    ExecutorShared::new(Box::new(CountingExecutor { submits: Arc::clone(&submits) }), TrampolineState::new());
+  let executor_for_check = executor.clone();
+  let settings = DispatcherConfig::with_defaults("drive-guard-panic");
+  let dispatcher = DefaultDispatcher::new(&settings, executor);
+  let shared = MessageDispatcherShared::new(Box::new(dispatcher));
+
+  let result = catch_unwind(AssertUnwindSafe(|| {
+    shared.run_with_drive_guard(|| {
+      panic!("boom");
+    })
+  }));
+  assert!(result.is_err(), "panic should propagate out of run_with_drive_guard");
+
+  // After unwind, the DriveGuardToken must have released the running slot
+  // so a subsequent enter_drive_guard can claim it again.
+  let retry = executor_for_check.enter_drive_guard();
+  assert!(retry.claimed(), "running slot must be released after f() panic via Drop");
 }

--- a/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/design.md
+++ b/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/design.md
@@ -1,0 +1,502 @@
+# 設計メモ: pekko-default-pre-restart-deferred
+
+## 参照 Pekko ソース
+
+| ファイル | 行 | 対応 fraktor 項目 |
+|---------|----|-------------------|
+| `Actor.scala` | 626-632 (default `preRestart`) | 既定 `Actor::pre_restart` が `stop_all_children` + `post_stop` を呼ぶ |
+| `dungeon/Children.scala` | 129-142 (`stop(actor)`) | `shallDie(actor)` で container を Terminating 化し `actor.stop()` で enqueue |
+| `dungeon/FaultHandling.scala` | 92-118 (`faultRecreate`) | `pre_restart` 後に `setChildrenTerminationReason(Recreation)` → 子が残れば defer |
+| `dungeon/FaultHandling.scala` | 278-303 (`finishRecreate`) | 最後の child termination を契機に起動 |
+| `dispatch/Mailbox.scala` | 228-238 (`Mailbox.run`) | 1 mailbox 単位の drain。**同一 thread 上で他 mailbox を再入 drain しない** |
+
+## 既存 `ExecutorShared` トランポリンの確認
+
+`modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs` (lines 40-146) は既に
+**外側トランポリン機構**を実装している:
+
+```rust
+pub struct ExecutorShared {
+    inner:      SharedLock<Box<dyn Executor>>,
+    trampoline: SharedLock<TrampolineState>,          // pending タスクキュー
+    running:    ArcShared<AtomicBool>,                // drain owner の排他
+}
+
+pub fn execute(&self, task: BoxedTask, affinity_key: u64) -> Result<(), ExecuteError> {
+    // Phase 1: queue the task
+    self.trampoline.with_lock(|state| state.pending.push_back(QueuedTask { task, affinity_key }));
+
+    // Phase 2: become drain owner via CAS
+    if self.running.compare_exchange(false, true, ...).is_err() {
+        return Ok(());  // 誰かが既に drain 中 → pending に積んだだけで return
+    }
+
+    // Phase 3: drain loop
+    loop {
+        let next = self.trampoline.with_lock(|state| state.pending.pop_front());
+        match next {
+            Some(queued) => self.with_write(|inner| inner.execute(queued.task, queued.affinity_key)),
+            None => break,
+        }
+    }
+    self.running.store(false, Ordering::Release);
+    // ...tail drain...
+}
+```
+
+このトランポリンは production / sync 両経路で **既に効いている**:
+- Production (ForkJoinExecutor / PinnedExecutor): worker thread 上で `ExecutorShared::execute` が呼ばれ、drain owner が確立。別 thread が送る task は pending に積まれて dain loop で処理される
+- Sync (InlineExecutor): 同一 thread 上で `ExecutorShared::execute` が再入しても、既に drain owner が確立していれば pending に積むだけで戻る
+
+## 観測されている破れ
+
+`al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate`
+(`modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs:1551`) が `#[ignore]`
+の理由として記録されている状況:
+
+```
+parent.system_invoke(Recreate(cause))    ← ActorCellInvoker 直呼び経路
+  │                                         ExecutorShared を経由していない、running=false のまま
+  └─ fault_recreate(cause)
+       └─ pre_restart default
+            └─ stop_all_children
+                 └─ for child in children:
+                      ├─ mark_child_dying(child)   // Normal → Terminating{UserRequest,[child]}
+                      ├─ unregister_watching(child) // WatchKind::User のみ除去
+                      ├─ remove_watch_with(child)
+                      └─ send_system_message(child, Stop)
+                           └─ dispatcher.system_dispatch
+                                └─ enqueue Stop + register_for_execution
+                                     └─ child.request_schedule: IDLE → SCHEDULED
+                                     └─ ExecutorShared::execute(child_run)
+                                          ├─ trampoline.pending.push(child_run)
+                                          ├─ running.CAS(false, true) → 成功 (誰も drain 中でない)
+                                          ├─ drain loop 開始
+                                          │   └─ pop child_run → with_write → InlineExecutor::execute(child_run)
+                                          │        └─ child mailbox.run
+                                          │             └─ handle_stop
+                                          │                  └─ notify_watchers_on_stop
+                                          │                       └─ send_system_message(parent, DeathWatchNotification)
+                                          │                            └─ ExecutorShared::execute(parent_run)
+                                          │                                 ├─ trampoline.pending.push(parent_run)
+                                          │                                 └─ running.CAS(false, true) → 失敗 (drain 中)
+                                          │                                 └─ return (drain owner に任せる)
+                                          ├─ drain loop 次: pop parent_run → with_write → InlineExecutor::execute(parent_run)
+                                          │   └─ parent mailbox.run
+                                          │        └─ handle_death_watch_notification(child)
+                                          │             └─ watching_contains_pid(child)=true (Supervision 残存)
+                                          │             └─ remove_child_and_get_state_change(child)
+                                          │                  // container: Terminating{UserRequest,[child]}
+                                          │                  // to_die 空 → reason=UserRequest で return
+                                          │             └─ state_change = Some(SuspendReason::UserRequest)
+                                          │             // Recreation ではないので finish_recreate 不発
+                                          └─ drain loop: pending 空 → break、running=false
+            └─ post_stop (default)
+       └─ set_children_termination_reason(Recreation(cause))
+            // container は既に Normal/Empty (child は上記で removed)
+            // → false を返す
+       └─ deferred=false なので finish_recreate(cause) へ即時 fall-through
+            └─ post_restart default → pre_start 連鎖が inline 実行
+```
+
+## 根本原因
+
+**parent の `ActorCellInvoker::system_invoke` は `ExecutorShared::execute` を経由しない直呼び経路のため、`ExecutorShared::running` が false のまま `send_system_message(child, Stop)` による child 側の execute が最初の drain owner になり、drain loop の中で parent mailbox への DWN 配送も同期処理されてしまう。**
+
+既存 `ExecutorShared` トランポリンは production では効いているが、test の直呼び経路では **誰も先に drain owner を確保していない** ため、child の execute が owner を奪い parent mailbox run まで drain してしまう。
+
+## 採用する設計: `ExecutorShared::enter_drive_guard` / `exit_drive_guard` で drain owner を外部宣言
+
+### 原則
+
+- **既存の `ExecutorShared::running` AtomicBool + trampoline pending キューを流用する**。新たな機構を作らない
+- **`Executor` trait には触らない**。guard は `ExecutorShared` レベルで完結する。production executor / InlineExecutor はいずれも変更不要
+- **ガード適用範囲は `fault_recreate` 内の `pre_restart` 呼び出し 1 点に限定**
+- **`enter_drive_guard` は既存 drain owner を尊重する**。CAS 失敗時は no-op で、外側 drain owner に任せる。これにより nested enter や production 並行経路との衝突が起きない
+- **`DriveGuardToken::drop` は pending を drain しない** (意図的な設計判断)。`claimed=true` なら `running=false` に戻すだけ。pending は次の外部 `execute` 呼び出しまで残る。これは Pekko async dispatcher の「invocation 終了時に他 actor mailbox を synchronous に flush しない」原則と一致
+  - **既存 `ExecutorShared::execute` の Step 4 tail drain (`executor_shared.rs:109-132`) との明示的な違い**:
+    `execute()` 関数は drain 終了後に pending が溜まっていれば自力で tail drain し直すが、
+    `DriveGuardToken::drop` は tail drain を実行しない。理由: tail drain を `drop` 時に実行すると、
+    guard 中に積まれた child.Stop が guard 解除直後に同期 drain され、child mailbox が parent の
+    fault_recreate スタック上で動いてしまう。これは Pekko async dispatcher では起こらない再入で、
+    test の `mid_snapshot` 契約 (`children_state_is_terminating() == true`) も破綻する。
+    `drop` で tail drain を追加してはならない (MUST NOT)
+
+### Pekko 互換性の非回帰確認
+
+本 change の変更は次の 2 箇所に限定される:
+
+1. `ExecutorShared` に `enter_drive_guard` / `exit_drive_guard` + RAII token 追加
+2. `ActorCell::fault_recreate` 内、`actor.pre_restart(&mut ctx, cause)` 呼び出し 1 行を
+   `MessageDispatcherShared::run_with_drive_guard` でラップ
+
+他の system message handler (`handle_stop` / `handle_kill` / `handle_watch` /
+`handle_unwatch` / `handle_death_watch_notification` / `handle_failure` 等) には**一切触れない**。
+`Executor` trait にも触れない。したがって以下の既存 passing テストは挙動変化を受けない:
+
+- `ac_h5_t*`: watch / unwatch / DeathWatchNotification 経路 (handle_watch / handle_unwatch)
+- `ac_h3_t*`: mailbox suspend / resume 経路 (handle_suspend / handle_resume)
+- `ac_h4_t2 / ac_h4_t3`: override pre_restart での deferred 経路 (pre_restart が stop_all_children を呼ばない
+  ため guard が有効でも挙動不変)
+- AL-H1 T1 / T3: override pre_restart 系
+- `handle_failure` / supervisor directive 経路
+- `executor_shared/tests.rs` の既存トランポリンテスト（guard は既存機構の上書きでなく orthogonal な追加）
+
+唯一挙動が変わるのは、**default pre_restart が `stop_all_children` を呼ぶ sync dispatch ケース**で、
+そこでは guard により「fault_recreate が pre_restart を呼ぶ前に ExecutorShared の drain owner を確保する」
+挙動になる。これは Pekko async dispatcher での挙動と一致する方向の変更であり、**Pekko 非互換を新たに
+作り出さない**。
+
+### API 追加
+
+#### `ExecutorShared` への追加
+
+```rust
+impl ExecutorShared {
+    /// Claims the drain-owner slot so that subsequent `execute` calls during
+    /// the caller's guarded window simply enqueue into the trampoline and
+    /// return without draining.
+    ///
+    /// If another drain owner is already active (CAS fails), returns a token
+    /// with `claimed = false`; the outer owner continues to drain as normal.
+    /// This no-op behaviour on contention keeps nested guards and production
+    /// multi-thread access safe without additional synchronisation.
+    ///
+    /// The returned token holds the drain-owner slot until it is dropped.
+    /// Callers MUST keep the token alive for the duration of the guarded
+    /// region; `#[must_use]` enforces this at the type level so that
+    /// `let _ = executor.enter_drive_guard();` (which would drop the token
+    /// immediately) is rejected at compile time with a `must_use` warning
+    /// promoted to an error by project-wide lint settings.
+    pub fn enter_drive_guard(&self) -> DriveGuardToken {
+        let claimed = self
+            .running
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok();
+        DriveGuardToken { claimed, running: self.running.clone() }
+    }
+}
+
+#[must_use = "DriveGuardToken must be held for the full guarded region; \
+              drop it at the end of the scope where `enter_drive_guard` was called"]
+pub struct DriveGuardToken {
+    claimed: bool,
+    running: ArcShared<AtomicBool>,
+}
+
+impl Drop for DriveGuardToken {
+    fn drop(&mut self) {
+        if self.claimed {
+            self.running.store(false, Ordering::Release);
+        }
+    }
+}
+```
+
+**注意**: release 経路は **RAII `Drop` のみ**。外部から直接呼び出す `exit_drive_guard` 等の API は
+公開しない。これにより enter / release のペア違反（release を忘れる、二重 release）が型システムで
+防止される。加えて `#[must_use]` 属性により、token を捨てる誤用（`let _ = ...` 等）もコンパイル時に
+検出できる。
+
+#### `MessageDispatcherShared::run_with_drive_guard`
+
+```rust
+impl MessageDispatcherShared {
+    /// Runs `f` on the calling thread while the underlying `ExecutorShared`
+    /// has its drain-owner slot claimed. Any nested `execute` calls triggered
+    /// by `f` will see `running = true` and enqueue into the trampoline
+    /// instead of draining synchronously on the current stack.
+    ///
+    /// Pending tasks accumulated during the guarded window are NOT drained on
+    /// exit — they remain in the `ExecutorShared` trampoline queue. This matches
+    /// Pekko async dispatcher semantics where actor invocation exit does not
+    /// implicitly flush other actors' mailboxes.
+    ///
+    /// Visibility is `pub(crate)`; external crates should not need this helper
+    /// directly. `fault_recreate` is the sole caller within `actor-core`.
+    pub(crate) fn run_with_drive_guard<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        // 既存 `MessageDispatcherShared::executor(&self) -> ExecutorShared`
+        // (`message_dispatcher_shared.rs:83`) を再利用。`ExecutorShared` は内部で
+        // `ArcShared<SpinSyncMutex<...>>` を保持するので clone は cheap で良い。
+        let executor = self.executor();
+        let _token = executor.enter_drive_guard();
+        f()
+        // _token は scope 終了で drop され、claimed=true なら running=false に戻る
+    }
+}
+```
+
+**設計**: `DriveGuard<'a>` のように外部参照を保持するラッパー struct は不要。`DriveGuardToken` が
+`running: ArcShared<AtomicBool>` を owned clone で持つため、ライフタイム制約もない。
+`run_with_drive_guard` は単に `_token` を let binding で保持して `Drop` まで生かす。
+
+### `ActorCell::fault_recreate` の局所ラップ
+
+**ガード適用範囲は `pre_restart` 呼び出し 1 点のみ**に限定する:
+
+```rust
+pub(crate) fn fault_recreate(&self, cause: &ActorErrorReason) -> Result<(), ActorError> {
+    if self.is_failed_fatally() { return Ok(()); }
+
+    {
+        let mut ctx = self.make_context();
+        ctx.cancel_receive_timeout();
+        // Pekko 互換: default `pre_restart` は `stop_all_children` を呼ぶ。この中で
+        // 各 child へ `send_system_message(child, Stop)` が発行されるが、同期
+        // dispatcher 環境では ActorCellInvoker::system_invoke 直呼び経路が
+        // ExecutorShared::running を立てていないため、child の execute が drain owner
+        // を奪い parent mailbox への DWN 配送まで同期処理されてしまう。
+        // `run_with_drive_guard` で外側 drain owner を確保し、nested execute 呼び出しを
+        // ExecutorShared 既存 trampoline で pending に積むだけにすることで、Pekko async
+        // dispatcher と同一の挙動を再現する。
+        let dispatcher = self.new_dispatcher_shared();
+        let result = dispatcher.run_with_drive_guard(|| {
+            self.actor.with_write(|actor| actor.pre_restart(&mut ctx, cause))
+        });
+        result?;
+        ctx.clear_sender();
+    }
+
+    debug_assert!(
+        self.mailbox().is_suspended(),
+        "fault_recreate expects the mailbox to be suspended (AC-H3 precondition)"
+    );
+
+    let deferred = self.state.with_write(|state| {
+        state.deferred_recreate_cause = Some(cause.clone());
+        state.children_state.set_children_termination_reason(SuspendReason::Recreation(cause.clone()))
+    });
+
+    if deferred { return Ok(()); }
+
+    self.finish_recreate(cause)
+}
+```
+
+`finish_recreate` 側の `post_restart` 呼び出しには **guard を適用しない**。理由:
+
+- default `post_restart` は `pre_start` を呼ぶだけで、通常 `pre_start` は child 群の
+  `send_system_message` を連鎖させない（child spawn 時の Create handshake は `spawn_with_parent`
+  経由で別途スケジュールされる）
+- 仮に override `post_restart` が子 spawn を行った場合でも、それは新規に start する child であり
+  restart state machine との再入はない
+- scope を最小化することで「ガードが想定外の副作用を生む」可能性を最小化
+
+### `Mailbox::run` 経路の扱い
+
+production ルートの `Mailbox::run` は既に `ExecutorShared::execute` の drain loop 内側で動いており
+`running=true` が確立されている。したがって `Mailbox::run` を経由する `system_invoke` では
+そもそも再入問題が発生しない。本 change は `Mailbox::run` 経路には触れない。
+
+`ActorCellInvoker::system_invoke` を直接呼ぶ test 経路でも、ガードは `fault_recreate` 内の
+`pre_restart` 呼び出しだけに限定されているため、他の system message (`Create` / `Stop` /
+`Watch` / `Unwatch` / `Suspend` / `Resume` / `Kill` / `StopChild` / `DeathWatchNotification` /
+`PipeTask` / `Failure`) を処理する既存 test は一切影響を受けない。
+
+## 決定ログ / 却下案
+
+### 却下案 1: `ActorCellInvoker::system_invoke` 全体を `run_with_drive_guard` でラップ
+
+**却下理由**:
+
+1. 他の system message (`Stop` / `Watch` / `Unwatch` / `Kill` 等) も guard 下で処理されることになり、
+   それらの handler が発行する `send_system_message` に対する drain 挙動が変化する
+2. actor-core の actor_cell/tests.rs には 80 箇所超、actor-core 全体で 47 件以上の `system_invoke`
+   テスト呼び出しがあり、その多くが「cross-cell 操作が inline で処理される」前提で assert している
+3. 局所化された問題 (default pre_restart + stop_all_children の再入) を解決するのに、テスト経路全体の
+   セマンティクスを変えるのは副作用が大きすぎる
+4. **新たな Pekko 非互換を作り出すリスクを排除**するため、ガード範囲は必要最小限に絞る
+
+### 却下案 2: `stop_all_children` を「mark + enqueue only」へ分離
+
+`stop_all_children` 内で `send_system_message(child, Stop)` を呼ばず、parent の post-turn
+action queue に詰めておき、`fault_recreate` の末尾で flush する案。
+
+**却下理由**:
+
+1. child を止める責務が `stop_all_children` から `fault_recreate` へ漏れるため責務境界が曖昧になる
+2. Termination / finishCreate 経路でも同様の問題が起きるが、それぞれ別の post-turn queue を用意するか or 統一 queue を作るかで複雑度が増す
+3. Pekko の `stop(actor)` も `actor.stop()` で即時 enqueue しており、責務分離ではなく
+   dispatcher 側の turn 境界で解決されている。本質的な根本治療は dispatch 側にある
+
+### 却下案 3: `fault_recreate` の先頭で container を `Terminating{Recreation(cause)}` に pre-promote
+
+`set_children_termination_reason` を `pre_restart` の前に呼ぶ案。
+
+**却下理由**:
+
+1. 現 `set_children_termination_reason` は container が既に `Terminating` の時だけ成功する。
+   `Normal` から直接 `Terminating{Recreation}` へ遷移する新 API が必要
+2. inline 経路で `handle_death_watch_notification` が先に走っても state_change が
+   `Some(Recreation(cause))` を返してしまい、`finish_recreate` が inline で起動する。
+   テスト期待値 `mid_snapshot == ["pre_start", "post_stop"]` を満たせない
+3. Pekko は `preRestart` → `setChildrenTerminationReason` の順序で、先に reason を書かない
+   → Pekko parity を崩す
+
+### 却下案 4: `Executor` trait に `enter_drive_guard` / `exit_drive_guard` を追加し `InlineExecutor` が override する
+
+**却下理由** (5 ラウンド目レビューで判明):
+
+1. `ExecutorShared` (`executor_shared.rs:40-146`) が既に `trampoline: SharedLock<TrampolineState>` +
+   `running: ArcShared<AtomicBool>` を使った外側トランポリンを実装している。この機構は production /
+   sync どちらの経路でも drain owner を CAS で排他制御している
+2. 問題は「`Executor` trait への guard 追加で解決できる」のではなく、「`ActorCellInvoker::system_invoke`
+   直呼び経路が `ExecutorShared` を経由しないため既存トランポリンに参加できない」こと
+3. したがって正しい介入点は `ExecutorShared` レベル。`InlineExecutor` や他の production executor を
+   override する必要は一切ない
+4. `Executor` trait に変更を加えると trait 実装者への潜在的影響が増える。`ExecutorShared` レベルで
+   完結する方が変更範囲が小さく、既存アーキテクチャと整合する
+
+### 却下案 5: guard exit で pending を drain する
+
+`DriveGuardToken::drop` の時点で pending 全件を drain する案。
+
+**却下理由**:
+
+1. テスト `al_h1_t2` は `system_invoke(Recreate)` 戻り直後の中間 snapshot で
+   children_state が Terminating であることを assert する。exit 時 drain だと、child の
+   Stop が drain され DWN が parent に届き finish_recreate が inline 起動、children_state が
+   Normal/Empty になって assert 失敗する
+2. Pekko の async dispatcher は actor invocation 終了時に他 actor の mailbox を synchronous
+   に flush しない。exit 時 drain は async dispatcher の挙動と乖離する
+3. pending 残留は sync dispatcher のテスト artifact としては許容できる。test は
+   `handle_death_watch_notification` を明示的に呼んで「DWN が届いた状態」を simulate するため、
+   child mailbox の実際の drain は不要
+
+### 採用案の利点
+
+- **既存 `ExecutorShared` トランポリン機構を 1 API 追加だけで拡張**、新機構を作らない
+- production dispatcher (`PinnedExecutor` / `ForkJoinExecutor` / `BalancingDispatcher`) /
+  `InlineExecutor` いずれも **変更不要**
+- `Executor` trait に変更なし → trait 実装者への影響ゼロ
+- ガード範囲が `pre_restart` 呼び出し 1 点に局所化されているため、他の system message 経路を
+  使うテストへの影響が**ゼロであることが型レベルで明らか**
+- 責務境界が明確: 「default pre_restart が stop_all_children を呼ぶ sync dispatch 経路でのみ
+  外側 drain owner を確保する」という不変条件が `ExecutorShared::enter_drive_guard` + `fault_recreate`
+  の 2 箇所に閉じる
+- **新たな Pekko 非互換を作らない**: guard が有効な状況 (sync dispatch + default pre_restart)
+  の挙動は Pekko async dispatcher と一致する方向の変更のみ
+- RAII `DriveGuardToken` により enter / exit のペア違反を型システムで防止
+
+## state machine
+
+本 change で state machine そのものは変化しない（`fault_recreate` / `finish_recreate` の
+2 フェーズ構造は維持）。変化するのは **`SystemMessage::Stop` が child mailbox に届いた
+後、その drain が同一 thread 上でいつ走るか** のスケジューリング境界のみ。
+
+```
+parent.system_invoke(Recreate(cause))
+  ├─ fault_recreate(cause)
+  │    ├─ pre_restart 呼び出し ― ここから run_with_drive_guard
+  │    │    ├─ executor.enter_drive_guard()  → DriveGuardToken { claimed=true }
+  │    │    │    // running.CAS(false, true) 成功。以後の execute は pending push で return
+  │    │    ├─ actor.pre_restart(ctx, cause) — default 実装:
+  │    │    │    ├─ ctx.stop_all_children()
+  │    │    │    │    └─ for child:
+  │    │    │    │         ├─ mark_child_dying(child)   // Normal → Terminating{UserRequest,[child]}
+  │    │    │    │         ├─ unregister_watching(child)
+  │    │    │    │         ├─ remove_watch_with(child)
+  │    │    │    │         └─ send_system_message(child, Stop)
+  │    │    │    │              └─ dispatcher.system_dispatch
+  │    │    │    │                   └─ enqueue Stop + register_for_execution
+  │    │    │    │                        └─ request_schedule: IDLE → SCHEDULED
+  │    │    │    │                        └─ ExecutorShared::execute(child_run)
+  │    │    │    │                             ├─ trampoline.pending.push(child_run)
+  │    │    │    │                             └─ running.CAS(false, true) → 失敗 (guard 保有中)
+  │    │    │    │                             └─ return (drain しない)
+  │    │    │    └─ self.post_stop(ctx)  — parent の post_stop (log: "post_stop")
+  │    │    └─ DriveGuardToken::drop
+  │    │         └─ running.store(false)、pending は残置
+  │    ├─ set_children_termination_reason(Recreation(cause))
+  │    │    // container: Terminating{UserRequest,[child]} → Terminating{Recreation(cause),[child]}
+  │    │    // returns true → deferred
+  │    └─ return Ok(()) (deferred)
+  └─ parent.system_invoke returns
+      // ExecutorShared.trampoline には child_run が残留しているが drain されない
+      // この時点で log = ["pre_start", "post_stop"]、children_state = Terminating{Recreation}
+
+  [test explicitly calls] parent.handle_death_watch_notification(child.pid())
+       ├─ watching_contains_pid(child) = true (Supervision 残存)
+       ├─ terminated_queued.push(child)
+       ├─ remove_child_and_get_state_change(child)
+       │    // container: Terminating{Recreation(cause),[child]}
+       │    // to_die 空 → reason=Recreation(cause) を返す
+       ├─ has_user_watch = false (stop_all_children で User unregister 済)
+       ├─ terminated_queued.retain (remove)
+       └─ finish_recreate(cause)
+            ├─ drop_pipe_tasks / drop_stash_messages / drop_timer_handles / drop_watch_with_messages
+            ├─ publish_lifecycle(Stopped)
+            ├─ recreate_actor — 新 actor instance 生成
+            ├─ clear_failed
+            ├─ mailbox.resume
+            └─ actor.post_restart(ctx, cause) — default:
+                 └─ self.pre_start(ctx)  — 新 actor の pre_start (log: "pre_start")
+```
+
+本 change の guard により、`system_invoke(Recreate)` が返った直後の中間 snapshot
+(`mid_snapshot`) では child は container 上で live（Terminating{Recreation} の to_die）
+として残っており、`children_state_is_terminating() == true` が成立する。
+
+production の async dispatcher 上では、parent の `mailbox.run` は別 worker thread に投入された
+task closure として実行される。`ExecutorShared::execute` 関数自体は内部 executor への task 引き渡し
+が済めばすぐに return するため、parent.mailbox.run 実行中の worker thread は `ExecutorShared::execute`
+の drain loop 内側にはおらず、`ExecutorShared::running` は通常 false である。したがって fault_recreate
+内で `enter_drive_guard` が呼ばれた時点でも **CAS が成功して `claimed=true` となる** (production /
+test 同じ)。
+
+production 固有の挙動:
+1. guard 保有中の `send_system_message(child, Stop)` は trampoline.pending に push、CAS 失敗で即 return
+2. `DriveGuardToken::drop` で `running=false` に戻ると、child.Stop task は trampoline queue に残存
+3. 直後にまた `ExecutorShared::execute` が (他 thread や後続の send から) 呼ばれたとき、そいつが drain
+   owner を CAS 取得して pending を drain → 内部 executor 経由で別 worker thread に投入
+4. 別 worker thread 上で child.mailbox.run が実行される → child 停止 → parent へ DWN 送信
+5. 別 thread / 別 turn で parent の `handle_death_watch_notification` → `finish_recreate` が駆動される
+
+production / test どちらの経路でも観測できる state 遷移の順序は一致し、timing (child.Stop が実際に
+drain されるタイミング) のみが thread boundary の有無で異なる:
+- test (sync): test が明示的に `handle_death_watch_notification` を呼ぶまで child.Stop は pending に残る
+- production (async): guard 解除後の後続 execute で child.Stop が別 thread に投入され自然に実行される
+
+## Pekko 参照実装との対応表
+
+| fraktor 変更点 | Pekko 対応箇所 | 意味論的合致 |
+|----------------|---------------|--------------|
+| `ExecutorShared::enter_drive_guard` / `DriveGuardToken` の Drop-based release | `dispatch/Mailbox.scala` の 1 actor 単位 drain 保証 | production dispatcher では既存トランポリンが自然に保証、guard は test 直呼び経路で同じ不変条件を確立 |
+| `fault_recreate` 内の `pre_restart` を guard でラップ | `dungeon/FaultHandling.scala:92-118` | Pekko は thread boundary で自然に deferred、fraktor は guard で明示化 |
+| `DriveGuardToken::drop` で pending を drain しない | Pekko async dispatcher の「invocation exit で他 actor mailbox を flush しない」原則 | 一致 |
+| ガード適用を `pre_restart` 1 点に限定 | Pekko `preRestart` の default が唯一 `stop_all_children` を呼ぶ lifecycle hook | 対応範囲最小 |
+
+## CQS 違反の扱い
+
+本 change では CQS 違反は新規に発生しない。`ExecutorShared::enter_drive_guard` は command
+（状態変更）+ token を返す。CQS では本来 command は戻り値なしだが、RAII token はコマンドの
+「解除手段をクライアントに渡す」ために必要な型。既存の `Vec::pop` / Builder パターン相当の
+例外に近い。ただし本 change はこの token を単に `_token` で scope-binding するだけで
+query として利用しないため、CQS 原則の精神には違反しない。
+
+## TOCTOU 警戒
+
+- `enter_drive_guard` の CAS 操作は atomic。競合する execute 呼び出しとは既存 `ExecutorShared::execute`
+  の CAS ロジックと同じ排他関係で安全
+- `DriveGuardToken::drop` は `running.store(false)` のみ。pending 側の操作はないため、
+  concurrent execute 呼び出しが drain owner を奪取することが可能（意図通り）
+- `enter_drive_guard` が CAS 失敗した token (`claimed=false`) は `Drop` で何もしないため、
+  二重 release の可能性なし
+- production の複数 worker thread 並行経路: thread A が drain 中のとき thread B が
+  `enter_drive_guard` を呼ぶと、B は CAS 失敗で `claimed=false`。B の `Drop` は何もしない。
+  A の drain 終了後 B が `f()` 内で execute した task は普通に trampoline 経由で処理される
+
+## 削除 / 非目標
+
+- `stop_all_children` の責務分離（mark / enqueue / execute）— 本 change では `ExecutorShared`
+  既存トランポリン + 外部 guard API で十分と判断。follow-up で必要になれば別 change で
+- `finish_terminate` / `finish_create` の deferred 化 — Phase A3
+- typed 層 `Behavior::pre_restart` / `post_restart` への reason 引数追加 — Phase A3
+- `ActorCellInvoker::system_invoke` 全体のラップ — Pekko 非互換を作らないために局所化
+- `finish_recreate` の `post_restart` への guard 追加 — 現状の default `post_restart` は
+  `pre_start` に委譲するのみで cross-cell `send_system_message` を発行しないため不要
+- `Executor` trait の拡張 — `ExecutorShared` レベルで完結するため不要（5 ラウンド目レビューで判明した
+  既存トランポリン機構の活用による設計簡素化）

--- a/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/proposal.md
+++ b/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/proposal.md
@@ -1,67 +1,68 @@
-## プロジェクト原則（全 change 共通）
-
-本 change は以下 4 原則に従って設計される:
-
-1. **Pekko 互換仕様の実現 + Rust らしい設計**: Pekko の lifecycle / supervision / death watch の意味論を再現しつつ、Rust の所有権と mailbox 実行モデルに合わせて翻訳する
-2. **手間が掛かっても本質的な設計を選ぶ**: 同期 dispatcher だけを黙らせる局所 workaround ではなく、restart completion の正しい scheduling 境界を定義する
-3. **フォールバックや後方互換性を保つコードを書かない**: 正式リリース前のため、暫定 API や互換層は増やさず、必要なら破壊的変更を許容する
-4. **no_std core + std adaptor 分離**: `modules/actor-core` の kernel / mailbox / dispatcher で完結させ、std 固有の都合を core に漏らさない
-
 ## Why
 
 `2026-04-20-pekko-restart-completion` で restart completion の 2 フェーズ化は入ったが、**default `pre_restart` が `stop_all_children()` を呼ぶ経路**はまだ Pekko parity に達していない。
 
 現状の fraktor-rs では同期 dispatcher / inline executor 環境で親が `SystemMessage::Recreate(cause)` を処理すると、
 
-1. `pre_restart` が `stop_all_children()` を呼ぶ
-2. child への `SystemMessage::Stop` がその場で実行される
-3. child 停止に伴う `DeathWatchNotification(child_pid)` も同じ mailbox run 中に親へ戻る
-4. `handle_death_watch_notification` が即座に `finish_recreate(cause)` を実行する
+1. `fault_recreate` → `pre_restart` default → `ctx.stop_all_children()` が呼ばれる
+2. `stop_all_children` は各 child を `mark_child_dying` で Terminating{UserRequest} へ遷移させ `SystemMessage::Stop` を送信する
+3. `send_system_message(child, Stop)` は `MessageDispatcherShared::system_dispatch` → `register_for_execution` → `ExecutorShared::execute` を起動する
+4. 親は mailbox 経由ではなく `ActorCellInvoker::system_invoke` で直接駆動されているため、**`ExecutorShared::running` フラグは false のまま**。したがって `ExecutorShared::execute` は `running.compare_exchange(false, true)` に成功し、drain owner になって child mailbox を drain する
+5. child が停止すると `notify_watchers_on_stop` が親へ `DeathWatchNotification(child)` を送り、これが親 mailbox に enqueue されて再度 `ExecutorShared::execute(parent_run)` が呼ばれる。このとき `running=true` は既存 drain loop のため、parent_run は trampoline queue に積まれ、child_run 完了後の drain loop 次サイクルで同期実行される
+6. 結果、parent の `handle_death_watch_notification` が fault_recreate スタック上で inline 実行される。この時点で `set_children_termination_reason(Recreation(cause))` はまだ呼ばれておらず、container は Terminating{UserRequest} のまま。`remove_child_and_get_state_change(child)` は `Some(SuspendReason::UserRequest)` を返し、`handle_death_watch_notification` は `finish_recreate` を駆動しない
+7. stop_all_children が全 child 分ループを終えた時点で container は Normal/Empty、`pre_restart` 復帰後の `set_children_termination_reason(Recreation)` は `false` を返して `fault_recreate` は即時 `finish_recreate` に fall-through する
 
-という流れになり、`fault_recreate()` の「子あり restart は child termination まで deferred する」という契約が、同一 dispatch turn の中で潰れてしまう。
+この挙動は Pekko の「default `pre_restart` でも子あり restart は deferred」という契約を破る。Pekko では dispatcher が child mailbox を別 turn で drain するため、`stop_all_children` 呼び出し中に container が空になることはない。
 
-このズレは ignored テスト `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate` が既に示している。問題は `stop_all_children` 単体ではなく、**restart completion をどの mailbox turn / scheduling boundary で完了させるか** という kernel 契約にあるため、既存 change から切り離した follow-up change として扱う。
+このズレは ignored テスト `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate` (`modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs:1551`) が既に示している。問題は `stop_all_children` 単体ではなく、**`ActorCellInvoker::system_invoke` 直呼び経路が `ExecutorShared` の既存トランポリンを通らないため、親の処理スタック上で child / parent mailbox が drain されてしまう** という dispatch 境界の不足にある。
 
 ## What Changes
 
-- `default pre_restart` 経路において、**child stop の enqueue** と **restart completion の実行** が同一 inline drain で潰れないよう、mailbox / dispatcher / actor kernel の scheduling 境界を見直す
-- `fault_recreate -> handle_death_watch_notification -> finish_recreate` の責務分割を再確認し、**同期 dispatcher でも「子あり restart は deferred」と言える条件**を明文化する
-- ignored テスト `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate` を pass させることを change の受け入れ条件にする
-- 必要に応じて、以下のいずれかを設計対象に含める
-  - restart path 専用の self-system-message による turn 分離
-  - mailbox system queue drain の再入制御
-  - `stop_all_children` の「mark / unwatch / queue stop」段階と、実 stop 実行段階の分離
-  - `finish_recreate` を同一 drain 中に実行しない明示的な completion boundary
+- **`ExecutorShared` 既存トランポリンの外部利用 API 追加**: `ExecutorShared` は既に `trampoline: SharedLock<TrampolineState>` + `running: ArcShared<AtomicBool>` を使った **外側トランポリン**を実装している（`executor_shared.rs:40-146`）。production 経路では `ExecutorShared::execute` が最初の呼び出しで `running=true` を CAS 確保し drain owner になり、再入呼び出しは pending queue に積むだけで drain しない。したがって production はこの既存機構のみで正しく deferred 挙動になる。本 change は、この既存機構に「外部から drain owner を宣言して execute を抑制する」API (`enter_drive_guard` / `exit_drive_guard`) を追加するだけで目的を達成する
+- **ガード適用範囲は `fault_recreate` 内の `pre_restart` 呼び出し 1 点に限定**: `ActorCellInvoker::system_invoke` 全体や `fault_recreate` 全体、`finish_recreate` / `post_restart` には **ガードを適用しない**。これは default `pre_restart` のみが `stop_all_children` を呼ぶ唯一の Pekko 互換 lifecycle hook であり、他の system message 経路（`handle_watch` / `handle_unwatch` / `handle_stop` / `handle_kill` / `handle_failure` 等）には同様の再入問題が存在しないこと、およびガード範囲を狭く保つことで **既存の passing テストに新たな Pekko 非互換を生まない** ことを保証するため
+- **`MessageDispatcherShared::run_with_drive_guard<F, R>(&self, f: F) -> R` 追加**: `f()` の実行前に `self.executor().enter_drive_guard()` を呼び、終了時に RAII ベースで `exit_drive_guard` を呼ぶ helper。panic 時も `exit_drive_guard` が呼ばれることを保証する
+- **`Executor` trait は変更しない** (重要な設計修正): 5 ラウンド目レビューで判明した `ExecutorShared` 既存トランポリンの発見により、`Executor` trait に `enter_drive_guard` / `exit_drive_guard` を追加する当初案は **却下**。`InlineExecutor` への override も不要。guard は `ExecutorShared` レベルで完結する
+- **ignored テスト `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate` の受け入れ条件化**: `#[ignore]` を外し、既定 `pre_restart` + `stop_all_children` + 明示的 `handle_death_watch_notification` → `finish_recreate` の flow が sync dispatch でも Pekko parity で pass することを CI ゲートで確認する。併せて test の `register_watching` (User) を `register_supervision_watching` (Supervision) に修正する（default pre_restart の `stop_all_children` が User watch を除去するため）
+- **複数 child の deferred 挙動検証**: 現行 T2 は child 1 件のみを検証しているため、child 2 件を持つケースで「最後の child の DWN でのみ `finish_recreate` が起動する」順序性を追加 integration test で確認する
+- **non-target の明示**: 本 change は restart 経路の deferred 契約のみを扱う。Termination（`finish_terminate`）経路の同様 deferred 化は Phase A3 送りのまま。typed 層の reason 伝播拡張、remote / cluster の死亡通知転送は扱わない。`stop_all_children` の API / 責務分割は本 change では変更しない
 
 ## Capabilities
 
 ### Modified Capabilities
 - `pekko-restart-completion`: default `pre_restart` を含む全 restart 経路で、同期 dispatcher でも Pekko と同じ deferred completion 契約を満たすようにする
-- `actor-runtime-safety`: restart 中の mailbox suspend / child termination / completion 実行順序を、実際の dispatch turn 境界まで含めて定義する
+- `actor-runtime-safety`: `ExecutorShared` に `enter_drive_guard` / `exit_drive_guard` API を追加し、既存トランポリンの drain owner を外部から宣言できる契約を明文化する。`fault_recreate` の `pre_restart` 呼び出しは `MessageDispatcherShared::run_with_drive_guard` でラップされる
 
 ## Impact
 
-- 対象は `modules/actor-core` に限定される見込み
-  - `core/kernel/actor/actor_cell.rs`
-  - `core/kernel/actor/actor_context.rs`
-  - `core/kernel/dispatch/mailbox/*`
-  - `core/kernel/dispatch/dispatcher/*`
-- 主な影響は restart completion の内部 scheduling であり、public API 変更は必須ではない。ただし correctness のために内部 system message や helper の追加・整理は許容する
-- `2026-04-20-pekko-restart-completion` の parity claim を本当に成立させる最後の詰めになる
+- 対象コード（すべて `modules/actor-core` に閉じる見込み）:
+  - `core/kernel/dispatch/dispatcher/executor_shared.rs` — `enter_drive_guard` / `exit_drive_guard` 追加。既存 `running: ArcShared<AtomicBool>` フィールドを操作
+  - `core/kernel/dispatch/dispatcher/message_dispatcher_shared.rs` — `run_with_drive_guard<F, R>(&self, f: F) -> R` を追加
+  - `core/kernel/dispatch/dispatcher/message_dispatcher_shared/drive_guard.rs` (**新規ファイル**) — RAII `DriveGuard<'a>` struct を分離配置（親ファイルが既に 326 行で type-organization の同居行数制限を満たせないため）
+  - `core/kernel/actor/actor_cell.rs` — `fault_recreate` 内の `actor.pre_restart(&mut ctx, cause)` 呼び出し 1 点を `run_with_drive_guard` でラップ（`ActorCellInvoker::system_invoke` 本体や `finish_recreate` / 他 handler には**触れない**）
+  - `core/kernel/actor/actor_cell/tests.rs` — `al_h1_t2_*` の `#[ignore]` 削除、`register_watching` → `register_supervision_watching` 修正、複数 child 検証の integration test 追加
+- Public API 変更:
+  - `ExecutorShared` に新 API メソッドが 2 つ追加される (既存 `pub fn` 群と同じスタイル)
+  - `Executor` trait は **変更なし**
+- 影響範囲の明示:
+  - production dispatcher (`PinnedExecutor` / `ForkJoinExecutor` / `BalancingDispatcher`) は ExecutorShared 既存トランポリンをそのまま使い続けるため挙動変化なし
+  - `enter_drive_guard` を呼ばないコード経路 (= `fault_recreate` の `pre_restart` ラップ以外のすべて) は既存挙動のまま
+  - 既存 passing テストのうち、`fault_recreate` を駆動しないものは guard の影響を一切受けない
+  - `fault_recreate` を駆動する既存テスト（AC-H4 T1 / T2 / T3 / AL-H1 T1 / T3）は override pre_restart または子なしケースのため、guard 適用後も挙動不変
+- 本 change は restart completion の correctness を確保する最終パッチ。`2026-04-21-2026-04-20-pekko-restart-completion` の parity claim を sync dispatcher でも成立させる
 
 ## Non-goals
 
-- panic guard や lifecycle hook 全般の例外処理は扱わない
-- remote / cluster の death watch 転送は扱わない
-- typed 側の reason 伝播拡張は扱わない
-- mailbox / dispatcher の一般的な性能最適化は目的にしない
+- `stop_all_children` の「mark / unwatch / queue stop」責務分離（`ExecutorShared` 既存トランポリン + `enter_drive_guard` API で足りるため本 change では行わない。不足が観測されたら follow-up）
+- panic guard や lifecycle hook 全般の例外処理（`pekko-panic-guard` change の守備範囲）
+- remote / cluster の death watch 転送
+- typed 側 `Behavior::pre_restart` / `post_restart` への reason 引数追加（Phase A3）
+- `finish_terminate` / `finish_create` の deferred 化（Phase A3、本 change は Recreation 経路のみ）
+- mailbox / dispatcher の一般的な性能最適化
+- InlineExecutor を production dispatcher で使用可能にすること（test-only restriction は維持）
+- `ActorCellInvoker::system_invoke` 全体や `fault_recreate` 全体、`finish_recreate` / `post_restart` への guard 適用（本 change では明示的に却下。理由は design.md 「却下案 1」参照）
+- `Executor` trait の拡張（`ExecutorShared` レベルで完結するため不要）
 
 ## Dependencies
 
-- **前提**: `2026-04-20-pekko-restart-completion`
-- 本 change はその follow-up であり、既存 restart completion change の設計意図を保ったまま、同期 dispatcher で破れている deferred completion 契約を補完する
-
-## Artifact 方針
-
-- 今回は `proposal.md` のみ先行作成する
-- `design.md` と `tasks.md` は、実装に着手する直前に current branch / failing tests / mailbox 実装差分を再確認してから起こす
+- **前提**: `2026-04-21-2026-04-20-pekko-restart-completion`（archive 済み）
+- 本 change はその follow-up であり、既存 restart completion change の設計意図を保ったまま、同期 dispatcher で破れている deferred completion 契約を `ExecutorShared` 既存トランポリンの外部駆動 API で補完する

--- a/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/specs/actor-runtime-safety/spec.md
+++ b/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/specs/actor-runtime-safety/spec.md
@@ -1,0 +1,155 @@
+## ADDED Requirements
+
+### Requirement: ExecutorShared は drain owner を外部から宣言する guard API を提供しなければならない
+
+`ExecutorShared` は、外部 caller が既存トランポリン機構の drain owner を宣言する API `enter_drive_guard(&self) -> DriveGuardToken` を提供しなければならない（MUST）。
+
+戻り値の `DriveGuardToken` は RAII でライフサイクル管理され、`Drop` 実装が唯一の release 経路である（MUST）。`DriveGuardToken` には `#[must_use]` 属性が付与されなければならない（MUST、`let _ = enter_drive_guard()` のような即 drop 誤用をコンパイル時に検出するため）。公開 `exit_drive_guard` メソッドは **提供してはならない**（MUST NOT）。これは enter / release のペア違反（release 忘れ・二重 release）を型システムで防止するためである。
+
+既存トランポリン機構は `running: ArcShared<AtomicBool>` + `trampoline: SharedLock<TrampolineState>` (`executor_shared.rs:40-146`) で構成される。`enter_drive_guard` は既存 `running` を `compare_exchange(false, true)` で claim する。
+CAS が成功した場合 `DriveGuardToken { claimed: true }` を返し、drop 時に `running` を false に戻す。
+CAS が失敗した場合（他の drain owner が既に active）は `DriveGuardToken { claimed: false }` を返し、
+drop 時は何もしない（外側 owner の運用を尊重する）。
+
+#### Scenario: enter_drive_guard は既存 running フラグを CAS で claim する
+
+- **GIVEN** `ExecutorShared` の `running` が `false` である状態
+- **WHEN** `enter_drive_guard()` が呼ばれる
+- **THEN** `running` が `true` に遷移する（atomic CAS）
+- **AND** 戻り値 `DriveGuardToken` の `claimed` フィールドが `true`
+
+#### Scenario: drain 中の enter_drive_guard は no-op token を返す
+
+- **GIVEN** 既存 `ExecutorShared::execute` が drain loop 実行中で `running = true` の状態
+- **WHEN** 別の caller が `enter_drive_guard()` を呼ぶ
+- **THEN** CAS が失敗し `running` は `true` のまま維持される
+- **AND** 戻り値 `DriveGuardToken` の `claimed` フィールドが `false`
+
+#### Scenario: DriveGuardToken drop は claimed=true のときのみ running を false にする
+
+- **GIVEN** `enter_drive_guard` で `claimed = true` の token を受け取った状態（`running = true`）
+- **WHEN** token が scope を抜けて drop される
+- **THEN** `running` が `false` に戻る
+- **AND** pending トランポリン queue は drain されない（残ったタスクは次の外部 `execute` 呼び出しで処理される）
+
+#### Scenario: DriveGuardToken drop で claimed=false は何もしない
+
+- **GIVEN** `enter_drive_guard` で `claimed = false` の token を受け取った状態（外側 drain owner が active）
+- **WHEN** token が scope を抜けて drop される
+- **THEN** `running` の状態は変化しない（外側 drain owner が継続運用）
+
+#### Scenario: 公開 exit_drive_guard API は存在しない
+
+- **WHEN** `modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs` の public
+  API を grep で確認する
+- **THEN** `pub fn exit_drive_guard` は定義されていない
+- **AND** release 経路は `DriveGuardToken::drop` のみ
+
+### Requirement: DriveGuardToken::drop は tail drain を実行してはならない
+
+`DriveGuardToken::drop` 実装は `running = false` への遷移以外のロジック（特に pending drain）を実行してはならない（MUST NOT）。
+
+具体的には、既存 `ExecutorShared::execute` の Step 4 "tail drain" (`executor_shared.rs:109-132`) 相当の pending drain を `drop` 内でコピー実装してはならない。これは、tail drain を `drop` 時に実行すると、guard 中に積まれた child.Stop が guard 解除直後に同期 drain され、parent の `fault_recreate` スタック上で child mailbox が動く再入が発生するためである。この再入は Pekko async dispatcher では起こらない挙動であり、`al_h1_t2` テストの `mid_snapshot == ["pre_start", "post_stop"]` + `children_state_is_terminating()` 契約を破壊する。
+
+pending task は `DriveGuardToken::drop` 後に誰かが `ExecutorShared::execute` を呼ぶまで trampoline queue に保持され、その時点で通常の drain owner 選出を経て処理される。
+
+#### Scenario: DriveGuardToken::drop 内には pending drain ロジックが書かれていない
+
+- **WHEN** `DriveGuardToken::drop` 実装を確認する
+- **THEN** `running.store(false, Ordering::Release)` 以外のロジックが存在しない（`claimed=true` 分岐内）
+- **AND** `trampoline.pending` / `with_write(|inner| inner.execute(...))` への参照が `drop` 実装内に
+  存在しない
+
+#### Scenario: guard 中に積まれた pending は token drop では drain されない
+
+- **GIVEN** `enter_drive_guard` で `claimed=true` の token を取得し、guard 中に `execute(task)` が
+  1 回以上呼ばれて `trampoline.pending` に task が積まれている状態
+- **WHEN** token が scope を抜けて drop される
+- **THEN** `task` は **実行されない**
+- **AND** `trampoline.pending` に `task` が残ったまま
+- **AND** `running` が `false` に戻る
+
+### Requirement: guard 中の execute は既存トランポリンにより pending に積まれなければならない
+
+`ExecutorShared::enter_drive_guard` で `claimed = true` の token を保持している間に `ExecutorShared::execute` が呼ばれた場合、task は `trampoline.pending` に push されるだけで inner executor に同期実行されてはならない（MUST NOT）。
+
+これは既存 `ExecutorShared::execute` の CAS ロジック（`running` が true なら drain owner になれず pending push で return）により自然に実現される。本 change で新規ロジックを追加するのではなく、既存機構に外部駆動 API を追加するだけで契約を満たす。
+
+#### Scenario: guard active 中の execute は pending に積まれる
+
+- **GIVEN** `ExecutorShared::enter_drive_guard` で `running = true` が claimed されている状態
+- **WHEN** `execute(task, affinity_key)` を呼び出す
+- **THEN** `task` は `trampoline.pending` に push される
+- **AND** `running.compare_exchange(false, true)` が失敗するため inner executor の
+  `execute` は同期的に呼ばれない
+- **AND** 呼び出しは `Ok(())` を返す
+
+#### Scenario: guard 解除後の pending は次の外部 execute で drain される
+
+- **GIVEN** `DriveGuardToken` drop により `running = false` に戻り、pending に 1 件以上の task が残存
+  している状態
+- **WHEN** 別の caller が `execute(new_task, affinity_key)` を呼ぶ
+- **THEN** `running.compare_exchange(false, true)` が成功し drain owner となる
+- **AND** `new_task` + 残存 pending が順次 inner executor で処理される
+
+### Requirement: MessageDispatcherShared::run_with_drive_guard は RAII で guard のペアを保証する
+
+`MessageDispatcherShared` は `run_with_drive_guard<F, R>(&self, f: F) -> R` を提供しなければならない（MUST）。
+
+この helper は内部で `self.executor().enter_drive_guard()` を呼び、RAII token を scope 終了まで保持しつつ `f()` を実行する。`f()` が panic しても `DriveGuardToken::drop` が呼ばれ `running` が false に戻ることを保証しなければならない（MUST）。
+
+#### Scenario: run_with_drive_guard は f 実行前に enter、後に token drop を行う
+
+- **WHEN** `run_with_drive_guard(|| { /* f body */ })` が呼ばれる
+- **THEN** `executor.enter_drive_guard()` が `f` 実行前に呼ばれる
+- **AND** `f` が正常終了した場合、戻り値を返す前に `DriveGuardToken::drop` が scope 終了で呼ばれる
+- **AND** `f` が panic した場合、panic unwind 中に `DriveGuardToken::drop` が呼ばれ `running` が
+  `claimed=true` の場合は false に戻される
+
+### Requirement: fault_recreate の pre_restart 呼び出しは reentrancy guard でラップされなければならない
+
+`ActorCell::fault_recreate` は `Actor::pre_restart` 呼び出しを `MessageDispatcherShared::run_with_drive_guard` でラップしなければならない（MUST）。
+
+ラップの範囲は `pre_restart` 呼び出し 1 点に限定され、`fault_recreate` 全体や `system_invoke` 全体、`finish_recreate` 内の `post_restart` 呼び出しには**適用してはならない**（MUST NOT）。これは
+
+- default `pre_restart` のみが `stop_all_children` を呼ぶ唯一の Pekko 互換 lifecycle hook であり、
+  他の system message 処理経路には同様の再入問題が存在しないこと
+- ガード範囲を狭く保つことで、他の passing テスト（`handle_watch` / `handle_unwatch` / `handle_stop`
+  / `handle_kill` / `handle_failure` 等を駆動するテスト）への副作用を避け、**新たな Pekko 非互換を
+  生まないこと**
+
+を保証するためである。
+
+#### Scenario: fault_recreate 内の pre_restart はガードされる
+
+- **WHEN** `ActorCell::fault_recreate` の実装を grep で検索する
+- **THEN** `run_with_drive_guard` の呼び出しが `actor.pre_restart(&mut ctx, cause)` を囲む形で
+  1 箇所だけ存在する
+- **AND** ガードの外側に `set_children_termination_reason` 呼び出しと `finish_recreate` への
+  fall-through ロジックが残っている
+
+#### Scenario: fault_recreate 以外にはガードが適用されない
+
+- **WHEN** `modules/actor-core/src/core/kernel/actor/` 配下で `run_with_drive_guard` の使用箇所を
+  grep する
+- **THEN** 呼び出し元は `fault_recreate` 関数内の 1 箇所のみである
+- **AND** `system_invoke` 関数本体、`finish_recreate` 関数内、`handle_*` 系関数群には
+  `run_with_drive_guard` が現れない
+
+#### Scenario: Executor trait には変更がない
+
+- **WHEN** `modules/actor-core/src/core/kernel/dispatch/dispatcher/executor.rs` を本 change の前後で
+  diff する
+- **THEN** trait 定義に変更がない（`enter_drive_guard` / `exit_drive_guard` 等の新メソッドが追加されて
+  いない）
+- **AND** `InlineExecutor` / `PinnedExecutor` / `ForkJoinExecutor` / `BalancingExecutor` などの
+  `impl Executor for` 実装も変更されていない
+
+#### Scenario: ガード適用によって既存の passing テストが Pekko 非互換を生じない
+
+- **WHEN** `rtk cargo test -p fraktor-actor-core-rs` を実行する
+- **THEN** `handle_watch` / `handle_unwatch` / `handle_stop` / `handle_kill` / `handle_failure` /
+  `handle_suspend` / `handle_resume` / `handle_create` / `handle_death_watch_notification` を駆動する
+  全テストが passing である
+- **AND** 既存 `executor_shared/tests.rs` の全トランポリンテストが passing である
+- **AND** 本 change で新規に `#[ignore]` が付与されたテストが存在しない

--- a/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/specs/pekko-restart-completion/spec.md
+++ b/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/specs/pekko-restart-completion/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: default pre_restart + 子あり restart は同期 dispatcher 上でも deferred されなければならない
+
+`Actor::pre_restart` の既定実装（`ctx.stop_all_children()` + `self.post_stop(ctx)`）を持つ actor が `SystemMessage::Recreate(cause)` を受信したとき、child が存在すれば `finish_recreate` の実行は最後の child からの `SystemMessage::DeathWatchNotification(child)` 受信まで deferred されなければならない（MUST）。この deferred 契約は production の async dispatcher 上だけでなく、同期 / inline dispatcher 上でも成立しなければならない（MUST）。
+
+この要件は `fault_recreate` 内の `pre_restart` 呼び出しを `MessageDispatcherShared::run_with_drive_guard` でラップし、既存 `ExecutorShared` トランポリン
+(`executor_shared.rs:40-146`) の `running: ArcShared<AtomicBool>` を外部から CAS で claim する
+ことで達成される。guard 中は `send_system_message(child, Stop)` が起動する `ExecutorShared::execute`
+が `running = true` を観測して `trampoline.pending` に task を push するだけで return し、
+同一 thread 上での child mailbox の inline drain（および parent への DWN 再入）が発生しない。
+production dispatcher は既にこのトランポリンを worker thread 経由で利用しているため、guard の有無に
+よらず挙動は変化しない。
+
+#### Scenario: default pre_restart + 子あり restart は Recreate 処理中に finish_recreate を起動しない
+
+- **GIVEN** parent actor が `Actor::pre_restart` の既定実装を使用しており、child 1 件以上を
+  `children_state` に保持している状態
+- **AND** parent の mailbox が `suspend()` 済み
+- **WHEN** `ActorCellInvoker::system_invoke(SystemMessage::Recreate(cause))` が呼ばれる
+- **THEN** `fault_recreate` → 既定 `pre_restart` → `ctx.stop_all_children()` + `self.post_stop(ctx)`
+  が実行される
+- **AND** `set_children_termination_reason(SuspendReason::Recreation(cause))` が `true` を返し
+  deferred=true で return する
+- **AND** `system_invoke` から制御が戻った直後の時点で、`actor.post_restart` はまだ呼ばれておらず、
+  `children_state` は `Terminating{Recreation(cause)}` 状態で child が `to_die` に残ったままである
+
+#### Scenario: 最後の child の DeathWatchNotification が finish_recreate を駆動する（sync dispatch 上）
+
+- **GIVEN** 前 scenario の終状態（parent が deferred、child が Terminating{Recreation} の to_die に残存）
+- **WHEN** 明示的に `parent.handle_death_watch_notification(child_pid)` が呼ばれる（production では
+  dispatcher が child の Stop を実行後 parent へ DWN を送ることで自然に起動、test では直接 simulate）
+- **THEN** `remove_child_and_get_state_change(child_pid)` が `Some(SuspendReason::Recreation(cause))`
+  を返す
+- **AND** `finish_recreate(cause)` が駆動され、既定 `post_restart` 経由で `pre_start` が呼ばれる
+- **AND** `parent.children_state_is_normal()` が真に戻る
+- **AND** `parent.mailbox().is_suspended()` が偽に戻る
+
+#### Scenario: default pre_restart は複数 child の全停止まで finish_recreate を deferred する
+
+- **GIVEN** parent actor が既定 `pre_restart` を使用しており、child A / B の 2 件を保持している状態
+- **WHEN** `SystemMessage::Recreate(cause)` が parent に届く
+- **THEN** `fault_recreate` 完了時点で `children_state` は `Terminating{Recreation(cause), to_die=[A, B]}`
+- **AND** child A の `handle_death_watch_notification(A)` が最初に届いても、`remove_child_and_get_state_change`
+  は `None` を返し `finish_recreate` は駆動されない
+- **AND** 続いて child B の `handle_death_watch_notification(B)` が届いたときに初めて
+  `Some(SuspendReason::Recreation(cause))` が返り、`finish_recreate` が駆動される

--- a/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/tasks.md
+++ b/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/tasks.md
@@ -1,0 +1,292 @@
+## 0. 前提確認
+
+- [ ] 0.1 ブランチが `main` から最新で、前提 change `2026-04-21-2026-04-20-pekko-restart-completion` が archive 済みであることを確認する
+- [ ] 0.2 現在の ignored テスト `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate`
+  (`modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs:1551`) がまだ `#[ignore]`
+  状態で残っていることを確認する。他の AC-H4 / AC-H5 / AL-H1 テストは passing であること
+- [ ] 0.3 `rtk cargo test -p fraktor-actor-core-rs --lib --no-run` が通り、既存テストを壊さない
+  ベースラインを確認する
+- [ ] 0.4 `ExecutorShared` 既存トランポリン実装 (`executor_shared.rs:40-146`) を読み、
+  `running: ArcShared<AtomicBool>` + `trampoline: SharedLock<TrampolineState>` の役割を把握する
+  （本 change は既存 `running` フィールドを外部から CAS で操作する API を追加する）
+
+## 1. `ExecutorShared` に `enter_drive_guard` + `DriveGuardToken` を追加
+
+- [ ] 1.1 `modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs` に以下 API を追加
+  （既存の `pub fn` パターンと同じ可視性 `pub` を使う）:
+  ```rust
+  pub fn enter_drive_guard(&self) -> DriveGuardToken;
+  ```
+  - 実装: `self.running.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire).is_ok()` で
+    claimed 判定。成功なら自分が drain owner、失敗なら外側 owner を尊重して no-op 挙動
+  - 戻り値: `DriveGuardToken { claimed: bool, running: ArcShared<AtomicBool> }`
+- [ ] 1.2 **`exit_drive_guard` という `&self` メソッドは公開しない** (重要)
+  - release 経路は `DriveGuardToken::drop` のみ。enter / exit ペア違反を型システムで防止する
+- [ ] 1.3 `DriveGuardToken` struct を配置する:
+  - 配置先判定: `executor_shared.rs` は現状 163 行。token struct (≤15 行程度) を同居させると
+    180 行前後で、type-organization.md の「同居先ファイルが同居後も 200 行を超えない」を**満たす**
+  - したがって **`executor_shared.rs` 内に同居可**
+  - ただし命名規約 (type-organization.md) では「Handle のライフサイクル責務」は独立ファイル推奨。
+    `DriveGuardToken` は RAII token で drain owner ライフサイクル管理の責務を持つ。**別ファイル
+    `executor_shared/drive_guard_token.rs` に分離する方が保守性が高い**
+  - 採用: **別ファイル `executor_shared/drive_guard_token.rs` に分離配置**
+  - `executor_shared.rs` に `mod drive_guard_token;` + `pub use drive_guard_token::DriveGuardToken;` を追加
+  - 既存 `executor_shared/tests.rs` のサブディレクトリ構造と一致する
+- [ ] 1.4 `DriveGuardToken` 実装:
+  ```rust
+  #[must_use = "DriveGuardToken must be held for the full guarded region; \
+                drop it at the end of the scope where `enter_drive_guard` was called"]
+  pub struct DriveGuardToken {
+      claimed: bool,
+      running: ArcShared<AtomicBool>,
+  }
+
+  impl Drop for DriveGuardToken {
+      fn drop(&mut self) {
+          if self.claimed {
+              self.running.store(false, Ordering::Release);
+          }
+      }
+  }
+  ```
+  - rustdoc 英語で、enter / drop のペア契約と「claimed=false の場合は drop で何もしない」仕様を明記
+  - **`#[must_use]` 属性必須**: `let _ = executor.enter_drive_guard();` のような即 drop 誤用を
+    コンパイル時に検出するため
+  - **コンストラクタアクセス方針**: `DriveGuardToken` の struct フィールドは private (デフォルト) と
+    し、`DriveGuardToken` の `impl` ブロックに `pub(crate) fn new(claimed: bool, running: ArcShared<AtomicBool>) -> Self`
+    を追加する。`ExecutorShared::enter_drive_guard` は `DriveGuardToken::new(claimed, self.running.clone())`
+    を呼んで token を生成する。**フィールドを `pub(super)` にして親モジュールから直接構築する案は採用
+    しない**（module 境界越しの field アクセスを増やさず、コンストラクタで invariant 保証を明確にする
+    ため）
+  - 外部 crate は `pub` な `enter_drive_guard` 経由でしか token を取得できない (`new` が `pub(crate)`
+    のため)。型システムで不正な token 構築を防ぐ
+  - **`drop` 実装に tail drain を追加してはならない (MUST NOT)**: 既存 `ExecutorShared::execute` の
+    Step 4 tail drain (`executor_shared.rs:109-132`) 相当の drain ロジックを `DriveGuardToken::drop`
+    に書かないこと。理由は design.md 「採用する設計」セクション末尾を参照（tail drain を `drop` で
+    実行すると guard 中に積まれた child.Stop が同期 drain され Pekko async dispatcher 非互換の再入を
+    引き起こす）。rustdoc にもこの禁止事項を明記する
+- [ ] 1.5 `executor_shared/tests.rs` に以下を検証するテストを追加:
+  - `enter_drive_guard` 呼び出し中の `execute` は trampoline に積まれるだけで `inner.execute` が呼ばれない
+    こと（既存 `execute` のロジックそのままで実現されるが、smoke test として記述）
+  - `enter_drive_guard` を連続呼び出すと、1 回目は `claimed=true`、2 回目は `claimed=false`
+  - token drop 後に `running=false` に戻っていること (1 回目)、2 回目 token drop は no-op
+  - `enter_drive_guard` → `f()` 内で `execute` → `f()` 終了後も pending に task が残り、
+    次の外部 `execute` で drain されること
+- [ ] 1.6 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
+
+## 2. `MessageDispatcherShared::run_with_drive_guard` を追加
+
+- [ ] 2.1 `modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared.rs` に
+  以下シグネチャの helper を追加（可視性は `pub(crate)`、外部 crate からの利用は本 change では不要）:
+  ```rust
+  pub(crate) fn run_with_drive_guard<F, R>(&self, f: F) -> R
+  where
+      F: FnOnce() -> R;
+  ```
+- [ ] 2.2 実装は以下:
+  1. 既存 `self.executor()` helper (`message_dispatcher_shared.rs:83`) を使って
+     `ExecutorShared` を取得する（`register_for_execution` と同じ経路を流用）
+  2. `let _token = executor.enter_drive_guard();` で RAII token を保持
+  3. `f()` を呼び戻り値を返す
+  4. scope 終了時に `_token` が drop され、`claimed=true` なら `running=false` に戻る
+- [ ] 2.3 **注意**: `DriveGuard<'a>` のような外部参照 wrapper 型は作らない。`DriveGuardToken` が
+  `ArcShared<AtomicBool>` を owned clone で保持するためライフタイム制約がない
+- [ ] 2.4 `message_dispatcher_shared/tests.rs` に以下を追加:
+  - `run_with_drive_guard` 内で `f()` が呼び出し直接実行されること
+  - `f()` が panic しても `DriveGuardToken::drop` が呼ばれ `running=false` に戻ること（RAII 確認）
+  - `f()` 内で `system_dispatch` を呼んだ場合、target mailbox は guard 解除後も pending として
+    残り synchronous に drain されないこと（`InlineExecutor` を差し替えた smoke test）
+- [ ] 2.5 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
+
+## 3. `fault_recreate` 内の `pre_restart` 呼び出しを guard でラップ
+
+**注: ガード適用範囲は `pre_restart` 呼び出し 1 点に限定する**。`ActorCellInvoker::system_invoke`
+全体や `fault_recreate` 全体はラップしない（design.md 「却下案 1」参照）。
+
+- [ ] 3.1 `modules/actor-core/src/core/kernel/actor/actor_cell.rs` の `fault_recreate` を編集し、
+  `self.actor.with_write(|actor| actor.pre_restart(&mut ctx, cause))?` の呼び出しを
+  `run_with_drive_guard` でラップする
+  - 実装例の詳細は **design.md の「ActorCell::fault_recreate の局所ラップ」セクション**参照
+    （`let dispatcher = self.new_dispatcher_shared()` → `dispatcher.run_with_drive_guard(closure)` →
+    `result?` → `ctx.clear_sender()` の順序を保持）
+  - closure 内では `self.actor.with_write(|actor| actor.pre_restart(&mut ctx, cause))` の戻り値
+    (`Result<(), ActorError>`) を返す
+  - `ctx` は closure に `&mut ctx` として借用され、closure 完了 (= `run_with_drive_guard` 戻り) で
+    borrow が解放されるので、後続の `ctx.clear_sender()` は通る
+  - 既存の Pekko parity コメント（`is_failed_fatally` no-op の意図説明、`debug_assert!` の
+    AC-H3 precondition コメント等）は **保持すること**（本 change の範囲外で削除しない）
+- [ ] 3.2 `fault_recreate` 内の他の処理 (`is_failed_fatally` 早期 return、`debug_assert!` の mailbox
+  suspended 検査、`set_children_termination_reason` 呼び出し、`finish_recreate` への fall-through) は
+  **guard の外側**に置く。これらは再入問題を起こさないため guard 不要
+- [ ] 3.3 rustdoc コメントで、pre_restart ラップの意図（「default pre_restart が stop_all_children を
+  呼ぶ sync dispatch 経路で child mailbox の inline 再入 drain を防ぐ。production は既存 ExecutorShared
+  トランポリンが効いているため no-op 的に通過する」）を明記
+- [ ] 3.4 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
+- [ ] 3.5 既存 AC-H4 / AC-H5 / AL-H1 テスト群が全 passing であることを確認（regression check）:
+  `rtk cargo test -p fraktor-actor-core-rs -- ac_h4 ac_h5 al_h1`
+- [ ] 3.6 `finish_recreate` の `post_restart` 呼び出しには **guard を適用しない**ことを確認
+  （design.md 「ActorCell::fault_recreate の局所ラップ」の末尾参照）
+
+## 4. ignored テストの復活 + watch 登録修正 + 複数 child 検証の追加
+
+- [ ] 4.1 `modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs:1549-1550` の
+  `#[ignore = "..."]` アトリビュートを削除する
+- [ ] 4.2 **watch 登録を `WatchKind::User` から `WatchKind::Supervision` へ変更する** (**MUST**)
+  - 現行 test の `parent.register_watching(child.pid())` (`actor_cell/tests.rs:1574`) は
+    `pub fn register_watching` 経由で `WatchKind::User` を登録している
+  - **問題**: default `pre_restart` の内部動作 `stop_all_children` は `unregister_watching(child_pid)`
+    を呼び、これは `WatchKind::User` のみ除去する（supervision は保持するが、test では supervision が
+    登録されていないので空になる）。この結果、後続の `parent.handle_death_watch_notification(child.pid())`
+    時点で `watching_contains_pid(child.pid()) == false` になり、silently return して
+    `finish_recreate` が起動しない
+  - **修正**: 該当行を `parent.register_supervision_watching(child.pid())` に変更する
+    （`pub(crate) fn register_supervision_watching` が `actor_cell.rs:528` に存在、`WatchKind::Supervision`
+    を登録する）
+  - この修正は、production における `spawn_with_parent` 経由の自動 supervision watch 配線を、
+    test で手動 simulate する意図と一致する（既存 AC-H4 T3 テストでも同様の手動登録を使用）
+- [ ] 4.3 テスト本体 (`al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate`) の
+  アサーション自体はそのまま維持する（本 change + 4.2 の修正で挙動が期待どおりに揃う前提）
+  - `mid_snapshot == vec!["pre_start", "post_stop"]`
+  - `parent.children_state_is_terminating()`
+  - `!parent.children_state_is_normal()`
+  - 明示的 `handle_death_watch_notification` 後の `final_snapshot == vec!["pre_start", "post_stop", "pre_start"]`
+  - `parent.children().is_empty()`
+  - `!parent.mailbox().is_suspended()`
+  - `parent.children_state_is_normal()`
+- [ ] 4.4 `rtk cargo test -p fraktor-actor-core-rs -- al_h1_t2` が passing であることを確認
+- [ ] 4.5 関連 regression として AC-H4 / AC-H5 / AL-H1 の全テストが passing であることを確認:
+  `rtk cargo test -p fraktor-actor-core-rs -- ac_h4 ac_h5 al_h1`
+- [ ] 4.6 **追加 integration test** を 1 件追加する: default `pre_restart` を持つ actor が
+  child を **2 件** 持っているケースで、Recreate 後に children 全員が Terminating{Recreation} に
+  残っており、最後の child の `handle_death_watch_notification` でのみ `finish_recreate` が起動する
+  ことを確認する（現行 T2 は child 1 件のため、複数 child での順序性も検証）
+  - テスト名: `al_h1_t2_default_pre_restart_with_multiple_children_defers_finish_recreate_until_last`
+  - 配置: 同ファイル `actor_cell/tests.rs` の `AL-H1` セクション内（T2 の直後）
+  - 構造: 既存 T2 の cell 作成パターンをコピーし、parent + child_a + child_b の 3 cell を作る
+    - Pid は既存テスト (810-812 は T2 で使用中) と衝突しないように 813 / 814 / 815 を使う
+    - `parent.register_child(child_a.pid())` / `parent.register_child(child_b.pid())` を両方呼ぶ
+  - watch 登録は両 child 分 `parent.register_supervision_watching(child_a.pid())` /
+    `parent.register_supervision_watching(child_b.pid())` を使う（4.2 と同様の理由）
+  - 検証ポイント:
+    - Recreate 後の `parent.children().len() == 2` + `parent.children_state_is_terminating() == true`
+    - child A の DWN を先に呼んで `parent.children_state_is_terminating() == true` のまま維持
+      （まだ to_die に B 残存、`parent.children().len() == 1`）
+    - child B の DWN 後に `parent.children_state_is_normal() == true` + `final_snapshot` に 3 つ目の
+      `"pre_start"` が追加されること（`vec!["pre_start", "post_stop", "pre_start"]`）
+    - `parent.mailbox().is_suspended() == false`
+
+## 5. Pekko 非互換の非回帰確認（**MUST**、本 change 固有のゲート）
+
+**本 change は既存の Pekko 互換テストを破壊してはならない。**ユーザーから明示的に念押しされた
+最重要原則。以下をすべて確認すること。
+
+- [ ] 5.1 `rtk cargo test -p fraktor-actor-core-rs` で全テスト passing（kernel 単体、既存 passing を
+  ignored にしていないこと）
+  - 特に `handle_watch` / `handle_unwatch` / `handle_stop` / `handle_kill` / `handle_failure` /
+    `handle_suspend` / `handle_resume` / `handle_create` / `handle_death_watch_notification` を駆動する
+    全テストが passing
+  - 既存 `executor_shared/tests.rs` の全トランポリンテストが passing（本 change は既存機構の
+    外部駆動 API を追加するだけで既存挙動を変えていない）
+- [ ] 5.2 本 change で新規に `#[ignore]` を追加したテストがないことを確認:
+  `rtk git diff main...HEAD -- modules/actor-core/src/ | grep -E "^\+.*#\[ignore"`
+  が `al_h1_t2` の ignore **削除** (`^-`) のみで、追加 (`^+`) が 0 件
+- [ ] 5.3 guard 適用範囲が `fault_recreate` 内の `pre_restart` 呼び出し 1 点に限定されていること:
+  `rtk grep -rn "run_with_drive_guard" modules/actor-core/src/core/kernel/actor/` が 1 件のみ
+  （`fault_recreate` 内）で、`actor_cell.rs` の他 handler や `system_invoke` 本体には含まれないこと
+- [ ] 5.4 `ActorCellInvoker::system_invoke` 本体が本 change で変更されていないこと:
+  `rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/actor/actor_cell.rs`
+  で `fn system_invoke` の match arm 群やラッパー追加が 0 件
+- [ ] 5.5 `finish_recreate` / `post_restart` 周辺が本 change で変更されていないこと（guard 非適用）:
+  同 git diff で `finish_recreate` 関数内や `post_restart` 呼び出しへの guard 適用が 0 件
+- [ ] 5.6 **`Executor` trait に変更がないこと**を確認:
+  `rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/dispatch/dispatcher/executor.rs`
+  で 0 行（本 change は `ExecutorShared` レベルで完結し、`Executor` trait は触らない）
+
+## 6. production dispatcher 影響確認
+
+- [ ] 6.1 `rtk cargo test -p fraktor-actor-core-rs` 全テスト passing（kernel）
+- [ ] 6.2 `rtk cargo test -p fraktor-actor-adaptor-std-rs` 全テスト passing（std adaptor）
+- [ ] 6.3 `rtk cargo test --workspace` 全テスト passing（ワークスペース全体）
+- [ ] 6.4 `rtk grep -rn "enter_drive_guard\|DriveGuardToken" modules/actor-adaptor-std/ modules/` で
+  adaptor-std や production 側で本 change API が不適切に呼ばれていないことを裏取り
+- [ ] 6.5 production dispatcher (`PinnedExecutor` / `ForkJoinExecutor` / `BalancingExecutor`) の
+  実装が本 change で変更されていないことを確認:
+  `rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/dispatch/dispatcher/pinned_dispatcher.rs
+  modules/actor-core/src/core/kernel/dispatch/dispatcher/default_dispatcher.rs
+  modules/actor-core/src/core/kernel/dispatch/dispatcher/balancing_dispatcher.rs
+  modules/actor-core/src/core/kernel/dispatch/dispatcher/inline_executor.rs`
+  で 0 行
+
+## 7. 品質ゲート（マージ前 MUST 条件）
+
+### 7.1 原則 1 (Pekko 互換 + Rust らしい設計) のゲート
+
+- [ ] 7.1.1 本 change の state machine 図 (design.md 「state machine」セクション) と実装が一致する
+  - `fault_recreate` の `pre_restart` 呼び出し入口で `enter_drive_guard`、戻り時に
+    `DriveGuardToken::drop` で release（RAII で保証）
+  - guard 中の `send_system_message(child, Stop)` が `ExecutorShared` 既存トランポリンで pending に
+    積まれるだけで同一 thread 上で drain されないこと
+- [ ] 7.1.2 Pekko 参照箇所 (`Actor.scala:626-632`, `dungeon/Children.scala:129-142`,
+  `dungeon/FaultHandling.scala:92-118`, `dungeon/FaultHandling.scala:278-303`) との対応が design.md
+  「Pekko 参照実装との対応表」に明記されている
+- [ ] 7.1.3 guard 適用によって Pekko 非互換が **新たに生じていない** ことの検証として、design.md
+  「Pekko 互換性の非回帰確認」セクションで挙げた全テストカテゴリが passing であること（§5 と重複するが
+  設計原則ゲートとして再確認）
+- [ ] 7.1.4 **`DriveGuardToken::drop` 実装に tail drain 相当のロジックが追加されていないこと**を
+  静的に確認 (spec.md Requirement 2 の検証):
+  `rtk grep -En "trampoline|with_write|inner\.execute|pending\.pop" modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared/drive_guard_token.rs`
+  で 0 件 (drop 内で pending キューや内部 executor 呼び出しをしないこと)
+  - 検出されたら実装が既存 `ExecutorShared::execute` Step 4 の tail drain ロジックを `drop` に
+    誤ってコピーしている可能性。design.md 「採用する設計」セクション末尾の禁止事項を参照して削除する
+
+### 7.2 原則 2 (本質的な設計を選ぶ) のゲート
+
+- [ ] 7.2.1 局所 workaround ではなく既存 `ExecutorShared` トランポリンの外部駆動 API を導入していることを
+  confirm。`stop_all_children` / `fault_recreate` 本体の state machine に特例分岐を追加していないこと
+    (`rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/actor/actor_cell.rs actor_context.rs
+    | grep -E "^\+.*// workaround|暫定|一時"` が 0 行)
+- [ ] 7.2.2 本 change で新規追加された `TODO(Phase A3)` は proposal.md の「非目標」に列挙済みの
+  項目のみであること（`finish_terminate` / `finish_create` / typed reason 伝播 / user message 経路
+  guard）:
+  `rtk git diff main...HEAD -- modules/actor-core/src/ | grep -E "^\+.*TODO\(Phase A3\):"`
+  で出力される全行を proposal.md「非目標」と手動で照合する
+
+### 7.3 原則 3 (後方互換性を保つコードを書かない) のゲート
+
+- [ ] 7.3.1 `ExecutorShared` の新規 `enter_drive_guard` API は既存 `pub fn execute` / `pub fn shutdown`
+  と同じスタイル。legacy alias / deprecated 経路を残していないこと
+- [ ] 7.3.2 **公開 `exit_drive_guard` メソッドが存在しないこと**を静的に確認 (spec.md Req1-S5
+  「公開 exit_drive_guard API は存在しない」の検証):
+  `rtk grep -En "pub fn exit_drive_guard|pub\(crate\) fn exit_drive_guard" modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs`
+  で 0 件
+  - release 経路は `DriveGuardToken::drop` のみ。enter / release ペア違反 (release 忘れ・二重 release)
+    を型システムで防止する設計意図を守ること
+- [ ] 7.3.3 暫定 API / 互換層を追加していないこと:
+  `rtk grep -rn "legacy\|compat\|deprecated\|backwards" modules/actor-core/src/core/kernel/dispatch/
+  dispatcher/ modules/actor-core/src/core/kernel/actor/actor_cell.rs` で本 change 由来のヒットが 0 件
+- [ ] 7.3.4 `#[allow(dead_code)]` を本 change で新規追加していないこと
+
+### 7.4 原則 4 (no_std core + std adaptor 分離) のゲート
+
+- [ ] 7.4.1 `rtk grep -rn "^use std::\|^use std$" modules/actor-core/src/core/kernel/dispatch/
+  dispatcher/` が本 change 由来の追加分 0 件
+- [ ] 7.4.2 `cfg-std-forbid` dylint が本 change の新規コードで違反検出しないこと（7.5.1 に含まれる）
+- [ ] 7.4.3 thread-local / `std::sync` 等の std 依存を新規に導入していないこと（本 change は `AtomicBool`
+  / `ArcShared` を流用するのみで新規 std 依存なし）:
+  `rtk grep -rn "std::thread_local\|std::sync::\|thread_local!" modules/actor-core/src/core/kernel/dispatch/dispatcher/`
+  で 0 件
+
+### 7.5 CI / lint の final ゲート
+
+- [ ] 7.5.1 **OpenSpec artifact 整合性の検証**:
+  `openspec validate 2026-04-20-pekko-default-pre-restart-deferred --strict`
+  が valid を返すこと
+  - change name は **ディレクトリ名そのまま** を指定する (archive 済み change 内の tasks.md で
+    日付なしで書かれている箇所があるが、実際の `openspec` CLI は実ディレクトリ名を受け付けるため
+    `2026-04-20-` プレフィックスが必要)
+  - proposal.md / design.md / tasks.md / specs/**/spec.md の構造整合性を OpenSpec 標準 validator で確認
+- [ ] 7.5.2 `./scripts/ci-check.sh ai all` が exit 0
+  - dylint 8 lint 全 pass: mod-file / module-wiring / type-per-file / tests-location / use-placement /
+    rustdoc / cfg-std-forbid / ambiguous-suffix
+  - cargo test / clippy / fmt が全て pass
+  - **TAKT ルール: 本ゲートは change のマージ直前にのみ実行する**

--- a/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/tasks.md
+++ b/openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/tasks.md
@@ -1,18 +1,18 @@
 ## 0. 前提確認
 
-- [ ] 0.1 ブランチが `main` から最新で、前提 change `2026-04-21-2026-04-20-pekko-restart-completion` が archive 済みであることを確認する
-- [ ] 0.2 現在の ignored テスト `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate`
+- [x] 0.1 ブランチが `main` から最新で、前提 change `2026-04-21-2026-04-20-pekko-restart-completion` が archive 済みであることを確認する
+- [x] 0.2 現在の ignored テスト `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate`
   (`modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs:1551`) がまだ `#[ignore]`
   状態で残っていることを確認する。他の AC-H4 / AC-H5 / AL-H1 テストは passing であること
-- [ ] 0.3 `rtk cargo test -p fraktor-actor-core-rs --lib --no-run` が通り、既存テストを壊さない
+- [x] 0.3 `rtk cargo test -p fraktor-actor-core-rs --lib --no-run` が通り、既存テストを壊さない
   ベースラインを確認する
-- [ ] 0.4 `ExecutorShared` 既存トランポリン実装 (`executor_shared.rs:40-146`) を読み、
+- [x] 0.4 `ExecutorShared` 既存トランポリン実装 (`executor_shared.rs:40-146`) を読み、
   `running: ArcShared<AtomicBool>` + `trampoline: SharedLock<TrampolineState>` の役割を把握する
   （本 change は既存 `running` フィールドを外部から CAS で操作する API を追加する）
 
 ## 1. `ExecutorShared` に `enter_drive_guard` + `DriveGuardToken` を追加
 
-- [ ] 1.1 `modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs` に以下 API を追加
+- [x] 1.1 `modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs` に以下 API を追加
   （既存の `pub fn` パターンと同じ可視性 `pub` を使う）:
   ```rust
   pub fn enter_drive_guard(&self) -> DriveGuardToken;
@@ -20,9 +20,9 @@
   - 実装: `self.running.compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire).is_ok()` で
     claimed 判定。成功なら自分が drain owner、失敗なら外側 owner を尊重して no-op 挙動
   - 戻り値: `DriveGuardToken { claimed: bool, running: ArcShared<AtomicBool> }`
-- [ ] 1.2 **`exit_drive_guard` という `&self` メソッドは公開しない** (重要)
+- [x] 1.2 **`exit_drive_guard` という `&self` メソッドは公開しない** (重要)
   - release 経路は `DriveGuardToken::drop` のみ。enter / exit ペア違反を型システムで防止する
-- [ ] 1.3 `DriveGuardToken` struct を配置する:
+- [x] 1.3 `DriveGuardToken` struct を配置する:
   - 配置先判定: `executor_shared.rs` は現状 163 行。token struct (≤15 行程度) を同居させると
     180 行前後で、type-organization.md の「同居先ファイルが同居後も 200 行を超えない」を**満たす**
   - したがって **`executor_shared.rs` 内に同居可**
@@ -32,7 +32,7 @@
   - 採用: **別ファイル `executor_shared/drive_guard_token.rs` に分離配置**
   - `executor_shared.rs` に `mod drive_guard_token;` + `pub use drive_guard_token::DriveGuardToken;` を追加
   - 既存 `executor_shared/tests.rs` のサブディレクトリ構造と一致する
-- [ ] 1.4 `DriveGuardToken` 実装:
+- [x] 1.4 `DriveGuardToken` 実装:
   ```rust
   #[must_use = "DriveGuardToken must be held for the full guarded region; \
                 drop it at the end of the scope where `enter_drive_guard` was called"]
@@ -65,45 +65,45 @@
     に書かないこと。理由は design.md 「採用する設計」セクション末尾を参照（tail drain を `drop` で
     実行すると guard 中に積まれた child.Stop が同期 drain され Pekko async dispatcher 非互換の再入を
     引き起こす）。rustdoc にもこの禁止事項を明記する
-- [ ] 1.5 `executor_shared/tests.rs` に以下を検証するテストを追加:
+- [x] 1.5 `executor_shared/tests.rs` に以下を検証するテストを追加:
   - `enter_drive_guard` 呼び出し中の `execute` は trampoline に積まれるだけで `inner.execute` が呼ばれない
     こと（既存 `execute` のロジックそのままで実現されるが、smoke test として記述）
   - `enter_drive_guard` を連続呼び出すと、1 回目は `claimed=true`、2 回目は `claimed=false`
   - token drop 後に `running=false` に戻っていること (1 回目)、2 回目 token drop は no-op
   - `enter_drive_guard` → `f()` 内で `execute` → `f()` 終了後も pending に task が残り、
     次の外部 `execute` で drain されること
-- [ ] 1.6 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
+- [x] 1.6 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
 
 ## 2. `MessageDispatcherShared::run_with_drive_guard` を追加
 
-- [ ] 2.1 `modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared.rs` に
+- [x] 2.1 `modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared.rs` に
   以下シグネチャの helper を追加（可視性は `pub(crate)`、外部 crate からの利用は本 change では不要）:
   ```rust
   pub(crate) fn run_with_drive_guard<F, R>(&self, f: F) -> R
   where
       F: FnOnce() -> R;
   ```
-- [ ] 2.2 実装は以下:
+- [x] 2.2 実装は以下:
   1. 既存 `self.executor()` helper (`message_dispatcher_shared.rs:83`) を使って
      `ExecutorShared` を取得する（`register_for_execution` と同じ経路を流用）
   2. `let _token = executor.enter_drive_guard();` で RAII token を保持
   3. `f()` を呼び戻り値を返す
   4. scope 終了時に `_token` が drop され、`claimed=true` なら `running=false` に戻る
-- [ ] 2.3 **注意**: `DriveGuard<'a>` のような外部参照 wrapper 型は作らない。`DriveGuardToken` が
+- [x] 2.3 **注意**: `DriveGuard<'a>` のような外部参照 wrapper 型は作らない。`DriveGuardToken` が
   `ArcShared<AtomicBool>` を owned clone で保持するためライフタイム制約がない
-- [ ] 2.4 `message_dispatcher_shared/tests.rs` に以下を追加:
+- [x] 2.4 `message_dispatcher_shared/tests.rs` に以下を追加:
   - `run_with_drive_guard` 内で `f()` が呼び出し直接実行されること
   - `f()` が panic しても `DriveGuardToken::drop` が呼ばれ `running=false` に戻ること（RAII 確認）
   - `f()` 内で `system_dispatch` を呼んだ場合、target mailbox は guard 解除後も pending として
     残り synchronous に drain されないこと（`InlineExecutor` を差し替えた smoke test）
-- [ ] 2.5 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
+- [x] 2.5 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
 
 ## 3. `fault_recreate` 内の `pre_restart` 呼び出しを guard でラップ
 
 **注: ガード適用範囲は `pre_restart` 呼び出し 1 点に限定する**。`ActorCellInvoker::system_invoke`
 全体や `fault_recreate` 全体はラップしない（design.md 「却下案 1」参照）。
 
-- [ ] 3.1 `modules/actor-core/src/core/kernel/actor/actor_cell.rs` の `fault_recreate` を編集し、
+- [x] 3.1 `modules/actor-core/src/core/kernel/actor/actor_cell.rs` の `fault_recreate` を編集し、
   `self.actor.with_write(|actor| actor.pre_restart(&mut ctx, cause))?` の呼び出しを
   `run_with_drive_guard` でラップする
   - 実装例の詳細は **design.md の「ActorCell::fault_recreate の局所ラップ」セクション**参照
@@ -115,23 +115,23 @@
     borrow が解放されるので、後続の `ctx.clear_sender()` は通る
   - 既存の Pekko parity コメント（`is_failed_fatally` no-op の意図説明、`debug_assert!` の
     AC-H3 precondition コメント等）は **保持すること**（本 change の範囲外で削除しない）
-- [ ] 3.2 `fault_recreate` 内の他の処理 (`is_failed_fatally` 早期 return、`debug_assert!` の mailbox
+- [x] 3.2 `fault_recreate` 内の他の処理 (`is_failed_fatally` 早期 return、`debug_assert!` の mailbox
   suspended 検査、`set_children_termination_reason` 呼び出し、`finish_recreate` への fall-through) は
   **guard の外側**に置く。これらは再入問題を起こさないため guard 不要
-- [ ] 3.3 rustdoc コメントで、pre_restart ラップの意図（「default pre_restart が stop_all_children を
+- [x] 3.3 rustdoc コメントで、pre_restart ラップの意図（「default pre_restart が stop_all_children を
   呼ぶ sync dispatch 経路で child mailbox の inline 再入 drain を防ぐ。production は既存 ExecutorShared
   トランポリンが効いているため no-op 的に通過する」）を明記
-- [ ] 3.4 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
-- [ ] 3.5 既存 AC-H4 / AC-H5 / AL-H1 テスト群が全 passing であることを確認（regression check）:
+- [x] 3.4 `rtk cargo check -p fraktor-actor-core-rs` がクリーンビルドされることを確認
+- [x] 3.5 既存 AC-H4 / AC-H5 / AL-H1 テスト群が全 passing であることを確認（regression check）:
   `rtk cargo test -p fraktor-actor-core-rs -- ac_h4 ac_h5 al_h1`
-- [ ] 3.6 `finish_recreate` の `post_restart` 呼び出しには **guard を適用しない**ことを確認
+- [x] 3.6 `finish_recreate` の `post_restart` 呼び出しには **guard を適用しない**ことを確認
   （design.md 「ActorCell::fault_recreate の局所ラップ」の末尾参照）
 
 ## 4. ignored テストの復活 + watch 登録修正 + 複数 child 検証の追加
 
-- [ ] 4.1 `modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs:1549-1550` の
+- [x] 4.1 `modules/actor-core/src/core/kernel/actor/actor_cell/tests.rs:1549-1550` の
   `#[ignore = "..."]` アトリビュートを削除する
-- [ ] 4.2 **watch 登録を `WatchKind::User` から `WatchKind::Supervision` へ変更する** (**MUST**)
+- [x] 4.2 **watch 登録を `WatchKind::User` から `WatchKind::Supervision` へ変更する** (**MUST**)
   - 現行 test の `parent.register_watching(child.pid())` (`actor_cell/tests.rs:1574`) は
     `pub fn register_watching` 経由で `WatchKind::User` を登録している
   - **問題**: default `pre_restart` の内部動作 `stop_all_children` は `unregister_watching(child_pid)`
@@ -144,7 +144,7 @@
     を登録する）
   - この修正は、production における `spawn_with_parent` 経由の自動 supervision watch 配線を、
     test で手動 simulate する意図と一致する（既存 AC-H4 T3 テストでも同様の手動登録を使用）
-- [ ] 4.3 テスト本体 (`al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate`) の
+- [x] 4.3 テスト本体 (`al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate`) の
   アサーション自体はそのまま維持する（本 change + 4.2 の修正で挙動が期待どおりに揃う前提）
   - `mid_snapshot == vec!["pre_start", "post_stop"]`
   - `parent.children_state_is_terminating()`
@@ -153,10 +153,10 @@
   - `parent.children().is_empty()`
   - `!parent.mailbox().is_suspended()`
   - `parent.children_state_is_normal()`
-- [ ] 4.4 `rtk cargo test -p fraktor-actor-core-rs -- al_h1_t2` が passing であることを確認
-- [ ] 4.5 関連 regression として AC-H4 / AC-H5 / AL-H1 の全テストが passing であることを確認:
+- [x] 4.4 `rtk cargo test -p fraktor-actor-core-rs -- al_h1_t2` が passing であることを確認
+- [x] 4.5 関連 regression として AC-H4 / AC-H5 / AL-H1 の全テストが passing であることを確認:
   `rtk cargo test -p fraktor-actor-core-rs -- ac_h4 ac_h5 al_h1`
-- [ ] 4.6 **追加 integration test** を 1 件追加する: default `pre_restart` を持つ actor が
+- [x] 4.6 **追加 integration test** を 1 件追加する: default `pre_restart` を持つ actor が
   child を **2 件** 持っているケースで、Recreate 後に children 全員が Terminating{Recreation} に
   残っており、最後の child の `handle_death_watch_notification` でのみ `finish_recreate` が起動する
   ことを確認する（現行 T2 は child 1 件のため、複数 child での順序性も検証）
@@ -180,36 +180,36 @@
 **本 change は既存の Pekko 互換テストを破壊してはならない。**ユーザーから明示的に念押しされた
 最重要原則。以下をすべて確認すること。
 
-- [ ] 5.1 `rtk cargo test -p fraktor-actor-core-rs` で全テスト passing（kernel 単体、既存 passing を
+- [x] 5.1 `rtk cargo test -p fraktor-actor-core-rs` で全テスト passing（kernel 単体、既存 passing を
   ignored にしていないこと）
   - 特に `handle_watch` / `handle_unwatch` / `handle_stop` / `handle_kill` / `handle_failure` /
     `handle_suspend` / `handle_resume` / `handle_create` / `handle_death_watch_notification` を駆動する
     全テストが passing
   - 既存 `executor_shared/tests.rs` の全トランポリンテストが passing（本 change は既存機構の
     外部駆動 API を追加するだけで既存挙動を変えていない）
-- [ ] 5.2 本 change で新規に `#[ignore]` を追加したテストがないことを確認:
+- [x] 5.2 本 change で新規に `#[ignore]` を追加したテストがないことを確認:
   `rtk git diff main...HEAD -- modules/actor-core/src/ | grep -E "^\+.*#\[ignore"`
   が `al_h1_t2` の ignore **削除** (`^-`) のみで、追加 (`^+`) が 0 件
-- [ ] 5.3 guard 適用範囲が `fault_recreate` 内の `pre_restart` 呼び出し 1 点に限定されていること:
+- [x] 5.3 guard 適用範囲が `fault_recreate` 内の `pre_restart` 呼び出し 1 点に限定されていること:
   `rtk grep -rn "run_with_drive_guard" modules/actor-core/src/core/kernel/actor/` が 1 件のみ
   （`fault_recreate` 内）で、`actor_cell.rs` の他 handler や `system_invoke` 本体には含まれないこと
-- [ ] 5.4 `ActorCellInvoker::system_invoke` 本体が本 change で変更されていないこと:
+- [x] 5.4 `ActorCellInvoker::system_invoke` 本体が本 change で変更されていないこと:
   `rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/actor/actor_cell.rs`
   で `fn system_invoke` の match arm 群やラッパー追加が 0 件
-- [ ] 5.5 `finish_recreate` / `post_restart` 周辺が本 change で変更されていないこと（guard 非適用）:
+- [x] 5.5 `finish_recreate` / `post_restart` 周辺が本 change で変更されていないこと（guard 非適用）:
   同 git diff で `finish_recreate` 関数内や `post_restart` 呼び出しへの guard 適用が 0 件
-- [ ] 5.6 **`Executor` trait に変更がないこと**を確認:
+- [x] 5.6 **`Executor` trait に変更がないこと**を確認:
   `rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/dispatch/dispatcher/executor.rs`
   で 0 行（本 change は `ExecutorShared` レベルで完結し、`Executor` trait は触らない）
 
 ## 6. production dispatcher 影響確認
 
-- [ ] 6.1 `rtk cargo test -p fraktor-actor-core-rs` 全テスト passing（kernel）
-- [ ] 6.2 `rtk cargo test -p fraktor-actor-adaptor-std-rs` 全テスト passing（std adaptor）
-- [ ] 6.3 `rtk cargo test --workspace` 全テスト passing（ワークスペース全体）
-- [ ] 6.4 `rtk grep -rn "enter_drive_guard\|DriveGuardToken" modules/actor-adaptor-std/ modules/` で
+- [x] 6.1 `rtk cargo test -p fraktor-actor-core-rs` 全テスト passing（kernel）
+- [x] 6.2 `rtk cargo test -p fraktor-actor-adaptor-std-rs` 全テスト passing（std adaptor）
+- [x] 6.3 `rtk cargo test --workspace` 全テスト passing（ワークスペース全体）
+- [x] 6.4 `rtk grep -rn "enter_drive_guard\|DriveGuardToken" modules/actor-adaptor-std/ modules/` で
   adaptor-std や production 側で本 change API が不適切に呼ばれていないことを裏取り
-- [ ] 6.5 production dispatcher (`PinnedExecutor` / `ForkJoinExecutor` / `BalancingExecutor`) の
+- [x] 6.5 production dispatcher (`PinnedExecutor` / `ForkJoinExecutor` / `BalancingExecutor`) の
   実装が本 change で変更されていないことを確認:
   `rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/dispatch/dispatcher/pinned_dispatcher.rs
   modules/actor-core/src/core/kernel/dispatch/dispatcher/default_dispatcher.rs
@@ -221,18 +221,18 @@
 
 ### 7.1 原則 1 (Pekko 互換 + Rust らしい設計) のゲート
 
-- [ ] 7.1.1 本 change の state machine 図 (design.md 「state machine」セクション) と実装が一致する
+- [x] 7.1.1 本 change の state machine 図 (design.md 「state machine」セクション) と実装が一致する
   - `fault_recreate` の `pre_restart` 呼び出し入口で `enter_drive_guard`、戻り時に
     `DriveGuardToken::drop` で release（RAII で保証）
   - guard 中の `send_system_message(child, Stop)` が `ExecutorShared` 既存トランポリンで pending に
     積まれるだけで同一 thread 上で drain されないこと
-- [ ] 7.1.2 Pekko 参照箇所 (`Actor.scala:626-632`, `dungeon/Children.scala:129-142`,
+- [x] 7.1.2 Pekko 参照箇所 (`Actor.scala:626-632`, `dungeon/Children.scala:129-142`,
   `dungeon/FaultHandling.scala:92-118`, `dungeon/FaultHandling.scala:278-303`) との対応が design.md
   「Pekko 参照実装との対応表」に明記されている
-- [ ] 7.1.3 guard 適用によって Pekko 非互換が **新たに生じていない** ことの検証として、design.md
+- [x] 7.1.3 guard 適用によって Pekko 非互換が **新たに生じていない** ことの検証として、design.md
   「Pekko 互換性の非回帰確認」セクションで挙げた全テストカテゴリが passing であること（§5 と重複するが
   設計原則ゲートとして再確認）
-- [ ] 7.1.4 **`DriveGuardToken::drop` 実装に tail drain 相当のロジックが追加されていないこと**を
+- [x] 7.1.4 **`DriveGuardToken::drop` 実装に tail drain 相当のロジックが追加されていないこと**を
   静的に確認 (spec.md Requirement 2 の検証):
   `rtk grep -En "trampoline|with_write|inner\.execute|pending\.pop" modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared/drive_guard_token.rs`
   で 0 件 (drop 内で pending キューや内部 executor 呼び出しをしないこと)
@@ -241,11 +241,11 @@
 
 ### 7.2 原則 2 (本質的な設計を選ぶ) のゲート
 
-- [ ] 7.2.1 局所 workaround ではなく既存 `ExecutorShared` トランポリンの外部駆動 API を導入していることを
+- [x] 7.2.1 局所 workaround ではなく既存 `ExecutorShared` トランポリンの外部駆動 API を導入していることを
   confirm。`stop_all_children` / `fault_recreate` 本体の state machine に特例分岐を追加していないこと
     (`rtk git diff main...HEAD -- modules/actor-core/src/core/kernel/actor/actor_cell.rs actor_context.rs
     | grep -E "^\+.*// workaround|暫定|一時"` が 0 行)
-- [ ] 7.2.2 本 change で新規追加された `TODO(Phase A3)` は proposal.md の「非目標」に列挙済みの
+- [x] 7.2.2 本 change で新規追加された `TODO(Phase A3)` は proposal.md の「非目標」に列挙済みの
   項目のみであること（`finish_terminate` / `finish_create` / typed reason 伝播 / user message 経路
   guard）:
   `rtk git diff main...HEAD -- modules/actor-core/src/ | grep -E "^\+.*TODO\(Phase A3\):"`
@@ -253,39 +253,39 @@
 
 ### 7.3 原則 3 (後方互換性を保つコードを書かない) のゲート
 
-- [ ] 7.3.1 `ExecutorShared` の新規 `enter_drive_guard` API は既存 `pub fn execute` / `pub fn shutdown`
+- [x] 7.3.1 `ExecutorShared` の新規 `enter_drive_guard` API は既存 `pub fn execute` / `pub fn shutdown`
   と同じスタイル。legacy alias / deprecated 経路を残していないこと
-- [ ] 7.3.2 **公開 `exit_drive_guard` メソッドが存在しないこと**を静的に確認 (spec.md Req1-S5
+- [x] 7.3.2 **公開 `exit_drive_guard` メソッドが存在しないこと**を静的に確認 (spec.md Req1-S5
   「公開 exit_drive_guard API は存在しない」の検証):
   `rtk grep -En "pub fn exit_drive_guard|pub\(crate\) fn exit_drive_guard" modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs`
   で 0 件
   - release 経路は `DriveGuardToken::drop` のみ。enter / release ペア違反 (release 忘れ・二重 release)
     を型システムで防止する設計意図を守ること
-- [ ] 7.3.3 暫定 API / 互換層を追加していないこと:
+- [x] 7.3.3 暫定 API / 互換層を追加していないこと:
   `rtk grep -rn "legacy\|compat\|deprecated\|backwards" modules/actor-core/src/core/kernel/dispatch/
   dispatcher/ modules/actor-core/src/core/kernel/actor/actor_cell.rs` で本 change 由来のヒットが 0 件
-- [ ] 7.3.4 `#[allow(dead_code)]` を本 change で新規追加していないこと
+- [x] 7.3.4 `#[allow(dead_code)]` を本 change で新規追加していないこと
 
 ### 7.4 原則 4 (no_std core + std adaptor 分離) のゲート
 
-- [ ] 7.4.1 `rtk grep -rn "^use std::\|^use std$" modules/actor-core/src/core/kernel/dispatch/
+- [x] 7.4.1 `rtk grep -rn "^use std::\|^use std$" modules/actor-core/src/core/kernel/dispatch/
   dispatcher/` が本 change 由来の追加分 0 件
-- [ ] 7.4.2 `cfg-std-forbid` dylint が本 change の新規コードで違反検出しないこと（7.5.1 に含まれる）
-- [ ] 7.4.3 thread-local / `std::sync` 等の std 依存を新規に導入していないこと（本 change は `AtomicBool`
+- [x] 7.4.2 `cfg-std-forbid` dylint が本 change の新規コードで違反検出しないこと（7.5.1 に含まれる）
+- [x] 7.4.3 thread-local / `std::sync` 等の std 依存を新規に導入していないこと（本 change は `AtomicBool`
   / `ArcShared` を流用するのみで新規 std 依存なし）:
   `rtk grep -rn "std::thread_local\|std::sync::\|thread_local!" modules/actor-core/src/core/kernel/dispatch/dispatcher/`
   で 0 件
 
 ### 7.5 CI / lint の final ゲート
 
-- [ ] 7.5.1 **OpenSpec artifact 整合性の検証**:
+- [x] 7.5.1 **OpenSpec artifact 整合性の検証**:
   `openspec validate 2026-04-20-pekko-default-pre-restart-deferred --strict`
   が valid を返すこと
   - change name は **ディレクトリ名そのまま** を指定する (archive 済み change 内の tasks.md で
     日付なしで書かれている箇所があるが、実際の `openspec` CLI は実ディレクトリ名を受け付けるため
     `2026-04-20-` プレフィックスが必要)
   - proposal.md / design.md / tasks.md / specs/**/spec.md の構造整合性を OpenSpec 標準 validator で確認
-- [ ] 7.5.2 `./scripts/ci-check.sh ai all` が exit 0
+- [x] 7.5.2 `./scripts/ci-check.sh ai all` が exit 0
   - dylint 8 lint 全 pass: mod-file / module-wiring / type-per-file / tests-location / use-placement /
     rustdoc / cfg-std-forbid / ambiguous-suffix
   - cargo test / clippy / fmt が全て pass


### PR DESCRIPTION
## 目的

Apache Pekko との `preRestart` parity を同期/inline dispatcher で復元する。default `preRestart` + 生存 child がある restart シナリオで `finish_recreate` が前倒しに発火していたギャップを埋める。

関連 OpenSpec change: `openspec/changes/2026-04-20-pekko-default-pre-restart-deferred/`

## 問題

`ActorCell::fault_recreate` の `pre_restart` が `stop_all_children` 経由で child mailbox へ `SystemMessage::Stop` を送ると、sync/inline dispatcher では呼び出し元スタック上で child mailbox drain が発生する。これにより `set_children_termination_reason(Recreation)` 適用前に `handle_death_watch_notification` が再入し、`finish_recreate` が `UserRequest` 扱い（no-op）で先に流れるか、即時 fall-through していた。ignored された `al_h1_t2` テストがこのギャップを捕捉していた。

## 設計の要点

既存の `ExecutorShared` trampoline (`running: AtomicBool` + `trampoline.pending`) を再利用し、**外部からの drain-owner claim API** を追加する。

- `ExecutorShared::enter_drive_guard() -> DriveGuardToken`
  - `compare_exchange(false, true, AcqRel, Acquire)` で CAS claim
  - 既に他の drain owner が active なら no-op token
  - **公開 `exit_drive_guard` は存在しない** — release は `Drop` のみ（`#[must_use]`、`const fn new`）
- `DriveGuardToken::drop`
  - `claimed=true` なら `running.store(false, Release)`
  - **tail drain は意図的に行わない** — pending は次の外部 `execute` が拾う（Pekko async dispatcher 呼び出し脱出時に他 actor の mailbox をflushしない動作と合致）
- `MessageDispatcherShared::run_with_drive_guard(f)` — RAII ラッパ（panic-safe）
- `ActorCell::fault_recreate` — **`pre_restart` の1行のみ** をラップ

## Pekko 互換性

`Executor` trait / `InlineExecutor` / `PinnedExecutor` / `BalancingExecutor` / `ForkJoinExecutor` / 他 handler（`handle_watch`/`unwatch`/`stop`/`kill`/`failure`/`suspend`/`resume`/`create`/`death_watch_notification`, `finish_recreate`/`post_restart`, `ActorCellInvoker::system_invoke`）は**一切変更なし**。production async dispatcher は既に `mailbox.run` スケジュール時にトランポリンへ入るため、この wrap は実質 no-op。

design.md に 5 つの rejected alternative（`system_invoke` 全体 wrap / `stop_all_children` 分離 / 事前 Recreation 昇格 / `Executor` trait 追加 / `Drop` での tail drain）を検討結果とともに明記。

## 検証

- `./scripts/ci-check.sh ai all` pass（8 custom dylints + cargo test/clippy/fmt）
- `openspec validate 2026-04-20-pekko-default-pre-restart-deferred --strict`: valid
- 新規/復活テスト
  - `al_h1_t2_default_pre_restart_stops_children_and_defers_finish_recreate` — 単一 child（`#[ignore]` 解除 + pre-wired watch を `register_supervision_watching` に切替）
  - `al_h1_t2_default_pre_restart_with_multiple_children_defers_finish_recreate_until_last` — 複数 child 順序検証
  - `DriveGuardToken`/`enter_drive_guard`/`run_with_drive_guard` の CAS・nested no-op・drop release・panic-safety ユニット
- workspace 全テスト: 4559 passed

## Artifacts

- `proposal.md` — Why / What Changes / Capabilities / Impact / Non-goals / Dependencies
- `design.md` — Pekko source 表 / 既存 trampoline 分析 / 採用設計 / 5 rejected alternatives / 状態遷移図
- `tasks.md` — 53タスク（全 `[x]`）
- `specs/actor-runtime-safety/spec.md` — 5 Requirements / 14 Scenarios
- `specs/pekko-restart-completion/spec.md` — 1 Requirement / 3 Scenarios

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core dispatcher/executor scheduling semantics and restart lifecycle ordering; although usage is narrowly scoped to `fault_recreate` and backed by new tests, subtle concurrency/ordering regressions are possible.
> 
> **Overview**
> Closes a Pekko-parity gap where `fault_recreate` could synchronously reenter parent/child mailboxes under inline/sync dispatch when default `pre_restart` stops children, causing restart completion to run too early.
> 
> Adds an `ExecutorShared` *drive guard* (`enter_drive_guard` + RAII `DriveGuardToken`) and `MessageDispatcherShared::run_with_drive_guard` so guarded regions claim the drain-owner slot and force nested `execute` calls to enqueue rather than drain on the current stack. `ActorCell::fault_recreate` now wraps only the `pre_restart` call with this guard.
> 
> Updates/expands tests to un-ignore and validate deferred restart with default `pre_restart` (including multiple-children ordering), and adds unit tests around guard CAS behavior, no tail-drain on drop, and panic-safety. Adds OpenSpec design/proposal/spec/task artifacts documenting the new requirements and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d18ab4aba038337c813a6092579156794119179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アクター障害回復時の並行実行制御を改善するドライブガード機構を追加しました。

* **バグ修正**
  * アクター再起動処理における同期化の問題を修正しました。メッセージ処理中の排出所有権管理が適切に行われるようになり、予期しない動作を防ぎます。

* **テスト**
  * ドライブガード機構と複数チャイルドアクターの再起動シナリオを検証する包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->