### PR TITLE
docs(openspec): propose async-first actor runtime adapters

### DIFF
--- a/docs/gap-analysis/actor-mailbox-gap-analysis.md
+++ b/docs/gap-analysis/actor-mailbox-gap-analysis.md
@@ -1,0 +1,226 @@
+# actor mailbox ギャップ分析
+
+更新日: 2026-04-26
+
+## 結論
+
+Mailbox にスコープを絞って深さ優先で見ると、fraktor-rs の actor mailbox は「実行時の drain / system 優先 / dead letter 観測」というコア挙動はかなり Pekko 互換に近い。
+
+一方で、弱いのは queue 実装そのものよりも **mailbox 選択契約** と **blocking bounded mailbox 契約** である。  
+つまり、`actor` モジュール全体では高い parity に見えても、Mailbox だけを掘ると「実行コアは強いが、設定・選択・bounded semantics はまだ簡略化されている」という非対称さが見える。
+
+## 比較スコープ定義
+
+今回の mailbox 調査では次を parity 対象に含める。
+
+| 領域 | fraktor-rs | Pekko |
+|------|------------|-------|
+| mailbox run loop / scheduling gate | `modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs` | `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala` |
+| message queue family | `modules/actor-core/src/core/kernel/dispatch/mailbox/*message_queue*.rs` | `Mailbox.scala` の各 `MailboxType` / `MessageQueue` |
+| mailbox registry / selection | `modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs` | `Mailboxes.scala` |
+| props / requirement / spawn-time validation | `modules/actor-core/src/core/kernel/actor/props/*.rs`, `modules/actor-core/src/core/kernel/system/base.rs` | `Mailboxes.scala`, `actor-typed/Props.scala` |
+| dispatcher-mailbox binding | `modules/actor-core/src/core/kernel/dispatch/dispatcher/*.rs` | `Dispatcher.scala`, `Dispatchers.scala`, `BalancingDispatcher.scala` |
+
+今回のスコープから外すもの:
+
+| 除外項目 | 理由 |
+|----------|------|
+| remote `AddressTerminated` 連携 | mailbox 単体ではなく remote / actor 境界の課題 |
+| supervision restart stash の全体設計 | mailbox requirement との接点だけ見る。再起動戦略全体は別スコープ |
+| testkit 専用 mailbox | runtime mailbox parity ではない |
+
+## サマリー
+
+| 観点 | 評価 | 要点 |
+|------|------|------|
+| run loop / scheduling | 高 | system message 優先、suspend 中の scheduling gate、throughput deadline、cleanup は強い |
+| queue family surface | 高 | bounded / unbounded / deque / priority / stable-priority / control-aware が揃う |
+| overflow / dead letter observability | 高 | reject / evict を dead letter に観測可能化している |
+| requirement / capability gate | 中 | spawn 前 capability 検証はあるが、Pekko の queue type mapping までは持たない |
+| mailbox selection / config 契約 | 中 | id registry はあるが、Pekko の `lookupByQueueType` や `bounded-capacity:` 相当はない |
+| blocking bounded mailbox semantics | 低 | `pushTimeOut` ベースの bounded mailbox 契約は未実装 |
+| BalancingDispatcher との mailbox 契約 | 中 | shared queue はあるが、Pekko の mailbox compatibility 契約は内部化されている |
+
+## 詳細評価
+
+### 1. run loop / scheduling gate は高い互換性
+
+fraktor-rs の `Mailbox::run` は、コメントと実装の両方で Pekko `Mailbox.run()` を明示的に追っている。  
+`process_all_system_messages` を先に回し、その後に `process_mailbox` を進める順序は Pekko と一致している。
+
+根拠:
+
+- fraktor-rs: `Mailbox::run`, `process_all_system_messages`, `process_mailbox`
+- Pekko: `Mailbox.run`, `processAllSystemMessages`, `processMailbox`
+
+特に互換性が高い点:
+
+- system message を user message より常に先に drain する
+- suspend 中は user dequeue を止めるが、system message は通す
+- throughput deadline を mailbox 側で判定する
+- close 後 cleanup で system queue を dead letters に必ず流す
+
+この領域は「Mailbox のコア挙動」としては strong で、深掘りしても大きな欠落は見えなかった。
+
+### 2. queue family surface もかなり揃っている
+
+`modules/actor-core/src/core/kernel/dispatch/mailbox.rs` には、Pekko mailbox 調査で期待する主要な queue family がまとまって存在する。
+
+確認できた主な型:
+
+- `BoundedMessageQueue` / `UnboundedMessageQueue`
+- `BoundedDequeMessageQueue` / `UnboundedDequeMessageQueue`
+- `BoundedPriorityMessageQueue` / `UnboundedPriorityMessageQueue`
+- `BoundedStablePriorityMessageQueue` / `UnboundedStablePriorityMessageQueue`
+- `BoundedControlAwareMessageQueue` / `UnboundedControlAwareMessageQueue`
+
+単に名前があるだけでなく、`Mailboxes::select_mailbox_type_from_config` で priority / stable-priority / control-aware / deque を切り替える経路も存在する。
+
+### 3. overflow と dead letter 観測は強い
+
+fraktor-rs は bounded queue overflow を「黙って捨てる」のではなく、mailbox 層で dead letter に記録する設計になっている。  
+`Mailbox::enqueue_envelope` は `EnqueueOutcome::Evicted` と `Rejected` を成功扱いしつつ、`DeadLetterReason::MailboxFull` で観測可能化している。
+
+これは Pekko の「enqueue 呼び出し側には成功に見えるが、損失は dead letters へ流す」という運用感にかなり近い。
+
+強い点:
+
+- `DropNewest` を `Rejected` として扱い、dead letter 記録する
+- `DropOldest` を `Evicted` として扱い、押し出された envelope を dead letter 記録する
+- priority queue / stable-priority queue でも overflow 観測を維持する
+
+### 4. requirement / capability gate は部分対応
+
+ここは「未実装」ではなく「Pekko より簡略化されている」が正しい。
+
+fraktor-rs 側には:
+
+- `MailboxRequirement` がある
+- `Deque` / `ControlAware` / `BlockingFuture` の capability を宣言できる
+- `ActorSystem::ensure_mailbox_requirements` が spawn 前に `requirement.ensure_supported(...)` を実行する
+- `Props::with_stash_mailbox()` で stash に必要な deque requirement を付けられる
+
+つまり、「この actor は deque-capable mailbox を必要とする」といった条件は検証できる。
+
+ただし、Pekko と比べると次がない:
+
+- `RequiresMessageQueue[T]` のような actor class ベースの queue type 宣言
+- `mailbox.requirements` 設定から queue type を mailbox id へ引く mapping
+- `lookupByQueueType(...)` による queue type 主導の mailbox 選択
+
+したがって、**capability 検証はあるが、queue type 解決モデルは Pekko よりかなり薄い**。
+
+### 5. mailbox selection / config 契約は部分対応
+
+Pekko の `Mailboxes.getMailboxType(...)` はかなり多段である。
+
+- `deploy.mailbox`
+- dispatcher config 上の `mailbox-type`
+- actor 側 requirement
+- dispatcher 側 requirement
+- default mailbox
+
+さらに `bounded-capacity:` のような programmatic bounded mailbox helper もある。
+
+これに対して fraktor-rs は次のように単純化されている。
+
+- `Props::with_mailbox_id(...)` で registry lookup
+- それ以外は `MailboxConfig`
+- `Mailboxes::select_mailbox_type_from_config(...)` は
+  - priority + stable-priority
+  - control-aware requirement
+  - deque requirement
+  - default
+  の順だけを見る
+
+つまり、**選択ルールは理解しやすいが、Pekko の config-driven mailbox resolution とは同等ではない**。
+
+ここで見えた具体差分:
+
+- mailbox registry は単純な id → factory で、Pekko mailbox 側の alias chain 解決はない
+- `bounded-capacity:` 相当の helper がない
+- dispatcher config 側 mailbox requirement と actor 側 requirement の優先順位調停がない
+
+### 6. blocking bounded mailbox semantics は弱い
+
+今回の mailbox 深掘りで、もっともはっきりした非互換ポイントはここだった。
+
+Pekko の bounded mailbox 群は `pushTimeOut` を持つ。
+
+- `BoundedMailbox`
+- `BoundedPriorityMailbox`
+- `BoundedStablePriorityMailbox`
+- `BoundedDequeBasedMailbox`
+- `BoundedControlAwareMailbox`
+
+そして `Mailboxes.lookupConfigurator(...)` は、非ゼロの `pushTimeOut` に対して warning を出す。
+
+fraktor-rs にはこの系統の契約がない。bounded 系 queue はすべて次の overflow strategy モデルに寄っている。
+
+- `DropNewest`
+- `DropOldest`
+- `Grow`
+
+つまり fraktor-rs は「bounded queue が満杯のとき、待つか、一定時間 block するか」ではなく、「どのメッセージを捨てるか」で振る舞いを決めている。
+
+この差は mailbox コアより大きい。  
+**Pekko の bounded mailbox semantics をそのまま使う前提では、ここが最大のギャップである。**
+
+### 7. control-aware mailbox は存在するが bounded semantics は変形されている
+
+`BoundedControlAwareMessageQueue` は control queue と normal queue を分け、control を先に drain する点では Pekko 互換に近い。
+
+ただし bounded overflow 時の扱いは Pekko と同型ではない。
+
+- fraktor-rs は `DropOldest` 時に normal queue から優先的に evict する
+- normal queue が空なら到着 control envelope を reject する
+- これは「control message をなるべく落とさない」ための設計判断
+
+Pekko は bounded control-aware mailbox を `pushTimeOut` 付き queue として扱うため、ここは **同じ目的に対する別設計** であり、完全互換ではない。
+
+### 8. BalancingDispatcher と mailbox の契約は部分対応
+
+Pekko の `BalancingDispatcherConfigurator` は mailbox requirement と mailbox type の互換を明示的に検証する。
+
+- `MultipleConsumerSemantics` を要求する
+- supplied mailbox が requirement を満たすか確認する
+
+fraktor-rs の `BalancingDispatcher` は別アプローチで、dispatcher 内部に `SharedMessageQueue` を持ち、`try_create_shared_mailbox(...)` で sharing mailbox を返す。
+
+これは runtime semantics としては妥当だが、次の差がある。
+
+- custom mailbox type を balancing dispatcher に差し込む契約が露出していない
+- compatibility check が mailbox type レベルではなく dispatcher 内部実装に吸収されている
+- sharing mailbox は `MailboxPolicy::unbounded(None)` で構築されるため、Pekko の「互換 mailbox type を選ぶ」構図ではない
+
+したがって、**負荷分散の実行セマンティクスはあるが、mailbox 契約としての Pekko parity は弱い**。
+
+## 主要ギャップ
+
+| ID | ギャップ | 重要度 | 内容 |
+|----|----------|--------|------|
+| MBX-H1 | blocking bounded mailbox 不在 | high | `pushTimeOut` 付き bounded mailbox 契約がなく、overflow strategy モデルへ置換されている |
+| MBX-M1 | mailbox requirement 解決モデルの簡略化 | medium | capability 検証はあるが、`RequiresMessageQueue[T]` / `lookupByQueueType` / `mailbox.requirements` mapping がない |
+| MBX-M2 | mailbox selection precedence の簡略化 | medium | Pekko の多段 config resolution ではなく、`mailbox_id` または `MailboxConfig` へ単純化されている |
+| MBX-M3 | BalancingDispatcher mailbox compatibility 契約の内部化 | medium | multiple-consumer mailbox compatibility が dispatcher 内部実装に吸収され、mailbox type 契約としては露出しない |
+| MBX-L1 | control-aware bounded overflow の差分 | low | control 優先保護のための独自 eviction ルールがあり、Pekko と完全同型ではない |
+
+## まとめ
+
+Mailbox だけを深く見ると、fraktor-rs の actor mailbox は「drain loop・system 優先・dead letter 観測・主要 queue family」という **実行時コア** は強い。
+
+一方で、Pekko 互換性が弱いのは次の領域である。
+
+- `pushTimeOut` を持つ bounded mailbox 契約
+- queue type / requirement ベースの mailbox 選択
+- BalancingDispatcher と mailbox type の compatibility contract
+
+したがって、Mailbox スコープの結論は次の一文に尽きる。
+
+**fraktor-rs の mailbox は runtime core parity は高いが、configuration-driven mailbox contract parity はまだ中程度である。**
+
+もし次に mailbox parity をさらに詰めるなら、優先順位は以下が妥当である。
+
+1. `pushTimeOut` 系 bounded mailbox を入れるか、意図的非互換として明文化する
+2. `lookupByQueueType` 相当の requirement-driven mailbox 解決を追加する
+3. BalancingDispatcher に mailbox compatibility contract を外部から見える形で持たせる

--- a/docs/plan/2026-04-26-mailbox-dispatcher-async-judgement.md
+++ b/docs/plan/2026-04-26-mailbox-dispatcher-async-judgement.md
@@ -1,0 +1,523 @@
+# mailbox / dispatcher / async 化 判断材料
+
+更新日: 2026-04-27
+
+## 目的
+
+`actor` モジュール全体ではなく、`mailbox` と `dispatcher` を責務単位で深掘りし、
+
+1. Pekko 互換性が部分対応に留まっている理由は何か
+2. その理由は妥当か
+3. `async` 化をどの層で受けるべきか
+
+を判断する材料をまとめる。
+
+この文書は実装方針そのものではなく、**設計判断の前提整理** を目的とする。
+
+## 固定前提
+
+この版では、次の前提を固定する。
+
+- **std 環境では Tokio を使う**
+- **embedded / no_std + async 環境では Embassy を使う**
+- `actor-core` は引き続き no_std / alloc 中心の kernel として保ち、Tokio / Embassy への接続は adaptor 層で受ける
+- 正式リリース前なので、後方互換のために現在の executor 名や既定動作へ固執しない
+
+この前提では、以前より async 化の価値が高くなる。  
+特に、Pekko の blocking bounded mailbox (`pushTimeOut`) を厚く再現するより、**Tokio / Embassy の task / timer / waker を活かせる executor adapter と、Pekko `pipeToSelf` 型の future-to-message adapter を整える** ほうが投資対効果が高い。
+
+## 結論
+
+短く言うと、固定前提後の推奨戦略は次である。
+
+- **mailbox の drain loop は sync / non-awaiting のまま保つ**
+- **default executor は async runtime の task 実行へ寄せる**
+- **blocking workload は `Blocking` dispatcher / blocking executor へ明示的に隔離する**
+- **actor-facing API は同期のまま保ち、async I/O は untyped kernel の `pipe_to_self` / `pipe_to` で message 化する**
+- **typed API は kernel contract の薄い wrapper として整える**
+
+この方針だと、mailbox の「部分対応」は単なる不足ではなく、**blocking mailbox 互換へ寄せすぎないための意図的な余白** と解釈できる。  
+ただし前回版より判断が変わる点がある。`std=tokio` / `embedded=embassy` を固定するなら、`async` は edge helper に留めるだけではもったいない。一方で、Pekko 互換性を考えると actor handler 自体を async 化するのではなく、`pipe_to_self` / `pipe_to` を async adapter 境界として維持するのが筋である。
+
+未解決論点は次の 2 点へ絞られる。
+
+1. default dispatcher を Tokio の `spawn_blocking` 前提から task 実行前提へ変えるか
+2. untyped kernel の `pipe_to_self` / `pipe_to` を先に固定し、その上で typed surface、docs、failure observability をどこまで強化するか
+
+現時点の推奨は、**full async core ではなく async-first adapter strategy** である。  
+つまり `Actor::receive` / `TypedActor::receive` / `MessageInvoker::invoke` / `Mailbox::run` を `async fn` 化するのではなく、runtime adapter と untyped-first の future-to-message adapter surface を厚くする。
+
+## 参照した主な実装
+
+### fraktor-rs
+
+- `modules/actor-core/src/core/kernel/dispatch/mailbox/base.rs`
+- `modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs`
+- `modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher.rs`
+- `modules/actor-core/src/core/kernel/dispatch/dispatcher/message_dispatcher_shared.rs`
+- `modules/actor-core/src/core/kernel/dispatch/dispatcher/executor.rs`
+- `modules/actor-core/src/core/kernel/dispatch/dispatcher/executor_shared.rs`
+- `modules/actor-adaptor-std/src/std/dispatch/dispatcher/tokio_executor.rs`
+- `modules/actor-adaptor-std/src/std/dispatch/dispatcher/threaded_executor.rs`
+- `modules/actor-core/src/core/kernel/actor/actor_lifecycle.rs`
+- `modules/actor-core/src/core/kernel/actor/context_pipe/task.rs`
+- `modules/actor-core/src/core/kernel/actor/actor_context.rs`
+- `modules/actor-core/src/core/typed/actor/actor_context.rs`
+- `modules/actor-core/src/core/typed/actor/typed_actor.rs`
+- `modules/actor-core/src/core/typed/dsl/behaviors.rs`
+- `modules/actor-core/src/core/kernel/actor/scheduler/scheduler_runner.rs`
+- `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_executor_signal.rs`
+- `modules/actor-adaptor-std/src/std/tick_driver/tokio_tick_driver.rs`
+- `docs/gap-analysis/actor-mailbox-gap-analysis.md`
+- `docs/plan/lock-strategy-analysis.md`
+
+### Pekko
+
+- `references/pekko/actor-typed/src/main/scala/org/apache/pekko/actor/typed/scaladsl/ActorContext.scala`
+- `references/pekko/actor-typed/src/main/scala/org/apache/pekko/actor/typed/javadsl/ActorContext.scala`
+- `references/pekko/docs/src/test/scala/docs/actor/typed/SharedMutableStateDocSpec.scala`
+- `references/pekko/actor-typed-tests/src/test/java/jdocs/org/apache/pekko/typed/InteractionPatternsTest.java`
+
+- `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/Mailbox.scala`
+- `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/Mailboxes.scala`
+- `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/Dispatcher.scala`
+- `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/AbstractDispatcher.scala`
+- `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/Dispatchers.scala`
+- `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/BalancingDispatcher.scala`
+- `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/PinnedDispatcher.scala`
+- `references/pekko/actor-typed/src/main/scala/org/apache/pekko/actor/typed/Props.scala`
+
+## 1. mailbox の部分対応には理由があるか
+
+### 1.1 ある。特に blocking bounded mailbox を避けている
+
+Pekko の bounded mailbox 群は `pushTimeOut` を持つ。
+
+- `BoundedMailbox`
+- `BoundedPriorityMailbox`
+- `BoundedStablePriorityMailbox`
+- `BoundedDequeBasedMailbox`
+- `BoundedControlAwareMailbox`
+
+Pekko 側では、bounded queue が満杯になったときに block / timeout を使う設計が存在する。  
+`Mailboxes.scala` も non-zero `pushTimeOut` に対して warning を出す。
+
+一方、fraktor-rs の bounded mailbox は `pushTimeOut` ではなく次の overflow strategy に寄っている。
+
+- `DropNewest`
+- `DropOldest`
+- `Grow`
+
+つまり、fraktor-rs は mailbox overflow を
+
+- 待つ
+- block する
+- 条件変数で空きを待つ
+
+ではなく、
+
+- reject する
+- evict する
+- 観測可能な dead letter に流す
+
+で扱う設計である。
+
+### 1.2 この理由は mailbox を hot path と見ているから
+
+`Mailbox::enqueue_envelope` は mailbox の最前線であり、高頻度で呼ばれる。  
+現在の実装は overflow も dead letter 観測も mailbox 層で閉じるが、enqueue 自体は sync / non-blocking 前提で整理されている。
+
+この設計は、Pekko の「bounded で待てる mailbox」を再現していない代わりに、
+**mailbox の hot path に blocking を持ち込まない** 方向へ寄っている。
+
+### 1.3 妥当性
+
+これは十分妥当である。理由は次のとおり。
+
+- actor runtime の基盤 hot path に blocking を入れると、executor / runtime 側の並列度や park/unpark の影響を強く受ける
+- no_std / std 分離を重視している現在の構造では、blocking semantics を core へ入れると std 依存や runtime 依存が増える
+- dead letter に観測できる overflow は運用上の説明責任を満たしやすい
+
+したがって、**Pekko 完全互換ではないが、設計としては筋が通っている**。
+
+## 2. dispatcher を深掘りすると何が見えるか
+
+### 2.1 現在の dispatcher は「mailbox を実行する sync scheduler」である
+
+`MessageDispatcherShared::register_for_execution` は、mailbox を scheduled にし、
+`Executor` へ `Box<dyn FnOnce()>` を投げる。  
+そこで実行されるのは `mailbox.run(throughput, throughput_deadline)` である。
+
+重要なのはここで、dispatcher は
+
+- `Future` を poll していない
+- async task を直接扱っていない
+- mailbox の drain loop を closure として実行している
+
+つまり current model は **future-driven dispatcher ではなく mailbox-driven dispatcher** である。
+
+### 2.2 Pekko との一致点
+
+この形は Pekko にかなり近い。
+
+- Pekko `Dispatcher.dispatch` も mailbox に enqueue して `registerForExecution` する
+- Pekko `registerForExecution` も mailbox を executor へ submit する
+- `Mailbox.run()` が system message → user message の順に drain する
+- `BalancingDispatcher` は共有 queue を mailbox 群で drain する
+
+したがって、dispatcher core の発想は「async runtime の executor」より **Pekko 型の mailbox scheduler** である。
+
+### 2.3 fraktor-rs 独自の差分
+
+差分として重要なのは次である。
+
+1. `MessageDispatcherShared` が orchestration を外側に持っている
+2. `dispatch` hook は mailbox 候補配列を返し、lock を離してから scheduling する
+3. `ExecutorShared` が trampoline を持ち、inline 実行や再入 submit を吸収する
+
+これは Rust 側の lock / ownership / reentrancy 制約に合わせた設計であり、
+**async 化のための布石というより、sync closure 実行を安全に回すための設計** である。
+
+## 3. blocking workload はどこで受ける設計か
+
+### 3.1 mailbox ではなく dispatcher / executor 側で受ける設計が見える
+
+typed 側には `DispatcherSelector::Blocking` がある。  
+typed dispatcher 層はこれを `pekko.actor.default-blocking-io-dispatcher` へ解決する。
+
+std adaptor 側でも:
+
+- `TokioExecutor` は `spawn_blocking` を使う
+- `ThreadedExecutor` は 1 task ごとに OS thread を切る blocking 向け executor である
+
+つまり、現行アーキテクチャの意図はかなり明確で、
+
+**block する可能性が高い処理は mailbox に持ち込まず、dispatcher / executor の選択で隔離する**
+
+となっている。
+
+### 3.2 この方針の利点
+
+- mailbox semantics を単純に保てる
+- bounded overflow と block を混ぜずに済む
+- no_std core と std adaptor の境界を保ちやすい
+- Tokio 環境でも、少なくとも blocking task は worker 直上ではなく blocking pool 側へ逃がせる
+
+### 3.3 この方針の弱点
+
+- Pekko の mailbox tuning をそのまま持ってくると違和感が出る
+- 「bounded mailbox が満杯なら一定時間待つ」という運用設計はそのまま移植できない
+- mailbox 選択だけで backpressure を調整する思想は薄くなる
+
+## 4. 既に存在する async 接続点
+
+### 4.1 actor 自体は sync contract
+
+`Actor` trait の中核は sync である。
+
+- `pre_start(&mut self, ...) -> Result<...>`
+- `receive(&mut self, ...) -> Result<...>`
+- `post_stop(&mut self, ...) -> Result<...>`
+
+`MessageInvoker` も sync であり、
+
+- `invoke(&mut self, message: AnyMessage) -> Result<...>`
+- `system_invoke(&mut self, message: SystemMessage) -> Result<...>`
+
+になっている。
+
+これは非常に重要で、今の runtime は **actor invocation そのものを async にしていない**。
+
+### 4.2 その代わり `pipe_to_self` / `pipe_to` がある
+
+一方で `ActorContext` には async future を mailbox へ橋渡しする seam がある。
+
+- `pipe_to_self`
+- `pipe_to`
+- `ask` の結果を future として受けて再投入する経路
+
+内部では `ContextPipeTask` が `Pin<Box<dyn Future<...>>>` を保持し、
+waker により再度 mailbox 側へ戻ってくる。
+
+つまり現在の async story は:
+
+- actor handler は sync
+- 非同期 I/O や future は actor 外で進む
+- 完了時に message として mailbox へ戻す
+
+である。
+
+これは Pekko typed の `pipeToSelf` 的な発想と整合している。
+
+重要なのは、この seam は typed convenience ではなく **untyped kernel contract** として先に存在している点である。  
+typed `TypedActorContext::pipe_to_self` / `pipe_to` は、kernel の future polling、waker、actor cell delivery、failure observation に乗る薄い wrapper として扱う。
+
+## 5. 固定前提で戦略がどう変わるか
+
+### 5.1 `spawn_blocking` は既定 executor として重くなる
+
+現状の `TokioExecutor` は `Handle::spawn_blocking` で mailbox drain closure を実行する。  
+これは「actor handler が blocking し得る」という保守的前提では安全側だが、`std=tokio` を固定し async-first に寄せるなら既定としては重い。
+
+Tokio 前提では、executor は少なくとも次の 2 系統へ分けたほうがよい。
+
+| dispatcher intent | executor | 想定用途 |
+|---|---|---|
+| default / non-blocking | Tokio task executor | mailbox drain が短く、handler が blocking I/O をしない actor |
+| blocking | Tokio blocking executor | 同期ファイル I/O、CPU heavy、既存 sync API 呼び出し |
+
+後方互換は不要なので、現在の `TokioExecutor` 名を残すことにこだわらず、既定側と blocking 側を責務で分けるほうがよい。  
+例えば設計上は `TokioTaskExecutor` と `TokioBlockingExecutor` のように分け、`DispatcherSelector::Blocking` は後者へ解決する。
+
+### 5.2 Embassy では blocking mailbox 互換の価値がさらに下がる
+
+Embassy 前提では、`pushTimeOut` 的な blocking bounded mailbox は環境に合わない。  
+embedded async では「満杯なら待つ」を thread block として実装できないし、executor 上で待つなら `await` 可能な backpressure protocol として設計する必要がある。
+
+したがって、embedded 側の戦略は次が自然である。
+
+- mailbox overflow は現行の `DropNewest` / `DropOldest` / `Grow` と観測可能な dead letter を維持する
+- backpressure は bounded mailbox の blocking put ではなく、typed delivery / ask / pull protocol / mailbox pressure notification で表現する
+- executor adapter は Embassy の static task / signal / bounded ready queue を使い、mailbox drain closure を短時間だけ実行する
+
+### 5.3 scheduler には async 化の入口が既にある
+
+`SchedulerRunner` には `AsyncHost` / `Hardware` のモード概念があり、`TickExecutorSignal` は `wait_async()` を持っている。  
+`TokioTickDriver` も `tokio::time::interval` と async task で tick を供給している。
+
+これは、actor invocation より先に **runtime driver を async 化する余地** が既にあることを示している。  
+つまり最初に async 化すべき対象は `Actor::receive` ではなく、Tokio / Embassy の task・timer・waker を actor runtime に接続する adapter 群である。
+
+### 5.4 async を入れてよい境界と入れない境界
+
+固定前提でも、`Mailbox::run` の内部で `.await` するのは避けたほうがよい。  
+理由は、mailbox drain は suspend / resume / system message priority / throughput / cleanup の整合性境界だからである。
+
+```
+Tokio / Embassy task
+  |
+  v
+Executor adapter
+  |
+  v
+MessageDispatcherShared::register_for_execution
+  |
+  v
+Mailbox::run(...)  // non-awaiting drain boundary
+  |
+  v
+MessageInvoker::invoke(...)
+```
+
+async はこの図の上下に入れるのがよい。
+
+- 上側: executor / tick driver / timer / wakeup signal
+- 下側: `pipe_to_self` / `pipe_to` が future を起動し、完了結果を mailbox message として戻す
+
+中央の mailbox drain に `.await` を入れると、lock discipline、reentrancy、supervision、stash、cleanup が一気に async state machine 化される。  
+そこは価値に対して破壊範囲が大きすぎる。
+
+## 6. async 化の選択肢
+
+### 選択肢 A: runtime adapter を async-first にする
+
+#### 内容
+
+- default Tokio executor は `tokio::spawn(async move { task(); })` 相当の task 実行へ寄せる
+- blocking 用には別 executor を用意し、`DispatcherSelector::Blocking` から明示的に選ばせる
+- Embassy adapter は static task + signal + bounded ready queue で mailbox drain を駆動する
+- `Mailbox::run` / `MessageDispatcherShared` / `Actor::receive` は sync contract のまま維持する
+
+#### 利点
+
+- Tokio / Embassy の runtime 資産を活かせる
+- full async core より影響範囲が小さい
+- `spawn_blocking` 既定の過剰保守を外せる
+- embedded 側でも「thread がある前提」に寄らない
+
+#### 欠点
+
+- default dispatcher 上の actor は blocking してはならない、という contract を明文化する必要がある
+- sync actor が重い処理をすると Tokio worker / Embassy executor を占有し得る
+- executor selector と cookbook の整備が必要になる
+
+#### 評価
+
+**固定前提では第一推奨**。  
+最も少ない破壊で「Tokio / Embassy を使うなら async 化しないともったいない」という意図に応えられる。
+
+### 選択肢 B: `pipe_to_self` / `pipe_to` を future-to-message adapter として厚くする
+
+#### 内容
+
+- 既存 `ActorContext::pipe_to_self` / `pipe_to` と `TypedActorContext::pipe_to_self` / `pipe_to` を Pekko `pipeToSelf` 型の async adapter として明文化する
+- 実装順序は untyped kernel first とし、`ActorContext` / `ContextPipeTask` / delivery 観測を固定してから typed wrapper を整える
+- actor handler は future を返さず、同期的に future を登録して `Behavior` / `Result` を返す
+- future completion は typed message として mailbox に戻し、state 更新は completion message handler で行う
+- ask / ask_with_status / delivery / timer と future-to-message の戻り方を統一する
+
+#### 利点
+
+- actor 利用者の async ergonomics が大きく上がる
+- Tokio / Embassy 前提と自然に整合する
+- mailbox drain の整合性境界を保てる
+- Pekko typed と同じ「同期 actor 記述 + future completion message」の境界を保てる
+- 既存 kernel `pipe_to_self` を壊さず、その上に typed surface の docs / tests / failure observability を厚くできる
+
+#### 欠点
+
+- async I/O 中心の actor では completion message 型を明示的に設計する必要がある
+- in-flight future の cancel / restart / stale result discard は generation token など利用者側プロトコルで扱う必要がある
+- `pipe_to_self` の mapper / adapter failure を観測可能にする tests と docs が必要になる
+
+#### 評価
+
+**第二推奨**。  
+runtime adapter async-first 化の次に取り組む価値が高い。ただしこれは handler が `Future` を返す新 contract を作る話ではなく、既存 `pipe_to_self` / `pipe_to` を Pekko 互換の future-to-message surface として磨く話である。
+
+### 選択肢 C: dispatcher / executor trait を future submit へ変える
+
+#### 内容
+
+- `Executor::execute(Box<dyn FnOnce()>)` を future submit へ置き換える、または併設する
+- `MessageDispatcherShared::register_for_execution` が async task を直接 submit する
+- mailbox drain 自体は sync closure として future 内で実行する
+
+#### 利点
+
+- Tokio / Embassy の spawn API に型として寄せやすい
+- executor adapter の意図は明確になる
+
+#### 欠点
+
+- `mailbox.run` が sync のままなら、本質的には closure を future に包むだけになりやすい
+- Embassy では dynamic future spawn が簡単とは限らず、static task + queue のほうが合う可能性がある
+- executor trait の破壊的変更に対する利益が選択肢 A より小さい
+
+#### 評価
+
+**選択肢 A の実装を進めてから再評価**。  
+trait を急いで future 化するより、まず runtime-specific executor adapter を分けるほうが情報が増える。
+
+### 選択肢 D: actor invocation まで含めて full async core にする
+
+#### 内容
+
+- `Actor::receive` を async 化
+- `MessageInvoker::invoke` を async 化
+- mailbox が「1 message = 1 future poll / wake」モデルに変わる
+- suspend / resume / restart / stash / death watch / mailbox pressure がすべて async state machine と絡む
+
+#### 利点
+
+- actor handler が自然に `await` できる
+- I/O 中心の actor にとって記述性が高い
+
+#### 欠点
+
+- 影響範囲が極めて大きい
+- mailbox / dispatcher / actor lifecycle / supervision の意味論がほぼ全面的に変わる
+- Pekko parity はかなり薄まる
+- `.await` を跨ぐ lock 禁止の規律が core 全体に入る
+
+#### 評価
+
+**現時点では非推奨**。  
+Tokio / Embassy 前提でも、この変更は「async 化」ではなく「runtime model の刷新」に近い。
+
+## 7. どこまでを妥当な非互換とみなすか
+
+### 7.1 妥当とみなせるもの
+
+- bounded mailbox を overflow strategy 中心で設計する
+- `pushTimeOut` 系 blocking bounded mailbox を core の既定にしない
+- blocking workload は `Blocking` dispatcher / blocking executor へ明示的に隔離する
+- mailbox drain は non-awaiting のまま保ち、async は runtime adapter と actor-facing API で受ける
+
+これは「Pekko を Rust へ翻訳する」のではなく、**Pekko の意味論を保ちつつ Rust 向けに整理する** という意味で妥当である。
+
+特に Embassy 前提では、blocking mailbox 互換を厚くするより、async backpressure と pressure notification を整えるほうが自然である。
+
+### 7.2 妥当性の条件
+
+ただし、これを妥当とするなら次を明文化する必要がある。
+
+1. default dispatcher 上の actor は blocking I/O をしてはならない
+2. blocking actor は `DispatcherSelector::Blocking` などで明示的に隔離する
+3. bounded mailbox の overflow は block ではなく policy / dead letter / pressure event で観測する
+4. async I/O は `pipe_to_self` / `pipe_to` 系で mailbox message へ戻す
+5. Embassy adapter は thread blocking を前提にしない
+
+何も書かないままだと、bounded mailbox が部分対応なのか、Tokio / Embassy 前提の意図的非互換なのかが曖昧になる。
+
+## 8. 推奨判断
+
+### 推奨 1: default executor を async runtime task 寄りに分ける
+
+固定前提では、`TokioExecutor = spawn_blocking` を既定とみなす設計は再考する。  
+default dispatcher は Tokio task executor へ寄せ、blocking dispatcher は Tokio blocking executor へ分ける。
+
+Embassy 側も同じ考え方で、blocking ではなく static task / signal / bounded ready queue による mailbox drain を設計する。
+
+### 推奨 2: `pipe_to_self` / `pipe_to` surface を次の主戦場にする
+
+`pipe_to_self` は良い基礎であり、Pekko typed でも同じく actor 記述は同期的なまま `pipeToSelf` で Future completion を message 化する。  
+そのため、まず untyped kernel の `ActorContext::pipe_to_self` / `pipe_to`、`ContextPipeTask`、waker、delivery failure 観測を固定する。  
+その上で typed 側は handler が `Future` を返す新 contract を増やすより、既存 `TypedActorContext::pipe_to_self` / `pipe_to` を薄い wrapper として docs、tests、adapter failure observability、cookbook を厚くする価値が高い。
+
+future は actor state を借用し続けず、owned value に閉じ込める。  
+完了結果は message として戻し、state 更新は通常の同期 handler で行う。
+
+### 推奨 3: mailbox / dispatcher core の full async 化は保留する
+
+`Actor::receive` / `MessageInvoker::invoke` / `Mailbox::run` の async 化は、supervision と mailbox scheduling の意味論を大きく変える。  
+Tokio / Embassy 前提でも、まずは runtime adapter と `pipe_to_self` / `pipe_to` surface を厚くしてから必要性を再評価する。
+
+### 推奨 4: blocking bounded mailbox は低優先度に落とす
+
+Pekko `pushTimeOut` 互換は、固定前提では優先度が下がる。  
+必要なら std 限定の compatibility option として後から足せるが、先にやるべきは async task executor、Embassy adapter、future-to-message adapter surface である。
+
+## 9. 次に詰めるべき具体論点
+
+1. `TokioExecutor` の責務をどう分けるか
+   - 既定を task executor にする
+   - blocking 用を別名 / 別 factory にする
+   - `DispatcherSelector::Blocking` の解決先を blocking executor に固定する
+2. Tokio current-thread runtime をサポート対象に入れるか
+   - lock / reentrancy / blocking 禁止の規律が強いため、初期は multi-thread runtime 前提が安全
+3. Embassy adapter の実行モデルをどうするか
+   - static worker task
+   - signal wakeup
+   - bounded ready queue
+   - `embassy-time` による scheduler tick
+4. `pipe_to_self` / `pipe_to` の cancel / restart / stop semantics をどう文書化するか
+   - actor restart 時に in-flight future を cancel するか
+   - stop 時に completion message を捨てるか dead letter にするか
+   - supervision error と future error をどう対応づけるか
+5. backpressure をどの API で表現するか
+   - mailbox overflow policy
+   - mailbox pressure notification
+   - typed delivery / pull protocol
+   - ask timeout
+
+## 10. 現時点の意思決定案
+
+現時点で最もバランスが良い案は次である。
+
+- **mailbox drain / actor invocation の core contract は sync / non-awaiting のまま維持**
+- **std の default dispatcher は Tokio task executor へ寄せる**
+- **blocking は別 executor と `Blocking` dispatcher selector で明示的に隔離**
+- **embedded は Embassy adapter を新設し、static task + signal + timer で駆動**
+- **async I/O ergonomics は untyped kernel の `pipe_to_self` / `pipe_to` を先に固定し、その上に typed thin wrapper を整える**
+- **Pekko `pushTimeOut` 互換は低優先度の optional compatibility とする**
+
+この案なら、
+
+- 既存の Pekko parity の強みを保てる
+- Tokio / Embassy の runtime 資産を活かせる
+- mailbox hot path に `.await` を持ち込まない
+- blocking と async の責務境界が明確になる
+- 将来 full async core が本当に必要になった場合も、前段の adapter / future-to-message surface 整備が土台になる
+
+という利点がある。

--- a/openspec/changes/async-first-actor-runtime-adapters/design.md
+++ b/openspec/changes/async-first-actor-runtime-adapters/design.md
@@ -1,0 +1,195 @@
+## Context
+
+現在の actor-core は Pekko 型の mailbox-driven scheduler をかなり忠実に持っている。`MessageDispatcherShared::register_for_execution` は mailbox を scheduled にし、`Executor` へ `Box<dyn FnOnce()>` を submit し、その closure が `Mailbox::run(throughput, throughput_deadline)` を実行する。
+
+この構造の強みは、`Mailbox::run` が system message priority、suspend / resume、throughput、throughput deadline、cleanup ownership を 1 つの non-awaiting 境界で扱える点である。ここに `.await` を入れると、lock discipline、reentrancy、supervision、stash、cleanup が一気に async state machine 化される。
+
+一方で、std 環境を Tokio 固定とするなら、現状の `TokioExecutor` が default mailbox drain を `spawn_blocking` に送っている点は重い。Embassy 前提では thread blocking の逃げ道自体がないため、Pekko の blocking bounded mailbox (`pushTimeOut`) 互換を厚くする方向はさらに合わない。
+
+したがって本 change では、core の mailbox drain は維持しつつ、外側の executor / tick driver / clock / wakeup と、既存 `pipe_to_self` / `pipe_to` による future-to-message adapter を async-first に整える。
+
+## Goals / Non-Goals
+
+### Goals
+
+- Tokio default dispatcher を non-blocking task executor として扱えるようにする。
+- Tokio blocking dispatcher を `spawn_blocking` 専用に分離する。
+- Embassy adapter crate を新設し、actor-core を Embassy task / signal / timer に接続する。
+- 既存 `ActorContext::pipe_to_self` / `pipe_to` と `ContextPipeTask` を future-to-message kernel contract として先に固定し、その上に `TypedActorContext::pipe_to_self` / `pipe_to` を薄い wrapper として維持する。
+- mailbox drain / actor invocation の core contract は sync / non-awaiting のまま守る。
+
+### Non-Goals
+
+- `Actor::receive` / `MessageInvoker::invoke` / `Mailbox::run` の full async 化。
+- `pushTimeOut` 系 blocking bounded mailbox の実装。
+- Embassy remote transport、Embassy stream materializer、Embassy persistence adapter。
+- Tokio current-thread runtime の初期対応。
+- actor / behavior handler が `Future` を返す API、`.await` を跨いで actor state を mutable borrow する API。
+
+## Decisions
+
+### Decision 1: `TokioExecutor` を default task executor として定義し直す
+
+`TokioExecutor` は `Handle::spawn` で async task を起動し、その task 内で mailbox drain closure を短時間実行する。`Executor` trait は `Box<dyn FnOnce()>` を受け取る sync submit primitive のままにするため、実装は概念上次の形になる。
+
+```rust
+fn execute(&mut self, task: Box<dyn FnOnce() + Send + 'static>, _affinity_key: u64) -> Result<(), ExecuteError> {
+  drop(self.handle.spawn(async move {
+    task();
+  }));
+  Ok(())
+}
+```
+
+この design は `Executor` trait を future submit に変えない。Embassy では dynamic future spawn より static task + queue のほうが合うため、core trait を Tokio 形に寄せすぎない。
+
+### Decision 2: `TokioBlockingExecutor` を追加する
+
+blocking actor 用には `TokioBlockingExecutor` を追加し、`Handle::spawn_blocking` を使う。既存の `TokioExecutor` が担っていた保守的な blocking 受け皿はここへ移す。
+
+`TokioBlockingExecutorFactory` も追加し、std Tokio helper が `DEFAULT_BLOCKING_DISPATCHER_ID` へ登録できるようにする。
+
+### Decision 3: default と blocking dispatcher の既定登録を分離する
+
+`Dispatchers::ensure_default` は現在、default と blocking に同じ configurator を入れ得る。core の no_std default は inline executor でよいが、std Tokio helper では default と blocking を別 factory で登録する必要がある。
+
+候補 API は次のどちらかにする。
+
+```rust
+pub fn with_default_dispatcher_factory(mut self, configurator: ArcShared<Box<dyn MessageDispatcherFactory>>) -> Self
+pub fn with_blocking_dispatcher_factory(mut self, configurator: ArcShared<Box<dyn MessageDispatcherFactory>>) -> Self
+```
+
+または、既存 `with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ...)` と `with_dispatcher_factory(DEFAULT_BLOCKING_DISPATCHER_ID, ...)` を使う std helper を `actor-adaptor-std` に置く。実装時は既存 API で十分なら新 API を足さない。
+
+### Decision 4: Embassy adapter は新 crate `actor-adaptor-embassy` として分離する
+
+Embassy 依存は `actor-core` に入れない。`modules/actor-adaptor-embassy` を追加し、`actor-core` の `Executor` / `TickDriver` / mailbox clock injection へ接続する adapter だけを持つ。
+
+初期構成は次の責務に分ける。
+
+- `EmbassyExecutor`: mailbox drain request を bounded ready queue へ積む。
+- `EmbassyExecutorDriver`: Embassy task 内で signal を待ち、ready queue から closure を drain する。
+- `EmbassyTickDriver`: `embassy-time::Ticker` または `Timer` で tick を供給する。
+- `EmbassyMailboxClock`: `embassy-time::Instant` を `MailboxClock` に変換して注入する helper。
+
+`Executor::execute` は sync method なので、Embassy 側では closure を queue に入れて signal を通知するだけにする。実行は Embassy task が所有する。
+
+`EmbassyTickDriver::kind()` は `TickDriverKind::Embassy` を返す。`AutoProfileKind::Embassy` は既に存在するため、metrics / snapshot 上の driver kind だけを追加する。
+
+### Decision 5: Embassy の ready queue は bounded とし、submit 失敗を `ExecuteError` として返す
+
+Embassy では unbounded allocation を前提にしない。ready queue は `embassy_sync::channel::Channel` などの bounded primitive を使う。満杯時は block せず `ExecuteError` を返し、dispatcher は既存どおり mailbox scheduling CAS を rollback する。
+
+これは backpressure を thread block で扱わない方針と一致する。
+
+### Decision 6: actor API は同期のまま、Future 連携は `pipe_to_self` に集約する
+
+Pekko typed は `Behavior` / `AbstractBehavior` の message handler を同期的に保ち、`ActorContext.pipeToSelf` で `Future` / `CompletionStage` の完了結果を actor message に戻す。fraktor-rs も同じ境界を既に持っている。
+
+現在の実装では、untyped 側に次がある。
+
+- `ActorContext::pipe_to_self(future, map) -> Result<(), PipeSpawnError>`
+- `ActorContext::pipe_to(future, target, map) -> Result<(), PipeSpawnError>`
+- `ContextPipeTask` が `Future<Output = Option<AnyMessage>>` を保持し、waker 経由で actor cell に再 poll を要求する
+- delivery 失敗は `record_send_error` と warn log に乗る
+
+この untyped 側が kernel contract であり、実装はここを先に固定する。typed 側は kernel contract の利用者であり、独立した async 実行モデルを持たせない。
+
+typed 側にも次がある。
+
+- `TypedActorContext::pipe_to_self(future, map_ok, map_err) -> Result<(), PipeSpawnError>`
+- `TypedActorContext::pipe_to(future, recipient, map_ok, map_err) -> Result<(), PipeSpawnError>`
+- `pipe_to_self` は `AdaptMessage` を使い、adapter 実行を actor thread 側へ戻す
+- `ask` / `ask_with_status` はこの typed `pipe_to_self` に乗っている
+
+したがって本 change では handler が `Future` を返す新 contract を足さない。既存 untyped `pipe_to_self` / `pipe_to` を kernel contract として守り、typed context はその薄い wrapper として `AnyMessage` を直接扱わせずに `Future` 完了結果を message 化できることをテストと docs で固定する。
+
+想定する利用形は次である。
+
+```rust
+ctx.pipe_to_self(
+  future,
+  |value| Ok(Msg::Completed(value)),
+  |error| Ok(Msg::Failed(error)),
+)?;
+Ok(Behaviors::same())
+```
+
+handler は future を起動するまでに必要な値を clone / move し、future 完了後は message として戻す。actor state の更新は completion message を処理する通常の同期 handler で行う。
+
+### Decision 7: async future の lifecycle は actor mailbox delivery に従う
+
+future 完了結果は actor mailbox へ user message として戻る。actor が停止済みなら delivery failure は既存の send error / dead letter 観測経路に乗せる。
+
+restart 時に in-flight future を強制 cancel する機構は初期スコープに入れない。これは actor state を future が borrow しない設計なら安全側であり、完了結果は restart 後の新 actor instance に通常 message として届く。cancel semantics が必要な場合は generation token を上位 API で追加する。
+
+### Decision 8: `pushTimeOut` 互換は optional compatibility として後回しにする
+
+Tokio / Embassy 前提では blocking bounded mailbox の優先度を下げる。bounded mailbox の満杯は現行の overflow strategy、dead letter、mailbox pressure event で観測する。待ちたいユースケースは typed delivery、ask timeout、pull protocol のほうで表現する。
+
+## Implementation Shape
+
+### Phase 1: Tokio executor split
+
+`TokioExecutor` を task executor へ変更し、`TokioBlockingExecutor` / `TokioBlockingExecutorFactory` を追加する。public surface tests を更新し、`DispatcherSelector::Blocking` 経路で blocking executor が使える構成を用意する。
+
+### Phase 2: std Tokio system helper
+
+`actor-adaptor-std` に Tokio 前提の system config helper を追加する。helper は default dispatcher に `TokioExecutorFactory`、blocking dispatcher に `TokioBlockingExecutorFactory`、tick driver に `TokioTickDriver` を入れる。
+
+### Phase 3: untyped kernel future-to-message contract の固定
+
+既存 `ActorContext::pipe_to_self` / `pipe_to`、`ContextPipeTask`、waker、actor cell の poll / delivery 経路を確認し、Pekko `pipeToSelf` と同じ future-to-message kernel contract として tests と rustdoc に固定する。actor cell 不在、停止済み、delivery failure、`pipe_to` の `None` delivery suppression を先に明文化する。
+
+### Phase 4: typed thin wrapper の固定
+
+`TypedActorContext::pipe_to_self` / `pipe_to` は untyped kernel adapter の薄い wrapper として維持する。typed E2E と context tests を追加し、Ok / Err future の両方を typed self message に変換すること、`AnyMessage` を caller に露出しないこと、`AdaptMessage` / adapter failure が actor の failure 経路で観測されることを検証する。
+
+### Phase 5: Embassy adapter crate
+
+`modules/actor-adaptor-embassy` を追加し、Embassy executor adapter、tick driver、clock injection helper を実装する。CI 対象 target / feature は別途確認し、初期は compile check と unit contract test を優先する。
+
+## Risks / Trade-offs
+
+### Risk 1: Tokio worker を actor handler が占有する
+
+default dispatcher が Tokio task executorになると、blocking actor が default dispatcher 上で同期 I/O を実行した場合、Tokio worker を占有する。
+
+緩和策として、docs と tests で「default dispatcher は non-blocking actor 用」「blocking actor は `DispatcherSelector::Blocking`」を明記し、blocking executor 分離を同じ change で提供する。
+
+### Risk 2: `tokio::spawn(async move { task(); })` は closure 実行自体を中断しない
+
+mailbox drain closure は `.await` しないため、task 内で一度動き始めると throughput / deadline まで同期実行される。これは現在の mailbox-driven scheduler と同じ性質であり、throughput / throughput deadline を適切に設定することで公平性を保つ。
+
+### Risk 3: Embassy の closure queue が `Box<dyn FnOnce()>` を扱えるか
+
+`actor-core` の `Executor` trait は `alloc` 前提の boxed closure を受け取る。Embassy target でも alloc を使う前提にするか、Embassy adapter だけ別 executor trait を必要とするかは実装時に確認する。
+
+初期案では `actor-core` が alloc crate であるため、Embassy adapter も alloc 有効 target を前提にする。
+
+### Risk 4: 既存 `pipe_to_self` の意味論を崩す
+
+`pipe_to_self` は Pekko 互換の重要な async adapter 境界であり、`ask` / `ask_with_status` もこの経路に依存している。ここを別の future-returning handler surface で置き換えると、同期 actor 記述と future 連携の分離が崩れる。
+
+緩和策として、actor API は同期維持を明文化し、既存 `pipe_to_self` / `pipe_to` の signature と delivery semantics を壊さない。改善は typed docs / tests / error observability の強化に限定する。
+
+### Risk 5: in-flight future の restart semantics
+
+future completion が restart 後の actor に届くことは、場合によっては望ましくない。初期 API では caller が generation token を message に含められるようにし、runtime が暗黙 cancel しないことを明文化する。
+
+## Validation
+
+- `actor-adaptor-std` の Tokio executor tests で default task executor と blocking executor の実行経路を分けて検証する。
+- typed integration test で `pipe_to_self` に渡した Ok / Err future の完了が typed message として self に戻ることを検証する。
+- `ask` / `ask_with_status` が既存 typed `pipe_to_self` 経路を維持していることを regression test または既存 test で確認する。
+- dispatcher tests で `DispatcherSelector::Blocking` が blocking dispatcher id に解決され、std Tokio helper で別 executor factory が登録されることを検証する。
+- Embassy adapter は初期段階では compile check と bounded queue / signal の unit contract を優先する。
+- 最終的にソースコード編集後は `./scripts/ci-check.sh ai all` を実行する。
+
+## Open Questions
+
+- Embassy adapter crate 名は `actor-adaptor-embassy` で確定するか、将来他の embedded executor も想定して `actor-adaptor-embedded` にするか。
+- `TokioExecutor` 名を task executor に再定義するか、`TokioTaskExecutor` を新設して `TokioExecutor` を削除するか。
+- `TypedActorContext::pipe_to_self` の rustdoc と cookbook をどこに置き、Pekko `pipeToSelf` との差分をどこまで明文化するか。
+- in-flight future の cancel API をこの change に含めるか、generation token cookbook に留めるか。

--- a/openspec/changes/async-first-actor-runtime-adapters/proposal.md
+++ b/openspec/changes/async-first-actor-runtime-adapters/proposal.md
@@ -1,0 +1,118 @@
+## Why
+
+`std=Tokio`、`embedded=Embassy` を固定前提にするなら、現在の actor 実行戦略はまだ async runtime の強みを十分に使えていない。
+
+現状の `TokioExecutor` は mailbox drain closure を `spawn_blocking` に流す。これは actor handler が blocking し得る前提では安全側だが、Tokio を std 環境の標準実行基盤にするなら既定 executor としては重い。逆に Embassy では thread blocking という逃げ道がないため、Pekko の `pushTimeOut` 型 blocking bounded mailbox 互換を厚くするより、task / timer / waker / signal を actor runtime adapter に接続するほうが自然である。
+
+この change は、`Mailbox::run` と `Actor::receive` の core 契約を full async 化せず、外側の executor / tick driver / timer と、既存 `pipe_to_self` / `pipe_to` による future-to-message adapter を async-first に整える。Pekko 互換の mailbox drain 意味論と `pipeToSelf` 型の利用者体験を保ちつつ、Tokio / Embassy を「ただの実行先」ではなく actor runtime の主実行基盤として使える状態にする。
+
+## What Changes
+
+### 1. Tokio executor を default task と blocking に分ける
+
+`actor-adaptor-std` の Tokio executor family を次の責務に分ける。
+
+- `TokioExecutor`: default dispatcher 用。`tokio::spawn` 相当で短時間の mailbox drain closure を async task として実行する。
+- `TokioBlockingExecutor`: blocking dispatcher 用。`tokio::task::spawn_blocking` で同期 I/O / CPU heavy / legacy sync API 呼び出しを隔離する。
+- `TokioExecutorFactory`: default dispatcher 用 factory として `TokioExecutor` を生成する。
+- `TokioBlockingExecutorFactory`: `DEFAULT_BLOCKING_DISPATCHER_ID` 用 factory として `TokioBlockingExecutor` を生成する。
+
+`DispatcherSelector::Blocking` は `pekko.actor.default-blocking-io-dispatcher` に解決済みなので、その解決先に blocking executor を登録できる構成を整える。
+
+### 2. default dispatcher と blocking dispatcher の既定登録を分離する
+
+現在の `Dispatchers::ensure_default` は default と blocking に同じ configurator を入れ得る。この change では、std / Tokio 構成で default dispatcher と blocking dispatcher に別 configurator を登録できる API または helper を追加する。
+
+`ActorSystemConfig::default()` の no_std / core 単体既定は引き続き inline executor でよい。一方、std Tokio 用 helper は default を Tokio task executor、blocking を Tokio blocking executor にする。
+
+### 3. Embassy adapter の設計を追加する
+
+新しい `actor-adaptor-embassy` workspace member を追加する。初期スコープは actor-core への Embassy 接続に限定し、remote / stream / persistence の Embassy 対応は含めない。
+
+Embassy adapter は次を提供する。
+
+- Embassy task で mailbox drain request を受ける dispatcher executor adapter
+- `embassy-time` による `TickDriver` 実装
+- `embassy-time::Instant` 相当を mailbox throughput deadline clock として注入する helper
+- thread blocking を前提にしない bounded ready queue / signal ベースの wakeup
+
+### 4. `pipe_to_self` / `pipe_to` を future-to-message adapter として維持する
+
+Pekko typed は actor 記述を同期的に保ちつつ、`ActorContext.pipeToSelf` で `Future` / `CompletionStage` の完了結果を self message に変換する。fraktor-rs も既に `ActorContext::pipe_to_self`、`ActorContext::pipe_to`、`TypedActorContext::pipe_to_self`、`TypedActorContext::pipe_to` を持つため、この change ではそれらを壊さず、Pekko 互換の async adapter 境界として明文化する。
+
+actor API 面では `Actor::receive`、`TypedActor::receive`、`Behaviors::receive_message`、`MessageInvoker::invoke` は同期 contract のまま維持する。async I/O の完了結果は `pipe_to_self` / `pipe_to` 経由で mailbox message に戻し、actor state の更新は completion message handler 内で同期的に行う。
+
+実装順序は untyped kernel first とする。まず `ActorContext::pipe_to_self` / `pipe_to`、`ContextPipeTask`、waker、delivery failure 観測を kernel contract として固定し、その上に `TypedActorContext::pipe_to_self` / `pipe_to` を薄い typed wrapper として整える。
+
+必要な改善は handler が `Future` を返す新 contract の追加ではなく、既存 typed pipe helper のテスト、rustdoc、adapter failure 観測、Pekko `pipeToSelf` との差分整理である。
+
+### 5. blocking bounded mailbox 互換を低優先度へ明文化する
+
+Pekko `pushTimeOut` 系 bounded mailbox は、この change では実装しない。Tokio / Embassy 前提では、bounded mailbox の満杯を thread block で待つより、overflow policy、mailbox pressure notification、typed delivery / ask / pull protocol で backpressure を表現する。
+
+## Capabilities
+
+### Modified Capabilities
+
+- **`dispatch-executor-unification`**
+  - Tokio executor family を default task executor と blocking executor に分ける。
+  - default dispatcher と blocking dispatcher の既定登録を分離する。
+  - mailbox drain は sync / non-awaiting のまま維持する。
+
+- **`std-tick-driver`**
+  - `TickDriverKind` に Embassy variant を追加し、Embassy driver を metrics / snapshot 上で識別できるようにする。
+
+### New Capabilities
+
+- **`actor-embassy-adapter`**
+  - `actor-core` を Embassy task / timer / signal に接続する adapter を定義する。
+
+- **`actor-future-to-message-surface`**
+  - 既存 `pipe_to_self` / `pipe_to` を Pekko `pipeToSelf` 型の async adapter surface として維持・強化する。
+
+## Impact
+
+**影響を受けるコード**:
+
+- `modules/actor-adaptor-std/src/std/dispatch/dispatcher/`
+  - `TokioExecutor` の実行方式変更
+  - `TokioBlockingExecutor` / `TokioBlockingExecutorFactory` 追加
+  - public re-export と public surface test 更新
+- `modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers.rs`
+  - default / blocking の同時登録または個別登録 helper 追加
+- `modules/actor-core/src/core/kernel/actor/setup/actor_system_config.rs`
+  - std adapter が default / blocking dispatcher を分けて登録しやすい config 経路追加
+- `modules/actor-core/src/core/kernel/actor/`
+  - `ActorContext::pipe_to_self` / `pipe_to`、`ContextPipeTask`、waker、delivery failure 観測を future-to-message kernel contract として固定
+- `modules/actor-core/src/core/typed/actor/`
+  - kernel contract の上に乗る薄い typed wrapper として、既存 `TypedActorContext::pipe_to_self` / `pipe_to` の互換性テスト、rustdoc、adapter failure 観測を強化
+- `modules/actor-core/src/core/kernel/actor/scheduler/tick_driver/tick_driver_kind.rs`
+  - `TickDriverKind::Embassy` 追加
+- `modules/actor-adaptor-embassy/` (新規)
+  - Embassy executor adapter / tick driver / clock injection helper 追加
+- `docs/plan/2026-04-26-mailbox-dispatcher-async-judgement.md`
+  - 実装後に採用判断と未解決論点を更新
+
+**影響を受ける公開 API 契約**:
+
+- `TokioExecutor` は default / non-blocking dispatcher 用 executor として定義し直される。
+- blocking 用に `TokioBlockingExecutor` と `TokioBlockingExecutorFactory` が追加される。
+- std Tokio 用 actor system helper が default / blocking dispatcher の別登録を提供する。
+- 既存 untyped `pipe_to_self` / `pipe_to` は future-to-message kernel adapter として維持される。
+- typed `pipe_to_self` / `pipe_to` は kernel adapter の薄い wrapper として維持され、typed actor 利用者が `AnyMessage` を直接扱わずに `Future` 完了結果を self / target message へ戻せることを公開契約として明文化する。
+- Embassy adapter crate が新規公開される。
+
+**破壊的変更**:
+
+- `TokioExecutor` の実行方式は `spawn_blocking` から Tokio task 実行へ変わる。
+- blocking 前提の actor は default dispatcher ではなく `DispatcherSelector::Blocking` を明示的に使う必要がある。
+- `TokioExecutorFactory` を blocking executor として使っていた内部テストや例は `TokioBlockingExecutorFactory` に移行する。
+
+## Non-goals
+
+- **full async core 化**: `Actor::receive`、`MessageInvoker::invoke`、`Mailbox::run` を `async fn` 化しない。
+- **Pekko `pushTimeOut` 互換 mailbox**: blocking bounded mailbox はこの change では実装しない。
+- **remote / stream / persistence の Embassy 対応**: 初期 Embassy adapter は actor runtime の executor / tick / clock 接続に限定する。
+- **Tokio current-thread runtime 対応**: 初期スコープでは multi-thread Tokio runtime を前提にし、current-thread runtime は明示的に非対応または future work とする。
+- **future-returning actor API**: actor / behavior handler が `Future` を返す新 contract はこの change では導入しない。
+- **`pipe_to_self` の置き換え**: 既存 `pipe_to_self` / `pipe_to` を別 API へ置き換えず、Pekko 互換の future-to-message adapter として維持する。

--- a/openspec/changes/async-first-actor-runtime-adapters/specs/actor-embassy-adapter/spec.md
+++ b/openspec/changes/async-first-actor-runtime-adapters/specs/actor-embassy-adapter/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: actor-adaptor-embassy は actor-core を Embassy task / signal / timer に接続する
+
+`actor-adaptor-embassy` は `actor-core` の port を Embassy 環境に接続する adapter crate として提供されなければならない (MUST)。Embassy 依存は `actor-adaptor-embassy` に閉じ込め、`actor-core` は `embassy-*` crate に依存してはならない (MUST NOT)。
+
+初期 scope は actor runtime の executor、tick driver、mailbox clock injection に限定しなければならない (MUST)。remote transport、stream materialization、persistence adapter は含めてはならない (MUST NOT)。
+
+#### Scenario: actor-core に Embassy 依存が入らない
+
+- **WHEN** `modules/actor-core/Cargo.toml` と `modules/actor-core/src/` を確認する
+- **THEN** `embassy-*` crate への dependency は存在しない
+- **AND** `use embassy_` で始まる import は存在しない
+
+#### Scenario: Embassy adapter crate が workspace member として存在する
+
+- **WHEN** workspace modules を確認する
+- **THEN** `modules/actor-adaptor-embassy` が存在する
+- **AND** その crate は `fraktor-actor-core-rs` に依存する
+- **AND** Embassy 依存はその crate 側にのみ置かれる
+
+### Requirement: EmbassyExecutor は bounded ready queue と signal で mailbox drain を駆動する
+
+`EmbassyExecutor` は core の `Executor` trait を実装しなければならない (MUST)。`Executor::execute` は mailbox drain closure を bounded ready queue へ enqueue し、Embassy task を wake する signal を通知しなければならない (MUST)。`execute` は thread blocking や busy wait を行ってはならない (MUST NOT)。
+
+ready queue が満杯の場合、`EmbassyExecutor::execute` は block せず `ExecuteError` を返さなければならない (MUST)。これにより dispatcher は既存の submit failure rollback 経路で mailbox schedule state を戻せる。
+
+#### Scenario: execute は ready queue へ enqueue して signal を通知する
+
+- **GIVEN** `EmbassyExecutor` が構築済みである
+- **WHEN** `Executor::execute(task, affinity_key)` が呼ばれる
+- **THEN** `task` は bounded ready queue に入る
+- **AND** Embassy worker task を起こす signal が通知される
+- **AND** `execute` 自体は mailbox drain closure を同期実行しない
+
+#### Scenario: ready queue 満杯時は ExecuteError を返す
+
+- **GIVEN** Embassy ready queue が満杯である
+- **WHEN** `EmbassyExecutor::execute(task, affinity_key)` が呼ばれる
+- **THEN** `Err(ExecuteError)` が返る
+- **AND** caller thread / task は空き待ちで block されない
+
+#### Scenario: Embassy worker task が ready queue を drain する
+
+- **GIVEN** Embassy worker task が起動済みである
+- **WHEN** ready queue signal が通知される
+- **THEN** worker task は ready queue から task を取り出す
+- **AND** 取り出した mailbox drain closure を同期的に実行する
+- **AND** closure 内部で `.await` は発生しない
+
+### Requirement: EmbassyTickDriver は embassy-time で scheduler tick を供給する
+
+`actor-adaptor-embassy` は `TickDriver` trait を実装する `EmbassyTickDriver` を提供しなければならない (MUST)。`EmbassyTickDriver` は `embassy-time` を使って tick を生成し、`TickFeedHandle` に tick を供給しなければならない (MUST)。
+
+`EmbassyTickDriver::kind()` は `TickDriverKind::Embassy` を返さなければならない (MUST)。`provision` が返す `TickDriverProvision::auto_metadata` は `AutoProfileKind::Embassy` を含まなければならない (MUST)。
+
+#### Scenario: EmbassyTickDriver は Embassy profile を公開する
+
+- **GIVEN** `EmbassyTickDriver::default()` が生成される
+- **WHEN** `kind()` が呼ばれる
+- **THEN** `TickDriverKind::Embassy` が返る
+
+#### Scenario: EmbassyTickDriver は embassy-time で tick を供給する
+
+- **GIVEN** `EmbassyTickDriver` が provision 済みである
+- **WHEN** configured resolution が経過する
+- **THEN** `TickFeedHandle` に tick が enqueue される
+- **AND** scheduler tick executor が Embassy task から駆動される
+
+### Requirement: Embassy adapter は mailbox throughput deadline 用 monotonic clock を注入する
+
+`actor-adaptor-embassy` は `embassy-time::Instant` 相当の monotonic time source を actor system config に注入する helper を提供しなければならない (MUST)。この clock は `Mailbox::run` の throughput deadline 判定に使われ、wall-clock に依存してはならない (MUST NOT)。
+
+#### Scenario: Embassy clock helper は mailbox clock を設定する
+
+- **WHEN** Embassy actor system config helper が呼ばれる
+- **THEN** config には Embassy monotonic clock 由来の `MailboxClock` が設定される
+- **AND** `Mailbox::run(..., Some(deadline))` は Embassy clock で deadline 判定を行う
+
+#### Scenario: clock injection は actor-core の no_std 境界を保つ
+
+- **WHEN** mailbox clock injection の実装を確認する
+- **THEN** Embassy 固有型は `actor-adaptor-embassy` 内に閉じている
+- **AND** `actor-core` から Embassy 固有型は参照されない

--- a/openspec/changes/async-first-actor-runtime-adapters/specs/actor-future-to-message-surface/spec.md
+++ b/openspec/changes/async-first-actor-runtime-adapters/specs/actor-future-to-message-surface/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: `pipe_to_self` / `pipe_to` は canonical future-to-message adapter として維持される
+
+actor runtime は、`Future` の完了結果を actor message に変換する canonical adapter として、既存 `ActorContext::pipe_to_self`、`ActorContext::pipe_to`、`TypedActorContext::pipe_to_self`、`TypedActorContext::pipe_to` を維持しなければならない (MUST)。この change はそれらを handler が `Future` を返す別 contract で置き換えてはならない (MUST NOT)。
+
+これらの adapter は Pekko typed の `ActorContext.pipeToSelf` と同じ設計意図を持つ。actor handler は同期的に future を起動し、future completion は mailbox message として actor に戻らなければならない (MUST)。
+
+untyped `ActorContext::pipe_to_self` / `pipe_to` と `ContextPipeTask` が future-to-message の kernel contract でなければならない (MUST)。typed `TypedActorContext::pipe_to_self` / `pipe_to` は、その kernel contract に委譲する薄い wrapper でなければならない (MUST)。
+
+#### Scenario: typed actor が future completion を self message として受け取る
+
+- **GIVEN** typed actor が `TypedActorContext::pipe_to_self(future, map_ok, map_err)` を呼ぶ
+- **WHEN** `future` が `Ok(value)` で完了する
+- **THEN** `map_ok(value)` で生成された typed message が同じ actor の mailbox に enqueue される
+- **AND** actor は通常の typed message handler でその message を受け取る
+
+#### Scenario: typed actor が future failure を self message として受け取る
+
+- **GIVEN** typed actor が `TypedActorContext::pipe_to_self(future, map_ok, map_err)` を呼ぶ
+- **WHEN** `future` が `Err(error)` で完了する
+- **THEN** `map_err(error)` で生成された typed message が同じ actor の mailbox に enqueue される
+- **AND** actor は通常の typed message handler でその message を受け取る
+
+### Requirement: typed pipe helper は `AnyMessage` を caller に露出しない
+
+typed actor context の future-to-message adapter は、caller に `AnyMessage` 変換を直接要求してはならない (MUST NOT)。typed self delivery では、`TypedActorContext::pipe_to_self` が `AdaptMessage` 相当の actor-thread adapter を使い、`map_ok` / `map_err` の結果を actor protocol `M` へ変換しなければならない (MUST)。
+
+typed adapter は future polling、waker registration、delivery retry、delivery failure 観測を独自に実装してはならない (MUST NOT)。それらは untyped kernel の `ContextPipeTask` / actor cell delivery 経路に委譲しなければならない (MUST)。
+
+adapter 変換が失敗した場合、その失敗は actor の adapter failure 経路、log、または明示的 error として観測可能でなければならず (MUST)、無言で握りつぶしてはならない (MUST NOT)。
+
+#### Scenario: caller は typed message だけを返す
+
+- **GIVEN** typed actor が `TypedActorContext::pipe_to_self` を呼ぶ
+- **WHEN** caller が `map_ok` / `map_err` を実装する
+- **THEN** caller は actor protocol `M` または `AdapterError` を返す
+- **AND** caller は `AnyMessage::new` を直接呼ぶ必要がない
+
+#### Scenario: adapter failure は観測される
+
+- **GIVEN** `map_ok` または `map_err` が `AdapterError` を返す
+- **WHEN** pipe completion message が actor thread で adapter 実行される
+- **THEN** failure は actor の adapter failure 経路または warn log で観測できる
+- **AND** 成功したふりをして typed message を配送してはならない
+
+### Requirement: actor API と typed behavior handler は同期 contract のまま維持される
+
+`Actor::receive`、`TypedActor::receive`、`MessageInvoker::invoke`、`Behaviors::receive`、`Behaviors::receive_message` は同期 contract のまま維持されなければならない (MUST)。この change は actor / behavior handler が `Future` を返す新 contract を導入してはならない (MUST NOT)。
+
+future が actor-owned state や `TypedActorContext` の mutable borrow を `.await` 跨ぎで保持できる API を提供してはならない (MUST NOT)。state 更新は completion message handler 内で同期的に行わなければならない (MUST)。
+
+#### Scenario: behavior handler は future を返さない
+
+- **WHEN** `Behaviors::receive_message` の handler signature を確認する
+- **THEN** handler は `Result<Behavior<M>, ActorError>` を同期的に返す
+- **AND** handler の戻り値は `Future` ではない
+
+#### Scenario: async I/O は message 化される
+
+- **GIVEN** actor が async I/O を開始する
+- **WHEN** async I/O の結果で actor state を更新したい
+- **THEN** actor は `pipe_to_self` で completion message を作る
+- **AND** actor state は completion message handler 内で更新される
+
+### Requirement: in-flight future completion は既存 delivery 観測経路に従う
+
+`pipe_to_self` / `pipe_to` から起動された in-flight future の completion message は、通常の user message delivery と同じ観測経路に従わなければならない (MUST)。対象 actor が停止済み、mailbox closed、または delivery 不可能な場合、失敗は既存の send error / dead letter / log などの観測経路に記録されなければならない (MUST)。
+
+restart 時の in-flight future は初期スコープでは runtime が暗黙 cancel してはならない (MUST NOT)。cancel や stale discard が必要な caller は generation token を message payload に含められなければならない (MUST)。
+
+#### Scenario: actor 停止後の completion は観測可能に失敗する
+
+- **GIVEN** future が actor 停止前に `pipe_to_self` で登録されている
+- **WHEN** actor 停止後に future が完了する
+- **THEN** completion message delivery は成功したふりをしない
+- **AND** 失敗は send error、dead letter、または warn log として観測可能である
+
+#### Scenario: restart 後の completion は通常 message として扱われる
+
+- **GIVEN** future 起動後に actor が restart している
+- **WHEN** future が完了する
+- **THEN** completion message は現在の actor instance に通常 user message として配送される
+- **AND** stale 判定が必要な actor は payload の generation token で discard できる

--- a/openspec/changes/async-first-actor-runtime-adapters/specs/dispatch-executor-unification/spec.md
+++ b/openspec/changes/async-first-actor-runtime-adapters/specs/dispatch-executor-unification/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Tokio executor family は default task executor と blocking executor を分離する
+
+`actor-adaptor-std` は Tokio 環境向け executor を default dispatcher 用と blocking dispatcher 用に分離しなければならない (MUST)。default dispatcher 用の `TokioExecutor` は `tokio::spawn` 相当の task 実行で mailbox drain closure を起動し、`spawn_blocking` を使ってはならない (MUST NOT)。blocking dispatcher 用の `TokioBlockingExecutor` は `tokio::task::spawn_blocking` で task を起動しなければならない (MUST)。
+
+両 executor は core の `Executor` trait を実装し、submit 失敗を `ExecuteError` として返さなければならない (MUST)。`TokioExecutorFactory` は `TokioExecutor` を生成し、`TokioBlockingExecutorFactory` は `TokioBlockingExecutor` を生成しなければならない (MUST)。
+
+#### Scenario: default Tokio executor は `spawn_blocking` を使わない
+
+- **GIVEN** `TokioExecutor` が `Executor::execute` を呼ばれる
+- **WHEN** mailbox drain closure が submit される
+- **THEN** closure は Tokio task として起動される
+- **AND** `TokioExecutor` の実装は `spawn_blocking` を呼ばない
+
+#### Scenario: blocking Tokio executor は `spawn_blocking` を使う
+
+- **GIVEN** `TokioBlockingExecutor` が `Executor::execute` を呼ばれる
+- **WHEN** blocking workload 用 task が submit される
+- **THEN** task は `tokio::task::spawn_blocking` で起動される
+- **AND** submit が拒否された場合は `ExecuteError` が返る
+
+#### Scenario: Tokio executor factories は責務別 executor を生成する
+
+- **WHEN** `TokioExecutorFactory::create(id)` が呼ばれる
+- **THEN** 返却される `ExecutorShared` は `TokioExecutor` を保持する
+- **WHEN** `TokioBlockingExecutorFactory::create(id)` が呼ばれる
+- **THEN** 返却される `ExecutorShared` は `TokioBlockingExecutor` を保持する
+
+### Requirement: std Tokio 構成は default dispatcher と blocking dispatcher に別 executor を登録する
+
+std Tokio 用の actor system 構築 helper は、`pekko.actor.default-dispatcher` と `pekko.actor.default-blocking-io-dispatcher` に別々の dispatcher configurator を登録しなければならない (MUST)。default dispatcher は `TokioExecutorFactory` を使い、blocking dispatcher は `TokioBlockingExecutorFactory` を使わなければならない (MUST)。
+
+`ActorSystemConfig::default()` の core 単体既定は inline executor のまま維持してよい (MAY)。ただし std Tokio helper を使った場合、blocking dispatcher が default dispatcher と同じ executor を共有してはならない (MUST NOT)。
+
+#### Scenario: std Tokio helper は default dispatcher に task executor を登録する
+
+- **WHEN** std Tokio helper で `ActorSystemConfig` を構築する
+- **THEN** `pekko.actor.default-dispatcher` には `TokioExecutorFactory` ベースの dispatcher configurator が登録される
+- **AND** default dispatcher で実行される mailbox drain は Tokio task executor に submit される
+
+#### Scenario: std Tokio helper は blocking dispatcher に blocking executor を登録する
+
+- **WHEN** std Tokio helper で `ActorSystemConfig` を構築する
+- **THEN** `pekko.actor.default-blocking-io-dispatcher` には `TokioBlockingExecutorFactory` ベースの dispatcher configurator が登録される
+- **AND** `DispatcherSelector::Blocking` を指定した actor は blocking executor 側で mailbox drain される
+
+#### Scenario: core default は no_std 依存を増やさない
+
+- **WHEN** `ActorSystemConfig::default()` を actor-core 単体で構築する
+- **THEN** Tokio 型への依存は発生しない
+- **AND** inline executor backed default dispatcher は維持される
+
+### Requirement: mailbox drain は async-first adapter 下でも non-awaiting 境界でなければならない
+
+Tokio / Embassy などの async runtime adapter を使う場合でも、`Mailbox::run`、`MessageDispatcherShared::register_for_execution`、`MessageInvoker::invoke`、`Actor::receive` の core contract は sync / non-awaiting のままでなければならない (MUST)。async runtime adapter は mailbox drain closure を実行する外側の task / signal / queue を提供し、mailbox drain loop の内部に `.await` を持ち込んではならない (MUST NOT)。
+
+#### Scenario: Tokio task executor は mailbox drain closure を同期的に実行する
+
+- **GIVEN** `TokioExecutor` が mailbox drain closure を Tokio task として起動している
+- **WHEN** task が poll される
+- **THEN** task 内では `Mailbox::run(throughput, throughput_deadline)` が同期的に呼ばれる
+- **AND** `Mailbox::run` の内部で `.await` は発生しない
+
+#### Scenario: async adapter は core trait を future submit に変更しない
+
+- **WHEN** `Executor` trait のシグネチャを確認する
+- **THEN** `execute` は `Box<dyn FnOnce() + Send + 'static>` を受け取る sync submit primitive のままである
+- **AND** `Executor` trait に runtime 固有の `Future` 型パラメータは追加されない

--- a/openspec/changes/async-first-actor-runtime-adapters/specs/std-tick-driver/spec.md
+++ b/openspec/changes/async-first-actor-runtime-adapters/specs/std-tick-driver/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: TickDriverKind は non_exhaustive で Std と Tokio variant を持つ
+
+`TickDriverKind` に `#[non_exhaustive]` を付与し、`Std`、`Tokio`、`Embassy` variant を含めなければならない（MUST）。これにより std / Tokio / Embassy の環境別 driver を event stream metrics と snapshot で区別できなければならない（MUST）。下流 crate は将来の variant 追加に備えて wildcard arm を持たなければならない。
+
+#### Scenario: TickDriverKind に Std、Tokio、Embassy が含まれる
+
+- **GIVEN** 本 change が適用された状態
+- **WHEN** `TickDriverKind` の variant を列挙する
+- **THEN** `Auto`, `Manual`, `Std`, `Tokio`, `Embassy` の variant が存在する
+- **AND** `#[non_exhaustive]` により下流 crate の `match` 文には wildcard arm が必須となる
+
+#### Scenario: EmbassyTickDriver は Embassy kind を返す
+
+- **GIVEN** `EmbassyTickDriver` が生成されている
+- **WHEN** `kind()` が呼ばれる
+- **THEN** `TickDriverKind::Embassy` が返る
+- **AND** provision 後の `TickDriverProvision::kind` も `TickDriverKind::Embassy` である

--- a/openspec/changes/async-first-actor-runtime-adapters/tasks.md
+++ b/openspec/changes/async-first-actor-runtime-adapters/tasks.md
@@ -1,0 +1,76 @@
+## Phase 1: 事前確認と設計固定
+
+- [ ] 1.1 `docs/plan/2026-04-26-mailbox-dispatcher-async-judgement.md` の固定前提を再確認する。
+- [ ] 1.2 `TokioExecutor` を task executor に再定義するか、`TokioTaskExecutor` を新設するかを決める。
+- [ ] 1.3 Embassy adapter crate 名を `actor-adaptor-embassy` で確定するか確認する。
+- [ ] 1.4 `Actor::receive` / `MessageInvoker::invoke` / `Mailbox::run` は本 change で async 化しないことを実装方針として固定する。
+- [ ] 1.5 `ActorContext::pipe_to_self` / `pipe_to` と `ContextPipeTask` を future-to-message kernel contract として先に固定し、その後 `TypedActorContext::pipe_to_self` / `pipe_to` を薄い wrapper として整える方針を固定する。
+
+## Phase 2: Tokio executor family の分離
+
+- [ ] 2.1 既存 `TokioExecutor` の tests を読み、`spawn_blocking` 前提になっている箇所を洗い出す。
+- [ ] 2.2 default dispatcher 用 executor を Tokio task 実行へ変更または新設する。
+- [ ] 2.3 `TokioBlockingExecutor` を追加し、`spawn_blocking` をここへ移す。
+- [ ] 2.4 `TokioBlockingExecutorFactory` を追加する。
+- [ ] 2.5 `std::dispatch::dispatcher` の public re-export を更新する。
+- [ ] 2.6 public surface tests に `TokioBlockingExecutorFactory` を追加する。
+
+## Phase 3: default / blocking dispatcher 登録の分離
+
+- [ ] 3.1 `Dispatchers::ensure_default` / `ensure_default_inline` / `replace_default_inline` の現状挙動を確認する。
+- [ ] 3.2 既存 `with_dispatcher_factory` だけで std Tokio helper が default / blocking を別登録できるか確認する。
+- [ ] 3.3 既存 API で十分でなければ `with_default_dispatcher_factory` / `with_blocking_dispatcher_factory` 相当を追加する。
+- [ ] 3.4 std Tokio 用 config helper を追加し、default に Tokio task executor、blocking に Tokio blocking executor、tick driver に `TokioTickDriver` を設定する。
+- [ ] 3.5 `DispatcherSelector::Blocking` が std Tokio helper 構成で blocking executor 側に到達する integration test を追加する。
+
+## Phase 4: untyped kernel future-to-message contract
+
+- [ ] 4.1 `ActorContext::pipe_to_self` / `pipe_to` と `ContextPipeTask` の現在の delivery / wakeup / error 観測経路を確認する。
+- [ ] 4.2 `ContextPipeTask` の waker が actor cell の再 poll 経路に戻ることを regression test で固定する。
+- [ ] 4.3 actor 停止済みや cell 不在時の `PipeSpawnError` が握りつぶされず caller に返ることを regression test で固定する。
+- [ ] 4.4 `pipe_to` の `None` delivery suppression と target delivery failure の観測経路を test / docs で固定する。
+- [ ] 4.5 untyped kernel contract を rustdoc に記載し、typed wrapper が依存する前提を明文化する。
+
+## Phase 5: typed thin wrapper
+
+- [ ] 5.1 `TypedActorContext::pipe_to_self` / `pipe_to` が untyped kernel adapter に委譲していることを確認する。
+- [ ] 5.2 typed wrapper が `AnyMessage` を caller に露出せず、`AdaptMessage` 経由で typed message に戻していることを確認する。
+- [ ] 5.3 typed `pipe_to_self` の Ok / Err future completion が self message として戻る integration test を追加または強化する。
+- [ ] 5.4 typed `pipe_to_self` の adapter failure が actor の adapter failure 経路で観測されることを test / docs で固定する。
+- [ ] 5.5 `ask` / `ask_with_status` が typed `pipe_to_self` 経路を維持していることを regression test または既存 test で確認する。
+
+## Phase 6: actor API 同期維持と docs
+
+- [ ] 6.1 `TypedActor::receive` と `Behaviors::receive_message` が同期 handler のままであることを public surface test または compile test で固定する。
+- [ ] 6.2 actor / behavior handler が `Future` を返す新 contract をこの change で追加しないことを docs / tasks に明記する。
+- [ ] 6.3 Pekko `ActorContext.pipeToSelf` と同じく、future completion は message として actor に戻し、state 更新は completion message handler で行うことを rustdoc または cookbook に記載する。
+- [ ] 6.4 restart 後の in-flight future completion は通常 message として扱われることを docs / tests で明記する。
+- [ ] 6.5 cancel が必要なユースケースは generation token を message に含める方針を cookbook または rustdoc に記載する。
+
+## Phase 7: Embassy adapter crate
+
+- [ ] 7.1 `modules/actor-adaptor-embassy` の Cargo package を追加する。
+- [ ] 7.2 `actor-core` へ Embassy 依存が入らないことを確認する。
+- [ ] 7.3 `EmbassyExecutor` を追加し、`Executor::execute` では bounded ready queue への enqueue と signal notify のみを行う。
+- [ ] 7.4 Embassy task 側で ready queue を drain する driver を追加する。
+- [ ] 7.5 ready queue 満杯時は block せず `ExecuteError` を返す。
+- [ ] 7.6 `TickDriverKind::Embassy` を追加する。
+- [ ] 7.7 `EmbassyTickDriver` を追加し、`embassy-time` で tick を供給する。
+- [ ] 7.8 `EmbassyMailboxClock` または同等 helper で mailbox throughput deadline clock を注入する。
+- [ ] 7.9 Embassy adapter の compile check 対象 target / feature を scripts または CI 方針に合わせて整理する。
+
+## Phase 8: docs / gap-analysis 更新
+
+- [ ] 8.1 `docs/plan/2026-04-26-mailbox-dispatcher-async-judgement.md` に採用した API 名と実装結果を反映する。
+- [ ] 8.2 mailbox gap analysis に `pushTimeOut` 系 blocking mailbox は意図的低優先度であることを追記する。
+- [ ] 8.3 std Tokio helper と blocking dispatcher の使い分けを docs または rustdoc に記載する。
+- [ ] 8.4 Embassy adapter の制約を docs または crate-level rustdoc に記載する。
+
+## Phase 9: 検証
+
+- [ ] 9.1 `actor-adaptor-std` の targeted tests を実行する。
+- [ ] 9.2 `actor-core` untyped `pipe_to_self` / `pipe_to` の targeted tests を実行する。
+- [ ] 9.3 `actor-core` typed `pipe_to_self` / `pipe_to` / `ask` の targeted tests を実行する。
+- [ ] 9.4 Embassy adapter の compile check / unit contract tests を実行する。
+- [ ] 9.5 `rtk rg -n "spawn_blocking" modules/actor-adaptor-std/src/std/dispatch/dispatcher` で default executor に `spawn_blocking` が残っていないことを確認する。
+- [ ] 9.6 ソースコード編集後の最終確認として `./scripts/ci-check.sh ai all` を実行し、完了を待つ。


### PR DESCRIPTION
## 概要

actor の mailbox / dispatcher / async 化方針について、OpenSpec change と関連設計メモを追加しました。

## 主な内容

- mailbox gap analysis を `Mailbox` に絞って深掘り
- `std=Tokio`、`embedded=Embassy` 固定前提での dispatcher / executor 方針を整理
- actor API は同期維持、`pipe_to_self` / `pipe_to` を future-to-message 境界として維持する方針を明文化
- 実装順序を untyped kernel first、typed thin wrapper second として OpenSpec に反映

## 検証

- docs / OpenSpec 追加のみのため `./scripts/ci-check.sh ai all` は未実行です。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds design/spec notes; no runtime or API code is modified in this PR.
> 
> **Overview**
> Adds new documentation and OpenSpec change materials to guide an *async-first actor runtime adapter* direction.
> 
> This introduces a mailbox-focused Pekko parity gap analysis, a planning memo for mailbox/dispatcher async strategy, and an OpenSpec proposal/design/specs/tasks that define splitting Tokio execution into **default task vs blocking** executors, adding an **Embassy adapter** concept, and explicitly keeping actor handlers synchronous while treating `pipe_to_self`/`pipe_to` as the canonical future-to-message boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e08161cea8934bb00cd44f608ec71c4e5675b9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* **ドキュメント**
  * mailbox機能に関するギャップ分析ドキュメントを追加しました
  * mailboxおよびdispatcher設計に関する非同期処理判断ドキュメントを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->