### PR TITLE
refactor(actor-core): unify builder argument style to impl Trait + 'static

### DIFF
--- a/modules/actor-adaptor-std/benches/actor_baseline.rs
+++ b/modules/actor-adaptor-std/benches/actor_baseline.rs
@@ -17,15 +17,11 @@ use fraktor_actor_core_rs::core::kernel::{
     setup::ActorSystemConfig,
   },
   dispatch::{
-    dispatcher::{
-      DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecutorShared, MessageDispatcherFactory,
-      TrampolineState,
-    },
+    dispatcher::{DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecutorShared, TrampolineState},
     mailbox::{Mailbox, MailboxOverflowStrategy, MailboxPolicy},
   },
   system::ActorSystem,
 };
-use fraktor_utils_core_rs::core::sync::ArcShared;
 use tokio::runtime::{Builder, Runtime};
 
 const WAIT_TIMEOUT: Duration = Duration::from_secs(1);
@@ -139,9 +135,8 @@ impl TokioBenchSystem {
       let config = ActorSystemConfig::new(TokioTickDriver::default());
       let settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
       let executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
-      let configurator: Box<dyn MessageDispatcherFactory> =
-        Box::new(DefaultDispatcherFactory::new(&settings, executor));
-      let config = config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(configurator));
+      let config =
+        config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor));
       ActorSystem::create_with_config(props, config).expect("actor system")
     });
     Self { runtime, system }

--- a/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
+++ b/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
@@ -33,11 +33,10 @@ use fraktor_actor_core_rs::core::kernel::{
   },
   dispatch::dispatcher::{
     BalancingDispatcherFactory, DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecutorShared,
-    MessageDispatcherFactory, SharedMessageQueue, TrampolineState,
+    SharedMessageQueue, TrampolineState,
   },
   system::ActorSystem,
 };
-use fraktor_utils_core_rs::core::sync::ArcShared;
 use tokio::runtime::{Builder, Runtime};
 
 const BALANCING_DISPATCHER_ID: &str = "balancing-bench";
@@ -125,18 +124,20 @@ impl DispatcherBenchSystem {
       let config = ActorSystemConfig::new(TokioTickDriver::default());
       let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
       let default_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle.clone())), TrampolineState::new());
-      let default_configurator: Box<dyn MessageDispatcherFactory> =
-        Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
 
       let balancing_settings = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
       let balancing_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
       let shared_queue = SharedMessageQueue::new();
-      let balancing_configurator: Box<dyn MessageDispatcherFactory> =
-        Box::new(BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue));
 
       let config = config
-        .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
-        .with_dispatcher_factory(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
+        .with_dispatcher_factory(
+          DEFAULT_DISPATCHER_ID,
+          DefaultDispatcherFactory::new(&default_settings, default_executor),
+        )
+        .with_dispatcher_factory(
+          BALANCING_DISPATCHER_ID,
+          BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue),
+        );
       let props = Props::from_fn(|| TeamGuardian);
       ActorSystem::create_with_config(&props, config).expect("actor system")
     });

--- a/modules/actor-adaptor-std/src/std/actor.rs
+++ b/modules/actor-adaptor-std/src/std/actor.rs
@@ -10,5 +10,5 @@ pub use panic_invoke_guard_factory::PanicInvokeGuardFactory;
 /// Installs the std panic guard into an actor-system configuration.
 #[must_use]
 pub fn install_panic_invoke_guard(config: ActorSystemConfig) -> ActorSystemConfig {
-  config.with_invoke_guard_factory(PanicInvokeGuardFactory::shared())
+  config.with_invoke_guard_factory(PanicInvokeGuardFactory::new())
 }

--- a/modules/actor-adaptor-std/src/std/actor/panic_invoke_guard_factory.rs
+++ b/modules/actor-adaptor-std/src/std/actor/panic_invoke_guard_factory.rs
@@ -1,7 +1,5 @@
 //! Factory for std panic-catching invoke guards.
 
-use alloc::boxed::Box;
-
 use fraktor_actor_core_rs::core::kernel::actor::invoke_guard::{InvokeGuard, InvokeGuardFactory};
 use fraktor_utils_core_rs::core::sync::ArcShared;
 
@@ -18,12 +16,6 @@ impl PanicInvokeGuardFactory {
   pub fn new() -> Self {
     let shared_guard: ArcShared<dyn InvokeGuard> = ArcShared::new(PanicInvokeGuard::new());
     Self { shared_guard }
-  }
-
-  /// Returns a shared trait-object wrapper of this factory.
-  #[must_use]
-  pub fn shared() -> ArcShared<Box<dyn InvokeGuardFactory>> {
-    ArcShared::new(Box::new(Self::new()) as Box<dyn InvokeGuardFactory>)
   }
 }
 

--- a/modules/actor-adaptor-std/src/std/dispatch/dispatcher/tests.rs
+++ b/modules/actor-adaptor-std/src/std/dispatch/dispatcher/tests.rs
@@ -112,18 +112,17 @@ fn build_system() -> ActorSystem {
   let config = ActorSystemConfig::new(TokioTickDriver::default());
   let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
   let default_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle.clone())), TrampolineState::new());
-  let default_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
 
   let balancing_settings = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
   let balancing_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
   let shared_queue = SharedMessageQueue::new();
-  let balancing_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue));
 
   let config = config
-    .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
-    .with_dispatcher_factory(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
+    .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&default_settings, default_executor))
+    .with_dispatcher_factory(
+      BALANCING_DISPATCHER_ID,
+      BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue),
+    );
   let props = Props::from_fn(|| TeamGuardian);
   ActorSystem::create_with_config(&props, config).expect("actor system")
 }

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_config.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_config.rs
@@ -104,33 +104,37 @@ impl ActorSystemConfig {
 
   /// Registers a custom actor-ref provider installer.
   #[must_use]
-  pub fn with_actor_ref_provider_installer<P>(mut self, installer: P) -> Self
-  where
-    P: ActorRefProviderInstaller + 'static, {
+  pub fn with_actor_ref_provider_installer(mut self, installer: impl ActorRefProviderInstaller + 'static) -> Self {
     self.provider_installer = Some(ArcShared::new(installer));
     self
   }
 
   /// Registers a custom invoke-guard factory.
+  ///
+  /// The builder wraps the supplied factory in `ArcShared<Box<dyn _>>`
+  /// internally; callers pass the concrete impl directly.
   #[must_use]
-  pub fn with_invoke_guard_factory(mut self, factory: ArcShared<Box<dyn InvokeGuardFactory>>) -> Self {
-    self.invoke_guard_factory = Some(factory);
+  pub fn with_invoke_guard_factory(mut self, factory: impl InvokeGuardFactory + 'static) -> Self {
+    self.invoke_guard_factory = Some(ArcShared::new(Box::new(factory)));
     self
   }
 
-  /// Registers a dispatcher configurator under the supplied id.
+  /// Registers a dispatcher factory under the supplied id.
   ///
   /// `ActorSystemConfig::default()` seeds the registry with an
-  /// `InlineExecutor`-backed configurator under the default id; production
-  /// users override the entry by calling this method with a configurator
+  /// `InlineExecutor`-backed factory under the default id; production
+  /// users override the entry by calling this method with a factory
   /// that uses a real executor (Tokio, threaded, pinned, etc.).
+  ///
+  /// The builder wraps the supplied factory in `ArcShared<Box<dyn _>>`
+  /// internally; callers pass the concrete factory type directly.
   #[must_use]
   pub fn with_dispatcher_factory(
     mut self,
     id: impl Into<String>,
-    configurator: ArcShared<Box<dyn MessageDispatcherFactory>>,
+    factory: impl MessageDispatcherFactory + 'static,
   ) -> Self {
-    self.dispatchers.register_or_update(id, configurator);
+    self.dispatchers.register_or_update(id, ArcShared::new(Box::new(factory)));
     self
   }
 

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
@@ -3,9 +3,7 @@
 #[cfg(test)]
 mod tests;
 
-use alloc::{boxed::Box, string::String};
-
-use fraktor_utils_core_rs::core::sync::ArcShared;
+use alloc::string::String;
 
 use crate::core::kernel::{
   actor::{
@@ -70,14 +68,17 @@ impl ActorSystemSetup {
     Self { config: self.config.with_actor_ref_provider_installer(installer) }
   }
 
-  /// Registers a dispatcher configurator under the supplied id.
+  /// Registers a dispatcher factory under the supplied id.
+  ///
+  /// The builder wraps the supplied factory in `ArcShared<Box<dyn _>>`
+  /// internally; callers pass the concrete factory type directly.
   #[must_use]
   pub fn with_dispatcher_factory(
     self,
     id: impl Into<String>,
-    configurator: ArcShared<Box<dyn MessageDispatcherFactory>>,
+    factory: impl MessageDispatcherFactory + 'static,
   ) -> Self {
-    Self { config: self.config.with_dispatcher_factory(id, configurator) }
+    Self { config: self.config.with_dispatcher_factory(id, factory) }
   }
 
   /// Registers or updates a mailbox configuration.

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
@@ -62,9 +62,7 @@ impl ActorSystemSetup {
 
   /// Registers a custom actor-ref provider installer.
   #[must_use]
-  pub fn with_actor_ref_provider_installer<P>(self, installer: P) -> Self
-  where
-    P: ActorRefProviderInstaller + 'static, {
+  pub fn with_actor_ref_provider_installer(self, installer: impl ActorRefProviderInstaller + 'static) -> Self {
     Self { config: self.config.with_actor_ref_provider_installer(installer) }
   }
 

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/balancing_dispatcher/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/balancing_dispatcher/tests.rs
@@ -153,7 +153,7 @@ fn balancing_dispatcher_load_balances_envelopes_across_team_via_shared_queue() {
   use alloc::sync::Arc;
   use core::sync::atomic::{AtomicUsize, Ordering};
 
-  use crate::core::kernel::dispatch::dispatcher::{BalancingDispatcherFactory, MessageDispatcherFactory};
+  use crate::core::kernel::dispatch::dispatcher::BalancingDispatcherFactory;
 
   struct InlineExec;
 
@@ -177,17 +177,11 @@ fn balancing_dispatcher_load_balances_envelopes_across_team_via_shared_queue() {
     }
   }
 
-  let configurator: ArcShared<Box<dyn MessageDispatcherFactory>> = {
+  let system = ActorSystem::new_empty_with(|config| {
     let executor = ExecutorShared::new(Box::new(InlineExec), TrampolineState::new());
     let settings = DispatcherConfig::new("balancing-load", nz(8), None, Duration::from_secs(1));
     let shared_queue = SharedMessageQueue::new();
-    let inner: Box<dyn MessageDispatcherFactory> =
-      Box::new(BalancingDispatcherFactory::new(&settings, executor, shared_queue));
-    ArcShared::new(inner)
-  };
-  let configurator_clone = configurator.clone();
-  let system = ActorSystem::new_empty_with(move |config| {
-    config.with_dispatcher_factory("balancing-load", configurator_clone.clone())
+    config.with_dispatcher_factory("balancing-load", BalancingDispatcherFactory::new(&settings, executor, shared_queue))
   });
   let state = system.state();
 

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatcher_sender/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatcher_sender/tests.rs
@@ -5,8 +5,6 @@ use core::{
   time::Duration,
 };
 
-use fraktor_utils_core_rs::core::sync::ArcShared;
-
 use crate::core::kernel::{
   actor::{ActorCell, messaging::AnyMessage},
   dispatch::dispatcher::{
@@ -55,7 +53,7 @@ fn actor_creation_attaches_to_new_dispatcher_and_increments_inhabitants() {
 
   use crate::core::kernel::{
     actor::{Actor, ActorCell, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props},
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
+    dispatch::dispatcher::DefaultDispatcherFactory,
     system::ActorSystem,
   };
 
@@ -70,9 +68,7 @@ fn actor_creation_attaches_to_new_dispatcher_and_increments_inhabitants() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
   });
   let state = system.state();
   let resolved = state.resolve_dispatcher(DEFAULT_DISPATCHER_ID).expect("configurator registered");
@@ -101,7 +97,7 @@ fn new_dispatcher_delivers_many_messages_to_single_actor_in_order() {
       messaging::{AnyMessage, AnyMessageView},
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
+    dispatch::dispatcher::DefaultDispatcherFactory,
     system::ActorSystem,
   };
 
@@ -121,9 +117,7 @@ fn new_dispatcher_delivers_many_messages_to_single_actor_in_order() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(16), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
   });
   let state = system.state();
   let seen = SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new());
@@ -159,7 +153,7 @@ fn new_dispatcher_handles_actor_to_actor_send_without_deadlock() {
       messaging::{AnyMessage, AnyMessageView},
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
+    dispatch::dispatcher::DefaultDispatcherFactory,
     system::ActorSystem,
   };
 
@@ -194,9 +188,7 @@ fn new_dispatcher_handles_actor_to_actor_send_without_deadlock() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(16), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
   });
   let state = system.state();
 
@@ -247,7 +239,7 @@ fn new_dispatcher_delivers_messages_to_multiple_actors_independently() {
       messaging::{AnyMessage, AnyMessageView},
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
+    dispatch::dispatcher::DefaultDispatcherFactory,
     system::ActorSystem,
   };
 
@@ -265,9 +257,7 @@ fn new_dispatcher_delivers_messages_to_multiple_actors_independently() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
   });
   let state = system.state();
 
@@ -311,7 +301,7 @@ fn removing_actor_cell_detaches_from_new_dispatcher_and_decrements_inhabitants()
 
   use crate::core::kernel::{
     actor::{Actor, ActorCell, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props},
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
+    dispatch::dispatcher::DefaultDispatcherFactory,
     system::ActorSystem,
   };
 
@@ -326,9 +316,7 @@ fn removing_actor_cell_detaches_from_new_dispatcher_and_decrements_inhabitants()
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
   });
   let state = system.state();
   let resolved = state.resolve_dispatcher(DEFAULT_DISPATCHER_ID).expect("configurator registered");
@@ -357,10 +345,7 @@ fn end_to_end_send_via_actor_system_with_dispatcher_factory() {
 
   use crate::core::kernel::{
     actor::{Actor, ActorContext, actor_ref::ActorRef, error::ActorError, messaging::AnyMessageView, props::Props},
-    dispatch::{
-      dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
-      mailbox::MailboxPolicy,
-    },
+    dispatch::{dispatcher::DefaultDispatcherFactory, mailbox::MailboxPolicy},
     system::ActorSystem,
   };
 
@@ -378,9 +363,7 @@ fn end_to_end_send_via_actor_system_with_dispatcher_factory() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
   });
   let state = system.state();
   let seen = Arc::new(AtomicUsize::new(0));
@@ -411,7 +394,7 @@ fn dispatcher_full_lifecycle_attach_dispatch_drain_detach_and_auto_shutdown() {
       Actor, ActorCell, ActorContext, Pid, actor_ref::ActorRef, error::ActorError, messaging::AnyMessageView,
       props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
+    dispatch::dispatcher::DefaultDispatcherFactory,
     system::ActorSystem,
   };
 
@@ -426,15 +409,11 @@ fn dispatcher_full_lifecycle_attach_dispatch_drain_detach_and_auto_shutdown() {
     }
   }
 
-  let configurator_for_resolve: ArcShared<Box<dyn MessageDispatcherFactory>> = {
+  let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new("lifecycle", nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    ArcShared::new(configurator)
-  };
-  let configurator_clone = configurator_for_resolve.clone();
-  let system =
-    ActorSystem::new_empty_with(move |config| config.with_dispatcher_factory("lifecycle", configurator_clone.clone()));
+    config.with_dispatcher_factory("lifecycle", DefaultDispatcherFactory::new(&settings, executor))
+  });
   let state = system.state();
   // Resolve once outside the spawn flow so we can observe the inhabitants
   // counter independently of the cell. The configurator returns a clone of
@@ -489,7 +468,7 @@ fn dispatcher_resolve_is_not_called_from_message_hot_path() {
     actor::{
       Actor, ActorCell, ActorContext, actor_ref::ActorRef, error::ActorError, messaging::AnyMessageView, props::Props,
     },
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
+    dispatch::dispatcher::DefaultDispatcherFactory,
     system::ActorSystem,
   };
 
@@ -507,9 +486,7 @@ fn dispatcher_resolve_is_not_called_from_message_hot_path() {
   let system = ActorSystem::new_empty_with(|config| {
     let executor = inline_executor_shared();
     let settings = DispatcherConfig::new(DEFAULT_DISPATCHER_ID, nz(8), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
+    config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
   });
   let state = system.state();
 

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared/tests.rs
@@ -145,12 +145,7 @@ fn dispatch_drives_user_message_through_actor_invoker() {
 
 #[test]
 fn resolve_dispatcher_from_actor_system_returns_registered_configurator() {
-  use fraktor_utils_core_rs::core::sync::ArcShared;
-
-  use crate::core::kernel::{
-    dispatch::dispatcher::{DefaultDispatcherFactory, MessageDispatcherFactory},
-    system::ActorSystem,
-  };
+  use crate::core::kernel::{dispatch::dispatcher::DefaultDispatcherFactory, system::ActorSystem};
 
   let system = ActorSystem::new_empty_with(|config| {
     let executor = ExecutorShared::new(
@@ -158,9 +153,7 @@ fn resolve_dispatcher_from_actor_system_returns_registered_configurator() {
       TrampolineState::new(),
     );
     let settings = DispatcherConfig::new("system-test-dispatch", nz(4), None, Duration::from_secs(1));
-    let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-    let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
-    config.with_dispatcher_factory("system-test-dispatch", configurator_handle)
+    config.with_dispatcher_factory("system-test-dispatch", DefaultDispatcherFactory::new(&settings, executor))
   });
   let resolved = system.state().resolve_dispatcher("system-test-dispatch").expect("registered configurator");
   assert_eq!(resolved.id(), "system-test-dispatch");

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -37,8 +37,7 @@ use crate::core::{
       spawn::SpawnError,
     },
     dispatch::dispatcher::{
-      DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared, MessageDispatcherFactory,
-      TrampolineState,
+      DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared, TrampolineState,
     },
     event::stream::{EventStreamEvent, EventStreamSubscriber, tests::subscriber_handle},
     system::{
@@ -180,11 +179,10 @@ impl Executor for NoopExecutor {
   fn shutdown(&mut self) {}
 }
 
-fn noop_dispatcher_configurator() -> ArcShared<Box<dyn MessageDispatcherFactory>> {
+fn noop_dispatcher_configurator() -> DefaultDispatcherFactory {
   let settings = DispatcherConfig::with_defaults("noop");
   let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
-  let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-  ArcShared::new(configurator)
+  DefaultDispatcherFactory::new(&settings, executor)
 }
 
 /// Noop stopper used in `StaticTickDriver`.

--- a/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state/tests.rs
@@ -29,9 +29,7 @@ use crate::core::kernel::{
     },
     setup::ActorSystemConfig,
   },
-  dispatch::dispatcher::{
-    DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, MessageDispatcherFactory, TrampolineState,
-  },
+  dispatch::dispatcher::{DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, TrampolineState},
   event::stream::{EventStreamEvent, EventStreamSubscriber, tests::subscriber_handle},
   system::{
     RegisterExtraTopLevelError, TerminationSignal,
@@ -814,12 +812,11 @@ impl Executor for NoopExecutor {
   fn shutdown(&mut self) {}
 }
 
-fn noop_dispatcher_configurator() -> ArcShared<Box<dyn MessageDispatcherFactory>> {
+fn noop_dispatcher_configurator() -> DefaultDispatcherFactory {
   use crate::core::kernel::dispatch::dispatcher::ExecutorShared;
   let settings = DispatcherConfig::with_defaults("noop");
   let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
-  let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
-  ArcShared::new(configurator)
+  DefaultDispatcherFactory::new(&settings, executor)
 }
 
 struct LogRecorder {

--- a/modules/actor-core/src/core/typed/dispatchers/tests.rs
+++ b/modules/actor-core/src/core/typed/dispatchers/tests.rs
@@ -59,12 +59,9 @@ fn lookup_from_config_preserves_user_override_of_pekko_alias() {
   use alloc::boxed::Box;
   use core::time::Duration;
 
-  use fraktor_utils_core_rs::core::sync::ArcShared;
-
   use crate::core::kernel::{
     dispatch::dispatcher::{
-      DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared, MessageDispatcherFactory,
-      TrampolineState,
+      DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared, TrampolineState,
     },
     system::ActorSystem,
   };
@@ -84,9 +81,10 @@ fn lookup_from_config_preserves_user_override_of_pekko_alias() {
     let custom_config =
       DispatcherConfig::with_defaults("custom-typed-dispatcher").with_shutdown_timeout(Duration::from_secs(2));
     let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
-    let custom: ArcShared<Box<dyn MessageDispatcherFactory>> =
-      ArcShared::new(Box::new(DefaultDispatcherFactory::new(&custom_config, executor)));
-    config.with_dispatcher_factory("pekko.actor.default-dispatcher", custom)
+    config.with_dispatcher_factory(
+      "pekko.actor.default-dispatcher",
+      DefaultDispatcherFactory::new(&custom_config, executor),
+    )
   });
 
   let dispatchers = Dispatchers::new(system.state());


### PR DESCRIPTION
## Summary

`ActorSystemConfig` / `ActorSystemSetup` の builder メソッドが 3 つの異なる引数スタイルを混在させていたため、`impl Trait + 'static` (Tier 1) に統一する。

### 変更前の不整合
| メソッド | 以前の引数 |
|---------|------------|
| `with_tick_driver` | `impl TickDriver + 'static` ✓ |
| `with_actor_ref_provider_installer` | `<P: ActorRefProviderInstaller + 'static>` (generic) |
| `with_invoke_guard_factory` | `ArcShared<Box<dyn InvokeGuardFactory>>` |
| `with_dispatcher_factory` | `ArcShared<Box<dyn MessageDispatcherFactory>>` |

### 変更後 (統一)
すべて `impl Trait + 'static` を受け取る。ビルダー内部で `ArcShared::new(Box::new(factory))` で wrap する。

## Depends on

- #1653 (D1 rename)

本 PR は #1653 にスタックしている。#1653 merge 後に rebase する。

## 検討した代替案 (Pattern A)

最初は Pattern A — `impl Into<ArcShared<Box<dyn Factory>>>` + blanket `impl<F: Factory + 'static> From<F>` — を検討したが、`ArcShared` が `fraktor-utils-core-rs` で定義されているため orphan rule により blanket `From` impl は actor-core に書けない。Tier 1 のほうが

- 既存の `with_tick_driver` / `with_extension_installers` と一貫
- Pekko の domain-term 命名 (例: `SupervisorStrategy`) と親和的
- 呼び出し側のコードが短くなる (`ArcShared::new(Box::new(...))` 定型句の削除)

で優位と判断した。

## 呼び出し側の変更

### before
```rust
let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&settings, executor));
let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, configurator_handle)
```

### after
```rust
config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory::new(&settings, executor))
```

## 削除

- `PanicInvokeGuardFactory::shared()` — Tier 1 化で呼び出し側が直接 `PanicInvokeGuardFactory::new()` を渡せるようになったため不要

## Stats

- Net -51 lines (boilerplate 削除)
- 13 files changed, 73 insertions(+), 124 deletions(-)

## Verification

- [x] `rtk cargo build --workspace --all-targets` → clean (0 warnings)
- [x] `rtk cargo test --workspace --lib` → 4627 passed, 2 ignored
- [x] `rtk cargo fmt --all` 適用済み

## Scope

actor-core / actor-adaptor-std のみ。他 crate への影響なし。後方互換性は CLAUDE.md 方針通り考慮せず、最適な設計を優先した。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes public builder method signatures (`with_dispatcher_factory`, `with_invoke_guard_factory`, `with_actor_ref_provider_installer`) and updates many call sites; behavior should be unchanged but downstream compilation/integration could break if they relied on the old boxed/`ArcShared` inputs.
> 
> **Overview**
> **Unifies `ActorSystemConfig`/`ActorSystemSetup` builder APIs** to consistently accept concrete `impl Trait + 'static` arguments for actor-ref provider installers, invoke-guard factories, and dispatcher factories, with the config layer now doing the internal `ArcShared<Box<dyn _>>` wrapping.
> 
> Updates benches/tests and std adaptor call sites to pass factories directly (removing boilerplate `Box<dyn ...>`/`ArcShared` wrapping), and deletes the now-unneeded `PanicInvokeGuardFactory::shared()` helper in favor of `PanicInvokeGuardFactory::new()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 660524340c89ba70f64959ff7be0149bddb2fb09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->