### PR TITLE
[codex] Upload actor coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: coverage
-      - name: Generate actor coverage HTML report
-        run: ./scripts/coverage.sh --tool llvm-cov --format html --output target/coverage
+      - name: Generate actor coverage reports
+        run: ./scripts/coverage.sh --tool llvm-cov --format html-lcov --output target/coverage
       - name: Upload actor coverage HTML report
         if: always()
         uses: actions/upload-artifact@v7
@@ -195,6 +195,15 @@ jobs:
           path: target/coverage/html
           if-no-files-found: warn
           retention-days: 14
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/coverage/lcov.info
+          disable_search: true
+          flags: actor
+          name: actor-coverage
+          fail_ci_if_error: true
 
   # Documentation build
   docs:

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -18,14 +18,14 @@ usage() {
 
 オプション:
   --tool <tool>       カバレッジツールを指定 (llvm-cov, grcov) [デフォルト: llvm-cov]
-  --format <format>   出力形式を指定 (html, lcov, json) [デフォルト: html]
+  --format <format>   出力形式を指定 (html, lcov, json, html-lcov) [デフォルト: html]
   --output <dir>      出力ディレクトリを指定 [デフォルト: target/coverage]
   --open              HTML出力後にブラウザで開く
   --help, -h          このヘルプを表示
 
 環境変数:
   COVERAGE_TOOL       カバレッジツール (llvm-cov, grcov)
-  COVERAGE_FORMAT     出力形式 (html, lcov, json)
+  COVERAGE_FORMAT     出力形式 (html, lcov, json, html-lcov)
   COVERAGE_DIR        出力ディレクトリ
 
 例:
@@ -34,6 +34,9 @@ usage() {
 
   # lcov形式で出力
   scripts/coverage.sh --format lcov
+
+  # HTML と Codecov 用 LCOV を同時に出力
+  scripts/coverage.sh --format html-lcov
 
   # grcovを使用してHTML出力
   scripts/coverage.sh --tool grcov --format html
@@ -148,6 +151,15 @@ run_llvm_cov() {
       rm -rf "${output_dir}/html"
       cargo llvm-cov "${package_args[@]}" "${feature_args[@]}" report --html --output-dir "${output_dir}/html" || return 1
       echo "カバレッジレポート: ${output_dir}/html/index.html"
+      ;;
+    html-lcov)
+      log_step "HTML形式でカバレッジレポートを生成: ${output_dir}/html"
+      rm -rf "${output_dir}/html"
+      cargo llvm-cov "${package_args[@]}" "${feature_args[@]}" report --html --output-dir "${output_dir}/html" || return 1
+      echo "カバレッジレポート: ${output_dir}/html/index.html"
+      log_step "LCOV形式でカバレッジレポートを生成: ${output_dir}/lcov.info"
+      cargo llvm-cov "${package_args[@]}" "${feature_args[@]}" report --lcov --output-path "${output_dir}/lcov.info" || return 1
+      echo "カバレッジレポート: ${output_dir}/lcov.info"
       ;;
     lcov)
       log_step "LCOV形式でカバレッジレポートを生成: ${output_dir}/lcov.info"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -299,7 +299,7 @@ main() {
   esac
 
   # ブラウザで開く
-  if [[ -n "${open_browser}" && "${OUTPUT_FORMAT}" == "html" ]]; then
+  if [[ -n "${open_browser}" && ( "${OUTPUT_FORMAT}" == "html" || "${OUTPUT_FORMAT}" == "html-lcov" ) ]]; then
     local html_file="${OUTPUT_DIR}/html/index.html"
     if [[ -f "${html_file}" ]]; then
       log_step "ブラウザでレポートを開いています..."


### PR DESCRIPTION
## 概要

actor カバレッジレポートを Codecov にアップロードする設定を追加します。

## 変更内容

- `scripts/coverage.sh` に `html-lcov` 出力形式を追加
- CI の `coverage` job で HTML artifact と LCOV を同時生成
- `codecov/codecov-action@v5` で `target/coverage/lcov.info` をアップロード
- `actor` flag / `actor-coverage` name を設定

## 前提

`CODECOV_TOKEN` は repository secret として設定済みです。

## 確認

- `bash -n scripts/coverage.sh`
- `.github/workflows/ci.yml` の YAML parse
- `git diff --check FETCH_HEAD..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that affects coverage generation and reporting; main failure mode is the `coverage` job failing if Codecov upload or `lcov.info` generation breaks.
> 
> **Overview**
> The `coverage` CI job now generates both HTML and LCOV in one run (`--format html-lcov`) and uploads `target/coverage/lcov.info` to Codecov via `codecov/codecov-action@v5` (flagged `actor`, named `actor-coverage`, and configured to fail the job on upload errors).
> 
> `scripts/coverage.sh` adds the new `html-lcov` output mode (and allows `--open` for it), enabling simultaneous HTML artifact output plus an LCOV file suitable for Codecov ingestion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d167fad9d5791db3e5a68b2031c8e29529c5819. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->