### PR TITLE
[codex] relax codecov project threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+# PR の追加変更行は引き続き厳格に見る一方で、
+# project 全体の 0.01% 程度の微小低下では PR を落とさない。
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.02
+    patch:
+      default:
+        target: 100%


### PR DESCRIPTION
## Summary
- add `codecov.yml` to codify repository coverage status behavior
- relax only `codecov/project` with a minimal `threshold: 0.02`
- keep `codecov/patch` at `100%` so changed lines remain strictly gated

## Why
Recent PRs were repeatedly failing `codecov/project` even when `codecov/patch` passed, because overall coverage dropped only `-0.01%` from `85.50%` to `85.49%`. That made tiny baseline drift block otherwise well-covered PRs.

## Impact
- PRs no longer fail on negligible project-wide coverage drift
- new or changed lines still need full patch coverage
- Codecov behavior is now explicit in-repo instead of relying on remote defaults

## Verification
- `rtk curl --data-binary @codecov.yml https://api.codecov.io/validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI coverage gating behavior changes; it slightly relaxes repo-wide coverage drift tolerance while keeping per-PR patch coverage strict.
> 
> **Overview**
> Adds an in-repo `codecov.yml` to make Codecov status checks explicit.
> 
> `coverage.status.project` is set to `target: auto` with a small `threshold: 0.02` to avoid failing PRs on negligible overall coverage drift, while `coverage.status.patch` remains `target: 100%` to keep changed lines strictly gated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65098d0dfbfc5eb73ba4450e641a25f1d41004a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD環境の構成を更新しました。コード品質レポートの基準値を設定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->