### PR TITLE
refactor(actor-core): remove redundant #[allow(dead_code)] on live items (Change B Phase 2)

### DIFF
--- a/modules/actor-core/src/core/kernel/actor/actor_ref_provider/actor_ref_provider_callers.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_ref_provider/actor_ref_provider_callers.rs
@@ -16,7 +16,7 @@ pub(crate) type ActorRefProviderCaller =
 pub(crate) struct ActorRefProviderCallers {
   map: HashMap<ActorPathScheme, ActorRefProviderCaller, RandomState>,
 }
-#[allow(dead_code)]
+
 impl ActorRefProviderCallers {
   /// Creates a new empty actor reference provider callers registry.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/actor/scheduler/diagnostics/diagnostics_registry.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/diagnostics/diagnostics_registry.rs
@@ -14,13 +14,12 @@ pub(crate) struct DiagnosticsSubscriber {
   pub(crate) id:     u64,
   pub(crate) buffer: ArcShared<DiagnosticsBuffer>,
 }
-#[allow(dead_code)]
 pub(crate) struct DiagnosticsBuffer {
   queue:    SharedLock<VecDeque<SchedulerDiagnosticsEvent>>,
   capacity: usize,
   _marker:  PhantomData<()>,
 }
-#[allow(dead_code)]
+
 impl DiagnosticsBuffer {
   pub(crate) fn new(capacity: usize) -> Self {
     Self { queue: SharedLock::new_with_driver::<DefaultMutex<_>>(VecDeque::new()), capacity, _marker: PhantomData }
@@ -54,7 +53,7 @@ impl Clone for DiagnosticsRegistry {
     Self { entries: self.entries.clone(), _marker: PhantomData }
   }
 }
-#[allow(dead_code)]
+
 impl DiagnosticsRegistry {
   pub(crate) fn new() -> Self {
     Self { entries: SharedLock::new_with_driver::<DefaultMutex<_>>(Vec::new()), _marker: PhantomData }

--- a/modules/actor-core/src/core/kernel/actor/scheduler/diagnostics/scheduler_diagnostics.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/diagnostics/scheduler_diagnostics.rs
@@ -17,7 +17,7 @@ pub struct SchedulerDiagnostics {
   stream_capacity:    usize,
   _marker:            PhantomData<()>,
 }
-#[allow(dead_code)]
+
 impl SchedulerDiagnostics {
   /// Creates a diagnostics container with logging disabled.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/actor/scheduler/diagnostics/scheduler_diagnostics_subscription.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/diagnostics/scheduler_diagnostics_subscription.rs
@@ -14,7 +14,7 @@ pub struct SchedulerDiagnosticsSubscription {
   buffer:   ArcShared<DiagnosticsBuffer>,
   detached: bool,
 }
-#[allow(dead_code)]
+
 impl SchedulerDiagnosticsSubscription {
   pub(crate) const fn new(id: u64, registry: DiagnosticsRegistry, buffer: ArcShared<DiagnosticsBuffer>) -> Self {
     Self { id, registry, buffer, detached: false }

--- a/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_metrics.rs
+++ b/modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_metrics.rs
@@ -16,7 +16,6 @@ pub struct SchedulerTickMetrics {
 
 impl SchedulerTickMetrics {
   /// Creates a metrics snapshot.
-  #[allow(dead_code)]
   pub(crate) const fn new(
     driver: TickDriverKind,
     ticks_per_sec: u32,

--- a/modules/actor-core/src/core/kernel/system/ask_futures.rs
+++ b/modules/actor-core/src/core/kernel/system/ask_futures.rs
@@ -10,7 +10,7 @@ use crate::core::kernel::{actor::messaging::AskResult, util::futures::ActorFutur
 pub(crate) struct AskFutures {
   futures: Vec<ActorFutureShared<AskResult>>,
 }
-#[allow(dead_code)]
+
 impl AskFutures {
   /// Creates a new empty ask futures registry.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -417,7 +417,6 @@ impl ActorSystem {
   /// # Errors
   ///
   /// Returns [`SpawnError::SystemUnavailable`] when the guardian is missing.
-  #[allow(dead_code)]
   pub(crate) fn spawn(&self, props: &Props) -> Result<ChildRef, SpawnError> {
     let guardian_pid = self.state.user_guardian_pid().ok_or_else(SpawnError::system_unavailable)?;
     self.spawn_child(guardian_pid, props)
@@ -458,7 +457,6 @@ impl ActorSystem {
   }
 
   /// Spawns a new actor under the system guardian (internal use only).
-  #[allow(dead_code)]
   pub(crate) fn system_actor_of(&self, props: &Props) -> Result<ChildRef, SpawnError> {
     let guardian_pid = self.state.system_guardian_pid().ok_or_else(SpawnError::system_unavailable)?;
     self.spawn_child(guardian_pid, props)

--- a/modules/actor-core/src/core/kernel/system/cells.rs
+++ b/modules/actor-core/src/core/kernel/system/cells.rs
@@ -10,7 +10,7 @@ use crate::core::kernel::actor::{ActorCell, Pid};
 pub(crate) struct Cells {
   map: HashMap<Pid, ArcShared<ActorCell>, RandomState>,
 }
-#[allow(dead_code)]
+
 impl Cells {
   /// Creates a new empty cell registry.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/system/cells_shared.rs
+++ b/modules/actor-core/src/core/kernel/system/cells_shared.rs
@@ -12,7 +12,7 @@ use super::cells::Cells;
 pub(crate) struct CellsShared {
   inner: SharedLock<Cells>,
 }
-#[allow(dead_code)]
+
 impl CellsShared {
   /// Creates a new shared wrapper around the provided registry.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/system/extensions.rs
+++ b/modules/actor-core/src/core/kernel/system/extensions.rs
@@ -14,7 +14,7 @@ pub(crate) struct Extensions {
   map:     HashMap<TypeId, ArcShared<dyn Any + Send + Sync + 'static>, RandomState>,
   _marker: PhantomData<()>,
 }
-#[allow(dead_code)]
+
 impl Extensions {
   /// Creates a new empty extensions registry.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/system/extra_top_levels.rs
+++ b/modules/actor-core/src/core/kernel/system/extra_top_levels.rs
@@ -11,7 +11,7 @@ use crate::core::kernel::actor::actor_ref::ActorRef;
 pub(crate) struct ExtraTopLevels {
   map: HashMap<String, ActorRef, RandomState>,
 }
-#[allow(dead_code)]
+
 impl ExtraTopLevels {
   /// Creates a new empty extra top-levels registry.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/system/registries.rs
+++ b/modules/actor-core/src/core/kernel/system/registries.rs
@@ -12,7 +12,7 @@ pub(crate) struct Registries {
   map:     HashMap<Option<Pid>, NameRegistry, RandomState>,
   _marker: PhantomData<()>,
 }
-#[allow(dead_code)]
+
 impl Registries {
   /// Creates a new empty registries collection.
   #[must_use]

--- a/modules/actor-core/src/core/kernel/system/state/system_state.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state.rs
@@ -539,7 +539,6 @@ impl SystemState {
 
   /// Returns the root guardian cell if initialised.
   #[must_use]
-  #[allow(dead_code)]
   pub(crate) fn root_guardian(&self) -> Option<ArcShared<ActorCell>> {
     self.guardian_cell_via_cells(GuardianKind::Root)
   }

--- a/modules/actor-core/src/core/kernel/system/temp_actors.rs
+++ b/modules/actor-core/src/core/kernel/system/temp_actors.rs
@@ -11,7 +11,7 @@ use crate::core::kernel::actor::{Pid, actor_ref::ActorRef};
 pub(crate) struct TempActors {
   map: HashMap<String, ActorRef, RandomState>,
 }
-#[allow(dead_code)]
+
 impl TempActors {
   /// Creates a new empty temporary actors registry.
   #[must_use]


### PR DESCRIPTION
## 概要

Phase 1 (#1648) の続き。**実際には使われているのに \`#[allow(dead_code)]\` が誤って付いていた項目から属性を除去**します。コード変更なし、属性除去のみ。

## 除去 17 件

### impl block-level allow (12 件) — 中のメソッドが全て live

- \`ActorRefProviderCallers\` / \`AskFutures\` / \`Cells\` / \`CellsShared\` / \`Extensions\` / \`ExtraTopLevels\` / \`Registries\` / \`TempActors\` (system-plumbing)
- \`DiagnosticsBuffer\` (struct + impl) / \`DiagnosticsRegistry\` / \`SchedulerDiagnostics\` / \`SchedulerDiagnosticsSubscription\` (diagnostics chain は SchedulerCore から live)

### item-level allow (4 件) — 呼び出し元あり

- \`ActorSystem::spawn\` (呼び出し元: \`actor_of\` / \`actor_of_named\`)
- \`ActorSystem::system_actor_of\` (呼び出し元: \`extended_actor_system\`)
- \`SchedulerTickMetrics::new\` (呼び出し元: \`tick_feed\`)
- \`SystemState::root_guardian\` (呼び出し元: \`SystemStateShared::root_guardian\`)

## Metrics

- \`#[allow(dead_code)]\` in actor-core: **32 → 15 (−17)**
- lib tests: 1855 passed
- \`./scripts/ci-check.sh ai all\`: exit 0

## Phase 3 で対応予定

delivery-controller enum の block-level allow を外したところ、Phase 1 で constructor を削除した結果 **variant 自体が never constructed** になる cascade 警告が 3 件判明:

- \`ConsumerControllerCommandKind::Retry\`
- \`ConsumerControllerCommandKind::ConsumerTerminated\`
- \`ProducerControllerCommandKind::MsgWithConfirmation\`
- \`Request::via_timeout\` field

本 PR の scope 外として \`#[allow(dead_code)]\` を variant/field 側に戻し、次 PR (Phase 3) で variant + \`consumer_controller.rs\` / \`producer_controller.rs\` の match アームを一括削除する方針にします。

## 残存 15 件の内訳

- delivery-controller の cascade 4 件 (Phase 3 候補)
- compile-time object-safety probe 2 件 (\`_assert_object_safe\`, \`_assert_box_object_safe\`)
- test-support helper 5 件 (\`new_with_builtin_lock\`, \`MiddlewareShared::new\`, \`Pipeline::from_middlewares\`, \`SchedulerRunner::manual\`, \`Mailbox::set_clock\`)
- module-level allow 2 ファイル (\`running_state.rs\`, \`booting_state.rs\` ← test-only 状態機械)
- \`#[cfg_attr(not(test), allow(dead_code))]\` 条件付き 1 件 (\`actor_cell.rs\`)

これらは EXEMPT 扱い (compile-time guard / test-support / platform-conditional) で今回は据え置き。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only removes `#[allow(dead_code)]` attributes from items that are already referenced, so runtime behavior is unchanged; the main risk is surfacing new compiler warnings if any usage assumptions were wrong.
> 
> **Overview**
> Removes redundant `#[allow(dead_code)]` annotations across `actor-core` for items that are now *provably live*, including several system registries (`ActorRefProviderCallers`, `AskFutures`, `Cells`, `Extensions`, etc.), scheduler diagnostics types, and internal helpers like `ActorSystem::spawn`/`system_actor_of`, `SchedulerTickMetrics::new`, and `SystemState::root_guardian`.
> 
> This is a refactor/cleanup aimed at tightening lint hygiene and letting the compiler report genuinely unused code without suppressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f79808a9f17c1085f4e5fc8dda41a21a56b6fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->