### PR TITLE
Enable Codex hooks for Rust edit dylint

### DIFF
--- a/.codex-corporate/config.toml
+++ b/.codex-corporate/config.toml
@@ -17,15 +17,6 @@ multi_agent = true
 js_repl = true
 prevent_idle_sleep = true
 
-[[hooks.PostToolUse]]
-matcher = "^(apply_patch|Edit|Write)$"
-
-[[hooks.PostToolUse.hooks]]
-type = "command"
-command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/run_dylint_after_rust_edit.py"'
-timeout = 1800
-statusMessage = "Rust 変更後の dylint を確認中"
-
 [agents]
 max_threads = 4
 max_depth = 1

--- a/.codex-corporate/config.toml
+++ b/.codex-corporate/config.toml
@@ -6,6 +6,7 @@ web_search = "live"
 personality = "pragmatic"
 
 [features]
+codex_hooks = true
 rmcp_client = true
 skills = true
 unified_exec = true
@@ -15,6 +16,15 @@ steer = true
 multi_agent = true
 js_repl = true
 prevent_idle_sleep = true
+
+[[hooks.PostToolUse]]
+matcher = "^(apply_patch|Edit|Write)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/run_dylint_after_rust_edit.py"'
+timeout = 1800
+statusMessage = "Rust 変更後の dylint を確認中"
 
 [agents]
 max_threads = 4

--- a/.codex-personal/config.toml
+++ b/.codex-personal/config.toml
@@ -15,15 +15,6 @@ shell_snapshot = true
 steer = true
 multi_agent = true
 
-[[hooks.PostToolUse]]
-matcher = "^(apply_patch|Edit|Write)$"
-
-[[hooks.PostToolUse.hooks]]
-type = "command"
-command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/run_dylint_after_rust_edit.py"'
-timeout = 1800
-statusMessage = "Rust 変更後の dylint を確認中"
-
 [agents]
 max_threads = 4
 max_depth = 1

--- a/.codex-personal/config.toml
+++ b/.codex-personal/config.toml
@@ -6,6 +6,7 @@ web_search = "live"
 personality = "pragmatic"
 
 [features]
+codex_hooks = true
 rmcp_client = true
 skills = true
 unified_exec = true
@@ -13,6 +14,15 @@ apps = false
 shell_snapshot = true
 steer = true
 multi_agent = true
+
+[[hooks.PostToolUse]]
+matcher = "^(apply_patch|Edit|Write)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/run_dylint_after_rust_edit.py"'
+timeout = 1800
+statusMessage = "Rust 変更後の dylint を確認中"
 
 [agents]
 max_threads = 4

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -30,6 +30,7 @@ config_file = "agents/worker.toml"
 description = "Implementation-focused agent for small targeted fixes."
 
 [features]
+codex_hooks = true
 js_repl = false
 multi_agent = true
 prevent_idle_sleep = true
@@ -37,6 +38,15 @@ rmcp_client = true
 shell_snapshot = true
 steer = true
 unified_exec = true
+
+[[hooks.PostToolUse]]
+matcher = "^(apply_patch|Edit|Write)$"
+
+[[hooks.PostToolUse.hooks]]
+type = "command"
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/run_dylint_after_rust_edit.py"'
+timeout = 1800
+statusMessage = "Rust 変更後の dylint を確認中"
 
 [projects."/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs"]
 trust_level = "trusted"

--- a/.codex/hooks/run_dylint_after_rust_edit.py
+++ b/.codex/hooks/run_dylint_after_rust_edit.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 PATCH_FILE_PATTERN = re.compile(r"^\*\*\* (?:Update|Add|Delete) File: (.+)$")
+DIRECT_RUST_PATH_KEYS = ("file_path", "path", "target_file")
 HOOK_LOCK_PATH = Path(".takt/.codex-hook-dylint.lock")
 CI_LOCK_PATH = Path(".takt/.ci-check.lock")
 LOCK_WAIT_TIMEOUT_SEC = 1800
@@ -29,11 +30,7 @@ def main() -> int:
     if not isinstance(tool_input, dict):
         return 0
 
-    patch_text = extract_patch_text(tool_input)
-    if patch_text is None:
-        return 0
-
-    rust_paths = find_rust_paths(patch_text)
+    rust_paths = extract_rust_paths(tool_input)
     if not rust_paths:
         return 0
 
@@ -76,6 +73,21 @@ def find_rust_paths(command: str) -> list[str]:
     return rust_paths
 
 
+def extract_rust_paths(tool_input: dict[str, object]) -> list[str]:
+    rust_paths: list[str] = []
+
+    for key in DIRECT_RUST_PATH_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.endswith(".rs"):
+            rust_paths.append(value)
+
+    patch_text = extract_patch_text(tool_input)
+    if patch_text is not None:
+        rust_paths.extend(find_rust_paths(patch_text))
+
+    return deduplicate_paths(rust_paths)
+
+
 def extract_patch_text(tool_input: dict[str, object]) -> str | None:
     command = tool_input.get("command")
     if isinstance(command, str):
@@ -92,6 +104,17 @@ def extract_patch_text(tool_input: dict[str, object]) -> str | None:
         return patch_input
 
     return None
+
+
+def deduplicate_paths(paths: list[str]) -> list[str]:
+    unique_paths: list[str] = []
+    seen_paths: set[str] = set()
+    for path in paths:
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        unique_paths.append(path)
+    return unique_paths
 
 
 def resolve_repo_root(payload: dict[str, object]) -> Path | None:
@@ -250,7 +273,10 @@ def summarize_failure_output(completed: subprocess.CompletedProcess[str]) -> str
 
 
 def block(message: str) -> int:
-    print(message, file=sys.stderr)
+    print(json.dumps({
+        "should_block": True,
+        "reason": message,
+    }, ensure_ascii=False))
     return 2
 
 

--- a/.codex/hooks/run_dylint_after_rust_edit.py
+++ b/.codex/hooks/run_dylint_after_rust_edit.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PATCH_FILE_PATTERN = re.compile(r"^\*\*\* (?:Update|Add|Delete) File: (.+)$")
+HOOK_LOCK_PATH = Path(".takt/.codex-hook-dylint.lock")
+CI_LOCK_PATH = Path(".takt/.ci-check.lock")
+LOCK_WAIT_TIMEOUT_SEC = 1800
+LOCK_POLL_INTERVAL_SEC = 1.0
+CI_COMMAND = ("./scripts/ci-check.sh", "ai", "dylint")
+MAX_FAILURE_LINES = 160
+MAX_FAILURE_CHARS = 12000
+
+
+def main() -> int:
+    payload = load_payload()
+    if payload is None:
+        return block("Codex hook の入力 JSON を解釈できませんでした。")
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return 0
+
+    rust_paths = find_rust_paths(command)
+    if not rust_paths:
+        return 0
+
+    repo_root = resolve_repo_root(payload)
+    if repo_root is None:
+        return block("Git ルートを特定できなかったため、自動 dylint を実行できませんでした。")
+
+    try:
+        run_auto_dylint(repo_root)
+    except HookFailure as failure:
+        touched_paths = ", ".join(rust_paths)
+        return block(
+            "Rust ファイル編集後の自動 `./scripts/ci-check.sh ai dylint` が失敗しました。\n"
+            f"対象: {touched_paths}\n\n"
+            f"{failure.message}"
+        )
+
+    return 0
+
+
+def load_payload() -> dict[str, object] | None:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def find_rust_paths(command: str) -> list[str]:
+    rust_paths: list[str] = []
+    for line in command.splitlines():
+        match = PATCH_FILE_PATTERN.match(line)
+        if match is None:
+            continue
+        path = match.group(1).strip()
+        if path.endswith(".rs"):
+            rust_paths.append(path)
+    return rust_paths
+
+
+def resolve_repo_root(payload: dict[str, object]) -> Path | None:
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        cwd = "."
+
+    completed = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return None
+
+    repo_root = completed.stdout.strip()
+    if not repo_root:
+        return None
+    return Path(repo_root)
+
+
+def run_auto_dylint(repo_root: Path) -> None:
+    repo_hook_lock_path = repo_root / HOOK_LOCK_PATH
+    repo_ci_lock_path = repo_root / CI_LOCK_PATH
+    repo_hook_lock_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with FileLock(repo_hook_lock_path, "codex hook dylint lock"):
+        wait_for_lock_release(repo_ci_lock_path, "ci-check.sh")
+        completed = subprocess.run(
+            CI_COMMAND,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            env=build_ci_environment(),
+        )
+
+    if completed.returncode == 0:
+        return
+
+    raise HookFailure(summarize_failure_output(completed))
+
+
+def build_ci_environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    environment.setdefault("CI_CHECK_HEARTBEAT", "0")
+    return environment
+
+
+def wait_for_lock_release(lock_path: Path, label: str) -> None:
+    deadline = time.monotonic() + LOCK_WAIT_TIMEOUT_SEC
+    while True:
+        pid = read_lock_pid(lock_path)
+        if pid is None:
+            return
+        if not process_exists(pid):
+            remove_stale_lock(lock_path)
+            return
+        if time.monotonic() >= deadline:
+            raise HookFailure(f"{label} のロック待機がタイムアウトしました。")
+        time.sleep(LOCK_POLL_INTERVAL_SEC)
+
+
+class FileLock:
+    def __init__(self, lock_path: Path, label: str) -> None:
+        self.lock_path = lock_path
+        self.label = label
+        self.fd: int | None = None
+
+    def __enter__(self) -> "FileLock":
+        deadline = time.monotonic() + LOCK_WAIT_TIMEOUT_SEC
+        while True:
+            try:
+                self.fd = os.open(
+                    self.lock_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+                os.write(self.fd, f"{os.getpid()}\n".encode("utf-8"))
+                return self
+            except FileExistsError:
+                pid = read_lock_pid(self.lock_path)
+                if pid is None or not process_exists(pid):
+                    remove_stale_lock(self.lock_path)
+                    continue
+                if time.monotonic() >= deadline:
+                    raise HookFailure(f"{self.label} の待機がタイムアウトしました。")
+                time.sleep(LOCK_POLL_INTERVAL_SEC)
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        if self.fd is not None:
+            os.close(self.fd)
+        try:
+            self.lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def read_lock_pid(lock_path: Path) -> int | None:
+    if not lock_path.exists():
+        return None
+
+    try:
+        pid_text = lock_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+    if not pid_text:
+        return None
+
+    try:
+        return int(pid_text)
+    except ValueError:
+        return None
+
+
+def process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def remove_stale_lock(lock_path: Path) -> None:
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def summarize_failure_output(completed: subprocess.CompletedProcess[str]) -> str:
+    lines: list[str] = []
+    for text in (completed.stdout, completed.stderr):
+        if not text:
+            continue
+        lines.extend(line.rstrip() for line in text.splitlines())
+
+    if not lines:
+        return f"`{' '.join(CI_COMMAND)}` が終了コード {completed.returncode} で失敗しました。"
+
+    tail = lines[-MAX_FAILURE_LINES:]
+    message = "\n".join(tail).strip()
+    if len(message) > MAX_FAILURE_CHARS:
+        message = message[-MAX_FAILURE_CHARS:]
+        first_newline = message.find("\n")
+        if first_newline != -1:
+            message = message[first_newline + 1 :]
+    return message
+
+
+def block(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 2
+
+
+class HookFailure(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/run_dylint_after_rust_edit.py
+++ b/.codex/hooks/run_dylint_after_rust_edit.py
@@ -29,11 +29,11 @@ def main() -> int:
     if not isinstance(tool_input, dict):
         return 0
 
-    command = tool_input.get("command")
-    if not isinstance(command, str):
+    patch_text = extract_patch_text(tool_input)
+    if patch_text is None:
         return 0
 
-    rust_paths = find_rust_paths(command)
+    rust_paths = find_rust_paths(patch_text)
     if not rust_paths:
         return 0
 
@@ -74,6 +74,24 @@ def find_rust_paths(command: str) -> list[str]:
         if path.endswith(".rs"):
             rust_paths.append(path)
     return rust_paths
+
+
+def extract_patch_text(tool_input: dict[str, object]) -> str | None:
+    command = tool_input.get("command")
+    if isinstance(command, str):
+        return command
+    if isinstance(command, list):
+        command_parts = [part for part in command if isinstance(part, str)]
+        if len(command_parts) >= 2 and command_parts[0] == "apply_patch":
+            return command_parts[1]
+        if len(command_parts) == 1:
+            return command_parts[0]
+
+    patch_input = tool_input.get("input")
+    if isinstance(patch_input, str):
+        return patch_input
+
+    return None
 
 
 def resolve_repo_root(payload: dict[str, object]) -> Path | None:

--- a/.codex/hooks/run_dylint_after_rust_edit.py
+++ b/.codex/hooks/run_dylint_after_rust_edit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import re
@@ -171,9 +172,14 @@ def build_ci_environment() -> dict[str, str]:
 def wait_for_lock_release(lock_path: Path, label: str) -> None:
     deadline = time.monotonic() + LOCK_WAIT_TIMEOUT_SEC
     while True:
-        pid = read_lock_pid(lock_path)
-        if pid is None:
+        exists, pid = read_lock_pid(lock_path)
+        if not exists:
             return
+        if pid is None:
+            if time.monotonic() >= deadline:
+                raise HookFailure(f"{label} のロック情報が解決できないままタイムアウトしました。")
+            time.sleep(LOCK_POLL_INTERVAL_SEC)
+            continue
         if not process_exists(pid):
             remove_stale_lock(lock_path)
             return
@@ -191,48 +197,56 @@ class FileLock:
     def __enter__(self) -> "FileLock":
         deadline = time.monotonic() + LOCK_WAIT_TIMEOUT_SEC
         while True:
+            fd = os.open(
+                self.lock_path,
+                os.O_RDWR | os.O_CREAT,
+                0o600,
+            )
             try:
-                self.fd = os.open(
-                    self.lock_path,
-                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                    0o600,
-                )
-                os.write(self.fd, f"{os.getpid()}\n".encode("utf-8"))
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                write_lock_pid(fd)
+                self.fd = fd
                 return self
-            except FileExistsError:
-                pid = read_lock_pid(self.lock_path)
-                if pid is None or not process_exists(pid):
-                    remove_stale_lock(self.lock_path)
-                    continue
+            except BlockingIOError:
+                os.close(fd)
                 if time.monotonic() >= deadline:
                     raise HookFailure(f"{self.label} の待機がタイムアウトしました。")
                 time.sleep(LOCK_POLL_INTERVAL_SEC)
+            except OSError:
+                os.close(fd)
+                raise
 
     def __exit__(self, exc_type, exc, traceback) -> None:
         if self.fd is not None:
-            os.close(self.fd)
-        try:
-            self.lock_path.unlink()
-        except FileNotFoundError:
-            pass
+            try:
+                fcntl.flock(self.fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self.fd)
 
 
-def read_lock_pid(lock_path: Path) -> int | None:
+def write_lock_pid(fd: int) -> None:
+    os.ftruncate(fd, 0)
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+    os.fsync(fd)
+
+
+def read_lock_pid(lock_path: Path) -> tuple[bool, int | None]:
     if not lock_path.exists():
-        return None
+        return False, None
 
     try:
         pid_text = lock_path.read_text(encoding="utf-8").strip()
     except OSError:
-        return None
+        return True, None
 
     if not pid_text:
-        return None
+        return True, None
 
     try:
-        return int(pid_text)
+        return True, int(pid_text)
     except ValueError:
-        return None
+        return True, None
 
 
 def process_exists(pid: int) -> bool:


### PR DESCRIPTION
## Summary
- enable `codex_hooks` in the shared, personal, and corporate Codex config layers
- add a repo-local `PostToolUse` hook for `apply_patch`/`Edit`/`Write` events
- auto-run `./scripts/ci-check.sh ai dylint` when a Rust file is edited and surface failures back to Codex

## Verification
- `env CODEX_HOME=$PWD/.codex-personal rtk proxy mise exec -- codex features list`
- `env CODEX_HOME=$PWD/.codex-corporate rtk proxy mise exec -- codex features list`
- `env CODEX_HOME=$PWD/.codex rtk proxy mise exec -- codex features list`
- `rtk proxy /usr/bin/python3 -m py_compile .codex/hooks/run_dylint_after_rust_edit.py`
- manual hook invocation with and without `.rs` edits
- `rtk ./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automatic PostToolUse hook that runs `./scripts/ci-check.sh ai dylint` after Rust file edits and can block tool execution on failures, which may impact developer workflow (latency/lock contention) and requires the hook script to be robust on all environments.
> 
> **Overview**
> Enables `codex_hooks` across the shared, personal, and corporate Codex configs and adds a repo-local `PostToolUse` hook that triggers on `apply_patch`/`Edit`/`Write`.
> 
> Introduces `.codex/hooks/run_dylint_after_rust_edit.py`, which detects when `.rs` files were touched, serializes executions with a lock (and waits for any existing `ci-check.sh` lock), runs `./scripts/ci-check.sh ai dylint`, and surfaces a truncated failure reason back to Codex to block further actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 631b00520620f5d706ffbb568c437e61681ed3a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->