### PR TITLE
feat(hooks): Claude Code/Codex 共通の dylint PostToolUse hook を導入

### DIFF
--- a/.agents/hooks/run_dylint_after_rust_edit.py
+++ b/.agents/hooks/run_dylint_after_rust_edit.py
@@ -1,7 +1,22 @@
 #!/usr/bin/env python3
+"""AI エージェント PostToolUse hook: Rust ファイル編集後に dylint を自動実行する。
+
+Claude Code と Codex CLI で共通利用するため、エージェント種別を `--agent`
+引数で切り替える。エージェントごとに異なるのは以下の3点のみ:
+
+* tool_input から編集対象パスを抽出する方法 (Claude は `file_path` のみ、
+  Codex は `apply_patch` コマンド本文も解釈する)
+* 自身の hook 用ロックファイルの配置先
+* 失敗時にエージェントへ返すブロック応答の形式 (Claude は stderr へ書き出し
+  て exit 2、Codex は `{should_block, reason}` の JSON を stdout へ出力)
+
+排他制御: ci-check.sh は `target/.ci-check.lock` で多重起動を弾くため、
+本 hook も先行する ci-check.sh の終了を待ってから dylint を起動する。
+"""
 
 from __future__ import annotations
 
+import argparse
 import fcntl
 import json
 import os
@@ -9,47 +24,72 @@ import re
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
-PATCH_FILE_PATTERN = re.compile(r"^\*\*\* (?:Update|Add|Delete) File: (.+)$")
-DIRECT_RUST_PATH_KEYS = ("file_path", "path", "target_file")
-HOOK_LOCK_PATH = Path(".takt/.codex-hook-dylint.lock")
-CI_LOCK_PATH = Path(".takt/.ci-check.lock")
+CI_LOCK_PATH = Path("target/.ci-check.lock")
 LOCK_WAIT_TIMEOUT_SEC = 1800
 LOCK_POLL_INTERVAL_SEC = 1.0
 CI_COMMAND = ("./scripts/ci-check.sh", "ai", "dylint")
 MAX_FAILURE_LINES = 160
 MAX_FAILURE_CHARS = 12000
 
+PATCH_FILE_PATTERN = re.compile(r"^\*\*\* (?:Update|Add|Delete) File: (.+)$")
+DIRECT_RUST_PATH_KEYS = ("file_path", "path", "target_file")
+
+
+@dataclass(frozen=True)
+class AgentProfile:
+    name: str
+    label: str
+    hook_lock_path: Path
+    extract_rust_paths: Callable[[dict[str, object]], list[str]]
+    block: Callable[[str], int]
+
 
 def main() -> int:
+    args = parse_args()
+    profile = AGENT_PROFILES[args.agent]
+
     payload = load_payload()
     if payload is None:
-        return block("Codex hook の入力 JSON を解釈できませんでした。")
+        return profile.block(f"{profile.label} hook の入力 JSON を解釈できませんでした。")
 
     tool_input = payload.get("tool_input")
     if not isinstance(tool_input, dict):
         return 0
 
-    rust_paths = extract_rust_paths(tool_input)
+    rust_paths = profile.extract_rust_paths(tool_input)
     if not rust_paths:
         return 0
 
     repo_root = resolve_repo_root(payload)
     if repo_root is None:
-        return block("Git ルートを特定できなかったため、自動 dylint を実行できませんでした。")
+        return profile.block("Git ルートを特定できなかったため、自動 dylint を実行できませんでした。")
 
     try:
-        run_auto_dylint(repo_root)
+        run_auto_dylint(repo_root, profile.hook_lock_path, profile.label)
     except HookFailure as failure:
         touched_paths = ", ".join(rust_paths)
-        return block(
+        return profile.block(
             "Rust ファイル編集後の自動 `./scripts/ci-check.sh ai dylint` が失敗しました。\n"
             f"対象: {touched_paths}\n\n"
             f"{failure.message}"
         )
 
     return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="dylint after Rust edit hook")
+    parser.add_argument(
+        "--agent",
+        required=True,
+        choices=sorted(AGENT_PROFILES.keys()),
+        help="呼び出し元のエージェント種別",
+    )
+    return parser.parse_args()
 
 
 def load_payload() -> dict[str, object] | None:
@@ -62,19 +102,17 @@ def load_payload() -> dict[str, object] | None:
     return None
 
 
-def find_rust_paths(command: str) -> list[str]:
+def extract_rust_paths_claude(tool_input: dict[str, object]) -> list[str]:
+    """Claude Code (Edit / Write / MultiEdit) の tool_input を解釈する。"""
     rust_paths: list[str] = []
-    for line in command.splitlines():
-        match = PATCH_FILE_PATTERN.match(line)
-        if match is None:
-            continue
-        path = match.group(1).strip()
-        if path.endswith(".rs"):
-            rust_paths.append(path)
+    file_path = tool_input.get("file_path")
+    if isinstance(file_path, str) and file_path.endswith(".rs"):
+        rust_paths.append(file_path)
     return rust_paths
 
 
-def extract_rust_paths(tool_input: dict[str, object]) -> list[str]:
+def extract_rust_paths_codex(tool_input: dict[str, object]) -> list[str]:
+    """Codex CLI の tool_input (apply_patch / Edit / Write) を解釈する。"""
     rust_paths: list[str] = []
 
     for key in DIRECT_RUST_PATH_KEYS:
@@ -84,9 +122,21 @@ def extract_rust_paths(tool_input: dict[str, object]) -> list[str]:
 
     patch_text = extract_patch_text(tool_input)
     if patch_text is not None:
-        rust_paths.extend(find_rust_paths(patch_text))
+        rust_paths.extend(find_rust_paths_in_patch(patch_text))
 
     return deduplicate_paths(rust_paths)
+
+
+def find_rust_paths_in_patch(command: str) -> list[str]:
+    rust_paths: list[str] = []
+    for line in command.splitlines():
+        match = PATCH_FILE_PATTERN.match(line)
+        if match is None:
+            continue
+        path = match.group(1).strip()
+        if path.endswith(".rs"):
+            rust_paths.append(path)
+    return rust_paths
 
 
 def extract_patch_text(tool_input: dict[str, object]) -> str | None:
@@ -139,12 +189,12 @@ def resolve_repo_root(payload: dict[str, object]) -> Path | None:
     return Path(repo_root)
 
 
-def run_auto_dylint(repo_root: Path) -> None:
-    repo_hook_lock_path = repo_root / HOOK_LOCK_PATH
+def run_auto_dylint(repo_root: Path, hook_lock_relative: Path, lock_label: str) -> None:
+    repo_hook_lock_path = repo_root / hook_lock_relative
     repo_ci_lock_path = repo_root / CI_LOCK_PATH
     repo_hook_lock_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with FileLock(repo_hook_lock_path, "codex hook dylint lock"):
+    with FileLock(repo_hook_lock_path, lock_label):
         wait_for_lock_release(repo_ci_lock_path, "ci-check.sh")
         completed = subprocess.run(
             CI_COMMAND,
@@ -286,7 +336,12 @@ def summarize_failure_output(completed: subprocess.CompletedProcess[str]) -> str
     return message
 
 
-def block(message: str) -> int:
+def block_claude(message: str) -> int:
+    print(message, file=sys.stderr)
+    return 2
+
+
+def block_codex(message: str) -> int:
     print(json.dumps({
         "should_block": True,
         "reason": message,
@@ -298,6 +353,24 @@ class HookFailure(Exception):
     def __init__(self, message: str) -> None:
         super().__init__(message)
         self.message = message
+
+
+AGENT_PROFILES: dict[str, AgentProfile] = {
+    "claude": AgentProfile(
+        name="claude",
+        label="Claude",
+        hook_lock_path=Path(".claude/dylint-hook.lock"),
+        extract_rust_paths=extract_rust_paths_claude,
+        block=block_claude,
+    ),
+    "codex": AgentProfile(
+        name="codex",
+        label="Codex",
+        hook_lock_path=Path(".codex/dylint-hook.lock"),
+        extract_rust_paths=extract_rust_paths_codex,
+        block=block_codex,
+    ),
+}
 
 
 if __name__ == "__main__":

--- a/.agents/hooks/run_dylint_after_rust_edit.py
+++ b/.agents/hooks/run_dylint_after_rust_edit.py
@@ -10,8 +10,11 @@ Claude Code と Codex CLI で共通利用するため、エージェント種別
 * 失敗時にエージェントへ返すブロック応答の形式 (Claude は stderr へ書き出し
   て exit 2、Codex は `{should_block, reason}` の JSON を stdout へ出力)
 
-排他制御: ci-check.sh は `target/.ci-check.lock` で多重起動を弾くため、
-本 hook も先行する ci-check.sh の終了を待ってから dylint を起動する。
+排他制御は二段:
+  1. `target/.ci-check.coordination.lock` で hook 同士 (エージェント横断) の
+     直列化を行い、ci-check.sh の起動権を一つに絞る (TOCTOU 防止)。
+  2. ci-check.sh 自身は `target/.ci-check.lock` で多重起動を弾くため、本
+     hook はその解放を待ってから coordination lock 内で dylint を起動する。
 """
 
 from __future__ import annotations
@@ -24,11 +27,12 @@ import re
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 CI_LOCK_PATH = Path("target/.ci-check.lock")
+COORDINATION_LOCK_PATH = Path("target/.ci-check.coordination.lock")
 LOCK_WAIT_TIMEOUT_SEC = 1800
 LOCK_POLL_INTERVAL_SEC = 1.0
 CI_COMMAND = ("./scripts/ci-check.sh", "ai", "dylint")
@@ -50,7 +54,14 @@ class AgentProfile:
 
 def main() -> int:
     args = parse_args()
-    profile = AGENT_PROFILES[args.agent]
+    profile = AGENT_PROFILES.get(args.agent)
+    if profile is None:
+        valid_agents = ", ".join(sorted(AGENT_PROFILES.keys()))
+        print(
+            f"未知のエージェント種別: {args.agent} (利用可能: {valid_agents})",
+            file=sys.stderr,
+        )
+        return 2
 
     payload = load_payload()
     if payload is None:
@@ -86,8 +97,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--agent",
         required=True,
-        choices=sorted(AGENT_PROFILES.keys()),
-        help="呼び出し元のエージェント種別",
+        help="呼び出し元のエージェント種別 (claude / codex)。未知の値は main() で検証する",
     )
     return parser.parse_args()
 
@@ -192,20 +202,31 @@ def resolve_repo_root(payload: dict[str, object]) -> Path | None:
 def run_auto_dylint(repo_root: Path, hook_lock_relative: Path, lock_label: str) -> None:
     repo_hook_lock_path = repo_root / hook_lock_relative
     repo_ci_lock_path = repo_root / CI_LOCK_PATH
+    repo_coordination_lock_path = repo_root / COORDINATION_LOCK_PATH
     repo_hook_lock_path.parent.mkdir(parents=True, exist_ok=True)
+    repo_coordination_lock_path.parent.mkdir(parents=True, exist_ok=True)
 
+    # 二段ロック構成:
+    #   1. per-agent lock: 同一エージェント内の hook 多重起動を直列化
+    #   2. coordination lock: エージェント横断 (Claude / Codex) の hook 同士を
+    #      直列化し、wait_for_lock_release と subprocess.run の間に別 hook が
+    #      割り込んで ci-check.sh を二重起動する TOCTOU を防ぐ
+    # ci-check.sh 自身の lockfile (target/.ci-check.lock) は noclobber で作成
+    # されるため、Python 側から直接 flock できない。代わりに別パスの
+    # coordination lock を使い、ci-check.sh の起動権を hook 同士で取り合う。
     with FileLock(repo_hook_lock_path, lock_label):
-        wait_for_lock_release(repo_ci_lock_path, "ci-check.sh")
-        completed = subprocess.run(
-            CI_COMMAND,
-            cwd=repo_root,
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-            env=build_ci_environment(),
-        )
+        with FileLock(repo_coordination_lock_path, "ci-check coordination"):
+            wait_for_lock_release(repo_ci_lock_path, "ci-check.sh")
+            completed = subprocess.run(
+                CI_COMMAND,
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+                env=build_ci_environment(),
+            )
 
     if completed.returncode == 0:
         return

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/run_dylint_after_rust_edit.py --agent claude",
+            "command": "/usr/bin/python3 \"$CLAUDE_PROJECT_DIR/.agents/hooks/run_dylint_after_rust_edit.py\" --agent claude",
             "timeout": 1800
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,19 @@
     "ask": [],
     "deny": []
   },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/run_dylint_after_rust_edit.py --agent claude"
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,7 +46,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/run_dylint_after_rust_edit.py --agent claude"
+            "command": "$CLAUDE_PROJECT_DIR/.agents/hooks/run_dylint_after_rust_edit.py --agent claude",
+            "timeout": 1800
           }
         ]
       }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -44,7 +44,7 @@ matcher = "^(apply_patch|Edit|Write)$"
 
 [[hooks.PostToolUse.hooks]]
 type = "command"
-command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.codex/hooks/run_dylint_after_rust_edit.py"'
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.agents/hooks/run_dylint_after_rust_edit.py" --agent codex'
 timeout = 1800
 statusMessage = "Rust 変更後の dylint を確認中"
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,9 @@ Cargo.lock
 
 /.claude/settings.local.json
 /.claude/scheduled_tasks.lock
+/.claude/dylint-hook.lock
 
+/.codex*/dylint-hook.lock
 /.codex*/cache/
 /.codex*/log/
 /.codex*/auth.json

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -55,7 +55,7 @@ CI_CHECK_GUARD_TIMEOUT_UNIT_SEC="${CI_CHECK_GUARD_TIMEOUT_UNIT_SEC:-}"
 CI_CHECK_GUARD_TIMEOUT_INTEGRATION_SEC="${CI_CHECK_GUARD_TIMEOUT_INTEGRATION_SEC:-}"
 CI_CHECK_GUARD_KILL_AFTER_SEC="${CI_CHECK_GUARD_KILL_AFTER_SEC:-15}"
 CI_CHECK_HANG_COOLDOWN_SEC="${CI_CHECK_HANG_COOLDOWN_SEC:-1800}"
-CI_CHECK_HANG_RECORD_FILE="${CI_CHECK_HANG_RECORD_FILE:-${REPO_ROOT}/.takt/.ci-check.last-hang}"
+CI_CHECK_HANG_RECORD_FILE="${CI_CHECK_HANG_RECORD_FILE:-${REPO_ROOT}/target/.ci-check.last-hang}"
 CI_CHECK_ALLOW_RERUN_AFTER_HANG="${CI_CHECK_ALLOW_RERUN_AFTER_HANG:-0}"
 export CI_CHECK_GUARD_TIMEOUT_SEC
 export CI_CHECK_GUARD_TIMEOUT_UNIT_SEC
@@ -1355,8 +1355,8 @@ run_all() {
 }
 
 main() {
-  mkdir -p "${REPO_ROOT}/.takt"
-  local lockfile="${REPO_ROOT}/.takt/.ci-check.lock"
+  mkdir -p "${REPO_ROOT}/target"
+  local lockfile="${REPO_ROOT}/target/.ci-check.lock"
   while true; do
     if ( set -o noclobber; printf '%s\n' "$$" > "${lockfile}" ) 2>/dev/null; then
       break


### PR DESCRIPTION
## 概要

Rust ソースコード (`*.rs`) 編集後に `./scripts/ci-check.sh ai dylint` を自動実行する PostToolUse hook を Claude Code でも有効化する。既存の Codex 用 hook (`.codex/hooks/run_dylint_after_rust_edit.py`) と差分が小さいため、`.agents/hooks/run_dylint_after_rust_edit.py` に統合し `--agent {claude|codex}` で挙動を切り替える設計に揃える。

## 変更内容

### Hook の統合と Claude Code 対応
- `.agents/hooks/run_dylint_after_rust_edit.py` を新設（旧 `.codex/hooks/...py` から rename + 拡張）
  - `--agent claude` / `--agent codex` でエージェント別差分を切り替え:
    - 入力 JSON 解析: Claude は `tool_input.file_path`、Codex は `apply_patch` コマンド本文と `file_path`/`path`/`target_file` の複数キー
    - 自身の hook ロックパス: `.claude/dylint-hook.lock` / `.codex/dylint-hook.lock`
    - 失敗時のブロック応答形式: Claude は stderr + exit 2、Codex は ``{should_block, reason}`` JSON + exit 2
  - 共通ロジック (ロック取得・ci-check.sh 待機・dylint 実行・失敗サマリ) は単一実装
- `.claude/settings.json` に `PostToolUse` matcher = `Edit|Write|MultiEdit` の hook を追加
- `.codex/config.toml` の hook コマンドを統合スクリプトへ向け直し（matcher などは現状維持）

### ci-check.sh ロックファイルの整理
- `scripts/ci-check.sh` の lockfile (`.ci-check.lock`) と hang record (`.ci-check.last-hang`) を `.takt/` から `target/` 配下に移動。`.takt/` は takt の中間生成物専用領域 (`CLAUDE.md` 参照) であり、CI 用ロックを混在させるべきではないため
- 統合 hook 側の `CI_LOCK_PATH` も `target/.ci-check.lock` を観測するよう更新

### .gitignore
- `/.claude/dylint-hook.lock` と `/.codex*/dylint-hook.lock` を追加（`target/` 配下は既存ルールでカバー済み）

## 動作確認

- `bash -n scripts/ci-check.sh` / `python3 -m py_compile .agents/hooks/run_dylint_after_rust_edit.py` 通過
- `./scripts/ci-check.sh --help` 起動時に `target/.ci-check.lock` が新パスで生成されることを確認
- 統合 hook の各種スモークテスト:
  - `--agent claude` / `--agent codex` × `.rs` 以外 → exit 0（早期 return）
  - `--agent claude` × invalid JSON → exit 2 + stderr メッセージ
  - `--agent codex` × invalid JSON → exit 2 + `{"should_block": true, "reason": ...}`
  - `--agent codex` × `apply_patch` 形式の `tool_input.command` → 既存ロジックのまま動作

## 補足

- 編集ごとに dylint を走らせる挙動はユーザー指示通り。連続編集に対しては hook 側のロックで直列化し、ci-check.sh の二重起動を抑止する
- README / CLAUDE.md / `.agents/rules/` に「毎回 dylint を実行しろ」系の AI/人間向け指示は元々存在しなかったため、ドキュメント側の削除はなし（`pr-green` skill 等の PR チェック文脈での dylint 言及は性質が異なるため残置）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect local developer tooling by auto-running `ci-check.sh` after Rust edits and altering lockfile locations; risk is mainly around concurrency/locking behavior and potential unexpected blocking of editor workflows.
> 
> **Overview**
> Rust ファイル編集後に `./scripts/ci-check.sh ai dylint` を自動実行する PostToolUse hook を **Claude Code と Codex で共通化**し、`--agent {claude|codex}` で入力解析・ロックパス・失敗時ブロック応答（stderr vs JSON）を切り替えるように変更しました。
> 
> hook 実行の排他制御を **二段ロック**（per-agent + `target/.ci-check.coordination.lock`）にして、`ci-check.sh` のロック解放待ち〜起動の間に別 hook が割り込む TOCTOU を抑止します。あわせて Claude/Codex の設定から新 hook を呼び出すよう更新し、`ci-check.sh` の lockfile と hang record を `.takt/` から `target/` 配下へ移動、関連 lock ファイルを `.gitignore` に追加しました。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b950941f4c86ec591a8a4c64c7a11013ec467a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 複数のエージェントに対応するようにdylintフックを再構築しました
  * エージェント別の設定構造を導入し、ロックファイルと出力形式を最適化しました
  * CI チェック関連のファイル保存場所を `target/` ディレクトリに統一しました

* **Chores**
  * `dylint-hook.lock` ファイルをgitignoreに追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->