### PR TITLE
[codex] Materialize okite script links

### DIFF
--- a/scripts/generate-agents-md.sh
+++ b/scripts/generate-agents-md.sh
@@ -1,1 +1,60 @@
-../references/okite-ai/scripts/generate-agents-md.sh
+#!/usr/bin/env bash
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+OKITE_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+# 第1引数でプロジェクトルートを指定可能（未指定時はOKITE_ROOT）
+TARGET_ROOT="${1:-${OKITE_ROOT}}"
+
+COMMON_MD="${TARGET_ROOT}/COMMON.md"
+RULES_DIR="${TARGET_ROOT}/.agents/rules"
+OUTPUT_FILE="${TARGET_ROOT}/AGENTS.md"
+
+echo "Generating AGENTS.md..."
+echo "  COMMON_MD: ${COMMON_MD}"
+echo "  RULES_DIR: ${RULES_DIR}"
+echo "  OUTPUT: ${OUTPUT_FILE}"
+
+# Check COMMON.md exists
+if [ ! -f "${COMMON_MD}" ]; then
+  echo "Error: COMMON.md not found at ${COMMON_MD}"
+  exit 1
+fi
+
+# Create rules directory if not exists
+mkdir -p "${RULES_DIR}"
+
+# Start with COMMON.md
+cp "${COMMON_MD}" "${OUTPUT_FILE}"
+
+# Append rules
+append_rules() {
+  local dir="$1"
+  local label="$2"
+  if ls "${dir}"/*.md 1>/dev/null 2>&1; then
+    # shellcheck disable=SC2129
+    echo "" >> "${OUTPUT_FILE}"
+    echo "# ${label}" >> "${OUTPUT_FILE}"
+    echo "" >> "${OUTPUT_FILE}"
+
+    for rule_file in "${dir}"/*.md; do
+      [ -e "$rule_file" ] || continue
+      rule_name=$(basename "$rule_file" .md)
+      echo "  - Appending rule: ${rule_name}"
+      # shellcheck disable=SC2129
+      echo "" >> "${OUTPUT_FILE}"
+      cat "$rule_file" >> "${OUTPUT_FILE}"
+      echo "" >> "${OUTPUT_FILE}"
+    done
+  else
+    echo "  No rules found in ${dir}"
+  fi
+}
+
+append_rules "${RULES_DIR}" "Rules"
+append_rules "${RULES_DIR}/rust" "Rust Rules"
+
+echo ""
+echo "Generated: ${OUTPUT_FILE}"

--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -1,1 +1,25 @@
-../references/okite-ai/scripts/run-claude-corporate.sh
+#!/usr/bin/env bash
+
+export CLAUDE_IDENTITY="corporate"
+export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
+
+# 親プロセス（Claude Code セッション等）から継承した OAuth トークンを除去し、
+# CLAUDE_CONFIG_DIR に対応する keychain エントリから認証情報を読ませる
+unset CLAUDE_CODE_OAUTH_TOKEN
+
+# --happy オプションを検出して Happy Coder モードで起動
+use_happy=false
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == "--happy" ]]; then
+    use_happy=true
+  else
+    args+=("$arg")
+  fi
+done
+
+if $use_happy; then
+  exec happy --permission-mode bypassPermissions "${args[@]}"
+else
+  exec claude --dangerously-skip-permissions "${args[@]}"
+fi

--- a/scripts/run-claude-personal.sh
+++ b/scripts/run-claude-personal.sh
@@ -1,1 +1,25 @@
-../references/okite-ai/scripts/run-claude-personal.sh
+#!/usr/bin/env bash
+
+export CLAUDE_IDENTITY="personal"
+export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
+
+# 親プロセス（Claude Code セッション等）から継承した OAuth トークンを除去し、
+# CLAUDE_CONFIG_DIR に対応する keychain エントリから認証情報を読ませる
+unset CLAUDE_CODE_OAUTH_TOKEN
+
+# --happy オプションを検出して Happy Coder モードで起動
+use_happy=false
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == "--happy" ]]; then
+    use_happy=true
+  else
+    args+=("$arg")
+  fi
+done
+
+if $use_happy; then
+  exec happy --permission-mode bypassPermissions "${args[@]}"
+else
+  exec claude --dangerously-skip-permissions "${args[@]}"
+fi

--- a/scripts/run-claude-zai.sh
+++ b/scripts/run-claude-zai.sh
@@ -1,1 +1,33 @@
-../references/okite-ai/scripts/run-claude-zai.sh
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+# 親プロセスから継承した OAuth トークンを除去し、このスクリプトの認証設定を優先させる
+unset CLAUDE_CODE_OAUTH_TOKEN
+
+. $HOME/.config/glm/env
+
+export ANTHROPIC_AUTH_TOKEN=${GLM_API_KEY}
+export ANTHROPIC_BASE_URL="https://api.z.ai/api/anthropic"
+export API_TIMEOUT_MS="3000000"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="glm-4.7",
+export ANTHROPIC_DEFAULT_SONNET_MODEL="GLM-5",
+export ANTHROPIC_DEFAULT_OPUS_MODEL="GLM-5"
+
+# --happy オプションを検出して Happy Coder モードで起動
+use_happy=false
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == "--happy" ]]; then
+    use_happy=true
+  else
+    args+=("$arg")
+  fi
+done
+
+if $use_happy; then
+  exec happy --permission-mode bypassPermissions "${args[@]}"
+else
+  exec claude --dangerously-skip-permissions "${args[@]}"
+fi

--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -1,1 +1,45 @@
-../references/okite-ai/scripts/run-codex-corporate.sh
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+export CODEX_HOME=${REPO_ROOT}/.codex-corporate
+
+ensure_local_codex_config() {
+  local config_path="${CODEX_HOME}/config.toml"
+  local base_config="${REPO_ROOT}/.codex/config.toml"
+  local project_header="[projects.\"${REPO_ROOT}\"]"
+
+  mkdir -p "${CODEX_HOME}"
+  if [[ -L "${config_path}" ]]; then
+    rm "${config_path}"
+  fi
+  if [[ ! -f "${config_path}" ]]; then
+    cp "${base_config}" "${config_path}"
+  fi
+  if ! grep -Fq "${project_header}" "${config_path}"; then
+    {
+      echo ""
+      echo "${project_header}"
+      echo 'trust_level = "trusted"'
+    } >> "${config_path}"
+  fi
+}
+
+ensure_local_codex_config
+# --happy オプションを検出して Happy Coder モードで起動
+use_happy=false
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == "--happy" ]]; then
+    use_happy=true
+  else
+    args+=("$arg")
+  fi
+done
+
+if $use_happy; then
+  exec mise exec -- happy codex "${args[@]}"
+else
+  exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "${args[@]}"
+fi

--- a/scripts/run-codex-personal.sh
+++ b/scripts/run-codex-personal.sh
@@ -1,1 +1,45 @@
-../references/okite-ai/scripts/run-codex-personal.sh
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+export CODEX_HOME=${REPO_ROOT}/.codex-personal
+
+ensure_local_codex_config() {
+  local config_path="${CODEX_HOME}/config.toml"
+  local base_config="${REPO_ROOT}/.codex/config.toml"
+  local project_header="[projects.\"${REPO_ROOT}\"]"
+
+  mkdir -p "${CODEX_HOME}"
+  if [[ -L "${config_path}" ]]; then
+    rm "${config_path}"
+  fi
+  if [[ ! -f "${config_path}" ]]; then
+    cp "${base_config}" "${config_path}"
+  fi
+  if ! grep -Fq "${project_header}" "${config_path}"; then
+    {
+      echo ""
+      echo "${project_header}"
+      echo 'trust_level = "trusted"'
+    } >> "${config_path}"
+  fi
+}
+
+ensure_local_codex_config
+# --happy オプションを検出して Happy Coder モードで起動
+use_happy=false
+args=()
+for arg in "$@"; do
+  if [[ "$arg" == "--happy" ]]; then
+    use_happy=true
+  else
+    args+=("$arg")
+  fi
+done
+
+if $use_happy; then
+  exec mise exec -- happy codex "${args[@]}"
+else
+  exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "${args[@]}"
+fi

--- a/scripts/run-cursor.sh
+++ b/scripts/run-cursor.sh
@@ -1,1 +1,6 @@
-../references/okite-ai/scripts/run-cursor.sh
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+cursor-agent --force "$@"

--- a/scripts/run-gemini.sh
+++ b/scripts/run-gemini.sh
@@ -1,1 +1,6 @@
-../references/okite-ai/scripts/run-gemini.sh
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+gemini --yolo "$@"

--- a/scripts/run-opencode.sh
+++ b/scripts/run-opencode.sh
@@ -1,1 +1,6 @@
-../references/okite-ai/scripts/run-opencode.sh
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+
+opencode "$@"


### PR DESCRIPTION
## 概要

`scripts` 配下で `references/okite-ai/scripts` を指していた symlink を実体ファイルに置き換えます。

## 変更内容

- `scripts/generate-agents-md.sh` を実体化
- `scripts/run-claude-*.sh` を実体化
- `scripts/run-codex-*.sh` を実体化
- `scripts/run-cursor.sh` / `run-gemini.sh` / `run-opencode.sh` を実体化
- symlink mode `120000` から executable script `100755` に変更

## 背景

worktree 作業時に `references/okite-ai` submodule の状態へ依存しないよう、参照元スクリプトをリポジトリ側に固定します。

## 確認

- `scripts` 直下に symlink が残っていないことを確認
- 実体化した各 script が `references/okite-ai/scripts/*` と同一内容であることを `diff -q` で確認
- 対象 script すべてで `bash -n` 成功
- `git diff --cached --check` 成功

ソースコード変更ではないため `./scripts/ci-check.sh ai all` は実行していません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this primarily converts symlinked tooling scripts into in-repo bash files; main risk is small behavior drift if the vendored script contents diverge from upstream or if env/permission flags affect local developer workflows.
> 
> **Overview**
> **Materializes previously symlinked scripts under `scripts/` into real executable bash files**, removing the runtime dependency on `references/okite-ai` (e.g., in worktrees).
> 
> Adds in-repo implementations for `generate-agents-md.sh` (builds `AGENTS.md` from `COMMON.md` plus `.agents/rules/**/*.md`) and runner wrappers for Claude/Codex/Cursor/Gemini/OpenCode, including identity-specific config/env setup and `--happy` argument handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e6d82da4bf0931ce863eb2616f79b74b5397792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 複数の新しいユーティリティスクリプトを追加しました。開発ツール（Claude、Codex、Cursor、Gemini、OpenCode）の実行を簡素化するラッパースクリプトと、企業設定および個人設定のモード対応が含まれています。
  * エージェント設定ファイルを自動生成するスクリプトを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->