### PR TITLE
docs(openspec): propose replace-exception-suffix-with-error change

### DIFF
--- a/.takt/facets/knowledge/pekko-porting.md
+++ b/.takt/facets/knowledge/pekko-porting.md
@@ -65,6 +65,7 @@ modules/{name}/src/
 |-------|-----------|-----|
 | `camelCase` メソッド | `snake_case` メソッド | `mapAsync` → `map_async` |
 | `PascalCase` 型 | `PascalCase` 型 | `Source` → `Source` |
+| `*Exception` 型 | `*Error` 型 | `DurableStateException` → `DurableStateError`, `ThrowableNotSerializableException` → `ThrowableNotSerializableError` |
 
 ※ 以前存在した `*Generic<TB>` サフィックスと型エイリアスのパターンは廃止済み。型は直接使用する。
 

--- a/.takt/facets/policies/fraktor-coding.md
+++ b/.takt/facets/policies/fraktor-coding.md
@@ -33,6 +33,7 @@ mod-file, module-wiring, type-per-file, tests-location, use-placement, rustdoc, 
 - Scala trait 階層 → Rust trait + 合成
 - Scala implicit → Rust ジェネリクスまたは通常の引数
 - sealed trait + case classes → enum
+- Java/Scala の `*Exception` 型 → Rust の `*Error` 型 (例: `ThrowableNotSerializableException` → `ThrowableNotSerializableError`)
 
 ## テストポリシー
 

--- a/docs/gap-analysis/persistence-gap-analysis.md
+++ b/docs/gap-analysis/persistence-gap-analysis.md
@@ -106,13 +106,13 @@ fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventso
 
 ### 5. Durable State store contract　✅ 実装済み 5/8 (63%)
 
-`DurableStateStore`、`DurableStateUpdateStore`、`DurableStateStoreProvider`、`DurableStateStoreRegistry`、`DurableStateException` は存在する。ただし Pekko の revision / tag を含む durable state write-side contract とはまだ差がある。
+`DurableStateStore`、`DurableStateUpdateStore`、`DurableStateStoreProvider`、`DurableStateStoreRegistry`、`DurableStateError` は存在する。ただし Pekko の revision / tag を含む durable state write-side contract とはまだ差がある。
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
 | `GetObjectResult[A]` | `state/scaladsl/DurableStateStore.scala:31`, `state/scaladsl/DurableStateStore.scala:35` | 未対応 | core/durable_state | trivial | 現状は `Option<A>` だけを返し、revision を保持しない |
 | revision / tag aware update store | `state/scaladsl/DurableStateUpdateStore.scala:37`, `state/scaladsl/DurableStateUpdateStore.scala:63` | 部分実装 | core/durable_state | medium | `upsert_object` と `delete_object` に revision / tag がない |
-| `DeleteRevisionException` | `state/exception/DurableStateException.scala:41` | 未対応 | core/durable_state | trivial | `DurableStateException` に revision mismatch 系の variant がない |
+| `DeleteRevisionException` | `state/exception/DurableStateException.scala:41` | 未対応 | core/durable_state | trivial | `DurableStateError` に revision mismatch 系の variant がない |
 
 ### 6. Plugin / extension / in-memory stores　✅ 実装済み 5/7 (71%)
 

--- a/docs/gap-analysis/remote-gap-analysis.md
+++ b/docs/gap-analysis/remote-gap-analysis.md
@@ -45,7 +45,7 @@
 | 固定スコープ概念カバレッジ | 約 33/54 (61%) |
 | raw public type declarations | 72（core: 52, std: 20） |
 | raw public method declarations | 254（core: 187, std: 67） |
-| hard / medium / easy / trivial gap | 8 / 8 / 1 / 0 |
+| hard / medium / easy / trivial gap | 8 / 8 / 0 / 0 |
 
 前回から改善された点は明確で、`remote-core` の公開境界は `core` に整理され、`DeadlineFailureDetector`、address-bound な `PhiAccrualFailureDetector`、`RemoteLogMarker`、`ListenStarted` event publish、association effects の lifecycle publish は実装済みになっている。
 
@@ -108,7 +108,7 @@
 | `MessageContainerSerializer` | `serialization/MessageContainerSerializer.scala:30` | 未対応 | actor-core/serialization | medium | actor selection message の remote payload 化がない |
 | `SystemMessageSerializer` | `serialization/SystemMessageSerializer.scala:22` | 未対応 | actor-core/serialization | medium | Watch / Unwatch / DeathWatchNotification / Terminate の serializer がない |
 | `MiscMessageSerializer` subset | `serialization/MiscMessageSerializer.scala:37` | 部分実装 | actor-core/serialization + core/wire | medium | `Address` / `UniqueAddress` はあるが、Identify / ActorIdentity / `RemoteRouterConfig` などの manifest 対応がない |
-| `ThrowableNotSerializableException` | `serialization/ThrowableNotSerializableException.scala:22` | 未対応 | actor-core/serialization | easy | 例外型追加で閉じる小さい差分 |
+| `ThrowableNotSerializableException` | `serialization/ThrowableNotSerializableException.scala:22` | 対応済み (新名 `ThrowableNotSerializableError`) | actor-core/serialization | easy | 対応済み。Rust 慣習に合わせ `*Error` 命名 |
 | Artery compression protocol (`CompressionProtocol`, `CompressionTable`, `InboundCompressions`, `TopHeavyHitters`) | `artery/compress/*`, `artery/Codecs.scala` | 未対応 | core/wire + core/association | hard | wire protocol 上の actor ref / manifest compression がごっそり未実装 |
 
 ### 5. Provider / remote actor ref / routing　✅ 実装済み 3/8 (38%)
@@ -156,12 +156,6 @@
 | Java serialization / Jackson module | serializer contract との接続点だけ対象 |
 
 ## 実装優先度
-
-### Phase 1: trivial / easy
-
-| 項目 | 実装先層 | 根拠 |
-|------|----------|------|
-| `ThrowableNotSerializableException` 相当 | actor-core/serialization | カテゴリ4 |
 
 ### Phase 2: medium
 

--- a/modules/actor-core/src/core/kernel/serialization.rs
+++ b/modules/actor-core/src/core/kernel/serialization.rs
@@ -25,7 +25,7 @@ mod serializer;
 mod serializer_id;
 mod serializer_id_error;
 mod string_manifest_serializer;
-mod throwable_not_serializable_exception;
+mod throwable_not_serializable_error;
 mod transport_information;
 
 pub use async_serializer::{AsyncSerializer, SerializationFuture};
@@ -49,5 +49,5 @@ pub use serializer::Serializer;
 pub use serializer_id::SerializerId;
 pub use serializer_id_error::SerializerIdError;
 pub use string_manifest_serializer::SerializerWithStringManifest;
-pub use throwable_not_serializable_exception::ThrowableNotSerializableException;
+pub use throwable_not_serializable_error::ThrowableNotSerializableError;
 pub use transport_information::TransportInformation;

--- a/modules/actor-core/src/core/kernel/serialization/error/tests.rs
+++ b/modules/actor-core/src/core/kernel/serialization/error/tests.rs
@@ -2,7 +2,7 @@ use alloc::{format, string::String};
 
 use super::SerializationError;
 use crate::core::kernel::serialization::{
-  ThrowableNotSerializableException, call_scope::SerializationCallScope, not_serializable_error::NotSerializableError,
+  ThrowableNotSerializableError, call_scope::SerializationCallScope, not_serializable_error::NotSerializableError,
   serializer_id::SerializerId,
 };
 
@@ -88,17 +88,17 @@ fn is_methods_return_correct_values() {
 }
 
 #[test]
-fn throwable_not_serializable_exception_preserves_original_message_and_class_name() {
+fn throwable_not_serializable_error_preserves_original_message_and_class_name() {
   let payload =
-    ThrowableNotSerializableException::new(String::from("serialization failed"), String::from("example::BrokenError"));
+    ThrowableNotSerializableError::new(String::from("serialization failed"), String::from("example::BrokenError"));
 
   assert_eq!(payload.original_message(), "serialization failed");
   assert_eq!(payload.original_class_name(), "example::BrokenError");
 }
 
 #[test]
-fn throwable_not_serializable_exception_is_cloneable_value_payload() {
-  let payload = ThrowableNotSerializableException::new(String::from("boom"), String::from("example::BrokenError"));
+fn throwable_not_serializable_error_is_cloneable_value_payload() {
+  let payload = ThrowableNotSerializableError::new(String::from("boom"), String::from("example::BrokenError"));
 
   let cloned = payload.clone();
 

--- a/modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_error.rs
+++ b/modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_error.rs
@@ -4,12 +4,12 @@ use alloc::string::String;
 
 /// Replacement payload used when an original throwable cannot be serialized.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ThrowableNotSerializableException {
+pub struct ThrowableNotSerializableError {
   original_message:    String,
   original_class_name: String,
 }
 
-impl ThrowableNotSerializableException {
+impl ThrowableNotSerializableError {
   /// Creates a replacement payload for the original throwable.
   #[must_use]
   pub fn new(original_message: impl Into<String>, original_class_name: impl Into<String>) -> Self {

--- a/modules/persistence-core/src/core.rs
+++ b/modules/persistence-core/src/core.rs
@@ -3,7 +3,7 @@
 mod at_least_once_delivery;
 mod at_least_once_delivery_config;
 mod at_least_once_delivery_snapshot;
-mod durable_state_exception;
+mod durable_state_error;
 mod durable_state_store;
 mod durable_state_store_provider;
 mod durable_state_store_registry;
@@ -60,7 +60,7 @@ mod write_event_adapter;
 pub use at_least_once_delivery::AtLeastOnceDelivery;
 pub use at_least_once_delivery_config::AtLeastOnceDeliveryConfig;
 pub use at_least_once_delivery_snapshot::AtLeastOnceDeliverySnapshot;
-pub use durable_state_exception::DurableStateException;
+pub use durable_state_error::DurableStateError;
 pub use durable_state_store::DurableStateStore;
 pub use durable_state_store_provider::DurableStateStoreProvider;
 pub use durable_state_store_registry::DurableStateStoreRegistry;

--- a/modules/persistence-core/src/core/durable_state_error.rs
+++ b/modules/persistence-core/src/core/durable_state_error.rs
@@ -8,7 +8,7 @@ use core::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Errors returned by durable state store operations.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum DurableStateException {
+pub enum DurableStateError {
   /// Failed to load a durable state object.
   GetObjectFailed(String),
   /// Failed to persist a durable state object.
@@ -23,7 +23,7 @@ pub enum DurableStateException {
   ProviderNotFound(String),
 }
 
-impl DurableStateException {
+impl DurableStateError {
   /// Creates a provider duplicate error.
   #[must_use]
   pub fn provider_already_registered(id: impl Into<String>) -> Self {
@@ -37,7 +37,7 @@ impl DurableStateException {
   }
 }
 
-impl Display for DurableStateException {
+impl Display for DurableStateError {
   fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
     match self {
       | Self::GetObjectFailed(reason) => write!(formatter, "get durable state object failed: {}", reason),

--- a/modules/persistence-core/src/core/durable_state_error/tests.rs
+++ b/modules/persistence-core/src/core/durable_state_error/tests.rs
@@ -3,42 +3,42 @@ use alloc::string::ToString;
 use crate::core::durable_state_error::DurableStateError;
 
 #[test]
-fn durable_state_exception_display_get_object_failed() {
+fn durable_state_error_display_get_object_failed() {
   let error = DurableStateError::GetObjectFailed("missing".into());
 
   assert_eq!(error.to_string(), "get durable state object failed: missing");
 }
 
 #[test]
-fn durable_state_exception_display_upsert_object_failed() {
+fn durable_state_error_display_upsert_object_failed() {
   let error = DurableStateError::UpsertObjectFailed("version conflict".into());
 
   assert_eq!(error.to_string(), "upsert durable state object failed: version conflict");
 }
 
 #[test]
-fn durable_state_exception_display_delete_object_failed() {
+fn durable_state_error_display_delete_object_failed() {
   let error = DurableStateError::DeleteObjectFailed("permission denied".into());
 
   assert_eq!(error.to_string(), "delete durable state object failed: permission denied");
 }
 
 #[test]
-fn durable_state_exception_display_changes_failed() {
+fn durable_state_error_display_changes_failed() {
   let error = DurableStateError::ChangesFailed("stream closed".into());
 
   assert_eq!(error.to_string(), "durable state changes failed: stream closed");
 }
 
 #[test]
-fn durable_state_exception_display_provider_already_registered() {
+fn durable_state_error_display_provider_already_registered() {
   let error = DurableStateError::provider_already_registered("in-memory");
 
   assert_eq!(error.to_string(), "durable state provider 'in-memory' already exists");
 }
 
 #[test]
-fn durable_state_exception_display_provider_not_found() {
+fn durable_state_error_display_provider_not_found() {
   let error = DurableStateError::provider_not_found("missing-provider");
 
   assert_eq!(error.to_string(), "durable state provider 'missing-provider' not found");

--- a/modules/persistence-core/src/core/durable_state_error/tests.rs
+++ b/modules/persistence-core/src/core/durable_state_error/tests.rs
@@ -1,45 +1,45 @@
 use alloc::string::ToString;
 
-use crate::core::durable_state_exception::DurableStateException;
+use crate::core::durable_state_error::DurableStateError;
 
 #[test]
 fn durable_state_exception_display_get_object_failed() {
-  let error = DurableStateException::GetObjectFailed("missing".into());
+  let error = DurableStateError::GetObjectFailed("missing".into());
 
   assert_eq!(error.to_string(), "get durable state object failed: missing");
 }
 
 #[test]
 fn durable_state_exception_display_upsert_object_failed() {
-  let error = DurableStateException::UpsertObjectFailed("version conflict".into());
+  let error = DurableStateError::UpsertObjectFailed("version conflict".into());
 
   assert_eq!(error.to_string(), "upsert durable state object failed: version conflict");
 }
 
 #[test]
 fn durable_state_exception_display_delete_object_failed() {
-  let error = DurableStateException::DeleteObjectFailed("permission denied".into());
+  let error = DurableStateError::DeleteObjectFailed("permission denied".into());
 
   assert_eq!(error.to_string(), "delete durable state object failed: permission denied");
 }
 
 #[test]
 fn durable_state_exception_display_changes_failed() {
-  let error = DurableStateException::ChangesFailed("stream closed".into());
+  let error = DurableStateError::ChangesFailed("stream closed".into());
 
   assert_eq!(error.to_string(), "durable state changes failed: stream closed");
 }
 
 #[test]
 fn durable_state_exception_display_provider_already_registered() {
-  let error = DurableStateException::provider_already_registered("in-memory");
+  let error = DurableStateError::provider_already_registered("in-memory");
 
   assert_eq!(error.to_string(), "durable state provider 'in-memory' already exists");
 }
 
 #[test]
 fn durable_state_exception_display_provider_not_found() {
-  let error = DurableStateException::provider_not_found("missing-provider");
+  let error = DurableStateError::provider_not_found("missing-provider");
 
   assert_eq!(error.to_string(), "durable state provider 'missing-provider' not found");
 }

--- a/modules/persistence-core/src/core/durable_state_store.rs
+++ b/modules/persistence-core/src/core/durable_state_store.rs
@@ -3,10 +3,10 @@
 use alloc::boxed::Box;
 use core::{future::Future, pin::Pin};
 
-use crate::core::durable_state_exception::DurableStateException;
+use crate::core::durable_state_error::DurableStateError;
 
 pub(crate) type DurableStateStoreFuture<'a, T> =
-  Pin<Box<dyn Future<Output = Result<T, DurableStateException>> + Send + 'a>>;
+  Pin<Box<dyn Future<Output = Result<T, DurableStateError>> + Send + 'a>>;
 
 /// Durable state store abstraction using object-safe boxed futures.
 pub trait DurableStateStore<A: Send>: Send + Sync + 'static {

--- a/modules/persistence-core/src/core/durable_state_store_registry.rs
+++ b/modules/persistence-core/src/core/durable_state_store_registry.rs
@@ -12,7 +12,7 @@ use alloc::{
 use fraktor_utils_core_rs::core::sync::ArcShared;
 
 use crate::core::{
-  durable_state_exception::DurableStateException, durable_state_store::DurableStateStore,
+  durable_state_error::DurableStateError, durable_state_store::DurableStateStore,
   durable_state_store_provider::DurableStateStoreProvider,
 };
 
@@ -32,16 +32,16 @@ impl<A: Send + 'static> DurableStateStoreRegistry<A> {
   ///
   /// # Errors
   ///
-  /// Returns [`DurableStateException::ProviderAlreadyRegistered`] when the identifier already
+  /// Returns [`DurableStateError::ProviderAlreadyRegistered`] when the identifier already
   /// exists.
   pub fn register(
     &mut self,
     provider_id: impl Into<String>,
     provider: ArcShared<dyn DurableStateStoreProvider<A>>,
-  ) -> Result<(), DurableStateException> {
+  ) -> Result<(), DurableStateError> {
     let provider_id = provider_id.into();
     match self.providers.entry(provider_id) {
-      | Entry::Occupied(entry) => Err(DurableStateException::provider_already_registered(entry.key().clone())),
+      | Entry::Occupied(entry) => Err(DurableStateError::provider_already_registered(entry.key().clone())),
       | Entry::Vacant(entry) => {
         entry.insert(provider);
         Ok(())
@@ -53,10 +53,9 @@ impl<A: Send + 'static> DurableStateStoreRegistry<A> {
   ///
   /// # Errors
   ///
-  /// Returns [`DurableStateException::ProviderNotFound`] when the identifier does not exist.
-  pub fn resolve(&self, provider_id: &str) -> Result<Box<dyn DurableStateStore<A>>, DurableStateException> {
-    let provider =
-      self.providers.get(provider_id).ok_or_else(|| DurableStateException::provider_not_found(provider_id))?;
+  /// Returns [`DurableStateError::ProviderNotFound`] when the identifier does not exist.
+  pub fn resolve(&self, provider_id: &str) -> Result<Box<dyn DurableStateStore<A>>, DurableStateError> {
+    let provider = self.providers.get(provider_id).ok_or_else(|| DurableStateError::provider_not_found(provider_id))?;
     Ok(provider.durable_state_store())
   }
 }

--- a/modules/persistence-core/src/core/durable_state_store_registry/tests.rs
+++ b/modules/persistence-core/src/core/durable_state_store_registry/tests.rs
@@ -13,7 +13,7 @@ use core::{
 use fraktor_utils_core_rs::core::sync::ArcShared;
 
 use crate::core::{
-  durable_state_exception::DurableStateException, durable_state_store::DurableStateStore,
+  durable_state_error::DurableStateError, durable_state_store::DurableStateStore,
   durable_state_store_provider::DurableStateStoreProvider, durable_state_store_registry::DurableStateStoreRegistry,
   durable_state_update_store::DurableStateUpdateStore,
 };
@@ -22,7 +22,7 @@ const TEST_PROVIDER_ID: &str = "in-memory";
 const TEST_PERSISTENCE_ID: &str = "persistence-1";
 const TEST_UNKNOWN_PROVIDER_ID: &str = "missing-provider";
 
-type DurableStateFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, DurableStateException>> + Send + 'a>>;
+type DurableStateFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, DurableStateError>> + Send + 'a>>;
 
 #[derive(Default)]
 struct TestDurableStateStore {
@@ -118,7 +118,7 @@ fn register_duplicate_provider_fails() {
   registry.register(TEST_PROVIDER_ID, provider.clone()).expect("first register provider");
 
   let result = registry.register(TEST_PROVIDER_ID, provider);
-  assert_eq!(result, Err(DurableStateException::ProviderAlreadyRegistered(TEST_PROVIDER_ID.to_string())));
+  assert_eq!(result, Err(DurableStateError::ProviderAlreadyRegistered(TEST_PROVIDER_ID.to_string())));
 }
 
 #[test]
@@ -126,7 +126,7 @@ fn resolve_unknown_provider_fails() {
   let registry = DurableStateStoreRegistry::<i32>::empty();
 
   let result = registry.resolve(TEST_UNKNOWN_PROVIDER_ID);
-  assert_eq!(result.err(), Some(DurableStateException::ProviderNotFound(TEST_UNKNOWN_PROVIDER_ID.to_string())));
+  assert_eq!(result.err(), Some(DurableStateError::ProviderNotFound(TEST_UNKNOWN_PROVIDER_ID.to_string())));
 }
 
 #[test]

--- a/openspec/changes/replace-exception-suffix-with-error/design.md
+++ b/openspec/changes/replace-exception-suffix-with-error/design.md
@@ -1,0 +1,60 @@
+## 設計判断
+
+### 新名
+
+| 旧名 | 新名 | 採用理由 |
+|------|------|----------|
+| `ThrowableNotSerializableException` | `ThrowableNotSerializableError` | `Throwable` 接頭辞は Pekko 元概念識別 (元 throwable の代替 payload という役割) のため保持。`*Error` で Rust 慣習に揃える |
+| `DurableStateException` | `DurableStateError` | Pekko `DurableStateException.scala` を直接参照する identity 識別子として `DurableState` を保持。`*Error` 接尾辞で慣習合わせ |
+
+### Pekko 互換性との整合
+
+両型とも Pekko 側に同名の class が存在する (`org.apache.pekko.remote.serialization.ThrowableNotSerializableException` / `org.apache.pekko.persistence.state.exception.DurableStateException`)。Rust 側で `*Error` に改名することで JVM 識別子と完全一致しなくなるが、fraktor-rs は wire 互換 (`SerializerId` / manifest など) のレベルで Pekko 互換を取る方針であり、Rust 識別子そのものを Pekko に合わせる意図はない。`Throwable` / `DurableState` 接頭辞を保持することで Pekko 由来であることは引き続き辿れる。
+
+### `Throwable` 接頭辞を残す根拠
+
+`ThrowableNotSerializableError` における `Throwable` は「元 throwable (Pekko / Java の Throwable インスタンス) を serialize できなかったことを示す代替 payload」という具体的な役割を識別する語として機能する。`NotSerializableError` (既存、別物) は serializer が serialize 不能と判定した汎用エラー型であり、本型と責務が異なる。`Throwable` を落とすと両者を識別できなくなるため保持する。
+
+将来「Java/JVM 概念依存の名前を Rust 概念に置き換える」検討を行う場合は、`SerializationFallbackPayload` 等への再 rename を別 change で扱う余地がある (本 change の Non-Goals)。
+
+### テスト関数名の扱い
+
+`throwable_not_serializable_exception_preserves_original_message_and_class_name` のようなテスト関数名 (現在 2 件) は型名 rename と同時に `throwable_not_serializable_error_*` に揃える。テスト関数名は型名と直結するため、片方だけ残すと grep ナビゲーションで noise になる。tasks.md で同時改名を明記する。
+
+`durable_state_exception/tests.rs` 内のテスト関数 (`fn xxx_failed_*` など) は型名を含まない命名のため改名不要。
+
+### gap analysis 表記の更新範囲
+
+`docs/gap-analysis/remote-gap-analysis.md` 内で `ThrowableNotSerializableException` を参照している箇所:
+- L111 (Pekko 側参照): `ThrowableNotSerializableException.scala:22` という Pekko ファイル名はそのまま (Pekko の識別子)。fraktor-rs 対応列の表記を「未対応」→「対応済み (新名 `ThrowableNotSerializableError`)」に変更。
+- L164 (Phase 1 trivial/easy 表): `ThrowableNotSerializableException` 相当 → `ThrowableNotSerializableError` 相当に更新、もしくは Phase 1 から外す (実装済みのため)。
+
+`DurableStateException` は `docs/gap-analysis/remote-gap-analysis.md` には登場しないため gap analysis 側の更新は ThrowableNotSerializable 側のみで完結する。
+
+### dylint との関係
+
+現状 `ambiguous-suffix-lint` は `Manager` / `Util` / `Facade` / `Service` / `Runtime` / `Engine` を対象としており、`Exception` は含まれていない (`.agents/rules/rust/naming-conventions.md`)。本 change で `*Exception` を一掃した後、再発防止として `Exception` を ambiguous suffix lint の禁止リストに追加するかは別途検討する (本 change のスコープ外、Non-Goals)。
+
+### takt 変換ルール文書の更新
+
+調査の結果、Scala/Pekko → Rust の命名変換ルール文書 2 箇所に `*Exception` → `*Error` の対応が **欠落** していた:
+
+- `.takt/facets/policies/fraktor-coding.md` 「Pekko → Rust 変換ルール」セクション (line 31-35): `Scala trait → Rust trait`、`Scala implicit → ジェネリクス`、`sealed trait → enum` のみ列挙され、`*Exception` 型 → `*Error` 型の対応が無い
+- `.takt/facets/knowledge/pekko-porting.md` 「命名規約」表 (line 62-68): `camelCase → snake_case` (メソッド)、`PascalCase → PascalCase` (型) のみ列挙され、`*Exception` → `*Error` の対応が無い
+
+両者とも本 change の本質的な動機 (Java/Scala 由来 `*Exception` を Rust 慣習の `*Error` に揃える) を新規 porting 作業に伝播するための 1 次資料であるため、本 change の tasks に記載追加を含める。これにより以後の Pekko porting で `*Exception` 型がそのまま Rust 側に再導入される事故を防ぐ。
+
+`.agents/rules/rust/naming-conventions.md` の禁止サフィックス表への追加は **dylint `ambiguous-suffix-lint` の拡張とセットで扱うべき** (機械強制の伴わないルール追加だけだと inconsistent になる) ため、本 change では触らず Non-Goals とする。
+
+### 移行戦略
+
+- 後方互換 alias (例: `pub use ThrowableNotSerializableError as ThrowableNotSerializableException;`) は提供しない。CLAUDE.md「後方互換は不要 (破壊的変更を恐れずに最適な設計を追求すること)」「リリース状況: まだ正式リリース前の開発フェーズ」方針に基づき、新名のみを残す。
+- 各 rename は「ファイル mv → 型名置換 → import 更新」の順序で 1 型ずつ完結させる (依存最小)。両型は別モジュール / 別 crate に独立しているため相互依存はなく、順序入れ替えも可能。
+
+## 影響範囲
+
+| crate | rename 対象ファイル | 参照更新ファイル |
+|-------|-------------------|-----------------|
+| `fraktor-actor-core-rs` | `serialization/throwable_not_serializable_exception.rs` | `serialization.rs` (mod / pub use)、`serialization/error/tests.rs` |
+| `fraktor-persistence-core-rs` | `core/durable_state_exception.rs`、`core/durable_state_exception/` (tests dir) | `core.rs` (mod / pub use)、`core/durable_state_store.rs`、`core/durable_state_store_registry.rs`、`core/durable_state_store_registry/tests.rs` |
+| `docs/` | (なし) | `docs/gap-analysis/remote-gap-analysis.md` |

--- a/openspec/changes/replace-exception-suffix-with-error/proposal.md
+++ b/openspec/changes/replace-exception-suffix-with-error/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Rust ではエラー型を `*Error` 接尾辞で命名するのが標準慣習であり、`std::io::Error`、`serde::de::Error`、`Box<dyn std::error::Error>` などエコシステム全体がこの形に揃っている。一方、fraktor-rs には Pekko / Java 由来の名前をそのまま移植した結果、`*Exception` 接尾辞の公開エラー型が 2 件残存している:
+
+- `actor-core` の `ThrowableNotSerializableException` (`modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_exception.rs`)
+- `persistence-core` の `DurableStateException` (`modules/persistence-core/src/core/durable_state_exception.rs`)
+
+両者とも周辺の Rust 側エラー型 (`NotSerializableError`、`SerializationError`、`SerializerIdError`、`SerializationBuilderError` など) は既に `*Error` 命名で揃っており、この 2 件だけが浮いている。さらに `docs/gap-analysis/remote-gap-analysis.md` の Phase 1 (trivial / easy) でも `ThrowableNotSerializableException` 相当として gap が立っているが、実装は既に存在しており残るのは命名整合のみ。
+
+本 change は Rust 慣習および周辺型と整合させるため、公開エラー型から `*Exception` 接尾辞を一掃する。
+
+## What Changes
+
+### 型・ファイル・モジュールの rename
+
+| Before | After |
+|--------|-------|
+| `ThrowableNotSerializableException` (struct) | `ThrowableNotSerializableError` |
+| `throwable_not_serializable_exception.rs` | `throwable_not_serializable_error.rs` |
+| `DurableStateException` (enum) | `DurableStateError` |
+| `durable_state_exception.rs` | `durable_state_error.rs` |
+| `durable_state_exception/` (tests dir) | `durable_state_error/` |
+
+`Throwable` 接頭辞は Pekko 元概念 (Java `Throwable` を serialize できなかった代替 payload) を識別する語として保持する。Rust に `Throwable` 概念は存在しないが、Pekko 互換層 serialization 側で「元 throwable の class name + message を保持する代替」という役割を端的に表す語として有用。
+
+### 参照箇所の追従更新
+
+- `modules/actor-core/src/core/kernel/serialization.rs` の `mod` / `pub use` 宣言
+- `modules/actor-core/src/core/kernel/serialization/error/tests.rs` の import / コンストラクタ呼び出し (3 箇所)
+- `modules/persistence-core/src/core.rs` の `mod` / `pub use` 宣言
+- `modules/persistence-core/src/core/durable_state_store.rs` の `Result<T, DurableStateException>` シグネチャ (2 箇所)
+- `modules/persistence-core/src/core/durable_state_store_registry.rs` の import / 戻り値型 / ファクトリ呼び出し (5 箇所)
+- `modules/persistence-core/src/core/durable_state_store_registry/tests.rs` (4 箇所)
+- `modules/persistence-core/src/core/durable_state_error/tests.rs` (移動後・7 箇所、import + assert)
+
+### gap analysis 表記の同期
+
+- `docs/gap-analysis/remote-gap-analysis.md` Phase 1 表の `ThrowableNotSerializableException` 相当行を「対応済み (新名 `ThrowableNotSerializableError`)」に更新
+- 表中の他箇所 (line 111) の `ThrowableNotSerializableException` 言及も新名に同期
+
+### BREAKING
+
+両型とも `pub` 公開のため workspace 外利用者がいる場合は破壊的変更になる。fraktor-rs は正式リリース前 (CLAUDE.md「リリース状況」参照) であり、後方互換は不要との方針が定められているため新名のみを残す。
+
+### Non-Goals
+
+- `actor-core/serialization` 全体の error 型再編 (例: `NotSerializableError` と `ThrowableNotSerializableError` の責務再整理) は対象外。本 change は単独の rename と命名整合に閉じる。
+- `DurableStateException` の variant 名 (`GetObjectFailed`、`UpsertObjectFailed`、`DeleteObjectFailed`、`ChangesFailed`、`ProviderAlreadyRegistered`、`ProviderNotFound`) の見直しは対象外。`Failed` 接尾辞は variant としては許容範囲とし、本 change では型名のみ整える。
+- `*Exception` 接尾辞の **テスト関数名** (`throwable_not_serializable_exception_preserves_*` 等) は本 change の対象外とするか、`*_error_*` に揃えて改名するかを design.md で決定する。

--- a/openspec/changes/replace-exception-suffix-with-error/tasks.md
+++ b/openspec/changes/replace-exception-suffix-with-error/tasks.md
@@ -28,7 +28,6 @@
   - 同ファイル内のテスト関数名 `throwable_not_serializable_exception_is_cloneable_value_payload` → `throwable_not_serializable_error_is_cloneable_value_payload`
 - [ ] 2.5 `cargo build -p fraktor-actor-core-rs` 通過確認
 - [ ] 2.6 `cargo test -p fraktor-actor-core-rs` pass 確認 (rename 済みテスト関数 2 件含む)
-- [ ] 2.7 `./scripts/ci-check.sh ai dylint -m fraktor-actor-core-rs` pass 確認 (mod-file / type-per-file / use-placement 等の lint が rename に追従していること)
 
 ## 3. Phase 2 — `DurableStateException` → `DurableStateError`
 
@@ -62,7 +61,6 @@
   - L121 / L129 の `DurableStateException::*` バリアント参照 → `DurableStateError::*`
 - [ ] 3.8 `cargo build -p fraktor-persistence-core-rs` 通過確認
 - [ ] 3.9 `cargo test -p fraktor-persistence-core-rs` pass 確認
-- [ ] 3.10 `./scripts/ci-check.sh ai dylint -m fraktor-persistence-core-rs` pass 確認
 
 ## 4. Phase 3 — gap analysis 同期
 
@@ -87,7 +85,7 @@
 ## 6. Phase 5 — final-ci
 
 - [ ] 6.1 ワークスペース全体の参照漏れ最終確認: `rg -n '\bThrowableNotSerializableException\b|\bDurableStateException\b' modules/ src/ docs/ .takt/facets/ openspec/specs/ openspec/changes/` の出力が、本 change 自身の proposal/design/tasks 内記述および Pekko 側 `.scala` ファイル名の言及だけになっていることを確認
-- [ ] 6.2 `./scripts/ci-check.sh ai all` を実行して fmt / dylint / clippy / no-std / doc / unit-test / integration-test 全て pass
+- [ ] 6.2 `./scripts/ci-check.sh ai all` を実行して fmt / clippy / no-std / doc / unit-test / integration-test 全て pass
 - [ ] 6.3 マージ後、別 PR で本 change を archive + main spec sync (本 change は specs delta を持たないため sync 対象は無し)
 
 ## 7. レビュー対応 / 後追い

--- a/openspec/changes/replace-exception-suffix-with-error/tasks.md
+++ b/openspec/changes/replace-exception-suffix-with-error/tasks.md
@@ -84,8 +84,8 @@
 
 ## 6. Phase 5 — final-ci
 
-- [ ] 6.1 ワークスペース全体の参照漏れ最終確認: `rg -n '\bThrowableNotSerializableException\b|\bDurableStateException\b' modules/ src/ docs/ .takt/facets/ openspec/specs/ openspec/changes/` の出力が、本 change 自身の proposal/design/tasks 内記述および Pekko 側 `.scala` ファイル名の言及だけになっていることを確認
-- [ ] 6.2 `./scripts/ci-check.sh ai all` を実行して fmt / clippy / no-std / doc / unit-test / integration-test 全て pass
+- [x] 6.1 ワークスペース全体の参照漏れ最終確認: `rg -n '\bThrowableNotSerializableException\b|\bDurableStateException\b' modules/ src/ docs/ .takt/facets/ openspec/specs/ openspec/changes/` の出力が、本 change 自身の proposal/design/tasks 内記述および Pekko 側 `.scala` ファイル名の言及だけになっていることを確認
+- [x] 6.2 `./scripts/ci-check.sh ai all` を実行して fmt / clippy / no-std / doc / unit-test / integration-test 全て pass
 - [ ] 6.3 マージ後、別 PR で本 change を archive + main spec sync (本 change は specs delta を持たないため sync 対象は無し)
 
 ## 7. レビュー対応 / 後追い

--- a/openspec/changes/replace-exception-suffix-with-error/tasks.md
+++ b/openspec/changes/replace-exception-suffix-with-error/tasks.md
@@ -1,0 +1,96 @@
+## 1. 事前確認
+
+- [ ] 1.1 `cargo test -p fraktor-actor-core-rs` ベースライン pass を確認 (rename 前)
+- [ ] 1.2 `cargo test -p fraktor-persistence-core-rs` ベースライン pass を確認 (rename 前)
+- [ ] 1.3 `rg -n 'pub (struct|enum|trait|type) \w+Exception\b' modules/ src/` で対象が以下 2 件のみであることを再確認
+  - `modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_exception.rs:7` の `ThrowableNotSerializableException`
+  - `modules/persistence-core/src/core/durable_state_exception.rs:11` の `DurableStateException`
+- [ ] 1.4 `rg -n '\bThrowableNotSerializableException\b' modules/ src/ openspec/specs/` で参照が `actor-core` 内 4 箇所 (定義 1 + impl 1 + pub use 1 + tests 3) に閉じることを確認
+- [ ] 1.5 `rg -n '\bDurableStateException\b' modules/ src/ openspec/specs/` で参照が `persistence-core` 内のみ (定義 / impl / pub use / store / registry / tests の合計 18 箇所程度) に閉じることを確認
+
+## 2. Phase 1 — `ThrowableNotSerializableException` → `ThrowableNotSerializableError`
+
+依存関係: 単一 crate (`fraktor-actor-core-rs`) 内に閉じている。`pub use` 経由で公開されているが workspace 外の参照は無し。
+
+- [ ] 2.1 ファイルリネーム: `git mv modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_exception.rs modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_error.rs`
+- [ ] 2.2 リネーム後ファイルの中身を更新:
+  - 構造体名 `ThrowableNotSerializableException` → `ThrowableNotSerializableError`
+  - `impl ThrowableNotSerializableException` → `impl ThrowableNotSerializableError`
+  - 冒頭 `//!` モジュール doc は内容に変化がなければ据え置き
+- [ ] 2.3 `modules/actor-core/src/core/kernel/serialization.rs` を更新:
+  - `mod throwable_not_serializable_exception;` → `mod throwable_not_serializable_error;`
+  - `pub use throwable_not_serializable_exception::ThrowableNotSerializableException;` → `pub use throwable_not_serializable_error::ThrowableNotSerializableError;`
+- [ ] 2.4 `modules/actor-core/src/core/kernel/serialization/error/tests.rs` を更新:
+  - L5 の import: `ThrowableNotSerializableException,` → `ThrowableNotSerializableError,`
+  - L93 の `ThrowableNotSerializableException::new(...)` → `ThrowableNotSerializableError::new(...)`
+  - L101 の `ThrowableNotSerializableException::new(...)` → `ThrowableNotSerializableError::new(...)`
+  - 同ファイル内のテスト関数名 `throwable_not_serializable_exception_preserves_original_message_and_class_name` → `throwable_not_serializable_error_preserves_original_message_and_class_name`
+  - 同ファイル内のテスト関数名 `throwable_not_serializable_exception_is_cloneable_value_payload` → `throwable_not_serializable_error_is_cloneable_value_payload`
+- [ ] 2.5 `cargo build -p fraktor-actor-core-rs` 通過確認
+- [ ] 2.6 `cargo test -p fraktor-actor-core-rs` pass 確認 (rename 済みテスト関数 2 件含む)
+- [ ] 2.7 `./scripts/ci-check.sh ai dylint -m fraktor-actor-core-rs` pass 確認 (mod-file / type-per-file / use-placement 等の lint が rename に追従していること)
+
+## 3. Phase 2 — `DurableStateException` → `DurableStateError`
+
+依存関係: 単一 crate (`fraktor-persistence-core-rs`) 内に閉じている。Phase 1 とは独立。
+
+- [ ] 3.1 ファイル / ディレクトリリネーム:
+  - `git mv modules/persistence-core/src/core/durable_state_exception.rs modules/persistence-core/src/core/durable_state_error.rs`
+  - `git mv modules/persistence-core/src/core/durable_state_exception modules/persistence-core/src/core/durable_state_error` (tests ディレクトリ)
+- [ ] 3.2 リネーム後ファイル `modules/persistence-core/src/core/durable_state_error.rs` を更新:
+  - `pub enum DurableStateException` → `pub enum DurableStateError`
+  - `impl DurableStateException` → `impl DurableStateError`
+  - `impl Display for DurableStateException` → `impl Display for DurableStateError`
+  - その他 `Self` を使っていない自己参照箇所すべて
+- [ ] 3.3 `modules/persistence-core/src/core/durable_state_error/tests.rs` (旧 `durable_state_exception/tests.rs`) を更新:
+  - L3 の `use crate::core::durable_state_exception::DurableStateException;` → `use crate::core::durable_state_error::DurableStateError;`
+  - L7 / L14 / L21 / L28 / L35 / L42 の `DurableStateException::*` 呼び出し全てを `DurableStateError::*` に
+- [ ] 3.4 `modules/persistence-core/src/core.rs` を更新:
+  - `pub use durable_state_exception::DurableStateException;` 周辺の `mod` / `pub use` を `durable_state_error::DurableStateError` に書き換え
+- [ ] 3.5 `modules/persistence-core/src/core/durable_state_store.rs` を更新:
+  - `use crate::core::durable_state_exception::DurableStateException;` → `use crate::core::durable_state_error::DurableStateError;`
+  - `Pin<Box<dyn Future<Output = Result<T, DurableStateException>> + Send + 'a>>` → `... DurableStateError ...`
+- [ ] 3.6 `modules/persistence-core/src/core/durable_state_store_registry.rs` を更新:
+  - L15 の import: `durable_state_exception::DurableStateException,` → `durable_state_error::DurableStateError,`
+  - L41 の戻り値型 `Result<(), DurableStateException>` → `Result<(), DurableStateError>`
+  - L44 の `DurableStateException::provider_already_registered(...)` → `DurableStateError::provider_already_registered(...)`
+  - L57 の戻り値型 `Result<Box<dyn DurableStateStore<A>>, DurableStateException>` → `... DurableStateError>`
+  - L59 の `DurableStateException::provider_not_found(...)` → `DurableStateError::provider_not_found(...)`
+- [ ] 3.7 `modules/persistence-core/src/core/durable_state_store_registry/tests.rs` を更新:
+  - L16 の import (`durable_state_exception::DurableStateException,`) → `durable_state_error::DurableStateError,`
+  - L25 の type alias の `DurableStateException` → `DurableStateError`
+  - L121 / L129 の `DurableStateException::*` バリアント参照 → `DurableStateError::*`
+- [ ] 3.8 `cargo build -p fraktor-persistence-core-rs` 通過確認
+- [ ] 3.9 `cargo test -p fraktor-persistence-core-rs` pass 確認
+- [ ] 3.10 `./scripts/ci-check.sh ai dylint -m fraktor-persistence-core-rs` pass 確認
+
+## 4. Phase 3 — gap analysis 同期
+
+- [ ] 4.1 `docs/gap-analysis/remote-gap-analysis.md` L111 表行 (Pekko `ThrowableNotSerializableException.scala:22` 行) の「fraktor-rs 対応」列を「未対応」→「対応済み (新名 `ThrowableNotSerializableError`)」に更新。「備考」列も「例外型追加で閉じる小さい差分」→「対応済み。Rust 慣習に合わせ `*Error` 命名」に更新
+- [ ] 4.2 `docs/gap-analysis/remote-gap-analysis.md` L164 「Phase 1: trivial / easy」表から `ThrowableNotSerializableException` 相当 行を削除 (実装済みのため Phase 1 残存項目から外す)。Phase 1 が空テーブルになる場合は表ごと削除し、見出しも整理
+- [ ] 4.3 `docs/gap-analysis/remote-gap-analysis.md` のサマリー (L41-48 付近) の `easy gap` カウントを 1 件減らす (現 `1` → `0`)
+- [ ] 4.4 `rg -n 'ThrowableNotSerializableException' docs/` で fraktor-rs 側を指す残存記述が無いことを確認 (Pekko 側のクラス名としての参照は許容)
+
+## 5. Phase 4 — takt 変換ルール文書の追記
+
+`*Exception` → `*Error` の Pekko → Rust 命名変換ルールが `.takt/facets/` の 2 つの 1 次資料に欠落しているため、再発防止として追記する。
+
+- [ ] 5.1 `.takt/facets/policies/fraktor-coding.md` の「Pekko → Rust 変換ルール」セクション (L31-35) に 1 行追加:
+  - 既存項目: `Scala trait 階層 → Rust trait + 合成` / `Scala implicit → ジェネリクス` / `sealed trait + case classes → enum`
+  - 追加項目: `Java/Scala の *Exception 型 → Rust の *Error 型 (例: ThrowableNotSerializableException → ThrowableNotSerializableError)`
+- [ ] 5.2 `.takt/facets/knowledge/pekko-porting.md` の「命名規約」表 (L62-68) に 1 行追加:
+  - 既存行: `camelCase メソッド` / `PascalCase 型`
+  - 追加行: `| *Exception 型 | *Error 型 | DurableStateException → DurableStateError, ThrowableNotSerializableException → ThrowableNotSerializableError |`
+- [ ] 5.3 追記後、両ファイルが既存 markdown フォーマット (見出しレベル / 表構造) を壊していないことを確認
+- [ ] 5.4 `rg -n '\*Exception\b' .takt/facets/` で他に同種の漏れが無いことを念のため再確認
+
+## 6. Phase 5 — final-ci
+
+- [ ] 6.1 ワークスペース全体の参照漏れ最終確認: `rg -n '\bThrowableNotSerializableException\b|\bDurableStateException\b' modules/ src/ docs/ .takt/facets/ openspec/specs/ openspec/changes/` の出力が、本 change 自身の proposal/design/tasks 内記述および Pekko 側 `.scala` ファイル名の言及だけになっていることを確認
+- [ ] 6.2 `./scripts/ci-check.sh ai all` を実行して fmt / dylint / clippy / no-std / doc / unit-test / integration-test 全て pass
+- [ ] 6.3 マージ後、別 PR で本 change を archive + main spec sync (本 change は specs delta を持たないため sync 対象は無し)
+
+## 7. レビュー対応 / 後追い
+
+- [ ] 7.1 PR レビュー対応 (CodeRabbit / Cursor Bugbot 指摘は Pekko 互換を崩さない範囲で対応、却下する場合は理由を reply してから resolve)
+- [ ] 7.2 マージ後、`/opsx:archive replace-exception-suffix-with-error` で archive

--- a/openspec/changes/replace-exception-suffix-with-error/tasks.md
+++ b/openspec/changes/replace-exception-suffix-with-error/tasks.md
@@ -1,86 +1,86 @@
 ## 1. 事前確認
 
-- [ ] 1.1 `cargo test -p fraktor-actor-core-rs` ベースライン pass を確認 (rename 前)
-- [ ] 1.2 `cargo test -p fraktor-persistence-core-rs` ベースライン pass を確認 (rename 前)
-- [ ] 1.3 `rg -n 'pub (struct|enum|trait|type) \w+Exception\b' modules/ src/` で対象が以下 2 件のみであることを再確認
+- [x] 1.1 `cargo test -p fraktor-actor-core-rs` ベースライン pass を確認 (rename 前)
+- [x] 1.2 `cargo test -p fraktor-persistence-core-rs` ベースライン pass を確認 (rename 前)
+- [x] 1.3 `rg -n 'pub (struct|enum|trait|type) \w+Exception\b' modules/ src/` で対象が以下 2 件のみであることを再確認
   - `modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_exception.rs:7` の `ThrowableNotSerializableException`
   - `modules/persistence-core/src/core/durable_state_exception.rs:11` の `DurableStateException`
-- [ ] 1.4 `rg -n '\bThrowableNotSerializableException\b' modules/ src/ openspec/specs/` で参照が `actor-core` 内 4 箇所 (定義 1 + impl 1 + pub use 1 + tests 3) に閉じることを確認
-- [ ] 1.5 `rg -n '\bDurableStateException\b' modules/ src/ openspec/specs/` で参照が `persistence-core` 内のみ (定義 / impl / pub use / store / registry / tests の合計 18 箇所程度) に閉じることを確認
+- [x] 1.4 `rg -n '\bThrowableNotSerializableException\b' modules/ src/ openspec/specs/` で参照が `actor-core` 内 4 箇所 (定義 1 + impl 1 + pub use 1 + tests 3) に閉じることを確認
+- [x] 1.5 `rg -n '\bDurableStateException\b' modules/ src/ openspec/specs/` で参照が `persistence-core` 内のみ (定義 / impl / pub use / store / registry / tests の合計 18 箇所程度) に閉じることを確認
 
 ## 2. Phase 1 — `ThrowableNotSerializableException` → `ThrowableNotSerializableError`
 
 依存関係: 単一 crate (`fraktor-actor-core-rs`) 内に閉じている。`pub use` 経由で公開されているが workspace 外の参照は無し。
 
-- [ ] 2.1 ファイルリネーム: `git mv modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_exception.rs modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_error.rs`
-- [ ] 2.2 リネーム後ファイルの中身を更新:
+- [x] 2.1 ファイルリネーム: `git mv modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_exception.rs modules/actor-core/src/core/kernel/serialization/throwable_not_serializable_error.rs`
+- [x] 2.2 リネーム後ファイルの中身を更新:
   - 構造体名 `ThrowableNotSerializableException` → `ThrowableNotSerializableError`
   - `impl ThrowableNotSerializableException` → `impl ThrowableNotSerializableError`
   - 冒頭 `//!` モジュール doc は内容に変化がなければ据え置き
-- [ ] 2.3 `modules/actor-core/src/core/kernel/serialization.rs` を更新:
+- [x] 2.3 `modules/actor-core/src/core/kernel/serialization.rs` を更新:
   - `mod throwable_not_serializable_exception;` → `mod throwable_not_serializable_error;`
   - `pub use throwable_not_serializable_exception::ThrowableNotSerializableException;` → `pub use throwable_not_serializable_error::ThrowableNotSerializableError;`
-- [ ] 2.4 `modules/actor-core/src/core/kernel/serialization/error/tests.rs` を更新:
+- [x] 2.4 `modules/actor-core/src/core/kernel/serialization/error/tests.rs` を更新:
   - L5 の import: `ThrowableNotSerializableException,` → `ThrowableNotSerializableError,`
   - L93 の `ThrowableNotSerializableException::new(...)` → `ThrowableNotSerializableError::new(...)`
   - L101 の `ThrowableNotSerializableException::new(...)` → `ThrowableNotSerializableError::new(...)`
   - 同ファイル内のテスト関数名 `throwable_not_serializable_exception_preserves_original_message_and_class_name` → `throwable_not_serializable_error_preserves_original_message_and_class_name`
   - 同ファイル内のテスト関数名 `throwable_not_serializable_exception_is_cloneable_value_payload` → `throwable_not_serializable_error_is_cloneable_value_payload`
-- [ ] 2.5 `cargo build -p fraktor-actor-core-rs` 通過確認
-- [ ] 2.6 `cargo test -p fraktor-actor-core-rs` pass 確認 (rename 済みテスト関数 2 件含む)
+- [x] 2.5 `cargo build -p fraktor-actor-core-rs` 通過確認
+- [x] 2.6 `cargo test -p fraktor-actor-core-rs` pass 確認 (rename 済みテスト関数 2 件含む)
 
 ## 3. Phase 2 — `DurableStateException` → `DurableStateError`
 
 依存関係: 単一 crate (`fraktor-persistence-core-rs`) 内に閉じている。Phase 1 とは独立。
 
-- [ ] 3.1 ファイル / ディレクトリリネーム:
+- [x] 3.1 ファイル / ディレクトリリネーム:
   - `git mv modules/persistence-core/src/core/durable_state_exception.rs modules/persistence-core/src/core/durable_state_error.rs`
   - `git mv modules/persistence-core/src/core/durable_state_exception modules/persistence-core/src/core/durable_state_error` (tests ディレクトリ)
-- [ ] 3.2 リネーム後ファイル `modules/persistence-core/src/core/durable_state_error.rs` を更新:
+- [x] 3.2 リネーム後ファイル `modules/persistence-core/src/core/durable_state_error.rs` を更新:
   - `pub enum DurableStateException` → `pub enum DurableStateError`
   - `impl DurableStateException` → `impl DurableStateError`
   - `impl Display for DurableStateException` → `impl Display for DurableStateError`
   - その他 `Self` を使っていない自己参照箇所すべて
-- [ ] 3.3 `modules/persistence-core/src/core/durable_state_error/tests.rs` (旧 `durable_state_exception/tests.rs`) を更新:
+- [x] 3.3 `modules/persistence-core/src/core/durable_state_error/tests.rs` (旧 `durable_state_exception/tests.rs`) を更新:
   - L3 の `use crate::core::durable_state_exception::DurableStateException;` → `use crate::core::durable_state_error::DurableStateError;`
   - L7 / L14 / L21 / L28 / L35 / L42 の `DurableStateException::*` 呼び出し全てを `DurableStateError::*` に
-- [ ] 3.4 `modules/persistence-core/src/core.rs` を更新:
+- [x] 3.4 `modules/persistence-core/src/core.rs` を更新:
   - `pub use durable_state_exception::DurableStateException;` 周辺の `mod` / `pub use` を `durable_state_error::DurableStateError` に書き換え
-- [ ] 3.5 `modules/persistence-core/src/core/durable_state_store.rs` を更新:
+- [x] 3.5 `modules/persistence-core/src/core/durable_state_store.rs` を更新:
   - `use crate::core::durable_state_exception::DurableStateException;` → `use crate::core::durable_state_error::DurableStateError;`
   - `Pin<Box<dyn Future<Output = Result<T, DurableStateException>> + Send + 'a>>` → `... DurableStateError ...`
-- [ ] 3.6 `modules/persistence-core/src/core/durable_state_store_registry.rs` を更新:
+- [x] 3.6 `modules/persistence-core/src/core/durable_state_store_registry.rs` を更新:
   - L15 の import: `durable_state_exception::DurableStateException,` → `durable_state_error::DurableStateError,`
   - L41 の戻り値型 `Result<(), DurableStateException>` → `Result<(), DurableStateError>`
   - L44 の `DurableStateException::provider_already_registered(...)` → `DurableStateError::provider_already_registered(...)`
   - L57 の戻り値型 `Result<Box<dyn DurableStateStore<A>>, DurableStateException>` → `... DurableStateError>`
   - L59 の `DurableStateException::provider_not_found(...)` → `DurableStateError::provider_not_found(...)`
-- [ ] 3.7 `modules/persistence-core/src/core/durable_state_store_registry/tests.rs` を更新:
+- [x] 3.7 `modules/persistence-core/src/core/durable_state_store_registry/tests.rs` を更新:
   - L16 の import (`durable_state_exception::DurableStateException,`) → `durable_state_error::DurableStateError,`
   - L25 の type alias の `DurableStateException` → `DurableStateError`
   - L121 / L129 の `DurableStateException::*` バリアント参照 → `DurableStateError::*`
-- [ ] 3.8 `cargo build -p fraktor-persistence-core-rs` 通過確認
-- [ ] 3.9 `cargo test -p fraktor-persistence-core-rs` pass 確認
+- [x] 3.8 `cargo build -p fraktor-persistence-core-rs` 通過確認
+- [x] 3.9 `cargo test -p fraktor-persistence-core-rs` pass 確認
 
 ## 4. Phase 3 — gap analysis 同期
 
-- [ ] 4.1 `docs/gap-analysis/remote-gap-analysis.md` L111 表行 (Pekko `ThrowableNotSerializableException.scala:22` 行) の「fraktor-rs 対応」列を「未対応」→「対応済み (新名 `ThrowableNotSerializableError`)」に更新。「備考」列も「例外型追加で閉じる小さい差分」→「対応済み。Rust 慣習に合わせ `*Error` 命名」に更新
-- [ ] 4.2 `docs/gap-analysis/remote-gap-analysis.md` L164 「Phase 1: trivial / easy」表から `ThrowableNotSerializableException` 相当 行を削除 (実装済みのため Phase 1 残存項目から外す)。Phase 1 が空テーブルになる場合は表ごと削除し、見出しも整理
-- [ ] 4.3 `docs/gap-analysis/remote-gap-analysis.md` のサマリー (L41-48 付近) の `easy gap` カウントを 1 件減らす (現 `1` → `0`)
-- [ ] 4.4 `rg -n 'ThrowableNotSerializableException' docs/` で fraktor-rs 側を指す残存記述が無いことを確認 (Pekko 側のクラス名としての参照は許容)
+- [x] 4.1 `docs/gap-analysis/remote-gap-analysis.md` L111 表行 (Pekko `ThrowableNotSerializableException.scala:22` 行) の「fraktor-rs 対応」列を「未対応」→「対応済み (新名 `ThrowableNotSerializableError`)」に更新。「備考」列も「例外型追加で閉じる小さい差分」→「対応済み。Rust 慣習に合わせ `*Error` 命名」に更新
+- [x] 4.2 `docs/gap-analysis/remote-gap-analysis.md` L164 「Phase 1: trivial / easy」表から `ThrowableNotSerializableException` 相当 行を削除 (実装済みのため Phase 1 残存項目から外す)。Phase 1 が空テーブルになる場合は表ごと削除し、見出しも整理
+- [x] 4.3 `docs/gap-analysis/remote-gap-analysis.md` のサマリー (L41-48 付近) の `easy gap` カウントを 1 件減らす (現 `1` → `0`)
+- [x] 4.4 `rg -n 'ThrowableNotSerializableException' docs/` で fraktor-rs 側を指す残存記述が無いことを確認 (Pekko 側のクラス名としての参照は許容)
 
 ## 5. Phase 4 — takt 変換ルール文書の追記
 
 `*Exception` → `*Error` の Pekko → Rust 命名変換ルールが `.takt/facets/` の 2 つの 1 次資料に欠落しているため、再発防止として追記する。
 
-- [ ] 5.1 `.takt/facets/policies/fraktor-coding.md` の「Pekko → Rust 変換ルール」セクション (L31-35) に 1 行追加:
+- [x] 5.1 `.takt/facets/policies/fraktor-coding.md` の「Pekko → Rust 変換ルール」セクション (L31-35) に 1 行追加:
   - 既存項目: `Scala trait 階層 → Rust trait + 合成` / `Scala implicit → ジェネリクス` / `sealed trait + case classes → enum`
   - 追加項目: `Java/Scala の *Exception 型 → Rust の *Error 型 (例: ThrowableNotSerializableException → ThrowableNotSerializableError)`
-- [ ] 5.2 `.takt/facets/knowledge/pekko-porting.md` の「命名規約」表 (L62-68) に 1 行追加:
+- [x] 5.2 `.takt/facets/knowledge/pekko-porting.md` の「命名規約」表 (L62-68) に 1 行追加:
   - 既存行: `camelCase メソッド` / `PascalCase 型`
   - 追加行: `| *Exception 型 | *Error 型 | DurableStateException → DurableStateError, ThrowableNotSerializableException → ThrowableNotSerializableError |`
-- [ ] 5.3 追記後、両ファイルが既存 markdown フォーマット (見出しレベル / 表構造) を壊していないことを確認
-- [ ] 5.4 `rg -n '\*Exception\b' .takt/facets/` で他に同種の漏れが無いことを念のため再確認
+- [x] 5.3 追記後、両ファイルが既存 markdown フォーマット (見出しレベル / 表構造) を壊していないことを確認
+- [x] 5.4 `rg -n '\*Exception\b' .takt/facets/` で他に同種の漏れが無いことを念のため再確認
 
 ## 6. Phase 5 — final-ci
 


### PR DESCRIPTION
## 概要

Java/Scala 由来の `*Exception` 接尾辞を持つ公開エラー型を Rust 慣習の `*Error` 接尾辞に整える openspec change を提案する。本 PR は change document (proposal/design/tasks) の追加のみで、実装は merge 後に別 PR で着手する。

## 対象

調査の結果、ワークスペース内で `*Exception` 接尾辞を持つ公開型は以下の 2 件のみ:

| 型 | 場所 | 参照箇所 |
|---|---|---|
| `ThrowableNotSerializableException` | `actor-core/.../serialization/throwable_not_serializable_exception.rs` | 3 箇所 + pub use |
| `DurableStateException` | `persistence-core/.../durable_state_exception.rs` | 18 箇所 + pub use |

両者とも周辺型 (`NotSerializableError`, `SerializationError`, `SerializerIdError` 等) は既に `*Error` 命名で揃っており、この 2 件だけが浮いている状態。

## change document の構成

### proposal.md
- Why: Rust 慣習 (`std::io::Error` 等) との整合、周辺型との一貫性、`docs/gap-analysis/remote-gap-analysis.md` Phase 1 trivial/easy の `ThrowableNotSerializableException` ギャップ解消
- What: 2 型の rename + ファイル名 + 参照箇所更新 + gap analysis 表記同期
- BREAKING: あり (両型とも `pub` 公開、ただしリリース前のため許容)

### design.md
- 新名選定根拠 (`Throwable` 接頭辞は Pekko 元概念識別のため保持)
- Pekko 互換性との整合 (wire 互換は別 layer、Rust 識別子は Rust 慣習を優先)
- テスト関数名 (`throwable_not_serializable_exception_*`) の同時 rename 方針
- dylint との関係 (`Exception` の `ambiguous-suffix-lint` 追加は Non-Goals)
- **takt 変換ルール文書の追記**: `.takt/facets/policies/fraktor-coding.md` 「Pekko → Rust 変換ルール」と `.takt/facets/knowledge/pekko-porting.md` 「命名規約」表に `*Exception` → `*Error` の対応が欠落していたため、本 change で再発防止として追記する

### tasks.md (5 phase 構成)
1. 事前確認 (ベースライン + 参照範囲確認)
2. Phase 1: `ThrowableNotSerializableException` → `ThrowableNotSerializableError` (actor-core)
3. Phase 2: `DurableStateException` → `DurableStateError` (persistence-core)
4. Phase 3: `docs/gap-analysis/remote-gap-analysis.md` 同期
5. Phase 4: `.takt/facets/` 変換ルール追記
6. Phase 5: final-ci + archive

## tasks-only change である理由

`actor-core/serialization` および `persistence-core` の DurableState 系は `openspec/specs/` に対応する main spec capability を持たないため、specs delta は作成しない。tasks-only パターンは既存 archive (`2026-04-24-retire-dead-internal-scaffolding/`) と同様の運用。

## 補足

`openspec validate` は specs/ の存在を必須としているため warning が出るが、これは tasks-only パターンの既知の挙動で、artifact graph (`openspec status --json` の `isComplete`) は別判定。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces breaking public API renames (`ThrowableNotSerializableException`→`ThrowableNotSerializableError`, `DurableStateException`→`DurableStateError`) that may impact downstream crates, though the changes are mechanical and localized.
> 
> **Overview**
> Standardizes public error-type naming by renaming the remaining `*Exception` types to Rust-idiomatic `*Error` across `actor-core` serialization and `persistence-core` durable state APIs, including file/module renames and all internal references/tests.
> 
> Updates related documentation and gap analyses to reflect the new names, and codifies the `*Exception`→`*Error` mapping in the Pekko→Rust porting/coding rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9709defb80a5a0a6b2a1f56116d5a8df6ef4e65e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * ギャップ分析ドキュメントを更新し、エラー型参照を統一しました

* **リファクタリング**
  * エラー型の命名規約を標準化しました（複数のエラー型をException型からError型へ統一）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->