### PR TITLE
refactor(actor-core): delete delivery-controller cascade (Change B Phase 3)

### DIFF
--- a/modules/actor-core/src/core/typed/delivery/consumer_controller.rs
+++ b/modules/actor-core/src/core/typed/delivery/consumer_controller.rs
@@ -172,12 +172,6 @@ impl ConsumerController {
                 should_stop = true;
               }
             },
-            | ConsumerControllerCommandKind::Retry => {
-              collect_send_request(state, &self_ref, true, &mut deferred);
-            },
-            | ConsumerControllerCommandKind::ConsumerTerminated => {
-              should_stop = true;
-            },
           }
           if !should_stop && state.stopping && !state.waiting_for_confirm && state.stashed.is_empty() {
             should_stop = true;
@@ -245,7 +239,7 @@ fn collect_on_sequenced_message<A>(
   }
 
   if state.should_request_more() || state.requested_seq_nr == 0 {
-    collect_send_request(state, self_ref, false, deferred);
+    collect_send_request(state, self_ref, deferred);
   }
 }
 
@@ -286,7 +280,7 @@ fn collect_on_confirmed<A>(
   collect_try_deliver_stashed(state, confirm_adapter, deferred);
 
   if state.should_request_more() {
-    collect_send_request(state, self_ref, false, deferred);
+    collect_send_request(state, self_ref, deferred);
   }
 }
 
@@ -309,20 +303,19 @@ fn collect_try_deliver_stashed<A>(
 fn collect_send_request<A>(
   state: &mut ConsumerControllerState<A>,
   _self_ref: &TypedActorRef<ConsumerControllerCommand<A>>,
-  via_timeout: bool,
   deferred: &mut Vec<DeferredAction<A>>,
 ) where
   A: Clone + Send + Sync + 'static, {
   let window = u64::from(state.settings.flow_control_window());
   let new_requested = state.received_seq_nr + window;
-  if (new_requested > state.requested_seq_nr || via_timeout)
+  if new_requested > state.requested_seq_nr
     && let Some(pc) = state.producer_controller.clone()
   {
     state.requested_seq_nr = new_requested;
     let support_resend = !state.settings.only_flow_control();
     deferred.push(DeferredAction::SendToProducer(
       pc,
-      ProducerControllerCommand::request(state.confirmed_seq_nr, state.requested_seq_nr, support_resend, via_timeout),
+      ProducerControllerCommand::request(state.confirmed_seq_nr, state.requested_seq_nr, support_resend),
     ));
   }
 }

--- a/modules/actor-core/src/core/typed/delivery/consumer_controller_command.rs
+++ b/modules/actor-core/src/core/typed/delivery/consumer_controller_command.rs
@@ -33,12 +33,6 @@ where
   Confirmed,
   /// Stop after delivering all remaining messages.
   DeliverThenStop,
-  /// Internal retry timer.
-  #[allow(dead_code)]
-  Retry,
-  /// Internal: consumer actor terminated.
-  #[allow(dead_code)]
-  ConsumerTerminated,
 }
 
 impl<A> ConsumerControllerCommand<A>

--- a/modules/actor-core/src/core/typed/delivery/internal/producer_controller.rs
+++ b/modules/actor-core/src/core/typed/delivery/internal/producer_controller.rs
@@ -301,13 +301,7 @@ impl ProducerController {
               state.awaiting_msg = false;
               collect_on_msg(state, message.clone(), &self_ref, &mut deferred);
             },
-            | ProducerControllerCommandKind::MsgWithConfirmation { message, .. } => {
-              state.awaiting_msg = false;
-              collect_on_msg(state, message.clone(), &self_ref, &mut deferred);
-            },
-            | ProducerControllerCommandKind::Request {
-              confirmed_seq_nr, request_up_to_seq_nr, support_resend, ..
-            } => {
+            | ProducerControllerCommandKind::Request { confirmed_seq_nr, request_up_to_seq_nr, support_resend } => {
               let previous_confirmed_seq_nr = state.confirmed_seq_nr;
               state.support_resend = *support_resend;
               state.on_confirmed(*confirmed_seq_nr);

--- a/modules/actor-core/src/core/typed/delivery/producer_controller_command.rs
+++ b/modules/actor-core/src/core/typed/delivery/producer_controller_command.rs
@@ -31,17 +31,8 @@ where
   RegisterConsumer { consumer_controller: TypedActorRef<ConsumerControllerCommand<A>> },
   /// A message from the producer (via `send_next_to`).
   Msg { message: A },
-  /// A message from the producer with confirmation (via `ask_next_to`).
-  #[allow(dead_code)]
-  MsgWithConfirmation { message: A, reply_to: TypedActorRef<SeqNr> },
   /// Demand request from the consumer controller.
-  Request {
-    confirmed_seq_nr:     SeqNr,
-    request_up_to_seq_nr: SeqNr,
-    support_resend:       bool,
-    #[allow(dead_code)]
-    via_timeout:          bool,
-  },
+  Request { confirmed_seq_nr: SeqNr, request_up_to_seq_nr: SeqNr, support_resend: bool },
   /// Resend request from the consumer controller.
   Resend { from_seq_nr: SeqNr },
   /// Ack from the consumer controller.
@@ -78,13 +69,8 @@ where
   }
 
   /// Creates a `Request` command (internal, from consumer controller).
-  pub(crate) const fn request(
-    confirmed_seq_nr: SeqNr,
-    request_up_to_seq_nr: SeqNr,
-    support_resend: bool,
-    via_timeout: bool,
-  ) -> Self {
-    Self(ProducerControllerCommandKind::Request { confirmed_seq_nr, request_up_to_seq_nr, support_resend, via_timeout })
+  pub(crate) const fn request(confirmed_seq_nr: SeqNr, request_up_to_seq_nr: SeqNr, support_resend: bool) -> Self {
+    Self(ProducerControllerCommandKind::Request { confirmed_seq_nr, request_up_to_seq_nr, support_resend })
   }
 
   /// Creates a `Resend` command (internal, from consumer controller).


### PR DESCRIPTION
## 概要

Change B Phase 1 (#1648) で delivery-controller の public constructor を削除した結果、Phase 2 (#1649) で variant 自体が never constructed として発覚した **3 variant + 1 field を一括削除**します。

## 削除

### \`consumer_controller_command.rs\`
- variant \`Retry\`
- variant \`ConsumerTerminated\`

### \`producer_controller_command.rs\`
- variant \`MsgWithConfirmation\` (+ \`reply_to\` field)
- field \`via_timeout\` from \`Request\` variant
- \`request()\` constructor の \`via_timeout\` 引数削除

### \`consumer_controller.rs\`
- match arm \`Retry\` (\`collect_send_request(.., true, ..)\` 呼び出しも消える)
- match arm \`ConsumerTerminated\`
- \`collect_send_request\` の \`via_timeout\` 引数削除 (Retry arm 削除後は常に false)
- 残 2 callers を新シグネチャに合わせて更新

### \`producer_controller.rs\` (internal)
- match arm \`MsgWithConfirmation\`
- Request match arm の destructure: \`..\` wildcard を削除 (via_timeout 消去後は不要)

## Verification

- \`rtk cargo test -p fraktor-actor-core-rs --lib\`: 1854 passed
- \`rtk cargo test -p fraktor-actor-core-rs --tests\`: 1928 passed
- \`./scripts/ci-check.sh ai all\`: exit 0

## 関連

- Change B Phase 1: #1648 (constructor 削除)
- Change B Phase 2: #1649 (LIVE-BUG allow 除去、本 cascade を検出)
- Change C: #1650 (全 legacy/compat 削除)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the internal consumer/producer controller message protocol by deleting unused command variants and simplifying `Request`/`collect_send_request` signatures, which could affect flow-control behavior if any hidden callers relied on the removed paths.
> 
> **Overview**
> Removes a cascade of now-never-constructed delivery controller commands: `ConsumerControllerCommandKind::Retry`/`ConsumerTerminated` and `ProducerControllerCommandKind::MsgWithConfirmation`.
> 
> Simplifies the demand request protocol by dropping `via_timeout` from `ProducerControllerCommandKind::Request` and updating `ConsumerController`’s `collect_send_request` to only send requests when the requested window advances, with corresponding call-site and match-arm updates in the internal `ProducerController` implementation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25c3072c83182a2170abd1e8c8f3c78387ccee7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->