### PR TITLE
[codex] array_scanner primitive要素の長さ制限を修正

### DIFF
--- a/modules/stream-core/src/core/dsl/json_framing.rs
+++ b/modules/stream-core/src/core/dsl/json_framing.rs
@@ -465,6 +465,9 @@ impl JsonArrayFramingLogic {
           if pos == self.scan_offset {
             return Ok(None);
           }
+          if pos - self.scan_offset > self.maximum_element_length {
+            return Err(StreamError::BufferOverflow);
+          }
           let element = self.buffer[self.scan_offset..pos].to_vec();
           self.scan_offset = pos;
           return Ok(Some(element));

--- a/modules/stream-core/src/core/dsl/json_framing/tests.rs
+++ b/modules/stream-core/src/core/dsl/json_framing/tests.rs
@@ -240,6 +240,26 @@ fn array_scanner_should_error_when_element_exceeds_max_length() {
 }
 
 #[test]
+fn array_scanner_should_error_when_primitive_exceeds_max_length() {
+  let framing = JsonFraming::array_scanner(5);
+  let source = Source::single(b"[123456,1]".to_vec());
+
+  let result = source.via(framing).collect_values();
+
+  assert!(matches!(result, Err(StreamError::BufferOverflow)));
+}
+
+#[test]
+fn array_scanner_should_error_when_primitive_exceeds_max_length_before_array_end() {
+  let framing = JsonFraming::array_scanner(5);
+  let source = Source::single(b"[123456]".to_vec());
+
+  let result = source.via(framing).collect_values();
+
+  assert!(matches!(result, Err(StreamError::BufferOverflow)));
+}
+
+#[test]
 fn array_scanner_should_error_on_unclosed_array() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[".to_vec());

--- a/modules/stream-core/src/core/dsl/json_framing/tests.rs
+++ b/modules/stream-core/src/core/dsl/json_framing/tests.rs
@@ -260,6 +260,16 @@ fn array_scanner_should_error_when_primitive_exceeds_max_length_before_array_end
 }
 
 #[test]
+fn array_scanner_should_error_when_primitive_exceeds_max_length_across_chunks() {
+  let framing = JsonFraming::array_scanner(5);
+  let source = Source::from(vec![b"[12345".to_vec(), b"6,1]".to_vec()]);
+
+  let result = source.via(framing).collect_values();
+
+  assert!(matches!(result, Err(StreamError::BufferOverflow)));
+}
+
+#[test]
 fn array_scanner_should_error_on_unclosed_array() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[".to_vec());


### PR DESCRIPTION
## 概要

`JsonFraming::array_scanner` の primitive 要素解析で、区切り文字検出時にも `maximum_element_length` を検査するようにしました。

## 背景

structured 要素と string 要素では返却前に最大長を検査していましたが、primitive 要素だけは `,` や `]` を検出すると長さ検査なしで `Vec<u8>` に複製して返していました。そのため、巨大な数値などが設定された最大長を超えて受理され、不要に大きな allocation が発生する可能性がありました。

## 変更内容

- primitive 要素を返す直前に `maximum_element_length` 超過を `StreamError::BufferOverflow` として扱うよう修正
- oversized primitive が `,` で終わる場合と `]` で終わる場合の回帰テストを追加

## 検証

- `rtk cargo test -p fraktor-stream-core-rs array_scanner_should_error_when_primitive_exceeds_max_length`
- `rtk cargo fmt --all --check`
- `rtk ./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error/overflow behavior in `JsonFraming::array_scanner` for primitive values, which could affect downstream parsing outcomes but is localized to length-checking logic.
> 
> **Overview**
> Fixes `JsonFraming::array_scanner` so *primitive* JSON elements (e.g., large numbers) are checked against `maximum_element_length` **before** being copied/emitted when a delimiter (``,``, `]`, or whitespace) is encountered, returning `StreamError::BufferOverflow` instead of allowing oversized allocations.
> 
> Adds regression tests covering oversized primitives that end with `,` or `]`, including a case where the primitive spans multiple input chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df90318525e3c1f6a8a2b67096928bda5f2f3a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * JSON配列プリミティブ値の処理時に、設定された最大長を超えるデータの検出をより早い段階で行うようにしました。バッファオーバーフロー検出の精度が向上しています。

* **テスト**
  * バッファオーバーフロー動作を検証する新しいテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->