### PR TITLE
feat(actor-core): allow user-defined MailboxType injection via MailboxConfig

### DIFF
--- a/modules/actor-core/src/core/kernel/actor/props/mailbox_config.rs
+++ b/modules/actor-core/src/core/kernel/actor/props/mailbox_config.rs
@@ -6,7 +6,7 @@ use core::{
 use fraktor_utils_core_rs::core::{collections::queue::capabilities::QueueCapabilityRegistry, sync::ArcShared};
 
 use super::{MailboxConfigError, MailboxRequirement};
-use crate::core::kernel::dispatch::mailbox::{MailboxPolicy, MessagePriorityGenerator};
+use crate::core::kernel::dispatch::mailbox::{MailboxPolicy, MailboxType, MessagePriorityGenerator};
 
 #[cfg(test)]
 mod tests;
@@ -17,14 +17,21 @@ mod tests;
 /// produces a priority-based message queue instead of the default FIFO queue.
 /// When `stable_priority` is also set, equal-priority messages are dequeued in
 /// FIFO (insertion) order.
+///
+/// To plug in a user-defined mailbox implementation, attach a custom
+/// [`MailboxType`] via [`with_mailbox_type`](Self::with_mailbox_type). A custom
+/// mailbox type takes precedence over every other selection rule
+/// (priority generator, control-aware / deque requirement, policy-based
+/// capacity selection).
 #[derive(Clone)]
 pub struct MailboxConfig {
-  policy:             MailboxPolicy,
-  warn_threshold:     Option<NonZeroUsize>,
-  requirement:        MailboxRequirement,
-  capabilities:       QueueCapabilityRegistry,
-  priority_generator: Option<ArcShared<dyn MessagePriorityGenerator>>,
-  stable_priority:    bool,
+  policy:              MailboxPolicy,
+  warn_threshold:      Option<NonZeroUsize>,
+  requirement:         MailboxRequirement,
+  capabilities:        QueueCapabilityRegistry,
+  priority_generator:  Option<ArcShared<dyn MessagePriorityGenerator>>,
+  stable_priority:     bool,
+  custom_mailbox_type: Option<ArcShared<dyn MailboxType>>,
 }
 
 impl MailboxConfig {
@@ -38,6 +45,7 @@ impl MailboxConfig {
       capabilities: QueueCapabilityRegistry::with_defaults(),
       priority_generator: None,
       stable_priority: false,
+      custom_mailbox_type: None,
     }
   }
 
@@ -75,6 +83,15 @@ impl MailboxConfig {
   #[must_use]
   pub const fn stable_priority(&self) -> bool {
     self.stable_priority
+  }
+
+  /// Returns the custom mailbox type override, if any.
+  ///
+  /// When `Some`, the selection logic uses this factory directly and
+  /// bypasses policy / requirement / priority-based selection.
+  #[must_use]
+  pub fn custom_mailbox_type(&self) -> Option<&ArcShared<dyn MailboxType>> {
+    self.custom_mailbox_type.as_ref()
   }
 
   /// Updates the warning threshold.
@@ -115,7 +132,25 @@ impl MailboxConfig {
     self
   }
 
+  /// Installs a user-defined [`MailboxType`] that overrides every other
+  /// selection rule.
+  ///
+  /// The supplied factory is wrapped in `ArcShared<dyn MailboxType>`
+  /// internally. When a custom mailbox type is set, `validate()` and
+  /// `create_message_queue_from_config` bypass priority / requirement /
+  /// policy-based selection and delegate directly to this factory.
+  #[must_use]
+  pub fn with_mailbox_type(mut self, mailbox_type: impl MailboxType + 'static) -> Self {
+    self.custom_mailbox_type = Some(ArcShared::new(mailbox_type));
+    self
+  }
+
   /// Validates the configuration contract.
+  ///
+  /// When a [custom mailbox type](Self::with_mailbox_type) is installed,
+  /// validation is skipped because the custom factory bypasses every other
+  /// selection rule — priority / requirement / capacity fields become
+  /// advisory metadata only.
   ///
   /// # Errors
   ///
@@ -131,6 +166,9 @@ impl MailboxConfig {
   /// Returns [`MailboxConfigError::DequeWithControlAware`] when both control-aware
   /// and deque semantics are requested simultaneously.
   pub fn validate(&self) -> Result<(), MailboxConfigError> {
+    if self.custom_mailbox_type.is_some() {
+      return Ok(());
+    }
     if self.stable_priority && self.priority_generator.is_none() {
       return Err(MailboxConfigError::StablePriorityWithoutGenerator);
     }
@@ -162,6 +200,7 @@ impl Debug for MailboxConfig {
       .field("capabilities", &self.capabilities)
       .field("has_priority_generator", &self.priority_generator.is_some())
       .field("stable_priority", &self.stable_priority)
+      .field("has_custom_mailbox_type", &self.custom_mailbox_type.is_some())
       .finish()
   }
 }

--- a/modules/actor-core/src/core/kernel/actor/props/mailbox_config/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/props/mailbox_config/tests.rs
@@ -92,3 +92,39 @@ fn validate_accepts_bounded_with_deque() {
   let config = MailboxConfig::new(bounded_policy).with_requirement(MailboxRequirement::requires_deque());
   assert_eq!(config.validate(), Ok(()));
 }
+
+#[test]
+fn with_mailbox_type_installs_custom_factory() {
+  use alloc::boxed::Box;
+
+  use crate::core::kernel::dispatch::mailbox::{MailboxType, MessageQueue, UnboundedMailboxType};
+
+  struct RecordingMailboxType;
+  impl MailboxType for RecordingMailboxType {
+    fn create(&self) -> Box<dyn MessageQueue> {
+      UnboundedMailboxType::new().create()
+    }
+  }
+
+  let config = MailboxConfig::default().with_mailbox_type(RecordingMailboxType);
+  assert!(config.custom_mailbox_type().is_some());
+}
+
+#[test]
+fn validate_skips_checks_when_custom_mailbox_type_is_installed() {
+  use alloc::boxed::Box;
+
+  use crate::core::kernel::dispatch::mailbox::{MailboxType, MessageQueue, UnboundedMailboxType};
+
+  struct NoopMailboxType;
+  impl MailboxType for NoopMailboxType {
+    fn create(&self) -> Box<dyn MessageQueue> {
+      UnboundedMailboxType::new().create()
+    }
+  }
+
+  // stable_priority without a generator would normally fail validation.
+  // With a custom mailbox type installed, validation is skipped.
+  let config = MailboxConfig::default().with_stable_priority(true).with_mailbox_type(NoopMailboxType);
+  assert!(config.validate().is_ok());
+}

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
@@ -43,18 +43,24 @@ pub(crate) fn create_message_queue_from_policy(policy: MailboxPolicy) -> Box<dyn
 /// Creates a message queue considering the policy, requirement, and priority generator
 /// from the config.
 ///
-/// When a priority generator is present, a priority-based queue is returned regardless
-/// of other requirements. When the config declares deque semantics and the policy is
-/// unbounded, this returns an [`UnboundedDequeMessageQueue`].
+/// Selection precedence (first match wins):
+/// 1. [`custom_mailbox_type`](MailboxConfig::custom_mailbox_type) — user-supplied factory
+/// 2. [`priority_generator`](MailboxConfig::priority_generator) — priority (stable or not)
+/// 3. [`requirement`](MailboxConfig::requirement) — control-aware / deque
+/// 4. [`policy`](MailboxConfig::policy) — capacity-based default
 ///
 /// # Errors
 ///
 /// Returns [`MailboxConfigError`] when the configuration contract is violated
-/// (e.g. `stable_priority` enabled without a priority generator).
+/// (e.g. `stable_priority` enabled without a priority generator). When a
+/// custom mailbox type is installed, validation is skipped.
 pub(crate) fn create_message_queue_from_config(
   config: &MailboxConfig,
 ) -> Result<Box<dyn MessageQueue>, MailboxConfigError> {
   config.validate()?;
+  if let Some(custom) = config.custom_mailbox_type() {
+    return Ok(custom.create());
+  }
   if let Some(generator) = config.priority_generator() {
     if config.stable_priority() {
       return Ok(stable_priority_mailbox_type_from_config(generator.clone(), config.policy()).create());

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes/tests.rs
@@ -119,3 +119,40 @@ fn create_message_queue_creates_bounded_control_aware_for_bounded_plus_control_a
   assert!(first.is_control());
   assert_eq!(first.payload().downcast_ref::<u32>().copied(), Some(99_u32));
 }
+
+#[test]
+fn create_message_queue_honors_custom_mailbox_type_over_policy() {
+  use alloc::{boxed::Box, sync::Arc};
+  use core::sync::atomic::{AtomicUsize, Ordering};
+
+  use crate::core::kernel::dispatch::mailbox::{MailboxType, MessageQueue, UnboundedMailboxType};
+
+  struct CountingMailboxType {
+    create_calls: Arc<AtomicUsize>,
+  }
+  impl MailboxType for CountingMailboxType {
+    fn create(&self) -> Box<dyn MessageQueue> {
+      self.create_calls.fetch_add(1, Ordering::SeqCst);
+      UnboundedMailboxType::new().create()
+    }
+  }
+
+  let create_calls = Arc::new(AtomicUsize::new(0));
+  let mailbox_type = CountingMailboxType { create_calls: create_calls.clone() };
+
+  // Bounded policy would normally produce a bounded queue. The custom
+  // mailbox type must take precedence and be invoked instead.
+  let capacity = NonZeroUsize::new(4).expect("capacity");
+  let bounded_policy = MailboxPolicy::bounded(capacity, MailboxOverflowStrategy::DropNewest, None);
+  let config = MailboxConfig::new(bounded_policy).with_mailbox_type(mailbox_type);
+
+  let mut registry = Mailboxes::new();
+  registry.register("custom-type", config).expect("register");
+  let _ = registry.create_message_queue("custom-type").expect("create queue via custom type");
+
+  assert_eq!(
+    create_calls.load(Ordering::SeqCst),
+    1,
+    "custom MailboxType::create must be invoked once, regardless of the bounded policy",
+  );
+}


### PR DESCRIPTION
## Summary

`MailboxType` trait は Pekko スタイルの message-queue factory 拡張ポイントとして既に定義されていたが、**builder 層から届いていなかった** — `with_mailbox(id, MailboxConfig)` は config データのみを受け付け、実際の mailbox 選択は `mailboxes.rs::mailbox_type_from_policy` 内のハードコード match で built-in 8 型から選ぶだけだった。

本 PR は `MailboxConfig` に optional `custom_mailbox_type: Option<ArcShared<dyn MailboxType>>` フィールドを追加し、`with_mailbox_type(impl MailboxType + 'static)` builder を公開する。セットされた場合、`create_message_queue_from_config` は policy / requirement / priority-based 選択を bypass してユーザー factory に直接委譲する。

## 選択優先順位 (先勝ち)

1. **`custom_mailbox_type`** ← 新規
2. `priority_generator` (stable or not)
3. `requirement` (control-aware / deque)
4. `policy` (capacity-based default)

## 使用例

```rust
struct MyMailboxType { /* ... */ }
impl MailboxType for MyMailboxType {
  fn create(&self) -> Box<dyn MessageQueue> { /* ... */ }
}

let config = MailboxConfig::default().with_mailbox_type(MyMailboxType { /* ... */ });
actor_system_config.with_mailbox(\"custom-id\", config)
```

## 互換性

- 既存 callsite は **一切変更不要**。`MailboxConfig::default()` / 既存の builder はそのまま動作する
- `validate()` は custom mailbox type 設定時にチェックを skip する (priority / requirement / capacity は advisory metadata 扱い)

## なぜこの approach か

検討した 3 案:
- **A. MailboxConfig 拡張 (採用)** — 最小 API 影響、既存コード無変更
- B. 新規 `with_mailbox_type(id, impl Trait)` builder 追加 — 2 つの entry point、混乱要因
- C. `Mailboxes` storage を `ArcShared<dyn MailboxType>` に変更 — `MailboxConfig` の warn_threshold / validate 等のメタデータを失う

A が immutability policy (元 config の immutable な拡張) とも整合。

## Tests

3 新規テスト:
- \`with_mailbox_type_installs_custom_factory\` — builder 表面
- \`validate_skips_checks_when_custom_mailbox_type_is_installed\` — validation override
- \`create_message_queue_honors_custom_mailbox_type_over_policy\` — **end-to-end** through \`Mailboxes\` registry。bounded policy を override して custom factory が AtomicUsize で観測可能な回数呼ばれることを確認

## Verification

- [x] \`rtk cargo build --workspace --all-targets\` → clean (0 warnings)
- [x] \`rtk cargo test --workspace --lib\` → 4630 passed, 2 ignored (+3 new)
- [x] \`rtk cargo fmt --all\` 適用済み

## Scope

actor-core のみ。他 crate への影響なし。

## Note

当初 PR \`impl/mailbox-type-custom-injection\` を push していたが、branch 名変更のため \`impl/mailbox-type-injection\` で再開。前者は未使用のまま。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mailbox queue selection to allow a user-supplied `MailboxType` to bypass existing policy/requirement/priority validation and creation paths, which could alter runtime ordering/capacity semantics if misused. Scope is contained to actor-core mailbox configuration/registry with added test coverage.
> 
> **Overview**
> **Adds first-class custom mailbox injection via `MailboxConfig`.** `MailboxConfig` now carries an optional `custom_mailbox_type` and a new `with_mailbox_type(...)` builder, plus a getter for downstream selection.
> 
> **Mailbox selection now honors a new highest-precedence rule.** `create_message_queue_from_config` checks `custom_mailbox_type` first and delegates queue creation directly to it; `MailboxConfig::validate()` short-circuits when a custom type is present (treating other fields as advisory). New unit tests cover installing the factory, skipped validation, and end-to-end precedence over bounded policies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d8a16e195736a3d0eacd5f1d65773a0523f20b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * メールボックス構成にカスタムメールボックスタイプのサポートが追加されました。
  * カスタムメールボックスを設定すると、既存の検証ルールがスキップされます。
  * ユーザーは独自のメールボックス実装を登録し、メッセージキューの作成に使用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->