### PR TITLE
[codex] add persistence effector typed api spec

### DIFF
--- a/openspec/changes/persistence-effector-typed-api/.openspec.yaml
+++ b/openspec/changes/persistence-effector-typed-api/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: "spec-driven"
+name: "persistence-effector-typed-api"
+createdAt: "2026-04-25T10:11:06Z"

--- a/openspec/changes/persistence-effector-typed-api/design.md
+++ b/openspec/changes/persistence-effector-typed-api/design.md
@@ -1,0 +1,294 @@
+## Context
+
+### fraktor-rs の現状
+
+`modules/persistence-core` は no_std core として classic persistence 相当の API を提供している。
+
+- `Eventsourced`
+- `PersistentActor`
+- `PersistentActorAdapter`
+- `PersistenceContext`
+- `Journal` / `SnapshotStore`
+- `JournalActor` / `SnapshotActor`
+- `InMemoryJournal` / `InMemorySnapshotStore`
+
+一方、`docs/gap-analysis/persistence-gap-analysis.md` では typed write-side API が未実装として整理されている。Pekko の現行推奨 API は `EventSourcedBehavior` だが、fraktor-rs へそのまま移植すると、typed actor の通常 DSL と persistence DSL が分離し、DDD 集約を自然に扱いにくい。
+
+### 参照する設計
+
+`pekko-persistence-effector` は以下の設計を採る。
+
+- 集約 actor は通常の typed `Behavior` として実装する
+- 永続化用 actor は集約 actor の child として隠蔽する
+- recovery では永続化用 actor が state を復元し、復元後の state と effector を集約 actor に渡す
+- command handler はドメインオブジェクトを呼び出して新 state と event を得る
+- event persist が成功したあと、command handler が返信し、次の `Behavior` に新 state を渡す
+
+fraktor-rs でもこの方向を採用する。ただし Rust では Scala の `PartialFunction` / path-dependent DSL を再現せず、型付き builder と closure で表現する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- typed actor が通常の `Behavior<M>` として書ける persistence API を提供する
+- domain command handling と event persistence を分離する
+- command handler 内でドメインオブジェクトが返した新 state を直接利用できる
+- recovery / persist / snapshot 中の stashing 契約を明確にする
+- `Persisted` / `Ephemeral` / `Deferred` を同一 API で切り替えられる
+- no_std core 境界を守る
+
+**Non-Goals:**
+
+- `EventSourcedBehavior` の完全互換実装
+- `Effect` chain DSL の導入
+- durable state typed behavior
+- read-side query
+- std filesystem snapshot store
+
+## Decisions
+
+### Decision 1: typed persistence の推奨 API は `PersistenceEffector` にする
+
+**選択:** `modules/persistence-core/src/core/typed/` に `PersistenceEffector<S, E, M>` を追加する。
+
+想定 public API:
+
+```rust
+pub struct PersistenceEffector<S, E, M> { /* private fields */ }
+
+impl<S, E, M> PersistenceEffector<S, E, M>
+where
+  S: Send + Sync + 'static,
+  E: Send + Sync + Clone + 'static,
+  M: Send + Sync + 'static,
+{
+  pub fn persist_event<F>(
+    &self,
+    ctx: &mut TypedActorContext<'_, M>,
+    event: E,
+    on_persisted: F,
+  ) -> Result<Behavior<M>, ActorError>
+  where
+    F: Fn(&E) -> Result<Behavior<M>, ActorError> + Send + Sync + 'static;
+
+  pub fn persist_events<F>(
+    &self,
+    ctx: &mut TypedActorContext<'_, M>,
+    events: Vec<E>,
+    on_persisted: F,
+  ) -> Result<Behavior<M>, ActorError>
+  where
+    F: Fn(&[E]) -> Result<Behavior<M>, ActorError> + Send + Sync + 'static;
+
+  pub fn persist_snapshot<F>(
+    &self,
+    ctx: &mut TypedActorContext<'_, M>,
+    snapshot: S,
+    force: bool,
+    on_persisted: F,
+  ) -> Result<Behavior<M>, ActorError>
+  where
+    F: Fn(&S) -> Result<Behavior<M>, ActorError> + Send + Sync + 'static;
+}
+```
+
+**Rationale:**
+
+- Rust の `Behavior` は message handler を `Fn` として保持するため、callback は `FnOnce` ではなく `Fn` を基本契約にする
+- `E: Clone` は persist 成功通知、snapshot criteria、in-memory replay で event を再利用するため要求する
+- aggregate actor は `Behavior<M>` を返すだけでよく、`EventSourcedBehavior` 専用 DSL を学習しなくてよい
+
+### Decision 2: `PersistenceEffector::from_config` は recovery 完了後に `(state, effector)` を渡す
+
+**選択:** entrypoint は `from_config` とし、`on_ready` closure が初期 behavior を返す。
+
+```rust
+impl<S, E, M> PersistenceEffector<S, E, M> {
+  pub fn from_config<F>(config: PersistenceEffectorConfig<S, E, M>, on_ready: F) -> Behavior<M>
+  where
+    F: Fn(S, PersistenceEffector<S, E, M>) -> Result<Behavior<M>, ActorError> + Send + Sync + 'static;
+}
+```
+
+**Rationale:**
+
+- recovery は actor 起動直後に必ず完了してから command processing へ移る
+- recovery 中に届いた user command は stash し、`on_ready` の behavior へ unstash する
+- `on_ready` は state pattern matching / state-specific handler 分岐の唯一の入口になる
+
+### Decision 3: 永続化用 child actor は classic persistence 基盤を使う
+
+**選択:** `Persisted` mode では typed aggregate actor の child として `PersistenceStoreActor<S, E>` 相当を起動し、その内部で既存 `PersistentActor` / `PersistenceContext` / journal / snapshot actor を使う。
+
+内部 protocol:
+
+```rust
+enum PersistenceStoreCommand<S, E> {
+  PersistEvent { event: E, reply_to: TypedActorRef<PersistenceStoreReply<S, E>> },
+  PersistEvents { events: Vec<E>, reply_to: TypedActorRef<PersistenceStoreReply<S, E>> },
+  PersistSnapshot { snapshot: S, reply_to: TypedActorRef<PersistenceStoreReply<S, E>> },
+  DeleteSnapshots { to_sequence_nr: u64, reply_to: TypedActorRef<PersistenceStoreReply<S, E>> },
+}
+
+enum PersistenceStoreReply<S, E> {
+  RecoveryCompleted { state: S, sequence_nr: u64 },
+  PersistedEvents { events: Vec<E>, sequence_nr: u64 },
+  PersistedSnapshot { snapshot: S, sequence_nr: u64 },
+  DeletedSnapshots { to_sequence_nr: u64 },
+  Failed { error: PersistenceError },
+}
+```
+
+**Rationale:**
+
+- classic persistence はすでに `PersistentActorAdapter` と `PersistenceContext` に recovery / write / stash 制御を持つ
+- typed API は永続化 store を新しく発明せず、既存 runtime を隠蔽する thin layer にする
+- recovery 時の `apply_event(&S, &E) -> S` は store actor 側でのみ実行し、aggregate actor の command handler は再実行しない
+
+### Decision 4: aggregate actor と store reply は message converter で接続する
+
+**選択:** `PersistenceEffectorMessageConverter<S, E, M>` を config に持たせる。
+
+```rust
+pub struct PersistenceEffectorMessageConverter<S, E, M> {
+  pub wrap_store_reply: ArcShared<dyn Fn(PersistenceStoreReply<S, E>) -> M + Send + Sync>,
+  pub unwrap_store_reply: ArcShared<dyn Fn(&M) -> Option<PersistenceStoreReply<S, E>> + Send + Sync>,
+}
+```
+
+**Rationale:**
+
+- fraktor-rs の typed `message_adapter` を使う場合でも、最終的に aggregate actor の message 型 `M` に store reply を包む必要がある
+- user command と internal persistence reply を同じ `Behavior<M>` が扱える
+- Scala 版の `MessageConverter` と同等の責務を Rust の closure で表す
+
+### Decision 5: persist 中は waiting behavior が user command を stash する
+
+**選択:** `persist_event` / `persist_events` / `persist_snapshot` は store actor へ command を送り、internal reply を待つ `Behavior<M>` を返す。この waiting behavior は次を満たす。
+
+- `unwrap_store_reply(message)` が対象 reply を返した場合だけ callback を実行する
+- その他の user command は `ctx.stash_with_limit(config.stash_capacity)` で stash する
+- callback が返した behavior へ `ctx.unstash_all()` する
+
+**Rationale:**
+
+- classic `persist` と同じ fencing semantics を typed actor で再現する
+- persist 完了前に次 command が現在 state を見て処理される事故を防ぐ
+- `persist_unfenced` 相当は本 change では追加しない
+
+### Decision 6: `Ephemeral` は同じ semantics を process 内 store で再現する
+
+**選択:** `Ephemeral` mode は journal plugin を使わず、effector 内部の in-memory event / snapshot store へ書き込む。recovery は同じ `apply_event` と snapshot criteria を通る。
+
+**Rationale:**
+
+- 開発初期に persistence extension / plugin を設定せずに aggregate logic をテストできる
+- `Persisted` と同じ callback / stashing / snapshot criteria を維持する
+- `InMemoryJournal` を使う integration test とは別に、effector 固有の lightweight mode として扱う
+
+### Decision 7: `Deferred` は no-op persist として扱う
+
+**選択:** `Deferred` mode は event / snapshot を保存せず、callback を即時実行する。
+
+**Rationale:**
+
+- upstream `pekko-persistence-effector` と同じ dry-run mode を提供する
+- performance test や persistence temporarily disabled の用途を満たす
+- `Deferred` では recovery は常に `initial_state`
+
+### Decision 8: snapshot / retention は effector の責務に含める
+
+**選択:** `SnapshotCriteria<S, E>` と `RetentionCriteria` を typed effector 層に追加する。
+
+```rust
+pub enum SnapshotCriteria<S, E> {
+  Never,
+  Always,
+  Every { number_of_events: u64 },
+  Predicate(ArcShared<dyn Fn(Option<&E>, &S, u64) -> bool + Send + Sync>),
+}
+
+pub struct RetentionCriteria {
+  pub snapshot_every: Option<u64>,
+  pub keep_snapshots: Option<u64>,
+}
+```
+
+**Rationale:**
+
+- event persist と snapshot 判定は同じ sequence number を共有する
+- snapshot 判定は command handler に散らさず effector に閉じる
+- retention は snapshot 成功後の cleanup として扱う
+
+### Decision 9: persistence failure と domain error を混ぜない
+
+**選択:** domain validation error は user command handler が reply して `Behaviors::same()` 等を返す。persistence failure は `PersistenceStoreReply::Failed` から `ActorError::fatal` に変換し、actor を停止させるのを default とする。
+
+**Rationale:**
+
+- persistence failure は「event が保存されていない」ため、domain success と同じ reply を返してはならない
+- failure retry / backoff は child store actor の supervision / `BackoffConfig` で扱う
+- user-visible domain error と infrastructure error の境界を保つ
+
+### Decision 10: module / file layout は 1file1type を守る
+
+**選択:** 新規型は原則として独立ファイルに置く。
+
+想定配置:
+
+```text
+modules/persistence-core/src/core/typed.rs
+modules/persistence-core/src/core/typed/persistence_id.rs
+modules/persistence-core/src/core/typed/persistence_mode.rs
+modules/persistence-core/src/core/typed/persistence_effector.rs
+modules/persistence-core/src/core/typed/persistence_effector_config.rs
+modules/persistence-core/src/core/typed/persistence_effector_message_converter.rs
+modules/persistence-core/src/core/typed/snapshot_criteria.rs
+modules/persistence-core/src/core/typed/retention_criteria.rs
+modules/persistence-core/src/core/typed/backoff_config.rs
+modules/persistence-core/src/core/typed/internal/persistence_store_actor.rs
+modules/persistence-core/src/core/typed/internal/persistence_store_command.rs
+modules/persistence-core/src/core/typed/internal/persistence_store_reply.rs
+```
+
+**Rationale:**
+
+- repo の dylint / 1file1type 方針に合わせる
+- public API と internal protocol の境界を明確にする
+
+## State Machine
+
+effector wrapper の状態は以下を持つ。
+
+```text
+Starting
+  -> Recovering
+  -> Ready(state, sequence_nr)
+  -> Persisting(kind, pending_callback)
+  -> Ready(new_state, sequence_nr)
+  -> Failed(error)
+```
+
+- `Starting`: typed behavior 起動直後
+- `Recovering`: store actor の recovery 完了待ち。user command は stash
+- `Ready`: aggregate behavior が command を処理可能
+- `Persisting`: persist / snapshot / delete の完了待ち。user command は stash
+- `Failed`: fatal error として actor 停止
+
+## Risks / Trade-offs
+
+### Risk 1: `Fn` callback 制約が使いにくい可能性
+
+typed `Behavior` の handler が `Fn` を要求するため、callback も `Fn` に寄せる。`FnOnce` でないため、reply target や new state は clone 可能な handle / value として捕捉する必要がある。必要なら実装時に internal `OnceCallback` wrapper を検討するが、初期仕様では `Fn` を採用する。
+
+### Risk 2: `PersistenceEffector` 名
+
+命名規約では曖昧サフィックスを避けるが、`PersistenceEffector` は upstream ライブラリ名そのものなので採用する。rustdoc では「永続化副作用を起動する handle」と責務を明記する。
+
+### Risk 3: typed `EventSourcedBehavior` parity から離れる
+
+Pekko typed API の移植率としては `EventSourcedBehavior` 未実装のまま残る。ただし本 change は fraktor-rs の推奨 typed persistence として effector pattern を定義する。Pekko API 互換 wrapper は別 capability として扱う。
+
+### Risk 4: in-memory mode と existing `InMemoryJournal` の重複
+
+`Ephemeral` は effector-level development mode、`InMemoryJournal` は persistence plugin としての journal 実装であり責務が異なる。仕様上は両方を残す。

--- a/openspec/changes/persistence-effector-typed-api/proposal.md
+++ b/openspec/changes/persistence-effector-typed-api/proposal.md
@@ -1,0 +1,97 @@
+## Why
+
+`modules/persistence-core` は classic 相当の `PersistentActor` / journal / snapshot / recovery を持つが、typed write-side API はまだ存在しない。Pekko の `EventSourcedBehavior` / `Effect` 体系をそのまま持ち込むと、`pekko-persistence-effector` が解いた以下の課題を fraktor-rs でも再発させる。
+
+- 通常の `Behavior` ベースの typed actor と異なる専用 DSL を強制する
+- 状態が増えるほど command handler / event handler が肥大化しやすい
+- ドメインオブジェクトが返した新状態を command handler 側で自然に使いにくく、ドメインロジックを event handler 側にも重複させがちになる
+
+fraktor-rs はまだ正式リリース前であり、Pekko parity を機械的に追うより、Rust の typed actor と DDD 集約を自然につなぐ API を先に定義する方がよい。そこで、typed 永続化 API は `EventSourcedBehavior` 直輸入ではなく、`pekko-persistence-effector` の「集約 actor は通常の typed `Behavior`、永続化は子 actor / effector が担当する」仕様を採用する。
+
+## What Changes
+
+### 1. typed persistence effector 層を追加する
+
+`modules/persistence-core/src/core/typed/` に typed write-side API を追加する。
+
+- `PersistenceId`
+- `PersistenceMode`
+- `PersistenceEffectorConfig<S, E, M>`
+- `PersistenceEffector<S, E, M>`
+- `SnapshotCriteria<S, E>`
+- `RetentionCriteria`
+- `BackoffConfig`
+- `PersistenceEffectorMessageConverter<S, E, M>`
+
+この層は `fraktor_actor_core_rs::core::typed::{Behavior, TypedActorContext}` と連携し、ユーザーの actor は `Behaviors::setup` / `Behaviors::receive_message_partial` / 状態別 handler 分割をそのまま使える。
+
+### 2. 永続化 store actor を hidden child として扱う
+
+`PersistenceMode::Persisted` では、effector が内部で永続化専用 child actor を起動する。child actor は既存 classic persistence 基盤 (`PersistentActor`, `PersistenceContext`, journal / snapshot actor) を使い、typed aggregate actor には以下だけを返す。
+
+- recovery 完了後の状態
+- persist event(s) 成功通知
+- snapshot 成功通知
+- snapshot delete 成功通知
+- persistence failure
+
+aggregate actor は recovery 中と persist 中に外部 command を stash し、永続化完了後に unstash する。
+
+### 3. 3 つの persistence mode を定義する
+
+- `Persisted`: journal / snapshot store に書き込む本番用 mode
+- `Ephemeral`: process 内 in-memory store に書き込む開発・テスト用 mode
+- `Deferred`: 永続化を行わず callback だけ実行する dry-run / performance test 用 mode
+
+`Persisted` / `Ephemeral` / `Deferred` は同じ `PersistenceEffector` API を使う。したがって、利用者は設定変更だけで段階的に移行できる。
+
+### 4. EventSourcedBehavior 相当の API は non-goal にする
+
+本 change では `EventSourcedBehavior` / `Effect` / `ReplyEffect` を公開 API として導入しない。typed persistence の第一の推奨 API は effector pattern とし、Pekko typed API の完全互換 wrapper が必要なら別 change で検討する。
+
+## Capabilities
+
+### New Capabilities
+
+- **`persistence-effector-typed-api`**:
+  - typed actor が通常の `Behavior<M>` として実装されたまま、event persistence / recovery / snapshot / retention を使える
+  - ドメイン操作は `Result<NewState, Event>` またはドメイン固有 result を返し、command handler は新状態を直接次の `Behavior` に渡せる
+  - recovery は `apply_event(&S, &E) -> S` によって state を復元し、復元後に `(state, effector)` を `on_ready` に渡す
+  - persist 中の command stashing、snapshot criteria、retention criteria、backoff restart を typed actor 側から設定できる
+
+### Modified Capabilities
+
+- **`persistence-gap-analysis`**:
+  - typed write-side API の方針を「Pekko `EventSourcedBehavior` 直接移植」から「effector-first typed persistence」に更新する
+  - gap-analysis の typed persistence hard gap を、本 change の完了後に effector pattern 実装済みとして再分類する
+
+## Impact
+
+**影響を受けるコード:**
+
+- `modules/persistence-core/src/core.rs`
+- `modules/persistence-core/src/core/typed/*.rs` 新規
+- `modules/persistence-core/src/core/typed/internal/*.rs` 新規
+- `modules/persistence-core/tests/*` typed persistence integration tests 新規
+- `docs/gap-analysis/persistence-gap-analysis.md`
+- 必要に応じて `showcases/std/persistence_effector/` 追加
+
+**公開 API 影響:**
+
+- 新規 API 追加のみ。ただし正式リリース前なので、実装中に classic persistence の内部型を整理する破壊的変更は許容する。
+- `PersistenceEffector` 名は `Effector` サフィックスを含むが、`pekko-persistence-effector` 由来の外部参照語彙として採用する。
+
+**挙動影響:**
+
+- typed actor が `EventSourcedBehavior` なしで persistence を使える
+- recovery 完了前と persist 中の外部 command は stash される
+- domain validation error と persistence failure は明確に分離される
+
+## Non-goals
+
+- Pekko typed `EventSourcedBehavior` / `Effect` / `ReplyEffect` の 1:1 移植
+- typed `DurableStateBehavior` の実装
+- persistence-query
+- storage backend 固有 plugin 実装
+- JVM / HOCON / reflection 相当の plugin loading
+- Java / Scala DSL convenience の再現

--- a/openspec/changes/persistence-effector-typed-api/specs/persistence-effector-typed-api/spec.md
+++ b/openspec/changes/persistence-effector-typed-api/specs/persistence-effector-typed-api/spec.md
@@ -1,0 +1,158 @@
+## ADDED Requirements
+
+### Requirement: typed persistence は通常の `Behavior` ベース actor として実装できる
+
+fraktor-rs の typed persistence API は、ユーザー actor に `EventSourcedBehavior` 相当の専用 command handler / event handler DSL を強制してはならない (MUST NOT)。ユーザーは `Behaviors::setup`、`Behaviors::receive_message`、`Behaviors::receive_message_partial`、状態別 handler 関数を使って aggregate actor を実装できなければならない (MUST)。
+
+typed persistence API は `PersistenceEffector::from_config(config, on_ready)` を提供し、recovery 完了後に `on_ready(state, effector)` を呼び出して初期 `Behavior<M>` を生成しなければならない (MUST)。
+
+#### Scenario: recovery 後に state-specific behavior を開始できる
+
+- **GIVEN** `PersistenceEffectorConfig` に `initial_state` と `apply_event` が設定されている
+- **WHEN** actor が起動し recovery が完了する
+- **THEN** `on_ready(recovered_state, effector)` が呼び出される
+- **AND** ユーザーは `recovered_state` の variant に応じて別々の `Behavior<M>` を返せる
+
+#### Scenario: recovery 中の user command は stash される
+
+- **GIVEN** actor が recovery 中である
+- **WHEN** user command が mailbox に届く
+- **THEN** effector wrapper はその command を stash する
+- **AND** recovery 完了後に `on_ready` が返した behavior へ unstash する
+
+### Requirement: `PersistenceEffector` は event persistence operation を提供する
+
+typed persistence API は `persist_event` と `persist_events` を提供しなければならない (MUST)。これらの operation は event を store actor または mode-specific store に保存し、保存成功後に callback を実行しなければならない (MUST)。
+
+persist operation は保存完了前に user command を処理してはならない (MUST NOT)。保存待ち中の user command は `stash_capacity` に従って stash しなければならない (MUST)。保存成功後、callback が返した behavior へ stashed command を戻さなければならない (MUST)。
+
+#### Scenario: 単一 event persist 成功後に callback が実行される
+
+- **GIVEN** aggregate actor が command を処理して event `E1` を生成する
+- **WHEN** actor が `effector.persist_event(ctx, E1, callback)` を呼ぶ
+- **AND** store actor が `PersistedEvents([E1])` を返す
+- **THEN** callback は `E1` を受け取って実行される
+- **AND** callback が返した behavior が次の active behavior になる
+
+#### Scenario: persist 中の command は保存成功まで処理されない
+
+- **GIVEN** `persist_event` の store reply を待っている
+- **WHEN** 別の user command が届く
+- **THEN** effector wrapper は command を stash する
+- **AND** persist 成功 callback 完了後に unstash する
+
+#### Scenario: 複数 event は batch として保存される
+
+- **GIVEN** command が複数 event `[E1, E2, E3]` を生成する
+- **WHEN** actor が `persist_events` を呼ぶ
+- **THEN** store actor は event sequence を同一 persistence id に順序通り保存する
+- **AND** callback は保存された event slice を順序通り受け取る
+
+### Requirement: recovery は command handler を再実行せず `apply_event` だけで state を復元する
+
+typed persistence effector は recovery 中に保存済み snapshot と event を読み込み、`apply_event(&S, &E) -> S` だけを使って state を復元しなければならない (MUST)。user command handler、domain command method、reply side effect は recovery 中に実行してはならない (MUST NOT)。
+
+#### Scenario: event replay は domain command を再実行しない
+
+- **GIVEN** journal に `Created`, `Deposited` event が保存されている
+- **WHEN** actor が再起動する
+- **THEN** effector は `initial_state` または snapshot から event を replay する
+- **AND** replay では `apply_event` だけを呼び出す
+- **AND** command handler の reply / side effect は実行されない
+
+### Requirement: command handler はドメインオブジェクトの新 state を直接利用できる
+
+typed persistence effector を使う aggregate actor は、domain object が返した新 state と event を command handler 内で受け取り、event persistence 成功後に新 state を次の behavior に渡せなければならない (MUST)。
+
+#### Scenario: ドメイン操作が返した新 state を次 behavior に渡す
+
+- **GIVEN** state `Created { account }` で `DepositCash` command を受け取る
+- **WHEN** `account.deposit(amount)` が `Ok((new_account, deposited_event))` を返す
+- **THEN** command handler は `deposited_event` を `persist_event` に渡す
+- **AND** persist 成功 callback は `new_account` を含む `Created` state の behavior を返す
+- **AND** event handler 側で同じ domain validation を二重実行しない
+
+### Requirement: persistence mode を設定で切り替えられる
+
+typed persistence effector は `PersistenceMode::Persisted`、`PersistenceMode::Ephemeral`、`PersistenceMode::Deferred` を提供しなければならない (MUST)。3 mode は同じ public API、同じ callback ordering、同じ stashing 契約を提供しなければならない (MUST)。
+
+#### Scenario: `Persisted` mode は journal / snapshot store に保存する
+
+- **GIVEN** persistence extension に journal actor と snapshot actor が登録されている
+- **WHEN** `PersistenceMode::Persisted` で `persist_event` を呼ぶ
+- **THEN** event は configured journal に保存される
+- **AND** actor 再起動後に recovery で replay される
+
+#### Scenario: `Ephemeral` mode は process 内 store から replay する
+
+- **GIVEN** `PersistenceMode::Ephemeral` の actor が event を保存している
+- **WHEN** 同一 process 内で同じ persistence id の actor を再作成する
+- **THEN** effector は in-memory snapshot / event から state を復元する
+- **AND** external journal plugin は不要である
+
+#### Scenario: `Deferred` mode は storage に書かず callback を実行する
+
+- **GIVEN** `PersistenceMode::Deferred` が設定されている
+- **WHEN** `persist_event` を呼ぶ
+- **THEN** event は journal に保存されない
+- **AND** callback は即時実行される
+- **AND** recovery state は常に `initial_state` から開始する
+
+### Requirement: snapshot criteria と retention criteria を提供する
+
+typed persistence effector は snapshot を保存するための `persist_snapshot`、event persist と同時に snapshot criteria を評価する `persist_event_with_snapshot` / `persist_events_with_snapshot` を提供しなければならない (MUST)。
+
+`SnapshotCriteria` は `Never`、`Always`、`Every { number_of_events }`、`Predicate` を表現できなければならない (MUST)。`RetentionCriteria` は snapshot 保存後に保持する snapshot 数を制御できなければならない (SHOULD)。
+
+#### Scenario: event count に基づいて snapshot を保存する
+
+- **GIVEN** `SnapshotCriteria::Every { number_of_events: 2 }` が設定されている
+- **WHEN** sequence number 2 の event persist が成功する
+- **THEN** effector は callback 完了前に snapshot を保存する
+
+#### Scenario: force snapshot は criteria を無視する
+
+- **GIVEN** `SnapshotCriteria::Never` が設定されている
+- **WHEN** `persist_snapshot(snapshot, force = true, callback)` を呼ぶ
+- **THEN** snapshot は保存される
+- **AND** callback が実行される
+
+#### Scenario: retention criteria は古い snapshot deletion を起動する
+
+- **GIVEN** `RetentionCriteria::snapshot_every(2, keep_snapshots = 2)` が設定されている
+- **WHEN** 新しい snapshot 保存が成功する
+- **THEN** effector は保持対象外の古い snapshot deletion を store actor に依頼する
+
+### Requirement: persistence failure と domain error を分離する
+
+typed persistence effector は domain validation failure と persistence failure を混同してはならない (MUST NOT)。domain validation failure は user command handler が通常の reply と behavior で処理する。persistence failure は infrastructure failure として扱い、default では actor を fatal error で停止しなければならない (MUST)。
+
+#### Scenario: domain validation failure は persistence を呼ばない
+
+- **GIVEN** withdraw command が残高不足になる
+- **WHEN** domain object が `Err(InsufficientFunds)` を返す
+- **THEN** command handler は failure reply を送る
+- **AND** `persist_event` は呼ばれない
+- **AND** actor は通常処理を継続する
+
+#### Scenario: journal write failure は success reply を送らない
+
+- **GIVEN** command handler が event を生成して `persist_event` を呼ぶ
+- **WHEN** journal write が失敗する
+- **THEN** success reply は送られない
+- **AND** persistence failure は `ActorError::fatal` として扱われる
+
+### Requirement: no_std core と既存モジュール規約を守る
+
+typed persistence effector 実装は `modules/persistence-core` の no_std 境界を守らなければならない (MUST)。`std::*` を core に導入してはならない (MUST NOT)。新規 public 型は原則 1 型 1 ファイルで配置し、`core.rs` / `typed.rs` から明示的に re-export しなければならない (MUST)。
+
+#### Scenario: core module に std dependency を追加しない
+
+- **WHEN** 実装差分を確認する
+- **THEN** `modules/persistence-core/src` に `std::` import は追加されない
+- **AND** in-memory mode は `alloc` と既存 sync primitive だけで実装される
+
+#### Scenario: public typed persistence API は re-export される
+
+- **WHEN** crate user が `fraktor_persistence_core_rs::core` を import する
+- **THEN** `PersistenceEffector`, `PersistenceEffectorConfig`, `PersistenceId`, `PersistenceMode`, `SnapshotCriteria`, `RetentionCriteria` を利用できる

--- a/openspec/changes/persistence-effector-typed-api/tasks.md
+++ b/openspec/changes/persistence-effector-typed-api/tasks.md
@@ -1,0 +1,84 @@
+## Phase 1: 準備と境界確認
+
+- [ ] 1.1 `modules/persistence-core/src/core` の existing classic persistence flow (`PersistentActor`, `PersistenceContext`, `PersistentActorAdapter`) を再確認する
+- [ ] 1.2 `modules/actor-core/src/core/typed` の `Behavior`, `TypedActorContext`, `message_adapter`, `stash`, `unstash_all`, `TypedProps` の制約を確認する
+- [ ] 1.3 `pekko-persistence-effector` の `PersistenceEffector`, `PersistenceEffectorConfig`, `PersistenceMode`, `SnapshotCriteria`, `RetentionCriteria` を参照し、Rust に移植する概念と移植しない概念を確定する
+- [ ] 1.4 `docs/gap-analysis/persistence-gap-analysis.md` の typed write-side gap を読み、実装完了後に更新する箇所を特定する
+
+## Phase 2: public typed module skeleton
+
+- [ ] 2.1 `modules/persistence-core/src/core/typed.rs` を追加し、`core.rs` から公開する
+- [ ] 2.2 `PersistenceId` を追加する (`of_unique_id`, `of_entity_id`, `as_str`)
+- [ ] 2.3 `PersistenceMode` を追加する (`Persisted`, `Ephemeral`, `Deferred`)
+- [ ] 2.4 `BackoffConfig` を追加する
+- [ ] 2.5 `SnapshotCriteria<S, E>` を追加する (`never`, `always`, `every`, `predicate`)
+- [ ] 2.6 `RetentionCriteria` を追加する (`none`, `snapshot_every`)
+- [ ] 2.7 rustdoc を日本語で追加し、missing_docs を満たす
+
+## Phase 3: config / converter
+
+- [ ] 3.1 `PersistenceEffectorConfig<S, E, M>` を追加する
+- [ ] 3.2 `apply_event: Fn(&S, &E) -> S` を config に保持する
+- [ ] 3.3 `PersistenceEffectorMessageConverter<S, E, M>` を追加する
+- [ ] 3.4 builder-style `with_persistence_mode`, `with_stash_capacity`, `with_snapshot_criteria`, `with_retention_criteria`, `with_backoff_config`, `with_message_converter` を追加する
+- [ ] 3.5 config validation を追加する (`stash_capacity > 0`, snapshot interval > 0, retention > 0)
+
+## Phase 4: internal store protocol
+
+- [ ] 4.1 `typed/internal/persistence_store_command.rs` を追加する
+- [ ] 4.2 `typed/internal/persistence_store_reply.rs` を追加する
+- [ ] 4.3 `typed/internal/persistence_store_actor.rs` を追加する
+- [ ] 4.4 store actor は existing classic persistence primitives を使って recovery / persist / snapshot / delete を実行する
+- [ ] 4.5 recovery 完了時に `RecoveryCompleted { state, sequence_nr }` を返す
+- [ ] 4.6 persist failure / snapshot failure は `Failed { error }` として返す
+
+## Phase 5: `PersistenceEffector` behavior builder
+
+- [ ] 5.1 `PersistenceEffector<S, E, M>` を追加する
+- [ ] 5.2 `PersistenceEffector::from_config(config, on_ready) -> Behavior<M>` を追加する
+- [ ] 5.3 `Persisted` mode で store child actor を起動し、recovery 完了まで user command を stash する
+- [ ] 5.4 recovery 完了後、`on_ready(state, effector)` が返した behavior へ unstash する
+- [ ] 5.5 store reply を `message_converter` 経由で aggregate message `M` に包む
+
+## Phase 6: persist / snapshot operations
+
+- [ ] 6.1 `persist_event` を追加し、store reply 待ち behavior を返す
+- [ ] 6.2 `persist_events` を追加し、複数 event を 1 batch として扱う
+- [ ] 6.3 `persist_snapshot(snapshot, force, callback)` を追加する
+- [ ] 6.4 `persist_event_with_snapshot` / `persist_events_with_snapshot` を追加し、snapshot criteria を評価する
+- [ ] 6.5 persist 中の user command は `stash_capacity` に従って stash する
+- [ ] 6.6 persist 成功後 callback を実行し、その behavior へ `unstash_all` する
+- [ ] 6.7 persistence failure は default で `ActorError::fatal` に変換する
+
+## Phase 7: mode-specific behavior
+
+- [ ] 7.1 `Ephemeral` mode 用 in-memory event / snapshot store を追加する
+- [ ] 7.2 `Ephemeral` recovery は latest snapshot + subsequent events を replay する
+- [ ] 7.3 `Deferred` mode は storage へ書かず callback を即時実行する
+- [ ] 7.4 3 mode で public API と callback ordering が一致することをテストする
+
+## Phase 8: snapshot / retention
+
+- [ ] 8.1 `SnapshotCriteria::every` が sequence number に基づいて snapshot を保存することを実装する
+- [ ] 8.2 `SnapshotCriteria::predicate` が event / state / sequence number を受け取ることを実装する
+- [ ] 8.3 `RetentionCriteria::snapshot_every` に基づいて古い snapshot deletion command を store actor へ送る
+- [ ] 8.4 delete snapshot failure の扱いを fatal / warn のどちらにするか実装前に確定し、仕様へ反映する
+
+## Phase 9: examples / integration tests
+
+- [ ] 9.1 typed bank account aggregate example を追加する
+- [ ] 9.2 `NotCreated` / `Created` の state-specific behavior 分割例を追加する
+- [ ] 9.3 domain object が `Result<NewState, Event>` を返し、command handler が新 state を次 behavior に渡す例を追加する
+- [ ] 9.4 `Persisted` + `InMemoryJournal` / `InMemorySnapshotStore` integration test を追加する
+- [ ] 9.5 `Ephemeral` mode unit test を追加する
+- [ ] 9.6 `Deferred` mode unit test を追加する
+- [ ] 9.7 persist 中 stashing / recovery 中 stashing のテストを追加する
+- [ ] 9.8 persistence failure と domain validation failure が混ざらないことをテストする
+
+## Phase 10: docs / gap-analysis / verification
+
+- [ ] 10.1 `docs/gap-analysis/persistence-gap-analysis.md` を更新し、typed write-side 方針を effector-first として反映する
+- [ ] 10.2 `README.ja.md` または persistence docs に typed persistence effector の短い利用例を追加する
+- [ ] 10.3 `rtk cargo test -p fraktor-persistence-core-rs` を実行する
+- [ ] 10.4 `./scripts/ci-check.sh ai dylint` を実行する
+- [ ] 10.5 最終確認として `./scripts/ci-check.sh ai all` を実行する


### PR DESCRIPTION
## Summary

- Add an OpenSpec change for bringing the pekko-persistence-effector pattern into fraktor-rs typed persistence.
- Define the effector-first API direction instead of directly porting Pekko typed EventSourcedBehavior.
- Capture proposal, technical design, implementation tasks, and acceptance requirements.

## Why

fraktor-rs currently has classic persistence primitives but no typed write-side persistence API. This spec keeps typed aggregate actors as normal Behavior-based actors while delegating event persistence, recovery, snapshotting, retention, and stashing to a PersistenceEffector layer.

## Validation

- ./scripts/opsx-cli.sh status --change persistence-effector-typed-api --json
- openspec validate was attempted, but the installed openspec shim is managed by mise and failed before validation in this checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenSpec addition; no runtime/code changes, so risk is limited to guiding future implementation decisions.
> 
> **Overview**
> Adds a new OpenSpec change, `persistence-effector-typed-api`, defining an *effector-first* typed persistence direction (based on `pekko-persistence-effector`) instead of porting Pekko’s typed `EventSourcedBehavior`.
> 
> Includes a detailed design/proposal plus acceptance requirements for `PersistenceEffector` (recovery handoff via `from_config`, persist operations with stashing, snapshot/retention criteria, and `Persisted`/`Ephemeral`/`Deferred` modes), along with an implementation task plan. No Rust code is modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64c4cdcb1a36bd265e007adcf5f5dbcdf9692d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->