### PR TITLE
[codex] Remove okite submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "references/pekko-persistence-effector"]
 	path = references/pekko-persistence-effector
 	url = git@github.com:j5ik2o/pekko-persistence-effector.git
-[submodule "references/okite-ai"]
-	path = references/okite-ai
-	url = git@github.com:j5ik2o/okite-ai.git
 [submodule "references/takt"]
 	path = references/takt
 	url = git@github.com:j5ik2o/takt.git


### PR DESCRIPTION
## 概要

`references/okite-ai` を Git submodule から外します。

## 変更内容

- `.gitmodules` から `references/okite-ai` の submodule 定義を削除
- `references/okite-ai` の gitlink を削除

## 背景

`.agents/skills`、`scripts`、`.claude` / `.codex` / `.gemini` の okite 由来 symlink は実体化済みのため、worktree 作業時に `references/okite-ai` submodule を必要としない状態にします。

## 確認

- `git submodule status` に `references/okite-ai` が出ないことを確認
- `git ls-files -s references/okite-ai` が空であることを確認
- `git diff --cached --check` 成功

`skills-lock.json` には skill の由来情報として `j5ik2o/okite-ai` が残っていますが、submodule / path dependency ではないためこの PR では変更していません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only updates `.gitmodules` to drop the `references/okite-ai` submodule and does not change runtime code paths. Risk is limited to developer workflows that still expect the submodule to be present.
> 
> **Overview**
> Removes the `references/okite-ai` Git submodule by deleting its entry from `.gitmodules`, leaving the remaining `references/*` submodules unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23cee973175c3141270411d761395e359522da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->