### PR TITLE
fix(remote-adaptor-std): WireFrameCodec の受信フレーム長に上限を追加

### DIFF
--- a/modules/remote-adaptor-std/src/std/tcp_transport/frame_codec.rs
+++ b/modules/remote-adaptor-std/src/std/tcp_transport/frame_codec.rs
@@ -12,6 +12,10 @@ use crate::std::tcp_transport::{frame_codec_error::FrameCodecError, wire_frame::
 
 /// Minimum bytes required to inspect the frame header (`length(4)` + `version(1)` + `kind(1)`).
 const FRAME_HEADER_LEN: usize = 6;
+/// Maximum allowed frame length declared in the 32-bit header.
+///
+/// This value includes bytes after the length field itself (`version + kind + body`).
+const MAX_FRAME_LENGTH: usize = 16 * 1024 * 1024;
 
 /// Zero-sized codec implementing `tokio_util::codec::{Encoder, Decoder}` for
 /// [`crate::std::tcp_transport::WireFrame`].
@@ -55,6 +59,9 @@ impl Decoder for WireFrameCodec {
     }
     // Peek at the length prefix without consuming the buffer.
     let length = u32::from_be_bytes([src[0], src[1], src[2], src[3]]) as usize;
+    if length > MAX_FRAME_LENGTH {
+      return Err(FrameCodecError::from(WireError::FrameTooLarge));
+    }
     let total = 4 + length;
     if src.len() < total {
       // Wait for the remainder of the frame.

--- a/modules/remote-adaptor-std/src/std/tcp_transport/frame_codec.rs
+++ b/modules/remote-adaptor-std/src/std/tcp_transport/frame_codec.rs
@@ -12,6 +12,8 @@ use crate::std::tcp_transport::{frame_codec_error::FrameCodecError, wire_frame::
 
 /// Minimum bytes required to inspect the frame header (`length(4)` + `version(1)` + `kind(1)`).
 const FRAME_HEADER_LEN: usize = 6;
+/// Minimum valid value for the declared frame length (`version + kind`).
+const MIN_FRAME_LENGTH: usize = 2;
 /// Maximum allowed frame length declared in the 32-bit header.
 ///
 /// This value includes bytes after the length field itself (`version + kind + body`).
@@ -59,6 +61,9 @@ impl Decoder for WireFrameCodec {
     }
     // Peek at the length prefix without consuming the buffer.
     let length = u32::from_be_bytes([src[0], src[1], src[2], src[3]]) as usize;
+    if length < MIN_FRAME_LENGTH {
+      return Err(FrameCodecError::from(WireError::InvalidFormat));
+    }
     if length > MAX_FRAME_LENGTH {
       return Err(FrameCodecError::from(WireError::FrameTooLarge));
     }

--- a/modules/remote-adaptor-std/src/std/tcp_transport/tests.rs
+++ b/modules/remote-adaptor-std/src/std/tcp_transport/tests.rs
@@ -108,6 +108,20 @@ fn wire_frame_codec_rejects_oversized_frame_length() {
   assert!(matches!(err, crate::std::tcp_transport::FrameCodecError::Wire(WireError::FrameTooLarge)));
 }
 
+#[test]
+fn wire_frame_codec_rejects_declared_frame_length_smaller_than_header() {
+  let mut codec = WireFrameCodec::new();
+  let mut buf = BytesMut::new();
+  // Declared frame length must include at least version + kind.
+  buf.extend_from_slice(&1_u32.to_be_bytes());
+  // Provide enough bytes to pass the outer header-length pre-check.
+  buf.extend_from_slice(&[1, 0]);
+
+  let err = codec.decode(&mut buf).expect_err("too-small frame length must be rejected");
+  assert!(matches!(err, crate::std::tcp_transport::FrameCodecError::Wire(WireError::InvalidFormat)));
+  assert_eq!(buf.len(), 6, "invalid header must not partially consume the buffer");
+}
+
 // ---------------------------------------------------------------------------
 // 2-node echo integration test
 // ---------------------------------------------------------------------------

--- a/modules/remote-adaptor-std/src/std/tcp_transport/tests.rs
+++ b/modules/remote-adaptor-std/src/std/tcp_transport/tests.rs
@@ -99,22 +99,23 @@ fn wire_frame_codec_handles_multiple_frames_in_one_buffer() {
 fn wire_frame_codec_rejects_oversized_frame_length() {
   let mut codec = WireFrameCodec::new();
   let mut buf = BytesMut::new();
-  // Declared frame length larger than 16 MiB limit.
+  // 宣言されたフレーム長が 16 MiB 上限を超えるケースを作る。
   buf.extend_from_slice(&(16 * 1024 * 1024 + 1_u32).to_be_bytes());
-  // Minimum bytes to pass header pre-check.
+  // ヘッダ事前チェックを通すための最小バイト数を追加する。
   buf.extend_from_slice(&[1, 0]);
 
   let err = codec.decode(&mut buf).expect_err("oversized frame must be rejected");
   assert!(matches!(err, crate::std::tcp_transport::FrameCodecError::Wire(WireError::FrameTooLarge)));
+  assert_eq!(buf.len(), 6, "oversized header must not partially consume the buffer");
 }
 
 #[test]
 fn wire_frame_codec_rejects_declared_frame_length_smaller_than_header() {
   let mut codec = WireFrameCodec::new();
   let mut buf = BytesMut::new();
-  // Declared frame length must include at least version + kind.
+  // 宣言されたフレーム長には最低でも version + kind が必要。
   buf.extend_from_slice(&1_u32.to_be_bytes());
-  // Provide enough bytes to pass the outer header-length pre-check.
+  // 外側のヘッダ長チェックを通すための十分なバイト数を追加する。
   buf.extend_from_slice(&[1, 0]);
 
   let err = codec.decode(&mut buf).expect_err("too-small frame length must be rejected");

--- a/modules/remote-adaptor-std/src/std/tcp_transport/tests.rs
+++ b/modules/remote-adaptor-std/src/std/tcp_transport/tests.rs
@@ -1,7 +1,7 @@
 use core::time::Duration;
 
 use bytes::{Bytes, BytesMut};
-use fraktor_remote_core_rs::core::wire::{AckPdu, ControlPdu, EnvelopePdu, HandshakePdu, HandshakeReq};
+use fraktor_remote_core_rs::core::wire::{AckPdu, ControlPdu, EnvelopePdu, HandshakePdu, HandshakeReq, WireError};
 use tokio::net::TcpListener;
 use tokio_util::codec::{Decoder, Encoder, Framed};
 
@@ -93,6 +93,19 @@ fn wire_frame_codec_handles_multiple_frames_in_one_buffer() {
   let decoded_b = codec.decode(&mut buf).unwrap().expect("second frame");
   assert_eq!(decoded_b, b);
   assert!(buf.is_empty());
+}
+
+#[test]
+fn wire_frame_codec_rejects_oversized_frame_length() {
+  let mut codec = WireFrameCodec::new();
+  let mut buf = BytesMut::new();
+  // Declared frame length larger than 16 MiB limit.
+  buf.extend_from_slice(&(16 * 1024 * 1024 + 1_u32).to_be_bytes());
+  // Minimum bytes to pass header pre-check.
+  buf.extend_from_slice(&[1, 0]);
+
+  let err = codec.decode(&mut buf).expect_err("oversized frame must be rejected");
+  assert!(matches!(err, crate::std::tcp_transport::FrameCodecError::Wire(WireError::FrameTooLarge)));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- `WireFrameCodec` がヘッダの 32-bit 長さを無条件で信頼して `tokio_util::codec::Framed` のバッファを伸張させるとリモートからのメモリ枯渇 DoS を招くため。 
- 既存のコア実装はフレーム長上限（`WireError::FrameTooLarge`）を扱っているため、std アダプタ側でも同等の保護が必要である。

### Description
- `modules/remote-adaptor-std/src/tcp_transport/frame_codec.rs` に `MAX_FRAME_LENGTH: usize = 16 * 1024 * 1024` を定義して上限を導入した。 
- `WireFrameCodec::decode` でヘッダの長さが `MAX_FRAME_LENGTH` を超える場合に `WireError::FrameTooLarge` を返すようにし早期拒否する処理を追加した。 
- 過大長さを検証する回帰テスト `wire_frame_codec_rejects_oversized_frame_length` を `modules/remote-adaptor-std/src/tcp_transport/tests.rs` に追加した。

### Testing
- `cargo test -p fraktor-remote-adaptor-std-rs wire_frame_codec_rejects_oversized_frame_length` を実行して該当ユニットテストは成功しました。 
- リポジトリの全 CI 相当のチェックとして `./scripts/ci-check.sh ai all` を実行しましたが、環境のネットワーク制限により `rustc-dev` コンポーネントのダウンロードが失敗し（`unsuccessful tunnel`）、CI 全体は完了できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec563a6528832d8259f9d26843e731)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new validation in the TCP decode path to reject too-small or >16MiB declared frame lengths, which can affect compatibility and error handling for malformed/large inputs but is localized to framing logic.
> 
> **Overview**
> **Adds defensive frame-length validation to the std TCP transport codec.** `WireFrameCodec::decode` now rejects frames whose declared length is smaller than the minimum header payload (`version + kind`) or exceeds a new 16MiB cap, returning `WireError::InvalidFormat` / `WireError::FrameTooLarge` before attempting to wait for or split the full frame.
> 
> **Extends tests** with regression coverage ensuring oversized and too-small declared lengths error out and do not partially consume the input buffer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 301eca2755377224f3c12ba616e59b393de6a8f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * TCP フレーム転送の検証機能を強化しました。最小サイズ未満または16MB を超えるフレームがより確実に検出・拒否されるようになり、不正なフレーム形式に対するエラーハンドリングが改善されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->