### PR TITLE
refactor(actor-core): rename MessageDispatcherConfigurator to MessageDispatcherFactory

### DIFF
--- a/modules/actor-adaptor-std/benches/actor_baseline.rs
+++ b/modules/actor-adaptor-std/benches/actor_baseline.rs
@@ -18,8 +18,8 @@ use fraktor_actor_core_rs::core::kernel::{
   },
   dispatch::{
     dispatcher::{
-      DEFAULT_DISPATCHER_ID, DefaultDispatcherConfigurator, DispatcherConfig, ExecutorShared,
-      MessageDispatcherConfigurator, TrampolineState,
+      DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecutorShared, MessageDispatcherFactory,
+      TrampolineState,
     },
     mailbox::{Mailbox, MailboxOverflowStrategy, MailboxPolicy},
   },
@@ -139,9 +139,9 @@ impl TokioBenchSystem {
       let config = ActorSystemConfig::new(TokioTickDriver::default());
       let settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
       let executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
-      let configurator: Box<dyn MessageDispatcherConfigurator> =
-        Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-      let config = config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, ArcShared::new(configurator));
+      let configurator: Box<dyn MessageDispatcherFactory> =
+        Box::new(DefaultDispatcherFactory::new(&settings, executor));
+      let config = config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(configurator));
       ActorSystem::create_with_config(props, config).expect("actor system")
     });
     Self { runtime, system }

--- a/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
+++ b/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
@@ -32,8 +32,8 @@ use fraktor_actor_core_rs::core::kernel::{
     setup::ActorSystemConfig,
   },
   dispatch::dispatcher::{
-    BalancingDispatcherConfigurator, DEFAULT_DISPATCHER_ID, DefaultDispatcherConfigurator, DispatcherConfig,
-    ExecutorShared, MessageDispatcherConfigurator, SharedMessageQueue, TrampolineState,
+    BalancingDispatcherFactory, DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecutorShared,
+    MessageDispatcherFactory, SharedMessageQueue, TrampolineState,
   },
   system::ActorSystem,
 };
@@ -125,18 +125,18 @@ impl DispatcherBenchSystem {
       let config = ActorSystemConfig::new(TokioTickDriver::default());
       let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
       let default_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle.clone())), TrampolineState::new());
-      let default_configurator: Box<dyn MessageDispatcherConfigurator> =
-        Box::new(DefaultDispatcherConfigurator::new(&default_settings, default_executor));
+      let default_configurator: Box<dyn MessageDispatcherFactory> =
+        Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
 
       let balancing_settings = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
       let balancing_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
       let shared_queue = SharedMessageQueue::new();
-      let balancing_configurator: Box<dyn MessageDispatcherConfigurator> =
-        Box::new(BalancingDispatcherConfigurator::new(&balancing_settings, balancing_executor, shared_queue));
+      let balancing_configurator: Box<dyn MessageDispatcherFactory> =
+        Box::new(BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue));
 
       let config = config
-        .with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
-        .with_dispatcher_configurator(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
+        .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
+        .with_dispatcher_factory(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
       let props = Props::from_fn(|| TeamGuardian);
       ActorSystem::create_with_config(&props, config).expect("actor system")
     });

--- a/modules/actor-adaptor-std/src/std/dispatch/dispatcher/tests.rs
+++ b/modules/actor-adaptor-std/src/std/dispatch/dispatcher/tests.rs
@@ -36,9 +36,9 @@ use fraktor_actor_core_rs::core::kernel::{
     setup::ActorSystemConfig,
   },
   dispatch::dispatcher::{
-    BalancingDispatcherConfigurator, DEFAULT_DISPATCHER_ID, DefaultDispatcherConfigurator, DispatcherConfig,
-    ExecuteError, Executor, ExecutorFactory, ExecutorShared, MessageDispatcherConfigurator,
-    PinnedDispatcherConfigurator, SharedMessageQueue, TrampolineState,
+    BalancingDispatcherFactory, DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecuteError,
+    Executor, ExecutorFactory, ExecutorShared, MessageDispatcherFactory, PinnedDispatcherFactory, SharedMessageQueue,
+    TrampolineState,
   },
   system::ActorSystem,
 };
@@ -112,18 +112,18 @@ fn build_system() -> ActorSystem {
   let config = ActorSystemConfig::new(TokioTickDriver::default());
   let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
   let default_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle.clone())), TrampolineState::new());
-  let default_configurator: Box<dyn MessageDispatcherConfigurator> =
-    Box::new(DefaultDispatcherConfigurator::new(&default_settings, default_executor));
+  let default_configurator: Box<dyn MessageDispatcherFactory> =
+    Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
 
   let balancing_settings = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
   let balancing_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
   let shared_queue = SharedMessageQueue::new();
-  let balancing_configurator: Box<dyn MessageDispatcherConfigurator> =
-    Box::new(BalancingDispatcherConfigurator::new(&balancing_settings, balancing_executor, shared_queue));
+  let balancing_configurator: Box<dyn MessageDispatcherFactory> =
+    Box::new(BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue));
 
   let config = config
-    .with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
-    .with_dispatcher_configurator(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
+    .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
+    .with_dispatcher_factory(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
   let props = Props::from_fn(|| TeamGuardian);
   ActorSystem::create_with_config(&props, config).expect("actor system")
 }
@@ -194,22 +194,22 @@ async fn tokio_executor_factory_creates_executor_shared() {
 }
 
 #[test]
-fn pinned_dispatcher_configurator_creates_fresh_dispatcher_per_call() {
+fn pinned_dispatcher_factory_creates_fresh_dispatcher_per_call() {
   let config = DispatcherConfig::with_defaults("pinned-test");
   let executor_factory: ArcShared<Box<dyn ExecutorFactory>> =
     ArcShared::new(Box::new(PinnedExecutorFactory::new("pinned-test")));
-  let configurator = PinnedDispatcherConfigurator::new(config, executor_factory, "pinned-test");
+  let configurator = PinnedDispatcherFactory::new(config, executor_factory, "pinned-test");
 
   let _first = configurator.dispatcher();
   let _second = configurator.dispatcher();
 }
 
 #[test]
-fn balancing_dispatcher_configurator_creates_dispatcher_with_shared_queue() {
+fn balancing_dispatcher_factory_creates_dispatcher_with_shared_queue() {
   let settings = DispatcherConfig::with_defaults("balancing-test");
   let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
   let shared_queue = SharedMessageQueue::new();
-  let configurator = BalancingDispatcherConfigurator::new(&settings, executor, shared_queue);
+  let configurator = BalancingDispatcherFactory::new(&settings, executor, shared_queue);
 
   let _dispatcher = configurator.dispatcher();
 }

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_config.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_config.rs
@@ -20,7 +20,7 @@ use crate::core::kernel::{
     setup::CircuitBreakerConfig,
   },
   dispatch::{
-    dispatcher::{Dispatchers, MessageDispatcherConfigurator},
+    dispatcher::{Dispatchers, MessageDispatcherFactory},
     mailbox::{MailboxClock, Mailboxes},
   },
   system::remote::RemotingConfig,
@@ -125,10 +125,10 @@ impl ActorSystemConfig {
   /// users override the entry by calling this method with a configurator
   /// that uses a real executor (Tokio, threaded, pinned, etc.).
   #[must_use]
-  pub fn with_dispatcher_configurator(
+  pub fn with_dispatcher_factory(
     mut self,
     id: impl Into<String>,
-    configurator: ArcShared<Box<dyn MessageDispatcherConfigurator>>,
+    configurator: ArcShared<Box<dyn MessageDispatcherFactory>>,
   ) -> Self {
     self.dispatchers.register_or_update(id, configurator);
     self

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
@@ -15,7 +15,7 @@ use crate::core::kernel::{
     scheduler::{SchedulerConfig, tick_driver::TickDriver},
     setup::{ActorSystemConfig, BootstrapSetup, CircuitBreakerConfig},
   },
-  dispatch::dispatcher::MessageDispatcherConfigurator,
+  dispatch::dispatcher::MessageDispatcherFactory,
 };
 
 /// Pekko-compatible setup aggregate backed by [`ActorSystemConfig`].
@@ -72,12 +72,12 @@ impl ActorSystemSetup {
 
   /// Registers a dispatcher configurator under the supplied id.
   #[must_use]
-  pub fn with_dispatcher_configurator(
+  pub fn with_dispatcher_factory(
     self,
     id: impl Into<String>,
-    configurator: ArcShared<Box<dyn MessageDispatcherConfigurator>>,
+    configurator: ArcShared<Box<dyn MessageDispatcherFactory>>,
   ) -> Self {
-    Self { config: self.config.with_dispatcher_configurator(id, configurator) }
+    Self { config: self.config.with_dispatcher_factory(id, configurator) }
   }
 
   /// Registers or updates a mailbox configuration.

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher.rs
@@ -1,9 +1,9 @@
 //! Dispatcher module aligned with Apache Pekko's `MessageDispatcher` model.
 
 mod balancing_dispatcher;
-mod balancing_dispatcher_configurator;
+mod balancing_dispatcher_factory;
 mod default_dispatcher;
-mod default_dispatcher_configurator;
+mod default_dispatcher_factory;
 mod dispatcher_config;
 mod dispatcher_core;
 mod dispatcher_sender;
@@ -16,18 +16,18 @@ mod executor_factory;
 mod executor_shared;
 mod inline_executor;
 mod message_dispatcher;
-mod message_dispatcher_configurator;
+mod message_dispatcher_factory;
 mod message_dispatcher_shared;
 mod pinned_dispatcher;
-mod pinned_dispatcher_configurator;
+mod pinned_dispatcher_factory;
 mod shared_message_queue;
 mod shutdown_schedule;
 mod trampoline_state;
 
 pub use balancing_dispatcher::BalancingDispatcher;
-pub use balancing_dispatcher_configurator::BalancingDispatcherConfigurator;
+pub use balancing_dispatcher_factory::BalancingDispatcherFactory;
 pub use default_dispatcher::DefaultDispatcher;
-pub use default_dispatcher_configurator::DefaultDispatcherConfigurator;
+pub use default_dispatcher_factory::DefaultDispatcherFactory;
 pub use dispatcher_config::DispatcherConfig;
 pub use dispatcher_core::DispatcherCore;
 pub use dispatcher_sender::DispatcherSender;
@@ -39,10 +39,10 @@ pub use executor_factory::ExecutorFactory;
 pub use executor_shared::ExecutorShared;
 pub use inline_executor::InlineExecutor;
 pub use message_dispatcher::MessageDispatcher;
-pub use message_dispatcher_configurator::MessageDispatcherConfigurator;
+pub use message_dispatcher_factory::MessageDispatcherFactory;
 pub use message_dispatcher_shared::MessageDispatcherShared;
 pub use pinned_dispatcher::PinnedDispatcher;
-pub use pinned_dispatcher_configurator::PinnedDispatcherConfigurator;
+pub use pinned_dispatcher_factory::PinnedDispatcherFactory;
 pub use shared_message_queue::SharedMessageQueue;
 pub use shutdown_schedule::ShutdownSchedule;
 pub use trampoline_state::TrampolineState;

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/balancing_dispatcher/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/balancing_dispatcher/tests.rs
@@ -143,7 +143,7 @@ fn sharing_mailbox_close_keeps_shared_queue_contents() {
 #[test]
 fn balancing_dispatcher_load_balances_envelopes_across_team_via_shared_queue() {
   // Phase 14.6: end-to-end load balancing check. Three actors are attached
-  // to the same `BalancingDispatcherConfigurator`, then 9 envelopes are
+  // to the same `BalancingDispatcherFactory`, then 9 envelopes are
   // dispatched through the first cell. Because all team members share the
   // same `SharedMessageQueue`, the inline executor drains the queue across
   // multiple actors instead of leaving everything on the receiver mailbox.
@@ -153,7 +153,7 @@ fn balancing_dispatcher_load_balances_envelopes_across_team_via_shared_queue() {
   use alloc::sync::Arc;
   use core::sync::atomic::{AtomicUsize, Ordering};
 
-  use crate::core::kernel::dispatch::dispatcher::{BalancingDispatcherConfigurator, MessageDispatcherConfigurator};
+  use crate::core::kernel::dispatch::dispatcher::{BalancingDispatcherFactory, MessageDispatcherFactory};
 
   struct InlineExec;
 
@@ -177,17 +177,17 @@ fn balancing_dispatcher_load_balances_envelopes_across_team_via_shared_queue() {
     }
   }
 
-  let configurator: ArcShared<Box<dyn MessageDispatcherConfigurator>> = {
+  let configurator: ArcShared<Box<dyn MessageDispatcherFactory>> = {
     let executor = ExecutorShared::new(Box::new(InlineExec), TrampolineState::new());
     let settings = DispatcherConfig::new("balancing-load", nz(8), None, Duration::from_secs(1));
     let shared_queue = SharedMessageQueue::new();
-    let inner: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(BalancingDispatcherConfigurator::new(&settings, executor, shared_queue));
+    let inner: Box<dyn MessageDispatcherFactory> =
+      Box::new(BalancingDispatcherFactory::new(&settings, executor, shared_queue));
     ArcShared::new(inner)
   };
   let configurator_clone = configurator.clone();
   let system = ActorSystem::new_empty_with(move |config| {
-    config.with_dispatcher_configurator("balancing-load", configurator_clone.clone())
+    config.with_dispatcher_factory("balancing-load", configurator_clone.clone())
   });
   let state = system.state();
 

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/balancing_dispatcher_factory.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/balancing_dispatcher_factory.rs
@@ -4,20 +4,20 @@ use alloc::boxed::Box;
 
 use super::{
   balancing_dispatcher::BalancingDispatcher, dispatcher_config::DispatcherConfig, executor_shared::ExecutorShared,
-  message_dispatcher_configurator::MessageDispatcherConfigurator, message_dispatcher_shared::MessageDispatcherShared,
+  message_dispatcher_factory::MessageDispatcherFactory, message_dispatcher_shared::MessageDispatcherShared,
   shared_message_queue::SharedMessageQueue,
 };
 
 /// Configurator that holds a single eagerly built [`BalancingDispatcher`] handle.
 ///
-/// Like [`DefaultDispatcherConfigurator`](super::DefaultDispatcherConfigurator),
+/// Like [`DefaultDispatcherFactory`](super::DefaultDispatcherFactory),
 /// `dispatcher()` returns a clone of the cached handle so that all actors
 /// share the same dispatcher (and thus the same shared message queue).
-pub struct BalancingDispatcherConfigurator {
+pub struct BalancingDispatcherFactory {
   shared: MessageDispatcherShared,
 }
 
-impl BalancingDispatcherConfigurator {
+impl BalancingDispatcherFactory {
   /// Builds a new configurator from the supplied settings and executor.
   #[must_use]
   pub fn new(settings: &DispatcherConfig, executor: ExecutorShared, shared_queue: SharedMessageQueue) -> Self {
@@ -26,7 +26,7 @@ impl BalancingDispatcherConfigurator {
   }
 }
 
-impl MessageDispatcherConfigurator for BalancingDispatcherConfigurator {
+impl MessageDispatcherFactory for BalancingDispatcherFactory {
   fn dispatcher(&self) -> MessageDispatcherShared {
     self.shared.clone()
   }

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/default_dispatcher_factory.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/default_dispatcher_factory.rs
@@ -4,18 +4,18 @@ use alloc::boxed::Box;
 
 use super::{
   default_dispatcher::DefaultDispatcher, dispatcher_config::DispatcherConfig, executor_shared::ExecutorShared,
-  message_dispatcher_configurator::MessageDispatcherConfigurator, message_dispatcher_shared::MessageDispatcherShared,
+  message_dispatcher_factory::MessageDispatcherFactory, message_dispatcher_shared::MessageDispatcherShared,
 };
 
 /// Configurator that holds a single eagerly built [`DefaultDispatcher`] handle.
 ///
 /// `dispatcher()` returns a clone of the cached [`MessageDispatcherShared`],
 /// matching Pekko's reuse semantics for non-pinned dispatchers.
-pub struct DefaultDispatcherConfigurator {
+pub struct DefaultDispatcherFactory {
   shared: MessageDispatcherShared,
 }
 
-impl DefaultDispatcherConfigurator {
+impl DefaultDispatcherFactory {
   /// Builds a new configurator from the supplied settings and executor.
   #[must_use]
   pub fn new(settings: &DispatcherConfig, executor: ExecutorShared) -> Self {
@@ -24,7 +24,7 @@ impl DefaultDispatcherConfigurator {
   }
 }
 
-impl MessageDispatcherConfigurator for DefaultDispatcherConfigurator {
+impl MessageDispatcherFactory for DefaultDispatcherFactory {
   fn dispatcher(&self) -> MessageDispatcherShared {
     self.shared.clone()
   }

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatcher_sender/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatcher_sender/tests.rs
@@ -44,7 +44,7 @@ fn inline_executor_shared() -> ExecutorShared {
 // released) split that keeps the inline-executor re-entrancy contract
 // intact. The end-to-end cases below
 // (`actor_creation_attaches_to_new_dispatcher_and_increments_inhabitants`,
-// `end_to_end_send_via_actor_system_with_dispatcher_configurator`,
+// `end_to_end_send_via_actor_system_with_dispatcher_factory`,
 // `dispatcher_full_lifecycle_attach_dispatch_drain_detach_and_auto_shutdown`,
 // and the `new_dispatcher_handles_actor_to_actor_send_without_deadlock`
 // regression test) cover the current send contract with a real cell.
@@ -55,7 +55,7 @@ fn actor_creation_attaches_to_new_dispatcher_and_increments_inhabitants() {
 
   use crate::core::kernel::{
     actor::{Actor, ActorCell, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props},
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -70,10 +70,9 @@ fn actor_creation_attaches_to_new_dispatcher_and_increments_inhabitants() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
   });
   let state = system.state();
   let resolved = state.resolve_dispatcher(DEFAULT_DISPATCHER_ID).expect("configurator registered");
@@ -102,7 +101,7 @@ fn new_dispatcher_delivers_many_messages_to_single_actor_in_order() {
       messaging::{AnyMessage, AnyMessageView},
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -122,10 +121,9 @@ fn new_dispatcher_delivers_many_messages_to_single_actor_in_order() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(16), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
   });
   let state = system.state();
   let seen = SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new());
@@ -161,7 +159,7 @@ fn new_dispatcher_handles_actor_to_actor_send_without_deadlock() {
       messaging::{AnyMessage, AnyMessageView},
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -196,10 +194,9 @@ fn new_dispatcher_handles_actor_to_actor_send_without_deadlock() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(16), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
   });
   let state = system.state();
 
@@ -250,7 +247,7 @@ fn new_dispatcher_delivers_messages_to_multiple_actors_independently() {
       messaging::{AnyMessage, AnyMessageView},
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -268,10 +265,9 @@ fn new_dispatcher_delivers_messages_to_multiple_actors_independently() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
   });
   let state = system.state();
 
@@ -315,7 +311,7 @@ fn removing_actor_cell_detaches_from_new_dispatcher_and_decrements_inhabitants()
 
   use crate::core::kernel::{
     actor::{Actor, ActorCell, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props},
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -330,10 +326,9 @@ fn removing_actor_cell_detaches_from_new_dispatcher_and_decrements_inhabitants()
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
   });
   let state = system.state();
   let resolved = state.resolve_dispatcher(DEFAULT_DISPATCHER_ID).expect("configurator registered");
@@ -357,13 +352,13 @@ fn removing_actor_cell_detaches_from_new_dispatcher_and_decrements_inhabitants()
 }
 
 #[test]
-fn end_to_end_send_via_actor_system_with_dispatcher_configurator() {
+fn end_to_end_send_via_actor_system_with_dispatcher_factory() {
   use alloc::string::ToString;
 
   use crate::core::kernel::{
     actor::{Actor, ActorContext, actor_ref::ActorRef, error::ActorError, messaging::AnyMessageView, props::Props},
     dispatch::{
-      dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+      dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
       mailbox::MailboxPolicy,
     },
     system::ActorSystem,
@@ -383,10 +378,9 @@ fn end_to_end_send_via_actor_system_with_dispatcher_configurator() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
   });
   let state = system.state();
   let seen = Arc::new(AtomicUsize::new(0));
@@ -417,7 +411,7 @@ fn dispatcher_full_lifecycle_attach_dispatch_drain_detach_and_auto_shutdown() {
       Actor, ActorCell, ActorContext, Pid, actor_ref::ActorRef, error::ActorError, messaging::AnyMessageView,
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -432,17 +426,15 @@ fn dispatcher_full_lifecycle_attach_dispatch_drain_detach_and_auto_shutdown() {
     }
   }
 
-  let configurator_for_resolve: ArcShared<Box<dyn MessageDispatcherConfigurator>> = {
+  let configurator_for_resolve: ArcShared<Box<dyn MessageDispatcherFactory>> = {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new("lifecycle", nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
     ArcShared::new(configurator)
   };
   let configurator_clone = configurator_for_resolve.clone();
-  let system = ActorSystem::new_empty_with(move |config| {
-    config.with_dispatcher_configurator("lifecycle", configurator_clone.clone())
-  });
+  let system =
+    ActorSystem::new_empty_with(move |config| config.with_dispatcher_factory("lifecycle", configurator_clone.clone()));
   let state = system.state();
   // Resolve once outside the spawn flow so we can observe the inhabitants
   // counter independently of the cell. The configurator returns a clone of
@@ -497,7 +489,7 @@ fn dispatcher_resolve_is_not_called_from_message_hot_path() {
     actor::{
       Actor, ActorCell, ActorContext, actor_ref::ActorRef, error::ActorError, messaging::AnyMessageView, props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -515,10 +507,9 @@ fn dispatcher_resolve_is_not_called_from_message_hot_path() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator(DEFAULT_DISPATCHER_ID, configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
   });
   let state = system.state();
 

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers.rs
@@ -2,7 +2,7 @@
 //!
 //! `Dispatchers` is the new dispatcher registry introduced in the
 //! dispatcher-pekko-1n-redesign change. It stores configurators behind
-//! `ArcShared<Box<dyn MessageDispatcherConfigurator>>` so the entry can be
+//! `ArcShared<Box<dyn MessageDispatcherFactory>>` so the entry can be
 //! resolved without internal mutability.
 //!
 //! # Alias chain resolution
@@ -18,7 +18,7 @@
 //! # Call-frequency contract
 //!
 //! `Dispatchers::resolve` is intended for spawn / bootstrap paths only. Do not
-//! call it from message dispatch hot paths: `PinnedDispatcherConfigurator`
+//! call it from message dispatch hot paths: `PinnedDispatcherFactory`
 //! constructs a fresh OS thread per call, and unrestricted hot-path resolution
 //! would leak threads.
 
@@ -33,9 +33,9 @@ use fraktor_utils_core_rs::core::sync::ArcShared;
 use hashbrown::{HashMap, hash_map::Entry};
 
 use super::{
-  default_dispatcher_configurator::DefaultDispatcherConfigurator, dispatcher_config::DispatcherConfig,
+  default_dispatcher_factory::DefaultDispatcherFactory, dispatcher_config::DispatcherConfig,
   dispatchers_error::DispatchersError, executor_shared::ExecutorShared, inline_executor::InlineExecutor,
-  message_dispatcher_configurator::MessageDispatcherConfigurator, message_dispatcher_shared::MessageDispatcherShared,
+  message_dispatcher_factory::MessageDispatcherFactory, message_dispatcher_shared::MessageDispatcherShared,
   trampoline_state::TrampolineState,
 };
 
@@ -65,7 +65,7 @@ const PEKKO_INTERNAL_DISPATCHER_ID: &str = "pekko.actor.internal-dispatcher";
 
 /// Registry mapping dispatcher identifiers to configurators.
 pub struct Dispatchers {
-  entries:       HashMap<String, ArcShared<Box<dyn MessageDispatcherConfigurator>>, RandomState>,
+  entries:       HashMap<String, ArcShared<Box<dyn MessageDispatcherFactory>>, RandomState>,
   /// Alias identifiers redirecting to another id (target may itself be an alias).
   ///
   /// Kept separate from `entries` so that `register` and `register_alias` can
@@ -126,7 +126,7 @@ impl Dispatchers {
   pub fn register(
     &mut self,
     id: impl Into<String>,
-    configurator: ArcShared<Box<dyn MessageDispatcherConfigurator>>,
+    configurator: ArcShared<Box<dyn MessageDispatcherFactory>>,
   ) -> Result<(), DispatchersError> {
     let id = id.into();
     if self.aliases.contains_key(&id) {
@@ -147,11 +147,11 @@ impl Dispatchers {
   /// existing alias with the same identifier is removed so the new entry
   /// takes precedence. This keeps the method infallible so it composes
   /// cleanly with builder-style configuration (e.g.
-  /// `ActorSystemConfig::with_dispatcher_configurator`).
+  /// `ActorSystemConfig::with_dispatcher_factory`).
   pub fn register_or_update(
     &mut self,
     id: impl Into<String>,
-    configurator: ArcShared<Box<dyn MessageDispatcherConfigurator>>,
+    configurator: ArcShared<Box<dyn MessageDispatcherFactory>>,
   ) {
     let id = id.into();
     self.aliases.remove(&id);
@@ -196,7 +196,7 @@ impl Dispatchers {
   /// **Call-frequency contract**: invoke from spawn / bootstrap paths only.
   /// Hot-path callers must cache the resolved [`MessageDispatcherShared`] (or
   /// the underlying dispatcher handle) instead of calling resolve repeatedly.
-  /// `PinnedDispatcherConfigurator` allocates a new OS thread on every call,
+  /// `PinnedDispatcherFactory` allocates a new OS thread on every call,
   /// so hot-path resolution leaks threads.
   ///
   /// Each invocation increments the diagnostic counter exposed by
@@ -268,11 +268,10 @@ impl Dispatchers {
     self.resolve_count.load(Ordering::Relaxed)
   }
 
-  fn build_default_inline_configurator() -> ArcShared<Box<dyn MessageDispatcherConfigurator>> {
+  fn build_default_inline_configurator() -> ArcShared<Box<dyn MessageDispatcherFactory>> {
     let settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
     let executor = ExecutorShared::new(Box::new(InlineExecutor::new()), TrampolineState::new());
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
     ArcShared::new(configurator)
   }
 
@@ -303,7 +302,7 @@ impl Dispatchers {
   /// exclusively, so the checks here are equivalent).
   fn register_alias_if_absent(
     aliases: &mut HashMap<String, String, RandomState>,
-    entries: &HashMap<String, ArcShared<Box<dyn MessageDispatcherConfigurator>>, RandomState>,
+    entries: &HashMap<String, ArcShared<Box<dyn MessageDispatcherFactory>>, RandomState>,
     alias: &str,
     target: &'static str,
   ) {
@@ -325,7 +324,7 @@ impl Dispatchers {
   /// entry insertion (matching [`Self::register_or_update`] semantics) so
   /// the freshly inserted entry is reachable via `resolve` without being
   /// shadowed by a stale alias.
-  pub fn ensure_default(&mut self, factory: impl FnOnce() -> ArcShared<Box<dyn MessageDispatcherConfigurator>>) {
+  pub fn ensure_default(&mut self, factory: impl FnOnce() -> ArcShared<Box<dyn MessageDispatcherFactory>>) {
     if !self.entries.contains_key(DEFAULT_DISPATCHER_ID) {
       let configurator = factory();
       self.insert_entry_wiping_alias(DEFAULT_DISPATCHER_ID, configurator.clone());
@@ -337,13 +336,13 @@ impl Dispatchers {
   }
 
   /// Ensures the default dispatcher entry exists, populating it with an
-  /// [`InlineExecutor`]-backed [`DefaultDispatcherConfigurator`] when missing.
+  /// [`InlineExecutor`]-backed [`DefaultDispatcherFactory`] when missing.
   ///
   /// This mirrors the legacy `Dispatchers::ensure_default` shape and is the
   /// configuration installed by `ActorSystemConfig::default()` so that all
   /// in-process tests run on the new dispatcher tree without bringing in
   /// `tokio` or another runtime. Production users override the entry through
-  /// `ActorSystemConfig::with_dispatcher_configurator`.
+  /// `ActorSystemConfig::with_dispatcher_factory`.
   pub fn ensure_default_inline(&mut self) {
     self.ensure_default(Self::build_default_inline_configurator);
   }
@@ -378,7 +377,7 @@ impl Dispatchers {
   /// stay consistent with [`Self::register_or_update`] last-writer-wins
   /// semantics and a pre-existing alias cannot shadow the fresh entry via
   /// [`Self::follow_alias_chain`].
-  fn insert_entry_wiping_alias(&mut self, id: &str, configurator: ArcShared<Box<dyn MessageDispatcherConfigurator>>) {
+  fn insert_entry_wiping_alias(&mut self, id: &str, configurator: ArcShared<Box<dyn MessageDispatcherFactory>>) {
     self.aliases.remove(id);
     self.entries.insert(id.to_owned(), configurator);
   }

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers/tests.rs
@@ -5,8 +5,8 @@ use fraktor_utils_core_rs::core::sync::ArcShared;
 
 use super::{DEFAULT_BLOCKING_DISPATCHER_ID, DEFAULT_DISPATCHER_ID, Dispatchers, DispatchersError};
 use crate::core::kernel::dispatch::dispatcher::{
-  DefaultDispatcherConfigurator, DispatcherConfig, ExecuteError, Executor, ExecutorShared,
-  MessageDispatcherConfigurator, TrampolineState,
+  DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared, MessageDispatcherFactory,
+  TrampolineState,
 };
 
 struct NoopExecutor;
@@ -19,11 +19,10 @@ impl Executor for NoopExecutor {
   fn shutdown(&mut self) {}
 }
 
-fn make_default_configurator(id: &str) -> ArcShared<Box<dyn MessageDispatcherConfigurator>> {
+fn make_default_configurator(id: &str) -> ArcShared<Box<dyn MessageDispatcherFactory>> {
   let settings = DispatcherConfig::with_defaults(id).with_shutdown_timeout(Duration::from_secs(2));
   let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
-  let configurator: Box<dyn MessageDispatcherConfigurator> =
-    Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
+  let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
   ArcShared::new(configurator)
 }
 

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers_error.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers_error.rs
@@ -29,7 +29,7 @@ pub enum DispatchersError {
   /// variant. `register_or_update`, on the other hand, follows last-writer-
   /// wins semantics and silently removes any pre-existing alias for the same
   /// id before inserting the entry (so the builder-style
-  /// `ActorSystemConfig::with_dispatcher_configurator` remains infallible).
+  /// `ActorSystemConfig::with_dispatcher_factory` remains infallible).
   AliasConflictsWithEntry(String),
 }
 

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_factory.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_factory.rs
@@ -8,7 +8,7 @@ use super::message_dispatcher_shared::MessageDispatcherShared;
 /// registry behind an `ArcShared` and called from spawn / bootstrap paths.
 /// `dispatcher` must be `&self` so that the registry can hand the configurator
 /// out without resorting to interior mutability.
-pub trait MessageDispatcherConfigurator: Send + Sync {
+pub trait MessageDispatcherFactory: Send + Sync {
   /// Returns a [`MessageDispatcherShared`] handle for the configured dispatcher.
   ///
   /// Concrete implementations decide whether to share a single dispatcher

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared/tests.rs
@@ -148,7 +148,7 @@ fn resolve_dispatcher_from_actor_system_returns_registered_configurator() {
   use fraktor_utils_core_rs::core::sync::ArcShared;
 
   use crate::core::kernel::{
-    dispatch::dispatcher::{DefaultDispatcherConfigurator, MessageDispatcherConfigurator},
+    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
     system::ActorSystem,
   };
 
@@ -158,10 +158,9 @@ fn resolve_dispatcher_from_actor_system_returns_registered_configurator() {
       TrampolineState::new(),
     );
     let settings = DispatcherConfig::new("system-test-dispatch", nz(4), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherConfigurator> =
-      Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherConfigurator>> = ArcShared::new(configurator);
-    config.with_dispatcher_configurator("system-test-dispatch", configurator_handle)
+    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
+    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+    config.with_dispatcher_factory("system-test-dispatch", configurator_handle)
   });
   let resolved = system.state().resolve_dispatcher("system-test-dispatch").expect("registered configurator");
   assert_eq!(resolved.id(), "system-test-dispatch");

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/pinned_dispatcher_factory.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/pinned_dispatcher_factory.rs
@@ -1,7 +1,7 @@
 //! Configurator for [`PinnedDispatcher`](super::PinnedDispatcher).
 //!
 //! Each call to `dispatcher()` constructs a brand-new dispatcher and executor,
-//! matching Pekko's `PinnedDispatcherConfigurator` behaviour. The thread name
+//! matching Pekko's `PinnedDispatcherFactory` behaviour. The thread name
 //! prefix is captured at construction time.
 
 use alloc::{boxed::Box, string::String};
@@ -10,18 +10,18 @@ use fraktor_utils_core_rs::core::sync::ArcShared;
 
 use super::{
   dispatcher_config::DispatcherConfig, executor_factory::ExecutorFactory,
-  message_dispatcher_configurator::MessageDispatcherConfigurator, message_dispatcher_shared::MessageDispatcherShared,
+  message_dispatcher_factory::MessageDispatcherFactory, message_dispatcher_shared::MessageDispatcherShared,
   pinned_dispatcher::PinnedDispatcher,
 };
 
 /// Configurator that produces a fresh [`PinnedDispatcher`] per call.
-pub struct PinnedDispatcherConfigurator {
+pub struct PinnedDispatcherFactory {
   config:             DispatcherConfig,
   executor_factory:   ArcShared<Box<dyn ExecutorFactory>>,
   thread_name_prefix: String,
 }
 
-impl PinnedDispatcherConfigurator {
+impl PinnedDispatcherFactory {
   /// Builds a new pinned configurator.
   #[must_use]
   pub fn new(
@@ -39,7 +39,7 @@ impl PinnedDispatcherConfigurator {
   }
 }
 
-impl MessageDispatcherConfigurator for PinnedDispatcherConfigurator {
+impl MessageDispatcherFactory for PinnedDispatcherFactory {
   fn dispatcher(&self) -> MessageDispatcherShared {
     let executor = self.executor_factory.create(self.config.id());
     let dispatcher = PinnedDispatcher::new(&self.config, executor);

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -37,8 +37,8 @@ use crate::core::{
       spawn::SpawnError,
     },
     dispatch::dispatcher::{
-      DefaultDispatcherConfigurator, DispatcherConfig, ExecuteError, Executor, ExecutorShared,
-      MessageDispatcherConfigurator, TrampolineState,
+      DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared, MessageDispatcherFactory,
+      TrampolineState,
     },
     event::stream::{EventStreamEvent, EventStreamSubscriber, tests::subscriber_handle},
     system::{
@@ -180,11 +180,10 @@ impl Executor for NoopExecutor {
   fn shutdown(&mut self) {}
 }
 
-fn noop_dispatcher_configurator() -> ArcShared<Box<dyn MessageDispatcherConfigurator>> {
+fn noop_dispatcher_configurator() -> ArcShared<Box<dyn MessageDispatcherFactory>> {
   let settings = DispatcherConfig::with_defaults("noop");
   let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
-  let configurator: Box<dyn MessageDispatcherConfigurator> =
-    Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
+  let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
   ArcShared::new(configurator)
 }
 
@@ -672,7 +671,7 @@ fn actor_system_terminate_when_already_terminated() {
 fn spawn_does_not_block_when_dispatcher_never_runs() {
   // Register NoopExecutor as "noop" dispatcher
   let system =
-    ActorSystem::new_empty_with(|config| config.with_dispatcher_configurator("noop", noop_dispatcher_configurator()));
+    ActorSystem::new_empty_with(|config| config.with_dispatcher_factory("noop", noop_dispatcher_configurator()));
   let log: ArcShared<SpinSyncMutex<Vec<&'static str>>> = ArcShared::new(SpinSyncMutex::new(Vec::new()));
 
   let props = Props::from_fn({
@@ -689,7 +688,7 @@ fn spawn_does_not_block_when_dispatcher_never_runs() {
 #[test]
 fn spawn_child_same_as_parent_inherits_dispatcher_selection_result() {
   let system =
-    ActorSystem::new_empty_with(|config| config.with_dispatcher_configurator("noop", noop_dispatcher_configurator()));
+    ActorSystem::new_empty_with(|config| config.with_dispatcher_factory("noop", noop_dispatcher_configurator()));
 
   let parent_props = Props::from_fn(|| TestActor).with_dispatcher_id("noop");
   let parent = system.spawn_with_parent(None, &parent_props).expect("parent spawn succeeds");
@@ -738,7 +737,7 @@ fn create_send_failure_triggers_rollback() {
 #[test]
 fn spawn_returns_child_ref_even_if_dispatcher_is_idle() {
   let system =
-    ActorSystem::new_empty_with(|config| config.with_dispatcher_configurator("noop", noop_dispatcher_configurator()));
+    ActorSystem::new_empty_with(|config| config.with_dispatcher_factory("noop", noop_dispatcher_configurator()));
   let props = Props::from_fn(|| TestActor).with_dispatcher_id("noop");
   let result = system.spawn_with_parent(None, &props);
 

--- a/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
@@ -30,8 +30,7 @@ use crate::core::kernel::{
     setup::ActorSystemConfig,
   },
   dispatch::dispatcher::{
-    DefaultDispatcherConfigurator, DispatcherConfig, ExecuteError, Executor, MessageDispatcherConfigurator,
-    TrampolineState,
+    DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, MessageDispatcherFactory, TrampolineState,
   },
   event::stream::{EventStreamEvent, EventStreamSubscriber, tests::subscriber_handle},
   system::{
@@ -102,7 +101,7 @@ fn build_shared_state() -> SystemStateShared {
 }
 
 fn build_shared_state_with_noop_dispatcher() -> SystemStateShared {
-  let config = base_config().with_dispatcher_configurator("noop", noop_dispatcher_configurator());
+  let config = base_config().with_dispatcher_factory("noop", noop_dispatcher_configurator());
   SystemStateShared::new(SystemState::build_from_owned_config(config).expect("state"))
 }
 
@@ -815,12 +814,11 @@ impl Executor for NoopExecutor {
   fn shutdown(&mut self) {}
 }
 
-fn noop_dispatcher_configurator() -> ArcShared<Box<dyn MessageDispatcherConfigurator>> {
+fn noop_dispatcher_configurator() -> ArcShared<Box<dyn MessageDispatcherFactory>> {
   use crate::core::kernel::dispatch::dispatcher::ExecutorShared;
   let settings = DispatcherConfig::with_defaults("noop");
   let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
-  let configurator: Box<dyn MessageDispatcherConfigurator> =
-    Box::new(DefaultDispatcherConfigurator::new(&settings, executor));
+  let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
   ArcShared::new(configurator)
 }
 

--- a/modules/actor-core/src/core/typed/dispatchers/tests.rs
+++ b/modules/actor-core/src/core/typed/dispatchers/tests.rs
@@ -63,8 +63,8 @@ fn lookup_from_config_preserves_user_override_of_pekko_alias() {
 
   use crate::core::kernel::{
     dispatch::dispatcher::{
-      DefaultDispatcherConfigurator, DispatcherConfig, ExecuteError, Executor, ExecutorShared,
-      MessageDispatcherConfigurator, TrampolineState,
+      DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared, MessageDispatcherFactory,
+      TrampolineState,
     },
     system::ActorSystem,
   };
@@ -84,9 +84,9 @@ fn lookup_from_config_preserves_user_override_of_pekko_alias() {
     let custom_config =
       DispatcherConfig::with_defaults("custom-typed-dispatcher").with_shutdown_timeout(Duration::from_secs(2));
     let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
-    let custom: ArcShared<Box<dyn MessageDispatcherConfigurator>> =
-      ArcShared::new(Box::new(DefaultDispatcherConfigurator::new(&custom_config, executor)));
-    config.with_dispatcher_configurator("pekko.actor.default-dispatcher", custom)
+    let custom: ArcShared<Box<dyn MessageDispatcherFactory>> =
+      ArcShared::new(Box::new(DefaultDispatcherFactory::new(&custom_config, executor)));
+    config.with_dispatcher_factory("pekko.actor.default-dispatcher", custom)
   });
 
   let dispatchers = Dispatchers::new(system.state());


### PR DESCRIPTION
## 概要

\`MessageDispatcherConfigurator\` trait は実質 **pure factory** (\`fn dispatcher() -> MessageDispatcherShared\`) にも関わらず名前が \`Configurator\`。Pekko/Scala 由来の実装詳細用語で、Rust trait の責務 (factory) と不一致。

\`.claude/rules/rust/naming-conventions.md\` の命名規約 (「生成・構築 → \`*Factory\`」) に従い **pure rename**。動作変更なし。

## 背景

\`MessageDispatcherConfigurator\` は Pekko の ubiquitous language ではなく Scala/Java 実装の命名。Rust 側で自然な \`*Factory\` に統一することで:

- \`ExtensionInstaller\` (bootstrap side-effect) との責務差を明示
- \`naming-conventions.md\` の推奨パターンと整合
- 今後 \`MailboxFactory\` / \`CircuitBreakerFactory\` を導入する際の統一基盤

## Rename 一覧

### trait + impl (4)
- \`MessageDispatcherConfigurator\` → \`MessageDispatcherFactory\`
- \`DefaultDispatcherConfigurator\` → \`DefaultDispatcherFactory\`
- \`BalancingDispatcherConfigurator\` → \`BalancingDispatcherFactory\`
- \`PinnedDispatcherConfigurator\` → \`PinnedDispatcherFactory\`

### file (4)
- \`message_dispatcher_configurator.rs\` → \`message_dispatcher_factory.rs\`
- \`default_dispatcher_configurator.rs\` → \`default_dispatcher_factory.rs\`
- \`balancing_dispatcher_configurator.rs\` → \`balancing_dispatcher_factory.rs\`
- \`pinned_dispatcher_configurator.rs\` → \`pinned_dispatcher_factory.rs\`

### public API (1)
- \`ActorSystemConfig::with_dispatcher_configurator(...)\` → \`with_dispatcher_factory(...)\`

## Verification

- \`rtk cargo test --workspace\`: 4861 passed, 8 ignored
- \`./scripts/ci-check.sh ai all\`: exit 0

## Follow-up (次 PR で対応予定)

- **PR D2**: Pattern A (\`impl Into<Box<dyn Factory>>\`) を \`with_dispatcher_factory\` / \`with_invoke_guard_factory\` に適用して UX 改善
- **PR D3**: \`MailboxFactory\` / \`CircuitBreakerFactory\` trait 新設、ActorSystemConfig の拡張ポイントを Factory 系で統一

これにより:
1. シンプル case: \`.with_mailbox("id", MailboxConfig::unbounded(100))\` (現状維持)
2. 拡張 case: \`.with_mailbox("id", MyCustomMailboxFactory::new(...))\` (同メソッド)

UX を保ちつつ拡張ポイントを用意します。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure API/identifier rename across dispatcher registry/config wiring and related tests/benches; risk is limited to compile-time breakage for downstream crates still using the old names.
> 
> **Overview**
> **Renames the dispatcher provider API from “Configurator” to “Factory”** across `actor-core` and `actor-adaptor-std` (trait, implementations, modules, and re-exports), reflecting that providers are pure `dispatcher()` producers.
> 
> Updates the public configuration surface from `ActorSystemConfig::with_dispatcher_configurator`/`ActorSystemSetup::with_dispatcher_configurator` to `with_dispatcher_factory`, and threads the new `MessageDispatcherFactory` type through the `Dispatchers` registry and all affected tests/benches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96e1c74de5225f7ef77eaf3f01c40e6f390f83e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->