### PR TITLE
refactor(actor-core): retire 16 half-finished implementations (Change B Phase 1)

### DIFF
--- a/docs/gap-analysis/actor-gap-analysis.md
+++ b/docs/gap-analysis/actor-gap-analysis.md
@@ -17,7 +17,7 @@
 - classic の Java 継承 DSL (`AbstractActor`, `ReceiveBuilder`, `AbstractActorWithTimers` 等) は JVM / Java モデル依存のため `n/a` 判定
 - Java DSL 全般 (`javadsl/`, `japi/`) は `n/a` 判定
 - Pekko IO パッケージ (`io/Tcp`, `io/Udp`, `io/Dns` 等) はネットワーク IO モジュールであり、fraktor-rs ではランタイム非依存の actor core に含めず、将来 remote / transport モジュールで扱うため `n/a` 判定
-- 分析日: 2026-04-23（初版: 2026-04-15、第2版: 2026-04-16、第3版: 2026-04-17、第4版: 2026-04-17、第5版: 2026-04-17、第6版: 2026-04-17、第7版: 2026-04-18、第8版: 2026-04-19、**第8.1版: 2026-04-19** — Phase A1 完了反映、**第9版: 2026-04-21** — InvokeGuard / PanicInvokeGuard による SP-H1.5 完了反映、**第10版: 2026-04-22** — Phase A2+ (AC-H2/H3/H4/H5/AL-H1/ES-H1) 全完了反映、**第11版: 2026-04-22** — SP-M1 (maxNrOfRetries 意味反転) 完了反映、`RestartLimit` enum + Pekko one-shot window 実装、**第12版: 2026-04-22** — MB-M1 (mailbox throughput deadline) 完了反映、**第13版: 2026-04-22** — AC-M5 (NotInfluenceReceiveTimeout marker) 完了反映、**第14版: 2026-04-23** — AC-M1/M3 (PinnedDispatcher 排他 / isFailed guard) 完了反映、**第15版: 2026-04-23** — AC-M4a (watchWith 重複チェック) + AL-M1 (post_restart) 完了反映、**第16版: 2026-04-23** — MB-M3 n/a 化 / ES-M1 low 降格、**第17版: 2026-04-23** — MB-M2 (BoundedDequeBasedMailbox / BoundedControlAwareMailbox) 完了反映、**第18版: 2026-04-23** — AC-M2 (Dispatchers alias chain resolution, MAX_ALIAS_DEPTH=20) 完了反映、HOCON dynamic loading は JVM reflection 依存のため n/a 確定、**第19版: 2026-04-23** — DP-M1 (Dispatcher primary id flip) + MB-P1 (Mailbox primary id flip) 完了反映、legacy `"default"` 完全退役）
+- 分析日: 2026-04-23（初版: 2026-04-15、第2版: 2026-04-16、第3版: 2026-04-17、第4版: 2026-04-17、第5版: 2026-04-17、第6版: 2026-04-17、第7版: 2026-04-18、第8版: 2026-04-19、**第8.1版: 2026-04-19** — Phase A1 完了反映、**第9版: 2026-04-21** — InvokeGuard / PanicInvokeGuard による SP-H1.5 完了反映、**第10版: 2026-04-22** — Phase A2+ (AC-H2/H3/H4/H5/AL-H1/ES-H1) 全完了反映、**第11版: 2026-04-22** — SP-M1 (maxNrOfRetries 意味反転) 完了反映、`RestartLimit` enum + Pekko one-shot window 実装、**第12版: 2026-04-22** — MB-M1 (mailbox throughput deadline) 完了反映、**第13版: 2026-04-22** — AC-M5 (NotInfluenceReceiveTimeout marker) 完了反映、**第14版: 2026-04-23** — AC-M1/M3 (PinnedDispatcher 排他 / isFailed guard) 完了反映、**第15版: 2026-04-23** — AC-M4a (watchWith 重複チェック) + AL-M1 (post_restart) 完了反映、**第16版: 2026-04-23** — MB-M3 n/a 化 / ES-M1 low 降格、**第17版: 2026-04-23** — MB-M2 (BoundedDequeBasedMailbox / BoundedControlAwareMailbox) 完了反映、**第18版: 2026-04-23** — AC-M2 (Dispatchers alias chain resolution, MAX_ALIAS_DEPTH=20) 完了反映、HOCON dynamic loading は JVM reflection 依存のため n/a 確定、**第19版: 2026-04-23** — DP-M1 (Dispatcher primary id flip) + MB-P1 (Mailbox primary id flip) 完了反映、legacy `"default"` 完全退役、**第20版: 2026-04-23** — 中途半端な実装の残骸削除 16 件 (change `pekko-dead-code-retire-phase1`))
 - **第8版での重大な是正**: 第7版までは「公開 API カバレッジ 100%」で parity 完了として扱っていたが、これは **型と関数シグネチャの存在** を測ったにすぎず、**内部セマンティクス (実行時の契約)** が Pekko と一致しているかは検証していなかった。第8版では Mailbox / Dispatcher / ActorCell / ChildrenContainer / FaultHandling / DeathWatch / ReceiveTimeout / ActorLifecycle / EventStream / FSM / Stash / SupervisorStrategy の計 34 観点を Pekko 参照実装と行単位で比較し、**high 11 件 / medium 13 件 / low 約 10 件の内部セマンティクス不一致を検出した**。公開 API カウントでのカバレッジ (100%) は維持するが、**"internal parity gap" は Phase A として未解決扱い**とし、本版末尾に「内部セマンティクスギャップ」セクションを追加する。
 - 第3版での追加検出: Pekko 側を `actor` / `actor-typed` 両パッケージから全件再抽出し、ergonomics 系 API と classic 補助パターンの未対応項目を新たに洗い出した。
 - 第4版での更新: `SmallestMailboxRoutingLogic` の Pekko 互換化を実装完了（2パス探索・`isSuspended`/`isProcessingMessage` 追跡・スコアリング）。部分実装ギャップは 1 件に減少。
@@ -474,6 +474,46 @@ low 判定約 10 件。公開 API には影響せず、優先度は低い。Phas
 各エージェントは **8〜16 観点**で一致判定（完全一致 / 部分一致 / 不一致 / 未実装）と深刻度（low / medium / high）を出力。合計 34 観点。
 
 今後は、**pekko-porting facets の implement ステップ** でこの比較手法を個別バッチに適用し、新規実装のたびに内部セマンティクス突合を必須化する。`.takt/facets/instructions/pekko-porting-implement.md` の Fake Gap チェックはシグネチャ面の偽装検出だが、**内部セマンティクス逸脱は Fake Gap チェックを通過してしまう** ため、別途「Pekko 内部参照の行単位突合」を追加する必要がある（今後の facets 改訂で検討）。
+
+## 中途半端な実装の残骸削除 (第20版)
+
+change: `pekko-dead-code-retire-phase1`
+scope: `modules/actor-core/`
+原則: CLAUDE.md "No half-finished implementations either" 遵守
+
+actor-core の `#[allow(dead_code)]` 46 箇所を監査し、**production / test 双方から参照ゼロ** の 16 項目を残骸として削除。Pekko 互換機能は他経路 (`SystemStateShared`, `ExtendedActorSystem` 等) で既に成立しているため、削除による機能退行はない。
+
+### 削除済み (残骸 16 件 + cascade)
+
+| # | item | 削除理由 |
+|---|------|---------|
+| 1 | `ActorRefProviders::contains_key` | 外部参照 0 |
+| 2 | `ActorRefProviders::values` | 外部参照 0 |
+| 3 | `Cells::contains` | 外部参照 0 |
+| 4 | `Cells::len` | 外部参照 0 |
+| 5 | `Cells::is_empty` | 外部参照 0 |
+| 6 | `ActorSystem::register_temp_actor` | `SystemStateShared` に同等機能、ActorSystem 層での再ラップ不要 |
+| 7 | `ActorSystem::unregister_temp_actor` | 同上 |
+| 8 | `ActorSystem::temp_actor` | 同上 |
+| 9 | `SystemStateShared::handle_failure` + `suspend_for_escalation` | 再帰 self-call のみ、external entry なし |
+| 10 | `SystemState::handle_failure` + `suspend_for_escalation` + `stop_actor` + test `recreate_send_failure_escalates_and_stops_parent` | 同上 |
+| 11 | `ConsumerControllerCommand::retry` (constructor) | variant は match で直接使用、constructor 未使用 |
+| 12 | `ConsumerControllerCommand::consumer_terminated` (constructor) | 同上 |
+| 13 | `ProducerControllerCommand::msg_with_confirmation` (constructor) | 同上 |
+| 14 | `TypedScheduler::inner` | 公開 accessor の未使用残骸 |
+| 15 | `Scheduler::raw` | 同上 |
+| 16 | `TypedActorSystem::spawn` (untyped パス alias) | 未使用 |
+
+#### Item 10 の連鎖削除 (handle_failure 除去に伴う孤児)
+
+`SystemState` の `forward_remote_watch` / `forward_remote_unwatch` / `send_system_message` / `record_send_error` は `handle_failure` および自身の再帰呼び出しのみから到達可能であり、handle_failure 除去後は非到達。同時に削除。対応する test `system_state_send_system_message_to_nonexistent_actor` / `system_state_record_send_error` (SystemState 層の duplicate API を検証していた冗長テスト) も削除。production 経路は `SystemStateShared::send_system_message` / `record_send_error` (生きている) に集約。
+
+### 結果
+
+- `#[allow(dead_code)]` 件数: **46 → 29 (−17 件)**
+- 削除後の残存 29 件の内訳:
+  - LIVE-BUG 系 (実際は使われているが `#[allow]` が誤って付いている) の除去は **次 PR** で対応予定
+  - EXEMPT (compile-time guard / test helper / platform-cfg) は原則残置
 
 ## まとめ
 

--- a/docs/gap-analysis/actor-gap-analysis.md
+++ b/docs/gap-analysis/actor-gap-analysis.md
@@ -510,9 +510,10 @@ actor-core の `#[allow(dead_code)]` 46 箇所を監査し、**production / test
 
 ### 結果
 
-- `#[allow(dead_code)]` 件数: **46 → 29 (−17 件)**
-- 削除後の残存 29 件の内訳:
-  - LIVE-BUG 系 (実際は使われているが `#[allow]` が誤って付いている) の除去は **次 PR** で対応予定
+- `#[allow(dead_code)]` 件数: **49 → 32 (−17 件)**
+- 内訳: 削除 item 16 件分の item-level allow 16 件 + `impl ActorRefProviders` の block-level allow 1 件 (item 削除に伴い LIVE-BUG 扱いで一括除去) = **17 件**
+- 削除後の残存 32 件:
+  - LIVE-BUG 系 (実際は使われているが `#[allow]` が誤って付いている、例: `impl Cells` の block-level allow 等) の除去は **次 PR** で対応予定
   - EXEMPT (compile-time guard / test helper / platform-cfg) は原則残置
 
 ## まとめ

--- a/modules/actor-core/src/core/kernel/actor/actor_ref_provider/actor_ref_providers.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_ref_provider/actor_ref_providers.rs
@@ -14,19 +14,11 @@ pub(crate) struct ActorRefProviders {
   map:     HashMap<TypeId, ArcShared<dyn Any + Send + Sync + 'static>, RandomState>,
   _marker: PhantomData<()>,
 }
-#[allow(dead_code)]
 impl ActorRefProviders {
   /// Creates a new empty actor reference providers registry.
   #[must_use]
   pub(crate) fn new() -> Self {
     Self { map: HashMap::with_hasher(RandomState::new()), _marker: PhantomData }
-  }
-
-  /// Returns `true` when a provider for the provided [`TypeId`] is registered.
-  #[allow(dead_code)]
-  #[must_use]
-  pub(crate) fn contains_key(&self, type_id: &TypeId) -> bool {
-    self.map.contains_key(type_id)
   }
 
   /// Returns a provider by [`TypeId`].
@@ -37,12 +29,6 @@ impl ActorRefProviders {
   /// Inserts a provider.
   pub(crate) fn insert(&mut self, type_id: TypeId, provider: ArcShared<dyn Any + Send + Sync + 'static>) {
     self.map.insert(type_id, provider);
-  }
-
-  /// Returns an iterator over the provider values.
-  #[allow(dead_code)]
-  pub(crate) fn values(&self) -> impl Iterator<Item = &ArcShared<dyn Any + Send + Sync + 'static>> {
-    self.map.values()
   }
 }
 

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -365,26 +365,6 @@ impl ActorSystem {
     self.state.cell(&pid).map(|cell| cell.actor_ref())
   }
 
-  /// Registers a temporary actor reference under `/temp` and returns the generated segment.
-  #[must_use]
-  #[allow(dead_code)]
-  pub(crate) fn register_temp_actor(&self, actor: ActorRef) -> String {
-    self.state.register_temp_actor(actor)
-  }
-
-  /// Removes a temporary actor mapping if present.
-  #[allow(dead_code)]
-  pub(crate) fn unregister_temp_actor(&self, name: &str) {
-    self.state.unregister_temp_actor(name);
-  }
-
-  /// Resolves a registered temporary actor reference.
-  #[must_use]
-  #[allow(dead_code)]
-  pub(crate) fn temp_actor(&self, name: &str) -> Option<ActorRef> {
-    self.state.temp_actor(name)
-  }
-
   /// Emits a log event with the specified severity.
   pub fn emit_log(
     &self,

--- a/modules/actor-core/src/core/kernel/system/cells.rs
+++ b/modules/actor-core/src/core/kernel/system/cells.rs
@@ -34,27 +34,6 @@ impl Cells {
   pub(crate) fn get(&self, pid: &Pid) -> Option<ArcShared<ActorCell>> {
     self.map.get(pid).cloned()
   }
-
-  /// Returns `true` if the registry contains the given [`Pid`].
-  #[must_use]
-  #[allow(dead_code)]
-  pub(crate) fn contains(&self, pid: &Pid) -> bool {
-    self.map.contains_key(pid)
-  }
-
-  /// Returns the number of cells in the registry.
-  #[must_use]
-  #[allow(dead_code)]
-  pub(crate) fn len(&self) -> usize {
-    self.map.len()
-  }
-
-  /// Returns `true` if the registry is empty.
-  #[must_use]
-  #[allow(dead_code)]
-  pub(crate) fn is_empty(&self) -> bool {
-    self.map.is_empty()
-  }
 }
 
 impl Default for Cells {

--- a/modules/actor-core/src/core/kernel/system/state/system_state.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state.rs
@@ -37,12 +37,8 @@ use crate::core::kernel::{
       dead_letter::{DeadLetterEntry, DeadLetterShared},
     },
     deploy::Deployer,
-    error::{ActorError, SendError},
     invoke_guard::{InvokeGuardFactory, NoopInvokeGuardFactory},
-    messaging::{
-      AnyMessage, AskResult,
-      system_message::{FailurePayload, SystemMessage},
-    },
+    messaging::{AnyMessage, AskResult, system_message::FailurePayload},
     props::MailboxConfig,
     scheduler::{
       SchedulerBackedDelayProvider, SchedulerContext, SchedulerShared,
@@ -53,7 +49,6 @@ use crate::core::kernel::{
       },
     },
     spawn::{NameRegistryError, SpawnError},
-    supervision::SupervisorDirective,
   },
   dispatch::{
     dispatcher::{Dispatchers, DispatchersError, MessageDispatcherShared},
@@ -813,52 +808,6 @@ impl SystemState {
     self.actor_ref_provider_callers_by_scheme.get(scheme).cloned()
   }
 
-  fn forward_remote_watch(&self, target: Pid, watcher: Pid) -> bool {
-    self.remote_watch_hook.handle_watch(target, watcher)
-  }
-
-  fn forward_remote_unwatch(&self, target: Pid, watcher: Pid) -> bool {
-    self.remote_watch_hook.handle_unwatch(target, watcher)
-  }
-
-  /// Sends a system message to the specified actor.
-  ///
-  /// # Errors
-  ///
-  /// Returns an error if the actor doesn't exist or the message cannot be enqueued.
-  pub(crate) fn send_system_message(&self, pid: Pid, message: SystemMessage) -> Result<(), SendError> {
-    if let Some(cell) = self.cell(&pid) {
-      cell.new_dispatcher_shared().system_dispatch(&cell, message)
-    } else {
-      match message {
-        | SystemMessage::Watch(watcher) => {
-          if self.forward_remote_watch(pid, watcher) {
-            return Ok(());
-          }
-          if let Err(e) = self.send_system_message(watcher, SystemMessage::DeathWatchNotification(pid)) {
-            self.record_send_error(Some(watcher), &e);
-          }
-          Ok(())
-        },
-        | SystemMessage::Unwatch(watcher) => {
-          if self.forward_remote_unwatch(pid, watcher) {
-            return Ok(());
-          }
-          Ok(())
-        },
-        | SystemMessage::DeathWatchNotification(_) => Ok(()),
-        | SystemMessage::PipeTask(_) => Ok(()),
-        | other => Err(SendError::closed(AnyMessage::new(other))),
-      }
-    }
-  }
-
-  /// Records a send error for diagnostics.
-  pub(crate) fn record_send_error(&self, recipient: Option<Pid>, error: &SendError) {
-    let timestamp = self.monotonic_now();
-    self.dead_letter.record_send_error(recipient, error, timestamp);
-  }
-
   /// Marks the system as terminated and wakes all observers.
   pub(crate) fn mark_terminated(&self) {
     self.termination_state.mark_terminated();
@@ -1017,93 +966,6 @@ impl SystemState {
     };
     let message = format!("failure outcome {} for {:?} (reason: {})", label, child, payload.reason().as_str());
     self.emit_log(LogLevel::Info, message, Some(child), None);
-  }
-
-  #[allow(dead_code)]
-  pub(crate) fn handle_failure(&self, pid: Pid, parent: Option<Pid>, error: &ActorError) {
-    let Some(parent_pid) = parent else {
-      self.stop_actor(pid);
-      return;
-    };
-
-    let Some(parent_cell) = self.cell(&parent_pid) else {
-      self.stop_actor(pid);
-      return;
-    };
-
-    let parent_cell_ref = &*parent_cell;
-    let parent_parent = parent_cell_ref.parent();
-    let now = self.monotonic_now();
-    let (directive, affected) = parent_cell_ref.handle_child_failure(pid, error, now);
-
-    match directive {
-      | SupervisorDirective::Restart => {
-        let mut escalate_due_to_recreate_failure = false;
-        for target in &affected {
-          // Pekko `SupervisorStrategy.restartChild(..., suspendFirst)`: the
-          // originally failing child already suspended itself via
-          // `report_failure`, but AllForOne siblings must be suspended before
-          // their `Recreate` is delivered so that `fault_recreate` observes
-          // the AC-H3 "suspended mailbox" precondition.
-          if *target != pid
-            && let Some(sibling_cell) = self.cell(target)
-          {
-            sibling_cell.mailbox().suspend();
-            sibling_cell.suspend_children();
-          }
-        }
-        for target in affected {
-          let cause = error.to_reason();
-          if let Err(send_error) = self.send_system_message(target, SystemMessage::Recreate(cause)) {
-            self.record_send_error(Some(target), &send_error);
-            if let Err(e) = self.send_system_message(target, SystemMessage::Stop) {
-              self.record_send_error(Some(target), &e);
-            }
-            escalate_due_to_recreate_failure = true;
-          }
-        }
-        if escalate_due_to_recreate_failure {
-          Self::suspend_for_escalation(&parent_cell);
-          self.handle_failure(parent_pid, parent_parent, error);
-        }
-      },
-      | SupervisorDirective::Stop => {
-        for target in affected {
-          self.stop_actor(target);
-        }
-      },
-      | SupervisorDirective::Escalate => {
-        for target in affected {
-          self.stop_actor(target);
-        }
-        // Pekko `FaultHandling.scala:62-67` handleInvokeFailure semantics:
-        // escalation throws in the supervisor, which triggers its own
-        // `handleInvokeFailure` → suspend self + children before reporting to
-        // its parent. Replicate that quiescence here so the grandparent's
-        // restart directive finds the supervisor with a suspended mailbox
-        // (AC-H3 precondition for `fault_recreate`).
-        Self::suspend_for_escalation(&parent_cell);
-        self.handle_failure(parent_pid, parent_parent, error);
-      },
-      | SupervisorDirective::Resume => {
-        for target in affected {
-          if let Err(e) = self.send_system_message(target, SystemMessage::Resume) {
-            self.record_send_error(Some(target), &e);
-          }
-        }
-      },
-    }
-  }
-
-  fn suspend_for_escalation(cell: &ActorCell) {
-    cell.mailbox().suspend();
-    cell.suspend_children();
-  }
-
-  fn stop_actor(&self, pid: Pid) {
-    if let Err(e) = self.send_system_message(pid, SystemMessage::Stop) {
-      self.record_send_error(Some(pid), &e);
-    }
   }
 
   /// Returns a reference to the ActorPathRegistry.

--- a/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
@@ -16,7 +16,7 @@ use crate::core::kernel::{
     actor_ref::ActorRef,
     error::ActorError,
     messaging::{
-      AnyMessage, AnyMessageView,
+      AnyMessageView,
       system_message::{FailurePayload, SystemMessage},
     },
     props::Props,
@@ -531,28 +531,6 @@ fn system_state_remote_authority_events() {
 }
 
 #[test]
-fn system_state_send_system_message_to_nonexistent_actor() {
-  use crate::core::kernel::actor::messaging::system_message::SystemMessage;
-
-  let state = build_state();
-  let pid = state.allocate_pid();
-
-  let result = state.send_system_message(pid, SystemMessage::Stop);
-  assert!(result.is_err());
-}
-
-#[test]
-fn system_state_record_send_error() {
-  use crate::core::kernel::actor::error::SendError;
-
-  let state = build_state();
-  let error = SendError::closed(AnyMessage::new(42_u32));
-
-  state.record_send_error(None, &error);
-  state.record_send_error(Some(state.allocate_pid()), &error);
-}
-
-#[test]
 fn guardian_cell_via_cells_returns_none_when_missing() {
   let state = build_shared_state();
   let user_pid = state.allocate_pid();
@@ -872,27 +850,4 @@ impl Actor for RestartProbeActor {
   fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
     Ok(())
   }
-}
-
-#[test]
-fn recreate_send_failure_escalates_and_stops_parent() {
-  let state = build_shared_state();
-  let parent_pid = state.allocate_pid();
-  let parent_props = Props::from_fn(|| RestartProbeActor);
-  let parent =
-    ActorCell::create(state.clone(), parent_pid, None, "parent".to_string(), &parent_props).expect("create actor cell");
-  state.register_cell(parent.clone());
-
-  let child_pid = state.allocate_pid();
-  let child_props = Props::from_fn(|| RestartProbeActor);
-  let child = ActorCell::create(state.clone(), child_pid, Some(parent_pid), "child".to_string(), &child_props)
-    .expect("create actor cell");
-  state.register_cell(child.clone());
-  state.register_child(parent_pid, child_pid);
-
-  state.remove_cell(&child_pid);
-  let error = ActorError::recoverable("boom");
-  state.handle_failure(child_pid, Some(parent_pid), &error);
-
-  assert!(state.cell(&parent_pid).is_none());
 }

--- a/modules/actor-core/src/core/kernel/system/state/system_state_shared.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state_shared.rs
@@ -42,7 +42,6 @@ use crate::core::kernel::{
       SchedulerBackedDelayProvider, SchedulerShared, task_run::TaskRunSummary, tick_driver::TickDriverBundle,
     },
     spawn::SpawnError,
-    supervision::SupervisorDirective,
   },
   dispatch::{
     dispatcher::{DispatchersError, MessageDispatcherShared},
@@ -764,95 +763,6 @@ impl SystemStateShared {
   pub fn record_send_error(&self, recipient: Option<Pid>, error: &SendError) {
     let timestamp = self.monotonic_now();
     self.dead_letter.record_send_error(recipient, error, timestamp);
-  }
-
-  /// Handles a failure in a child actor according to supervision strategy.
-  #[allow(dead_code)]
-  pub fn handle_failure(&self, pid: Pid, parent: Option<Pid>, error: &ActorError) {
-    let Some(parent_pid) = parent else {
-      if let Err(e) = self.send_system_message(pid, SystemMessage::Stop) {
-        self.record_send_error(Some(pid), &e);
-      }
-      return;
-    };
-
-    let Some(parent_cell) = self.cell(&parent_pid) else {
-      if let Err(e) = self.send_system_message(pid, SystemMessage::Stop) {
-        self.record_send_error(Some(pid), &e);
-      }
-      return;
-    };
-
-    let parent_parent = parent_cell.parent();
-    let now = self.monotonic_now();
-    let (directive, affected) = parent_cell.handle_child_failure(pid, error, now);
-
-    match directive {
-      | SupervisorDirective::Restart => {
-        let mut escalate_due_to_recreate_failure = false;
-        for target in &affected {
-          // Pekko `SupervisorStrategy.restartChild(..., suspendFirst)`: the
-          // originally failing child already suspended itself via
-          // `report_failure`, but AllForOne siblings must be suspended before
-          // their `Recreate` is delivered so that `fault_recreate` observes
-          // the AC-H3 "suspended mailbox" precondition.
-          if *target != pid
-            && let Some(sibling_cell) = self.cell(target)
-          {
-            sibling_cell.mailbox().suspend();
-            sibling_cell.suspend_children();
-          }
-        }
-        for target in affected {
-          let cause = error.to_reason();
-          if let Err(send_error) = self.send_system_message(target, SystemMessage::Recreate(cause)) {
-            self.record_send_error(Some(target), &send_error);
-            if let Err(e) = self.send_system_message(target, SystemMessage::Stop) {
-              self.record_send_error(Some(target), &e);
-            }
-            escalate_due_to_recreate_failure = true;
-          }
-        }
-        if escalate_due_to_recreate_failure {
-          Self::suspend_for_escalation(&parent_cell);
-          self.handle_failure(parent_pid, parent_parent, error);
-        }
-      },
-      | SupervisorDirective::Stop => {
-        for target in affected {
-          if let Err(e) = self.send_system_message(target, SystemMessage::Stop) {
-            self.record_send_error(Some(target), &e);
-          }
-        }
-      },
-      | SupervisorDirective::Escalate => {
-        for target in affected {
-          if let Err(e) = self.send_system_message(target, SystemMessage::Stop) {
-            self.record_send_error(Some(target), &e);
-          }
-        }
-        // Pekko `FaultHandling.scala:62-67` handleInvokeFailure semantics:
-        // escalation throws in the supervisor, which triggers its own
-        // `handleInvokeFailure` → suspend self + children before reporting to
-        // its parent. Replicate that quiescence here so the grandparent's
-        // restart directive finds the supervisor with a suspended mailbox
-        // (AC-H3 precondition for `fault_recreate`).
-        Self::suspend_for_escalation(&parent_cell);
-        self.handle_failure(parent_pid, parent_parent, error);
-      },
-      | SupervisorDirective::Resume => {
-        for target in affected {
-          if let Err(e) = self.send_system_message(target, SystemMessage::Resume) {
-            self.record_send_error(Some(target), &e);
-          }
-        }
-      },
-    }
-  }
-
-  fn suspend_for_escalation(cell: &ActorCell) {
-    cell.mailbox().suspend();
-    cell.suspend_children();
   }
 
   /// Records an explicit deadletter entry originating from runtime logic.

--- a/modules/actor-core/src/core/typed/delivery/consumer_controller_command.rs
+++ b/modules/actor-core/src/core/typed/delivery/consumer_controller_command.rs
@@ -72,18 +72,6 @@ where
     Self(ConsumerControllerCommandKind::DeliverThenStop)
   }
 
-  /// Creates a `Retry` command (internal timer).
-  #[allow(dead_code)]
-  pub(crate) const fn retry() -> Self {
-    Self(ConsumerControllerCommandKind::Retry)
-  }
-
-  /// Creates a `ConsumerTerminated` command (internal watch notification).
-  #[allow(dead_code)]
-  pub(crate) const fn consumer_terminated() -> Self {
-    Self(ConsumerControllerCommandKind::ConsumerTerminated)
-  }
-
   /// Returns a reference to the command kind.
   pub(crate) const fn kind(&self) -> &ConsumerControllerCommandKind<A> {
     &self.0

--- a/modules/actor-core/src/core/typed/delivery/producer_controller_command.rs
+++ b/modules/actor-core/src/core/typed/delivery/producer_controller_command.rs
@@ -77,12 +77,6 @@ where
     Self(ProducerControllerCommandKind::Msg { message })
   }
 
-  /// Creates a `MsgWithConfirmation` command.
-  #[allow(dead_code)]
-  pub(crate) const fn msg_with_confirmation(message: A, reply_to: TypedActorRef<SeqNr>) -> Self {
-    Self(ProducerControllerCommandKind::MsgWithConfirmation { message, reply_to })
-  }
-
   /// Creates a `Request` command (internal, from consumer controller).
   pub(crate) const fn request(
     confirmed_seq_nr: SeqNr,

--- a/modules/actor-core/src/core/typed/internal/typed_scheduler.rs
+++ b/modules/actor-core/src/core/typed/internal/typed_scheduler.rs
@@ -25,12 +25,6 @@ impl<'a> TypedScheduler<'a> {
     Self { scheduler }
   }
 
-  /// Returns a mutable reference to the underlying scheduler (primarily for testing).
-  #[allow(dead_code)]
-  pub(crate) const fn inner(&mut self) -> &mut Scheduler {
-    self.scheduler
-  }
-
   /// Schedules a typed message for one-shot delivery.
   ///
   /// # Errors

--- a/modules/actor-core/src/core/typed/scheduler.rs
+++ b/modules/actor-core/src/core/typed/scheduler.rs
@@ -35,13 +35,6 @@ impl Scheduler {
     Self { inner }
   }
 
-  /// Returns the underlying shared scheduler handle (for internal wiring).
-  #[must_use]
-  #[allow(dead_code)]
-  pub(crate) fn raw(&self) -> TypedSchedulerShared {
-    self.inner.clone()
-  }
-
   /// Schedules a single message delivery after the given delay.
   ///
   /// Corresponds to Pekko's `Scheduler.scheduleOnce`.

--- a/modules/actor-core/src/core/typed/system.rs
+++ b/modules/actor-core/src/core/typed/system.rs
@@ -35,7 +35,6 @@ use crate::core::{
   },
   typed::{
     TypedActorRef, TypedActorSystemConfig, TypedActorSystemLog,
-    actor::TypedChildRef,
     dispatchers::Dispatchers,
     eventstream::EventStreamCommand,
     internal::TypedSchedulerShared,
@@ -384,15 +383,6 @@ where
   /// Publishes a raw event to the event stream.
   pub fn publish_event(&self, event: &EventStreamEvent) {
     self.inner.publish_event(event)
-  }
-
-  /// Spawns a new top-level actor under the user guardian.
-  #[allow(dead_code)]
-  pub(crate) fn spawn<C>(&self, typed_props: &TypedProps<C>) -> Result<TypedChildRef<C>, SpawnError>
-  where
-    C: Send + Sync + 'static, {
-    let child = self.inner.spawn(typed_props.to_untyped())?;
-    Ok(TypedChildRef::from_untyped(child))
   }
 
   /// Spawns a named actor under the `/system` guardian.


### PR DESCRIPTION
## 概要

actor-core 内の **中途半端な実装 (残骸) 16 件** を削除します。これらは \`#[allow(dead_code)]\` で隠されていましたが、production / test 双方から参照ゼロで、Pekko 互換機能は他経路 (\`SystemStateShared\`, \`ExtendedActorSystem\` 等) で既に成立しているため、削除で機能退行はありません。

CLAUDE.md 「No half-finished implementations either」原則に準拠。

## 削除対象 16 件

| # | item | 削除理由 |
|---|------|---------|
| 1-2 | \`ActorRefProviders::{contains_key, values}\` | 外部参照 0 |
| 3-5 | \`Cells::{contains, len, is_empty}\` | 外部参照 0 |
| 6-8 | \`ActorSystem::{register_temp_actor, unregister_temp_actor, temp_actor}\` | \`SystemStateShared\` に同等機能、ActorSystem 層での再ラップ不要 |
| 9-10 | \`{SystemStateShared, SystemState}::handle_failure\` + \`suspend_for_escalation\` (+ \`stop_actor\` for item 10) | 再帰 self-call のみ、external entry なし |
| 11-13 | \`ConsumerControllerCommand::{retry, consumer_terminated}\` + \`ProducerControllerCommand::msg_with_confirmation\` (constructors) | variant は match で直接使用、constructor 未使用 |
| 14-16 | \`TypedScheduler::inner\` / \`Scheduler::raw\` / \`TypedActorSystem::spawn\` | 公開 accessor/spawn の未使用残骸 |

## 連鎖削除 (handle_failure 除去に伴う孤児)

\`SystemState::{forward_remote_watch, forward_remote_unwatch, send_system_message, record_send_error}\` は \`handle_failure\` + 自身の再帰呼び出しのみから到達可能だったため同時削除。production 経路は \`SystemStateShared::send_system_message\` / \`record_send_error\` (生きている) に集約されています。

削除したテスト: \`recreate_send_failure_escalates_and_stops_parent\`, \`system_state_send_system_message_to_nonexistent_actor\`, \`system_state_record_send_error\` (いずれも削除された API の直接呼び出しテスト)。

不要になった import も除去: \`SupervisorDirective\`, \`ActorError\`, \`SendError\`, \`SystemMessage\`, \`TypedChildRef\`, \`AnyMessage\`.

## enum variant は温存

items 11-13 は public constructor のみ削除。enum variant (\`ConsumerControllerCommandKind::{Retry, ConsumerTerminated}\`, \`ProducerControllerCommandKind::MsgWithConfirmation\`) は \`consumer_controller.rs\` / \`producer_controller.rs\` で match アームとして直接使用されているため残置。対応する \`#[allow(dead_code)]\` も variant 側に残しています。

## Metrics

- \`#[allow(dead_code)]\` in actor-core: **46 → 29 (−17)**
- \`rtk cargo test -p fraktor-actor-core-rs --lib\`: 1855 passed, 2 ignored
- \`rtk cargo test -p fraktor-actor-core-rs --tests\`: 1929 passed, 2 ignored
- \`rtk cargo test --workspace\`: 4867 passed, 8 ignored
- \`./scripts/ci-check.sh ai all\`: exit 0

## gap-analysis

\`docs/gap-analysis/actor-gap-analysis.md\` に **第20版** として新セクション「中途半端な実装の残骸削除」を追加。16 件の削除 item と削除理由を表形式で記録し、Pekko 互換 audit 上での削除トレーサビリティを確保。

## 次 PR (Change B Phase 2)

残存 29 件のうち、**LIVE-BUG 21 件** (コードは使われているが \`#[allow(dead_code)]\` が誤って付いている) の allow 削除は次 PR で対応予定。**EXEMPT 8 件** (compile-time guard / test helper / platform-conditional) は原則残置。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily removes unused internal methods and the tests that exercised them; risk is low but any missed callsite would surface as compile errors or missing test coverage around the deleted wrappers.
> 
> **Overview**
> Removes **16 unreferenced, `#[allow(dead_code)]`-guarded leftovers** across `actor-core`, including unused registry helpers (`ActorRefProviders`, `Cells`), redundant `ActorSystem` temp-actor wrappers, unused typed scheduler/system accessors, and dead constructor helpers in typed delivery commands.
> 
> Cleans up `SystemState`/`SystemStateShared` by deleting an unreachable supervision/failure-handling path and its now-orphaned internal system-message forwarding helpers, and drops the associated unit tests. Updates the gap-analysis doc with a new **v20** section documenting the dead-code retirement and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcfde96bfa9e7062a21b1566f8aacd23b99d92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * 内部ドキュメントを更新し、コード最適化フェーズの実施内容を反映

* **Refactor**
  * 不要なメソッドと未使用のAPI エントリポイントを削除し、コードベースを簡潔化
  * システムメッセージング機構および監督ロジックを削除

* **Tests**
  * 削除されたメソッドに関連するテストケースを整理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->