### PR TITLE
ci(coverage): Codecov トークン削除・OIDC でのアップロードに変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,8 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
+        # third-party action の mutable tag リスクを避けるため、v6 の commit SHA に固定する。
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
         with:
           use_oidc: true
           files: target/coverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,9 @@ jobs:
     name: Coverage Report
     runs-on: self-hosted
     needs: integration-e2e
+    permissions:
+      contents: read
+      id-token: write
     env:
       TEST_TIME_FACTOR: "2.0"
       CI_CHECK_GUARD_TIMEOUT_INTEGRATION_SEC: "5400"
@@ -198,7 +201,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: target/coverage/lcov.info
           disable_search: true
           flags: actor


### PR DESCRIPTION
### Motivation
- Codecov Action に mutable tag を使ってシークレットを渡しているとタグ乗っ取り時にトークンが流出するリスクがあるため、OIDC に切り替えてシークレット受け渡しを排除しサプライチェーンリスクを軽減します。

### Description
- `.github/workflows/ci.yml` の `coverage` ジョブに `permissions: contents: read` と `id-token: write` を追加し、`codecov/codecov-action@v6` ステップから `token: ${{ secrets.CODECOV_TOKEN }}` を削除して `use_oidc: true` を設定しました。

### Testing
- `./scripts/ci-check.sh ai all` を実行して検証を開始しましたが、実行環境のネットワーク制限により `rustc-dev` のダウンロードが失敗し CI チェックは完走できませんでした（開始は成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec53dd9a14832db9591633870c70fb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but coverage uploads may fail if the repo/Codecov OIDC configuration or GitHub job permissions are incorrect.
> 
> **Overview**
> **Secures Codecov uploads in CI.** The `coverage` job now grants `id-token: write` (and `contents: read`) and switches Codecov authentication from a secret token to `use_oidc: true`.
> 
> **Hardens supply-chain risk** by pinning `codecov/codecov-action` from the mutable `@v6` tag to a specific commit SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e4fff07b2ccb93d7c2475aabbe9e5cb846c0ced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインのセキュリティ改善を実施しました。Codecovへのアップロード認証をOIDC認証に変更し、静的なトークンの使用を廃止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->