### PR TITLE
feat(actor-core): introduce MailboxFactory trait as builder-facing extension point

### DIFF
--- a/.agents/skills/pr-green
+++ b/.agents/skills/pr-green
@@ -1,1 +1,0 @@
-../../references/okite-ai/skills/pr-green

--- a/.claude/skills/error-classification
+++ b/.claude/skills/error-classification
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/error-classification
+../../.agents/skills/error-classification

--- a/.claude/skills/error-handling
+++ b/.claude/skills/error-handling
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/error-handling
+../../.agents/skills/error-handling

--- a/.claude/skills/intent-based-dedup
+++ b/.claude/skills/intent-based-dedup
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/intent-based-dedup
+../../.agents/skills/intent-based-dedup

--- a/.claude/skills/law-of-demeter
+++ b/.claude/skills/law-of-demeter
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/law-of-demeter
+../../.agents/skills/law-of-demeter

--- a/.claude/skills/package-design
+++ b/.claude/skills/package-design
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/package-design
+../../.agents/skills/package-design

--- a/.claude/skills/parse-dont-validate
+++ b/.claude/skills/parse-dont-validate
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/parse-dont-validate
+../../.agents/skills/parse-dont-validate

--- a/.claude/skills/refactoring-packages
+++ b/.claude/skills/refactoring-packages
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/refactoring-packages
+../../.agents/skills/refactoring-packages

--- a/.claude/skills/reviewing-skills
+++ b/.claude/skills/reviewing-skills
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/reviewing-skills
+../../.agents/skills/reviewing-skills

--- a/.claude/skills/tell-dont-ask
+++ b/.claude/skills/tell-dont-ask
@@ -1,1 +1,1 @@
-../../references/okite-ai/skills/tell-dont-ask
+../../.agents/skills/tell-dont-ask

--- a/.serena-home/.serena/serena_config.yml
+++ b/.serena-home/.serena/serena_config.yml
@@ -29,24 +29,20 @@ line_ending: native
 # we have to live with this limitation for now.
 gui_log_window: false
 
-# whether to open the Serena web dashboard (which will be accessible through your web browser) that
-# provides access to Serena's configuration and state as well as the current session logs.
-# The web dashboard is supported on all platforms.
-# We strongly recommend to always enable this option, since the dashboard provides important information
-# about the current state of Serena, including the configuration, the logs and tool usage statistics.
-# If you don't want the browser window to pop up automatically, set the `web_dashboard_open_on_launch` to False
-# (either here or through the corresponding flag in the `start-mcp-server` CLI command).
-# You can then open the dashboard by asking your agent to do so (e.g., by saying "open the dashboard"), Serena provides
-# a tool for this.
+# whether to start the Serena Dashboard, which provides detailed information on your Serena session,
+# the current configuration and furthermore allows some settings to be conveniently modified on the fly.
+# We strongly recommend to always enable this option!
+# If you want to prevent the Dashboard window from being opened on launch,
+# set `web_dashboard_open_on_launch` to false (see below).
 # Further information: https://oraios.github.io/serena/02-usage/060_dashboard.html
 web_dashboard: false
 
 # the address the web dashboard will listen on (bind address).
 web_dashboard_listen_address: 127.0.0.1
 
-# whether to open a browser window with the web dashboard when Serena starts (provided that web_dashboard
-# is enabled). See also the web_dashboard option.
-# If set to false, you can still open the dashboard manually by
+# whether to open the Dashboard window/browser tab when Serena starts (provided that web_dashboard is enabled).
+# If set to false, you can still open the dashboard manually by clicking on the Serena icon in your system
+# tray on Windows and macOS. On Linux, there is no system tray support, so you can only open the dashboard by
 # a) telling the LLM to "open the dashboard" (provided that the open_dashboard tool is enabled) or by
 # b) manually navigating to http://localhost:24282/dashboard/ in your web browser (actual port
 #    may be higher if you have multiple instances running; try ports 24283, 24284, etc.)
@@ -104,10 +100,6 @@ base_modes:
 default_modes:
 - interactive
 - editing
-
-# Used as default for tools where the apply method has a default maximal answer length.
-# Even though the value of the max_answer_chars can be changed when calling the tool, it may make sense to adjust this default
-# through the global configuration.
 default_max_tool_answer_chars: 150000
 
 # the name of the token count estimator to use for tool usage statistics.
@@ -151,3 +143,18 @@ projects:
 # You can extend the list on a per-project basis in the project.yml configuration file.
 # Example: ["_archive/.*", "_episodes/.*"]
 ignored_memory_patterns: []
+
+# defines the interface (application mode) used for the web dashboard (if enabled).
+# If empty/null, use platform-dependent default. Otherwise, possible values:
+#  * browser: the dashboard is opened in the default browser (if `web_dashboard_open_on_launch` is true)
+#      This is supported on all platforms.
+#  * app: the dashboard is opened in a separate native-like app window with accompanying tray icon, whose
+#      lifecycle is tied to the Serena process.
+#      If `web_dashboard_open_on_launch` is false, the dashboard can be conveniently accessed via the tray icon.
+#      This is supported on Windows and macOS, but note that on macOS, where tray icons are very visible,
+#      this may result in too many icons being displayed when using multi-agent setups.
+#  * tray_manager: use a global tray icon to provide access to the dashboards of all running Serena instances,
+#      opening the dashboard in browser tabs when selected from the tray menu.
+#      This is EXPERIMENTAL. It is tested on Windows only. We will establish macOS support, but it is yet untested.
+#      On Linux, this cannot be universally supported, but it may work in some desktop environments.
+web_dashboard_interface:

--- a/modules/actor-core/src/core/kernel/actor/actor_cell.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_cell.rs
@@ -39,7 +39,9 @@ use crate::core::{
     },
     dispatch::{
       dispatcher::{DEFAULT_DISPATCHER_ID, DispatcherSender, MessageDispatcherShared},
-      mailbox::{Mailbox, MailboxCapacity, MailboxInstrumentation, metrics_event::MailboxPressureEvent},
+      mailbox::{
+        Mailbox, MailboxCapacity, MailboxFactory, MailboxInstrumentation, metrics_event::MailboxPressureEvent,
+      },
     },
     event::{logging::LogLevel, stream::EventStreamEvent},
     system::{
@@ -129,10 +131,10 @@ impl ActorCell {
   ) -> Result<ArcShared<Self>, SpawnError> {
     let mailbox_id = props.mailbox_id();
 
-    let mailbox_config = if let Some(id) = mailbox_id {
+    let mailbox_factory: ArcShared<dyn MailboxFactory> = if let Some(id) = mailbox_id {
       system.resolve_mailbox(id).map_err(|error| SpawnError::invalid_props(alloc::format!("{error:?}")))?
     } else {
-      props.mailbox_config().clone()
+      ArcShared::new(props.mailbox_config().clone())
     };
 
     let dispatcher_id = Self::resolve_dispatcher_id(&system, parent, props)?;
@@ -145,7 +147,7 @@ impl ActorCell {
     // dispatcher 自身が mailbox を用意したい場合 (例: `BalancingDispatcher` は
     // 単一の team queue をラップする sharing mailbox を返す) に先に問い合わせる。
     // per-actor queue を使う dispatcher は `None` を返し、`ActorCell` は
-    // `MailboxConfig` ベースの経路にフォールバックする。
+    // `MailboxFactory` ベースの経路にフォールバックする。
     // system 由来の `MailboxSharedSet` を取得し、std adaptor が
     // `ActorSystemConfig::with_mailbox_clock` 経由で install した throughput
     // deadline clock を新規構築の mailbox に伝播させる。bundle の `clock = None`
@@ -156,21 +158,21 @@ impl ActorCell {
     } else if let Some(id) = mailbox_id {
       let queue =
         system.create_mailbox_queue(id).map_err(|error| SpawnError::invalid_props(alloc::format!("{error:?}")))?;
-      ArcShared::new(Mailbox::new_with_queue_and_shared_set(mailbox_config.policy(), queue, &mailbox_shared_set))
+      ArcShared::new(Mailbox::new_with_queue_and_shared_set(mailbox_factory.policy(), queue, &mailbox_shared_set))
     } else {
       ArcShared::new(
-        Mailbox::new_from_config_with_shared_set(&mailbox_config, &mailbox_shared_set)
+        Mailbox::new_from_factory_with_shared_set(&*mailbox_factory, &mailbox_shared_set)
           .map_err(|error| SpawnError::invalid_props(alloc::format!("{error}")))?,
       )
     };
     {
-      let policy = mailbox_config.policy();
+      let policy = mailbox_factory.policy();
       let capacity = match policy.capacity() {
         | MailboxCapacity::Bounded { capacity } => Some(capacity.get()),
         | MailboxCapacity::Unbounded => None,
       };
       let throughput = policy.throughput_limit().map(|limit| limit.get());
-      let warn_threshold = mailbox_config.warn_threshold().map(|threshold| threshold.get());
+      let warn_threshold = mailbox_factory.warn_threshold().map(|threshold| threshold.get());
       let instrumentation = MailboxInstrumentation::new(system.clone(), pid, capacity, throughput, warn_threshold);
       mailbox.set_instrumentation(instrumentation);
     }

--- a/modules/actor-core/src/core/kernel/actor/props/base.rs
+++ b/modules/actor-core/src/core/kernel/actor/props/base.rs
@@ -224,11 +224,6 @@ impl Props {
     self.mailbox_id = None;
     self
   }
-
-  pub(crate) fn with_resolved_mailbox_config(mut self, mailbox_config: MailboxConfig) -> Self {
-    self.mailbox_config = mailbox_config;
-    self
-  }
 }
 
 impl Clone for Props {

--- a/modules/actor-core/src/core/kernel/actor/props/mailbox_config.rs
+++ b/modules/actor-core/src/core/kernel/actor/props/mailbox_config.rs
@@ -162,12 +162,12 @@ impl MailboxFactory for MailboxConfig {
     // off policy / requirement / priority_generator / stable_priority.
     // Wrap the resolved factory in `ArcShared` so the caller sees a
     // stable trait-object reference per invocation.
-    let boxed = crate::core::kernel::dispatch::mailbox::mailboxes::select_mailbox_type_from_config(self);
+    let boxed = crate::core::kernel::dispatch::mailbox::select_mailbox_type_from_config(self);
     ArcShared::from_boxed(boxed)
   }
 
   fn create_message_queue(&self) -> Result<Box<dyn MessageQueue>, MailboxConfigError> {
-    crate::core::kernel::dispatch::mailbox::mailboxes::create_message_queue_from_config(self)
+    crate::core::kernel::dispatch::mailbox::create_message_queue_from_config(self)
   }
 
   fn policy(&self) -> MailboxPolicy {

--- a/modules/actor-core/src/core/kernel/actor/props/mailbox_config.rs
+++ b/modules/actor-core/src/core/kernel/actor/props/mailbox_config.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::{
   fmt::{Debug, Formatter, Result as FmtResult},
   num::NonZeroUsize,
@@ -6,7 +7,9 @@ use core::{
 use fraktor_utils_core_rs::core::{collections::queue::capabilities::QueueCapabilityRegistry, sync::ArcShared};
 
 use super::{MailboxConfigError, MailboxRequirement};
-use crate::core::kernel::dispatch::mailbox::{MailboxPolicy, MessagePriorityGenerator};
+use crate::core::kernel::dispatch::mailbox::{
+  MailboxFactory, MailboxPolicy, MailboxType, MessagePriorityGenerator, MessageQueue,
+};
 
 #[cfg(test)]
 mod tests;
@@ -150,6 +153,37 @@ impl MailboxConfig {
 impl Default for MailboxConfig {
   fn default() -> Self {
     MailboxConfig::new(MailboxPolicy::unbounded(None))
+  }
+}
+
+impl MailboxFactory for MailboxConfig {
+  fn mailbox_type(&self) -> ArcShared<dyn MailboxType> {
+    // The built-in selection logic returns a `Box<dyn MailboxType>` keyed
+    // off policy / requirement / priority_generator / stable_priority.
+    // Wrap the resolved factory in `ArcShared` so the caller sees a
+    // stable trait-object reference per invocation.
+    let boxed = crate::core::kernel::dispatch::mailbox::mailboxes::select_mailbox_type_from_config(self);
+    ArcShared::from_boxed(boxed)
+  }
+
+  fn create_message_queue(&self) -> Result<Box<dyn MessageQueue>, MailboxConfigError> {
+    crate::core::kernel::dispatch::mailbox::mailboxes::create_message_queue_from_config(self)
+  }
+
+  fn policy(&self) -> MailboxPolicy {
+    self.policy
+  }
+
+  fn warn_threshold(&self) -> Option<NonZeroUsize> {
+    self.warn_threshold
+  }
+
+  fn requirement(&self) -> MailboxRequirement {
+    self.requirement
+  }
+
+  fn capabilities(&self) -> QueueCapabilityRegistry {
+    self.capabilities
   }
 }
 

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_config.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_config.rs
@@ -15,13 +15,12 @@ use crate::core::kernel::{
     actor_ref_provider::ActorRefProviderInstaller,
     extension::ExtensionInstallers,
     invoke_guard::{InvokeGuardFactory, NoopInvokeGuardFactory},
-    props::MailboxConfig,
     scheduler::{SchedulerConfig, tick_driver::TickDriver},
     setup::CircuitBreakerConfig,
   },
   dispatch::{
     dispatcher::{Dispatchers, MessageDispatcherFactory},
-    mailbox::{MailboxClock, Mailboxes},
+    mailbox::{MailboxClock, MailboxFactory, Mailboxes},
   },
   system::remote::RemotingConfig,
 };
@@ -134,10 +133,15 @@ impl ActorSystemConfig {
     self
   }
 
-  /// Registers or updates a mailbox configuration.
+  /// Registers or updates a mailbox factory under the supplied id.
+  ///
+  /// Accepts any [`MailboxFactory`] implementation. Since
+  /// [`MailboxConfig`] implements [`MailboxFactory`], existing callers can
+  /// continue to pass a `MailboxConfig` directly; custom factory types can
+  /// also be plugged in to override queue construction and metadata.
   #[must_use]
-  pub fn with_mailbox(mut self, id: impl Into<String>, config: MailboxConfig) -> Self {
-    self.mailboxes.register_or_update(id, config);
+  pub fn with_mailbox(mut self, id: impl Into<String>, factory: impl MailboxFactory + 'static) -> Self {
+    self.mailboxes.register_or_update(id, factory);
     self
   }
 

--- a/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
+++ b/modules/actor-core/src/core/kernel/actor/setup/actor_system_setup.rs
@@ -11,11 +11,10 @@ use crate::core::kernel::{
   actor::{
     actor_ref_provider::ActorRefProviderInstaller,
     extension::ExtensionInstallers,
-    props::MailboxConfig,
     scheduler::{SchedulerConfig, tick_driver::TickDriver},
     setup::{ActorSystemConfig, BootstrapSetup, CircuitBreakerConfig},
   },
-  dispatch::dispatcher::MessageDispatcherFactory,
+  dispatch::{dispatcher::MessageDispatcherFactory, mailbox::MailboxFactory},
 };
 
 /// Pekko-compatible setup aggregate backed by [`ActorSystemConfig`].
@@ -80,10 +79,13 @@ impl ActorSystemSetup {
     Self { config: self.config.with_dispatcher_factory(id, configurator) }
   }
 
-  /// Registers or updates a mailbox configuration.
+  /// Registers or updates a mailbox factory under the supplied id.
+  ///
+  /// Accepts any [`MailboxFactory`] implementation, including
+  /// [`MailboxConfig`] via its bridge impl.
   #[must_use]
-  pub fn with_mailbox(self, id: impl Into<String>, config: MailboxConfig) -> Self {
-    Self { config: self.config.with_mailbox(id, config) }
+  pub fn with_mailbox(self, id: impl Into<String>, factory: impl MailboxFactory + 'static) -> Self {
+    Self { config: self.config.with_mailbox(id, factory) }
   }
 
   /// Replaces the default circuit-breaker configuration.

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox.rs
@@ -44,6 +44,8 @@ mod envelope;
 mod mailbox_cleanup_policy;
 /// Monotonic clock callback type for throughput deadline enforcement.
 mod mailbox_clock;
+/// High-level factory trait registered with the actor-system builder.
+mod mailbox_factory;
 mod mailbox_instrumentation;
 mod mailbox_poll_future;
 mod mailbox_queue_handles;
@@ -51,7 +53,7 @@ mod mailbox_queue_state;
 mod mailbox_registry_error;
 /// Factory trait for creating message queue instances.
 mod mailbox_type;
-mod mailboxes;
+pub(crate) mod mailboxes;
 /// Priority generator for priority-based message queues.
 mod message_priority_generator;
 /// Pluggable message queue trait.
@@ -111,6 +113,7 @@ pub use enqueue_outcome::EnqueueOutcome;
 pub use envelope::Envelope;
 pub use mailbox_cleanup_policy::MailboxCleanupPolicy;
 pub use mailbox_clock::MailboxClock;
+pub use mailbox_factory::MailboxFactory;
 pub use mailbox_instrumentation::MailboxInstrumentation;
 pub use mailbox_poll_future::MailboxPollFuture;
 pub(crate) use mailbox_queue_handles::QueueStateHandle;

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox.rs
@@ -53,7 +53,7 @@ mod mailbox_queue_state;
 mod mailbox_registry_error;
 /// Factory trait for creating message queue instances.
 mod mailbox_type;
-pub(crate) mod mailboxes;
+mod mailboxes;
 /// Priority generator for priority-based message queues.
 mod message_priority_generator;
 /// Pluggable message queue trait.
@@ -120,6 +120,7 @@ pub(crate) use mailbox_queue_handles::QueueStateHandle;
 pub use mailbox_registry_error::MailboxRegistryError;
 pub use mailbox_type::MailboxType;
 pub use mailboxes::Mailboxes;
+pub(crate) use mailboxes::{create_message_queue_from_config, select_mailbox_type_from_config};
 pub use message_priority_generator::MessagePriorityGenerator;
 pub use message_queue::MessageQueue;
 pub use overflow_strategy::MailboxOverflowStrategy;

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs
@@ -9,8 +9,8 @@ use core::{num::NonZeroUsize, time::Duration};
 use fraktor_utils_core_rs::core::sync::{SharedAccess, SyncOnce, WeakShared};
 
 use super::{
-  CloseRequestOutcome, DequeMessageQueue, MailboxScheduleState, RunFinishOutcome, ScheduleHints, SystemQueue,
-  enqueue_error::EnqueueError, enqueue_outcome::EnqueueOutcome, envelope::Envelope,
+  CloseRequestOutcome, DequeMessageQueue, MailboxFactory, MailboxScheduleState, RunFinishOutcome, ScheduleHints,
+  SystemQueue, enqueue_error::EnqueueError, enqueue_outcome::EnqueueOutcome, envelope::Envelope,
   mailbox_cleanup_policy::MailboxCleanupPolicy, mailbox_clock::MailboxClock,
   mailbox_instrumentation::MailboxInstrumentation, message_queue::MessageQueue,
 };
@@ -20,7 +20,7 @@ use crate::core::kernel::{
     actor_ref::dead_letter::DeadLetterReason,
     error::SendError,
     messaging::{AnyMessage, message_invoker::MessageInvokerShared, system_message::SystemMessage},
-    props::{MailboxConfig, MailboxConfigError},
+    props::MailboxConfigError,
   },
   dispatch::mailbox::policy::MailboxPolicy,
   event::logging::LogLevel,
@@ -85,33 +85,33 @@ impl Mailbox {
     Self::new_with_queue_and_shared_set(policy, queue, shared_set)
   }
 
-  /// Creates a new mailbox from the provided configuration.
+  /// Creates a new mailbox from the provided factory.
   ///
-  /// When the config declares deque semantics and the policy is unbounded, this produces a
-  /// deque-capable queue that supports O(1) front insertion in
+  /// When the factory declares deque semantics and the policy is unbounded,
+  /// this produces a deque-capable queue that supports O(1) front insertion in
   /// [`prepend_user_messages_deque`](Self::prepend_user_messages_deque).
   ///
   /// # Errors
   ///
   /// Returns [`MailboxConfigError`](crate::core::kernel::actor::props::MailboxConfigError) when the
   /// configuration contract is violated.
-  pub fn new_from_config(config: &MailboxConfig) -> Result<Self, MailboxConfigError> {
+  pub fn new_from_factory(factory: &dyn MailboxFactory) -> Result<Self, MailboxConfigError> {
     let shared_set = MailboxSharedSet::builtin();
-    Self::new_from_config_with_shared_set(config, &shared_set)
+    Self::new_from_factory_with_shared_set(factory, &shared_set)
   }
 
-  /// Creates a mailbox from configuration using the supplied lock bundle.
+  /// Creates a mailbox from the provided factory using the supplied lock bundle.
   ///
   /// # Errors
   ///
   /// Returns [`MailboxConfigError`](crate::core::kernel::actor::props::MailboxConfigError) when the
   /// configuration contract is violated.
-  pub fn new_from_config_with_shared_set(
-    config: &MailboxConfig,
+  pub fn new_from_factory_with_shared_set(
+    factory: &dyn MailboxFactory,
     shared_set: &MailboxSharedSet,
   ) -> Result<Self, MailboxConfigError> {
-    let policy = config.policy();
-    let queue = super::mailboxes::create_message_queue_from_config(config)?;
+    let policy = factory.policy();
+    let queue = factory.create_message_queue()?;
     Ok(Self::new_with_queue_and_shared_set(policy, queue, shared_set))
   }
 

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailbox_factory.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailbox_factory.rs
@@ -1,0 +1,86 @@
+//! Builder-facing factory trait that bundles a [`MailboxType`] with the
+//! metadata consulted by the actor-cell spawn path.
+
+#[cfg(test)]
+mod tests;
+
+use alloc::boxed::Box;
+use core::num::NonZeroUsize;
+
+use fraktor_utils_core_rs::core::{collections::queue::capabilities::QueueCapabilityRegistry, sync::ArcShared};
+
+use super::{MailboxPolicy, MailboxType, MessageQueue};
+use crate::core::kernel::actor::props::{MailboxConfigError, MailboxRequirement};
+
+/// Builder-facing extension point for mailbox installation.
+///
+/// `MailboxFactory` is the high-level factory registered with
+/// [`ActorSystemConfig::with_mailbox`](crate::core::kernel::actor::setup::ActorSystemConfig::with_mailbox).
+/// It bundles a low-level [`MailboxType`] (which produces the concrete
+/// [`MessageQueue`]) with the metadata consulted by `ActorCell` at spawn
+/// time (policy, warn threshold, required and available queue capabilities).
+///
+/// Unlike [`MailboxType`], which is intentionally a thin queue-factory trait,
+/// `MailboxFactory` is the unit users plug into the builder. Custom
+/// implementations can produce arbitrary mailbox behavior while advertising
+/// the metadata the runtime needs for instrumentation and capability checks.
+///
+/// [`MailboxConfig`](crate::core::kernel::actor::props::MailboxConfig)
+/// implements this trait as a bridge so existing callers keep working
+/// unchanged.
+pub trait MailboxFactory: Send + Sync {
+  /// Returns the underlying [`MailboxType`].
+  ///
+  /// The returned factory is invoked during mailbox construction to produce
+  /// the concrete [`MessageQueue`]. Implementations should return a stable
+  /// `ArcShared` so each call resolves to the same factory instance.
+  fn mailbox_type(&self) -> ArcShared<dyn MailboxType>;
+
+  /// Creates a user-message queue.
+  ///
+  /// The default implementation delegates to
+  /// [`mailbox_type().create()`](MailboxType::create). Factory implementations
+  /// that need richer construction (e.g. configuration validation) can
+  /// override this.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`MailboxConfigError`] when the factory rejects the
+  /// configuration it was built with.
+  fn create_message_queue(&self) -> Result<Box<dyn MessageQueue>, MailboxConfigError> {
+    Ok(self.mailbox_type().create())
+  }
+
+  /// Returns the policy used for instrumentation (capacity / throughput).
+  ///
+  /// The default value is unbounded with no throughput cap. Custom factories
+  /// can override to feed capacity metrics and throughput limits into the
+  /// runtime instrumentation layer.
+  fn policy(&self) -> MailboxPolicy {
+    MailboxPolicy::unbounded(None)
+  }
+
+  /// Returns the warning threshold for queue depth instrumentation.
+  ///
+  /// When `Some(n)`, the mailbox instrumentation layer emits a warning
+  /// once the queue depth exceeds `n`. The default is `None` (no warning).
+  fn warn_threshold(&self) -> Option<NonZeroUsize> {
+    None
+  }
+
+  /// Returns the queue capabilities this factory **requires**.
+  ///
+  /// `ActorCell::create` validates that the `capabilities()` registry
+  /// provides every capability listed here before constructing the mailbox.
+  fn requirement(&self) -> MailboxRequirement {
+    MailboxRequirement::none()
+  }
+
+  /// Returns the queue capabilities this factory **advertises**.
+  ///
+  /// Used in conjunction with [`requirement`](Self::requirement) for
+  /// spawn-time capability checks.
+  fn capabilities(&self) -> QueueCapabilityRegistry {
+    QueueCapabilityRegistry::with_defaults()
+  }
+}

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailbox_factory/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailbox_factory/tests.rs
@@ -1,0 +1,97 @@
+use alloc::{boxed::Box, sync::Arc};
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use fraktor_utils_core_rs::core::sync::ArcShared;
+
+use super::MailboxFactory;
+use crate::core::kernel::{
+  actor::props::MailboxConfig,
+  dispatch::mailbox::{MailboxType, Mailboxes, MessageQueue, UnboundedMailboxType},
+};
+
+/// Counting MailboxType so tests can observe how many queues a factory
+/// produced, and prove that a user-supplied factory actually drives queue
+/// construction.
+struct CountingMailboxType {
+  create_calls: Arc<AtomicUsize>,
+}
+
+impl MailboxType for CountingMailboxType {
+  fn create(&self) -> Box<dyn MessageQueue> {
+    self.create_calls.fetch_add(1, Ordering::SeqCst);
+    UnboundedMailboxType::new().create()
+  }
+}
+
+/// A custom MailboxFactory that wraps a CountingMailboxType and surfaces
+/// metadata so the trait default methods can be exercised.
+struct CustomMailboxFactory {
+  mailbox_type: ArcShared<dyn MailboxType>,
+}
+
+impl CustomMailboxFactory {
+  fn new(create_calls: Arc<AtomicUsize>) -> Self {
+    let mailbox_type: ArcShared<dyn MailboxType> = ArcShared::new(CountingMailboxType { create_calls });
+    Self { mailbox_type }
+  }
+}
+
+impl MailboxFactory for CustomMailboxFactory {
+  fn mailbox_type(&self) -> ArcShared<dyn MailboxType> {
+    self.mailbox_type.clone()
+  }
+}
+
+#[test]
+fn mailbox_config_bridges_into_mailbox_factory() {
+  // `MailboxConfig` implements `MailboxFactory`, so the same registry that
+  // stores user-supplied factories also accepts a `MailboxConfig` directly.
+  let mut registry = Mailboxes::new();
+  registry.register("config-bridge", MailboxConfig::default()).expect("register config as factory");
+
+  let factory = registry.resolve("config-bridge").expect("resolve");
+  // Default config uses unbounded policy + no warn threshold.
+  assert!(matches!(factory.policy().capacity(), crate::core::kernel::dispatch::mailbox::MailboxCapacity::Unbounded));
+  assert!(factory.warn_threshold().is_none());
+
+  // The factory produces a message queue end-to-end through the registry.
+  let _queue = registry.create_message_queue("config-bridge").expect("create queue");
+}
+
+#[test]
+fn custom_mailbox_factory_drives_queue_construction() {
+  // Registering a user-defined MailboxFactory causes `create_message_queue`
+  // to invoke that factory's MailboxType rather than the built-in
+  // policy-based selection.
+  let create_calls = Arc::new(AtomicUsize::new(0));
+  let factory = CustomMailboxFactory::new(create_calls.clone());
+
+  let mut registry = Mailboxes::new();
+  registry.register("custom", factory).expect("register custom factory");
+
+  let _queue = registry.create_message_queue("custom").expect("create queue via custom factory");
+  assert_eq!(
+    create_calls.load(Ordering::SeqCst),
+    1,
+    "custom MailboxType::create must be invoked exactly once per queue construction",
+  );
+
+  // Re-resolving through the trait-object handle also goes through the
+  // same factory instance.
+  let _queue2 = registry.create_message_queue("custom").expect("create queue again");
+  assert_eq!(create_calls.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn mailbox_factory_default_metadata_is_applied() {
+  // A MailboxFactory that only overrides `mailbox_type` inherits unbounded
+  // policy, no warn threshold, empty requirement, and a default capability
+  // registry from the trait default methods.
+  let factory = CustomMailboxFactory::new(Arc::new(AtomicUsize::new(0)));
+  assert!(factory.warn_threshold().is_none());
+  assert!(!factory.requirement().needs_control_aware());
+  assert!(!factory.requirement().needs_deque());
+  // `capabilities().with_defaults()` is the declared default.
+  let defaults = factory.capabilities();
+  let _ = defaults; // smoke test: default constructor must not panic.
+}

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
@@ -8,7 +8,7 @@ use hashbrown::HashMap;
 use crate::core::kernel::{
   actor::props::{MailboxConfig, MailboxConfigError},
   dispatch::mailbox::{
-    MailboxRegistryError, bounded_control_aware_mailbox_type::BoundedControlAwareMailboxType,
+    MailboxFactory, MailboxRegistryError, bounded_control_aware_mailbox_type::BoundedControlAwareMailboxType,
     bounded_deque_mailbox_type::BoundedDequeMailboxType, bounded_mailbox_type::BoundedMailboxType,
     bounded_priority_mailbox_type::BoundedPriorityMailboxType,
     bounded_stable_priority_mailbox_type::BoundedStablePriorityMailboxType, capacity::MailboxCapacity,
@@ -55,19 +55,35 @@ pub(crate) fn create_message_queue_from_config(
   config: &MailboxConfig,
 ) -> Result<Box<dyn MessageQueue>, MailboxConfigError> {
   config.validate()?;
+  Ok(select_mailbox_type_from_config(config).create())
+}
+
+/// Selects the [`MailboxType`] that matches the supplied [`MailboxConfig`].
+///
+/// Selection precedence:
+/// 1. `priority_generator` with `stable_priority` → stable-priority factory
+/// 2. `priority_generator` → priority factory
+/// 3. `requirement.needs_control_aware()` → control-aware factory
+/// 4. `requirement.needs_deque()` → deque factory
+/// 5. default → capacity-based unbounded / bounded factory
+///
+/// Callers that invoke [`MailboxType::create`] directly on the returned
+/// factory must pre-validate via
+/// [`MailboxConfig::validate`](crate::core::kernel::actor::props::MailboxConfig::validate).
+pub(crate) fn select_mailbox_type_from_config(config: &MailboxConfig) -> Box<dyn MailboxType> {
   if let Some(generator) = config.priority_generator() {
     if config.stable_priority() {
-      return Ok(stable_priority_mailbox_type_from_config(generator.clone(), config.policy()).create());
+      return stable_priority_mailbox_type_from_config(generator.clone(), config.policy());
     }
-    return Ok(priority_mailbox_type_from_config(generator.clone(), config.policy()).create());
+    return priority_mailbox_type_from_config(generator.clone(), config.policy());
   }
   if config.requirement().needs_control_aware() {
-    return Ok(control_aware_mailbox_type_from_policy(config.policy()).create());
+    return control_aware_mailbox_type_from_policy(config.policy());
   }
   if config.requirement().needs_deque() {
-    return Ok(deque_mailbox_type_from_policy(config.policy()).create());
+    return deque_mailbox_type_from_policy(config.policy());
   }
-  Ok(create_message_queue_from_policy(config.policy()))
+  mailbox_type_from_policy(config.policy())
 }
 
 fn priority_mailbox_type_from_config(
@@ -121,9 +137,15 @@ fn bounded_mailbox_type(capacity: NonZeroUsize, overflow: MailboxOverflowStrateg
   Box::new(BoundedMailboxType::new(capacity, overflow))
 }
 
-/// Registry that manages mailbox configurations keyed by identifier.
+/// Registry that manages mailbox factories keyed by identifier.
+///
+/// Each entry is stored as a trait-object factory
+/// ([`ArcShared<dyn MailboxFactory>`]). [`MailboxConfig`] implements
+/// [`MailboxFactory`] as a bridge so high-level callers register a
+/// `MailboxConfig` and low-level callers pass a custom
+/// [`MailboxFactory`] implementation directly.
 pub struct Mailboxes {
-  entries: HashMap<String, MailboxConfig, RandomState>,
+  entries: HashMap<String, ArcShared<dyn MailboxFactory>, RandomState>,
   _marker: PhantomData<()>,
 }
 
@@ -140,53 +162,55 @@ impl Mailboxes {
     Self { entries: HashMap::with_hasher(RandomState::new()), _marker: PhantomData }
   }
 
-  /// Registers a mailbox configuration.
+  /// Registers a mailbox factory.
   ///
   /// # Errors
   ///
   /// Returns [`MailboxRegistryError::Duplicate`] when the identifier already exists.
-  pub fn register(&mut self, id: impl Into<String>, config: MailboxConfig) -> Result<(), MailboxRegistryError> {
+  pub fn register(
+    &mut self,
+    id: impl Into<String>,
+    factory: impl MailboxFactory + 'static,
+  ) -> Result<(), MailboxRegistryError> {
     let id = id.into();
     if self.entries.contains_key(&id) {
       return Err(MailboxRegistryError::duplicate(&id));
     }
-    self.entries.insert(id, config);
+    self.entries.insert(id, ArcShared::new(factory));
     Ok(())
   }
 
-  /// Registers or updates a mailbox configuration for the provided identifier.
+  /// Registers or updates a mailbox factory for the provided identifier.
   ///
-  /// If the identifier already exists, the configuration is updated.
-  pub fn register_or_update(&mut self, id: impl Into<String>, config: MailboxConfig) {
-    self.entries.insert(id.into(), config);
+  /// If the identifier already exists, the factory is replaced.
+  pub fn register_or_update(&mut self, id: impl Into<String>, factory: impl MailboxFactory + 'static) {
+    self.entries.insert(id.into(), ArcShared::new(factory));
   }
 
-  /// Resolves the mailbox configuration for the provided identifier.
+  /// Resolves the mailbox factory for the provided identifier.
   ///
   /// # Errors
   ///
   /// Returns [`MailboxRegistryError::Unknown`] when the identifier has not been registered.
-  pub fn resolve(&self, id: &str) -> Result<MailboxConfig, MailboxRegistryError> {
+  pub fn resolve(&self, id: &str) -> Result<ArcShared<dyn MailboxFactory>, MailboxRegistryError> {
     self.entries.get(id).cloned().ok_or_else(|| MailboxRegistryError::unknown(id))
   }
 
-  /// Creates a user-message queue from the configuration registered under `id`.
-  ///
-  /// When a priority generator is present, a priority-based queue is produced.
-  /// When the registered configuration declares deque semantics and the policy is
-  /// unbounded, this returns a deque-capable queue.
+  /// Creates a user-message queue from the factory registered under `id`.
   ///
   /// # Errors
   ///
-  /// Returns [`MailboxRegistryError::Unknown`] when the identifier has not been registered.
+  /// Returns [`MailboxRegistryError::Unknown`] when the identifier has not been
+  /// registered; wraps [`MailboxConfigError`] from the factory via
+  /// [`MailboxRegistryError::from`].
   pub fn create_message_queue(&self, id: &str) -> Result<Box<dyn MessageQueue>, MailboxRegistryError> {
-    let config = self.resolve(id)?;
-    Ok(create_message_queue_from_config(&config)?)
+    let factory = self.resolve(id)?;
+    Ok(factory.create_message_queue()?)
   }
 
   /// Ensures the default mailbox configuration is registered.
   pub fn ensure_default(&mut self) {
-    self.entries.entry(DEFAULT_MAILBOX_ID.to_owned()).or_default();
+    self.entries.entry(DEFAULT_MAILBOX_ID.to_owned()).or_insert_with(|| ArcShared::new(MailboxConfig::default()));
   }
 }
 

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -684,18 +684,18 @@ impl ActorSystem {
     if let Some(mailbox_id) = props.mailbox_id() {
       let factory =
         self.state.resolve_mailbox(mailbox_id).map_err(|error| SpawnError::invalid_props(error.to_string()))?;
-      Self::ensure_requirements_from(&factory.requirement(), &factory.capabilities())
+      Self::ensure_requirements_from(factory.requirement(), factory.capabilities())
     } else {
       let config = props.mailbox_config();
-      Self::ensure_requirements_from(&config.requirement(), &config.capabilities())
+      Self::ensure_requirements_from(config.requirement(), config.capabilities())
     }
   }
 
   fn ensure_requirements_from(
-    requirement: &MailboxRequirement,
-    registry: &QueueCapabilityRegistry,
+    requirement: MailboxRequirement,
+    registry: QueueCapabilityRegistry,
   ) -> Result<(), SpawnError> {
-    requirement.ensure_supported(registry).map_err(|error| {
+    requirement.ensure_supported(&registry).map_err(|error| {
       let reason = Self::missing_capability_reason(error.missing());
       SpawnError::invalid_props(reason)
     })

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -11,7 +11,10 @@ use alloc::{
 };
 use core::time::Duration;
 
-use fraktor_utils_core_rs::core::{collections::queue::capabilities::QueueCapability, sync::ArcShared};
+use fraktor_utils_core_rs::core::{
+  collections::queue::capabilities::{QueueCapability, QueueCapabilityRegistry},
+  sync::ArcShared,
+};
 
 use super::{
   ActorSystemWeak, Blocker, ExtendedActorSystem, TerminationSignal,
@@ -31,7 +34,7 @@ use crate::core::{
       actor_selection::ActorSelection,
       error::SendError,
       messaging::{AnyMessage, AskResult, system_message::SystemMessage},
-      props::Props,
+      props::{MailboxRequirement, Props},
       scheduler::{SchedulerBackedDelayProvider, SchedulerShared, tick_driver::TickDriverBundle},
       setup::{ActorSystemConfig, ActorSystemSetup, CircuitBreakerConfig},
       spawn::SpawnError,
@@ -670,15 +673,29 @@ impl ActorSystem {
     name: String,
     props: &Props,
   ) -> Result<ArcShared<ActorCell>, SpawnError> {
-    let resolved = self.resolve_props(parent, props)?;
-    Self::ensure_mailbox_requirements(&resolved)?;
-    ActorCell::create(self.state.clone(), pid, parent, name, &resolved)
+    self.ensure_mailbox_requirements(props)?;
+    ActorCell::create(self.state.clone(), pid, parent, name, props)
   }
 
-  fn ensure_mailbox_requirements(props: &Props) -> Result<(), SpawnError> {
-    let requirement = props.mailbox_config().requirement();
-    let registry = props.mailbox_config().capabilities();
-    requirement.ensure_supported(&registry).map_err(|error| {
+  fn ensure_mailbox_requirements(&self, props: &Props) -> Result<(), SpawnError> {
+    // Requirements come from the factory that will actually be used at spawn
+    // time: the registered factory when `mailbox_id` is set, otherwise the
+    // inline `MailboxConfig` carried by the props.
+    if let Some(mailbox_id) = props.mailbox_id() {
+      let factory =
+        self.state.resolve_mailbox(mailbox_id).map_err(|error| SpawnError::invalid_props(error.to_string()))?;
+      Self::ensure_requirements_from(&factory.requirement(), &factory.capabilities())
+    } else {
+      let config = props.mailbox_config();
+      Self::ensure_requirements_from(&config.requirement(), &config.capabilities())
+    }
+  }
+
+  fn ensure_requirements_from(
+    requirement: &MailboxRequirement,
+    registry: &QueueCapabilityRegistry,
+  ) -> Result<(), SpawnError> {
+    requirement.ensure_supported(registry).map_err(|error| {
       let reason = Self::missing_capability_reason(error.missing());
       SpawnError::invalid_props(reason)
     })
@@ -691,16 +708,6 @@ impl ActorSystem {
       | QueueCapability::BlockingFuture => "mailbox requires blocking-future capability",
       | QueueCapability::ControlAware => "mailbox requires control-aware capability",
     }
-  }
-
-  fn resolve_props(&self, _parent: Option<Pid>, props: &Props) -> Result<Props, SpawnError> {
-    let mut resolved = props.clone();
-    if let Some(mailbox_id) = resolved.mailbox_id() {
-      let config =
-        self.state.resolve_mailbox(mailbox_id).map_err(|error| SpawnError::invalid_props(error.to_string()))?;
-      resolved = resolved.with_resolved_mailbox_config(config);
-    }
-    Ok(resolved)
   }
 
   fn perform_create_handshake(

--- a/modules/actor-core/src/core/kernel/system/extended_actor_system.rs
+++ b/modules/actor-core/src/core/kernel/system/extended_actor_system.rs
@@ -15,12 +15,12 @@ use crate::core::kernel::{
     actor_selection::ActorSelection,
     error::SendError,
     extension::{Extension, ExtensionId},
-    props::{MailboxConfig, Props},
+    props::Props,
     spawn::SpawnError,
   },
   dispatch::{
     dispatcher::{DispatchersError, MessageDispatcherShared},
-    mailbox::MailboxRegistryError,
+    mailbox::{MailboxFactory, MailboxRegistryError},
   },
 };
 
@@ -59,12 +59,12 @@ impl ExtendedActorSystem {
     self.inner.state().resolve_dispatcher(id).ok_or_else(|| DispatchersError::Unknown(ToString::to_string(id)))
   }
 
-  /// Resolves the mailbox configuration for the identifier.
+  /// Resolves the mailbox factory for the identifier.
   ///
   /// # Errors
   ///
   /// Returns [`MailboxRegistryError::Unknown`] when the identifier has not been registered.
-  pub fn resolve_mailbox(&self, id: &str) -> Result<MailboxConfig, MailboxRegistryError> {
+  pub fn resolve_mailbox(&self, id: &str) -> Result<ArcShared<dyn MailboxFactory>, MailboxRegistryError> {
     self.inner.state().resolve_mailbox(id)
   }
 

--- a/modules/actor-core/src/core/kernel/system/state/system_state.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state.rs
@@ -39,7 +39,6 @@ use crate::core::kernel::{
     deploy::Deployer,
     invoke_guard::{InvokeGuardFactory, NoopInvokeGuardFactory},
     messaging::{AnyMessage, AskResult, system_message::FailurePayload},
-    props::MailboxConfig,
     scheduler::{
       SchedulerBackedDelayProvider, SchedulerContext, SchedulerShared,
       task_run::TaskRunSummary,
@@ -52,7 +51,7 @@ use crate::core::kernel::{
   },
   dispatch::{
     dispatcher::{Dispatchers, DispatchersError, MessageDispatcherShared},
-    mailbox::{MailboxRegistryError, Mailboxes, MessageQueue},
+    mailbox::{MailboxFactory, MailboxRegistryError, Mailboxes, MessageQueue},
   },
   event::{
     logging::{DefaultLoggingFilter, LogEvent, LogLevel, LoggingFilter},
@@ -880,12 +879,12 @@ impl SystemState {
     self.dispatchers.resolve_call_count()
   }
 
-  /// Resolves the mailbox configuration for the identifier.
+  /// Resolves the mailbox factory for the identifier.
   ///
   /// # Errors
   ///
   /// Returns [`MailboxRegistryError::Unknown`] when the identifier has not been registered.
-  pub fn resolve_mailbox(&self, id: &str) -> Result<MailboxConfig, MailboxRegistryError> {
+  pub fn resolve_mailbox(&self, id: &str) -> Result<ArcShared<dyn MailboxFactory>, MailboxRegistryError> {
     self.mailboxes.resolve(id)
   }
 

--- a/modules/actor-core/src/core/kernel/system/state/system_state_shared.rs
+++ b/modules/actor-core/src/core/kernel/system/state/system_state_shared.rs
@@ -37,7 +37,6 @@ use crate::core::kernel::{
       AnyMessage, AskResult,
       system_message::{FailurePayload, SystemMessage},
     },
-    props::MailboxConfig,
     scheduler::{
       SchedulerBackedDelayProvider, SchedulerShared, task_run::TaskRunSummary, tick_driver::TickDriverBundle,
     },
@@ -45,7 +44,7 @@ use crate::core::kernel::{
   },
   dispatch::{
     dispatcher::{DispatchersError, MessageDispatcherShared},
-    mailbox::{MailboxRegistryError, MessageQueue},
+    mailbox::{MailboxFactory, MailboxRegistryError, MessageQueue},
   },
   event::{
     logging::{LogEvent, LogLevel, LoggingFilter},
@@ -838,12 +837,12 @@ impl SystemStateShared {
     self.inner.with_read(|inner| inner.dispatcher_resolve_call_count())
   }
 
-  /// Resolves the mailbox configuration for the identifier.
+  /// Resolves the mailbox factory for the identifier.
   ///
   /// # Errors
   ///
   /// Returns [`MailboxRegistryError::Unknown`] when the identifier has not been registered.
-  pub fn resolve_mailbox(&self, id: &str) -> Result<MailboxConfig, MailboxRegistryError> {
+  pub fn resolve_mailbox(&self, id: &str) -> Result<ArcShared<dyn MailboxFactory>, MailboxRegistryError> {
     self.inner.with_read(|inner| inner.resolve_mailbox(id))
   }
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,10 +1,105 @@
 {
   "version": 1,
   "skills": {
+    "aggregate-design": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "d79dd9d27ffd06fe093c853af877c551d2d9254a3d088951679084174e027b83"
+    },
+    "aggregate-transaction-boundary": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "cfa9da35bb1a00b010e5f4bec33de8aafc45cf3a50c62a1636d8a77431479e82"
+    },
+    "breach-encapsulation-naming": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "055239f0e8ba801615073ef0e7f242826de68fec9bc492f2b67eab83deb2aa37"
+    },
+    "clean-architecture": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "084ce499caf6ff50cb967712d1ad17d4561279bca38636357717a829eb6a0627"
+    },
+    "ddd-module-pattern": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "997a0dc3c13eacff66aa0a17d70a6bfc80d8ec6dbff74dc8c2f7df79f96d5ac8"
+    },
+    "domain-building-blocks": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "b80e4c9f07e697f21f702657a072b15a667b4c75d95220eb6c7ff8b12514ddef"
+    },
+    "domain-model-first": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "7766287cc67707f9aeabe5ca33487a9e8d28fca0991f723436a7b1abd682d6b9"
+    },
+    "domain-primitives-and-always-valid": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "55ee376d86beb014e79508d239032d0effed2dceff85b92dc720b15115ed2943"
+    },
+    "error-classification": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "88ef374be5460211f9ba8b4e4b002b4922b806dd6b8dcda375d6eb675f53c539"
+    },
+    "error-handling": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "8297fc7c44942bd50a9eae080b3331c9f2016cd39c42d84607566b869a383600"
+    },
+    "first-class-collection": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "bd5c6abac5d9940cbb10701522b874c649bff3930c4d466a1a478ccc594f6253"
+    },
+    "intent-based-dedup": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "12e6751e487f028ccfff5ff9cabfa85204f756f97dd6197333f7f7fb2392111b"
+    },
+    "law-of-demeter": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "6b2d1c6ee44df3c2240ba92817cb611559740e5d7b24abd0ef55dec9829243c1"
+    },
+    "package-design": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "d93d5c7c35eeb37978edea45a32f3cbb2f9eec0e8e8155d894b637b5d68a473b"
+    },
+    "parse-dont-validate": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "3302a298db838f7394143606ff833b9eec0257cd028e0f7fc6d0852d66d53562"
+    },
     "readme-blueprint-generator": {
       "source": "github/awesome-copilot",
       "sourceType": "github",
       "computedHash": "e2c7dabf2e455794260f1516e2ceda6a82dc92a409578cc184fcb0f45bddca54"
+    },
+    "refactoring-packages": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "03e070ad176bb4ca112d351fde52a9ebca4e6a363a7f082fdb1dbfb4bd459e76"
+    },
+    "repository-design": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "8eff644d6162c3f2265177f05b122330434013b854099ef4bd148b41bf82228e"
+    },
+    "repository-placement": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "12d676922bc3264ac22baee9749d08c0af46cd483516336ebe576c600067bbf0"
+    },
+    "reviewing-skills": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "e95552c38835eb514b93c78e14fd161d8ee97d29b3bf427a21e5dc92573b756d"
     },
     "skill-forge": {
       "source": "j5ik2o/ai-tools",
@@ -45,6 +140,16 @@
       "source": "j5ik2o/ai-tools",
       "sourceType": "github",
       "computedHash": "3acc6533d44a5e5164ea623166e17d0119a2bbcb05b024df068174ed481c38f2"
+    },
+    "tell-dont-ask": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "396308e424f41a83f6803864f5ceb733cc859d2cc4c8b1deefdc6fe4707dbd0f"
+    },
+    "when-to-wrap-primitives": {
+      "source": "j5ik2o/okite-ai",
+      "sourceType": "github",
+      "computedHash": "a9da0c8882a39b473d0a49c95295523b0ce723f9b3869fd9fefdf65ccf2e3f7d"
     }
   }
 }


### PR DESCRIPTION
## Summary

新規 `MailboxFactory` trait を導入し、mailbox 拡張ポイントを **builder 層から届く形** に再設計する。

## 背景 / 却下された案

以前の試案 (PR #1655) では `MailboxConfig` に optional `custom_mailbox_type: Option<ArcShared<dyn MailboxType>>` field を追加したが、これは **責務分離違反** (SRP)。MailboxConfig は config データ、MailboxType は factory であり、両者を 1 つの struct に混ぜるべきではない。→ close 済み。

本 PR では **factory と config を型レベルで分離** する。

## 設計

| 役割 | 型 | 備考 |
|------|----|------|
| 低レベル queue factory | `MailboxType` | 既存、変更なし |
| **高レベル builder-facing factory** | `MailboxFactory` **(新規)** | mailbox_type() + metadata accessors |
| 設定データ | `MailboxConfig` | dumb data、field に factory を持たない |
| Bridge | `impl MailboxFactory for MailboxConfig` | 既存 MailboxConfig 呼び出しが無変更で動作 |

D2 の `MessageDispatcherFactory` と同じ Tier 1 パターン:
```rust
pub fn with_mailbox(mut self, id: impl Into<String>, factory: impl MailboxFactory + 'static) -> Self
```

## MailboxFactory trait

```rust
pub trait MailboxFactory: Send + Sync {
  fn mailbox_type(&self) -> ArcShared<dyn MailboxType>;
  fn create_message_queue(&self) -> Result<Box<dyn MessageQueue>, MailboxConfigError> { ... }
  fn policy(&self) -> MailboxPolicy { ... }
  fn warn_threshold(&self) -> Option<NonZeroUsize> { None }
  fn requirement(&self) -> MailboxRequirement { ... }
  fn capabilities(&self) -> QueueCapabilityRegistry { ... }
}
```

デフォルト実装が揃っているため、最小カスタム実装は `mailbox_type()` のみを override すれば済む。

## 使用例

```rust
struct MyMailboxFactory { ... }
impl MailboxFactory for MyMailboxFactory {
  fn mailbox_type(&self) -> ArcShared<dyn MailboxType> { ... }
  // policy / warn_threshold / requirement / capabilities を必要に応じて override
}

actor_system_config.with_mailbox("custom-id", MyMailboxFactory { ... })
```

## 互換性

`MailboxConfig: MailboxFactory` bridge により、既存の

```rust
config.with_mailbox(id, MailboxConfig::default())
```

は **一切変更不要**。

## 内部変更

- `Mailboxes`: storage を `HashMap<String, MailboxConfig>` → `HashMap<String, ArcShared<dyn MailboxFactory>>` に変更
- `resolve_mailbox(id)`: `MailboxConfig` → `ArcShared<dyn MailboxFactory>` を返す
- `Mailbox::new_from_config_with_shared_set(&MailboxConfig, ...)` → `new_from_factory_with_shared_set(&dyn MailboxFactory, ...)` に rename
- `actor_cell.rs`: resolved factory 経由で `policy()` / `warn_threshold()` にアクセス
- `base.rs`: `ensure_mailbox_requirements` を factory-aware に refactor、不要になった `Props::with_resolved_mailbox_config` を削除

## Tests

3 新規 (`dispatch/mailbox/mailbox_factory/tests.rs`):
- `mailbox_config_bridges_into_mailbox_factory` — MailboxConfig が factory として registry に入ることを確認
- `custom_mailbox_factory_drives_queue_construction` — カスタム factory の `MailboxType::create` が AtomicUsize で観測可能な回数呼ばれる end-to-end 検証
- `mailbox_factory_default_metadata_is_applied` — trait default 実装の smoke test

既存 4627 → 4630 passed。

## Verification

- [x] `rtk cargo build --workspace --all-targets` → clean
- [x] `rtk cargo test --workspace --lib` → 4630 passed, 2 ignored
- [x] `rtk cargo fmt --all` 適用済み
- [x] `./scripts/ci-check.sh ai all` → exit 0

## Scope

actor-core のみ。他 crate への影響なし。
