### PR TITLE
[codex] Rust edit hook の品質チェックを拡張

### DIFF
--- a/.agents/hooks/run_rust_checks_after_edit.py
+++ b/.agents/hooks/run_rust_checks_after_edit.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""AI エージェント PostToolUse hook: Rust ファイル編集後に dylint を自動実行する。
+"""AI エージェント PostToolUse hook: Rust ファイル編集後に品質チェックを自動実行する。
 
 Claude Code と Codex CLI で共通利用するため、エージェント種別を `--agent`
 引数で切り替える。エージェントごとに異なるのは以下の3点のみ:
@@ -14,7 +14,7 @@ Claude Code と Codex CLI で共通利用するため、エージェント種別
   1. `target/.ci-check.coordination.lock` で hook 同士 (エージェント横断) の
      直列化を行い、ci-check.sh の起動権を一つに絞る (TOCTOU 防止)。
   2. ci-check.sh 自身は `target/.ci-check.lock` で多重起動を弾くため、本
-     hook はその解放を待ってから coordination lock 内で dylint を起動する。
+     hook はその解放を待ってから coordination lock 内で品質チェックを起動する。
 """
 
 from __future__ import annotations
@@ -35,7 +35,7 @@ CI_LOCK_PATH = Path("target/.ci-check.lock")
 COORDINATION_LOCK_PATH = Path("target/.ci-check.coordination.lock")
 LOCK_WAIT_TIMEOUT_SEC = 1800
 LOCK_POLL_INTERVAL_SEC = 1.0
-CI_COMMAND = ("./scripts/ci-check.sh", "ai", "dylint")
+RUST_CHECK_COMMAND = ("./scripts/ci-check.sh", "ai", "fmt", "dylint", "clippy")
 MAX_FAILURE_LINES = 160
 MAX_FAILURE_CHARS = 12000
 
@@ -77,14 +77,14 @@ def main() -> int:
 
     repo_root = resolve_repo_root(payload)
     if repo_root is None:
-        return profile.block("Git ルートを特定できなかったため、自動 dylint を実行できませんでした。")
+        return profile.block("Git ルートを特定できなかったため、自動 Rust 品質チェックを実行できませんでした。")
 
     try:
-        run_auto_dylint(repo_root, profile.hook_lock_path, profile.label)
+        run_auto_rust_checks(repo_root, profile.hook_lock_path, profile.label)
     except HookFailure as failure:
         touched_paths = ", ".join(rust_paths)
         return profile.block(
-            "Rust ファイル編集後の自動 `./scripts/ci-check.sh ai dylint` が失敗しました。\n"
+            "Rust ファイル編集後の自動 `./scripts/ci-check.sh ai fmt dylint clippy` が失敗しました。\n"
             f"対象: {touched_paths}\n\n"
             f"{failure.message}"
         )
@@ -93,7 +93,7 @@ def main() -> int:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="dylint after Rust edit hook")
+    parser = argparse.ArgumentParser(description="Rust checks after edit hook")
     parser.add_argument(
         "--agent",
         required=True,
@@ -199,7 +199,7 @@ def resolve_repo_root(payload: dict[str, object]) -> Path | None:
     return Path(repo_root)
 
 
-def run_auto_dylint(repo_root: Path, hook_lock_relative: Path, lock_label: str) -> None:
+def run_auto_rust_checks(repo_root: Path, hook_lock_relative: Path, lock_label: str) -> None:
     repo_hook_lock_path = repo_root / hook_lock_relative
     repo_ci_lock_path = repo_root / CI_LOCK_PATH
     repo_coordination_lock_path = repo_root / COORDINATION_LOCK_PATH
@@ -218,7 +218,7 @@ def run_auto_dylint(repo_root: Path, hook_lock_relative: Path, lock_label: str) 
         with FileLock(repo_coordination_lock_path, "ci-check coordination"):
             wait_for_lock_release(repo_ci_lock_path, "ci-check.sh")
             completed = subprocess.run(
-                CI_COMMAND,
+                RUST_CHECK_COMMAND,
                 cwd=repo_root,
                 capture_output=True,
                 text=True,
@@ -345,7 +345,7 @@ def summarize_failure_output(completed: subprocess.CompletedProcess[str]) -> str
         lines.extend(line.rstrip() for line in text.splitlines())
 
     if not lines:
-        return f"`{' '.join(CI_COMMAND)}` が終了コード {completed.returncode} で失敗しました。"
+        return f"`{' '.join(RUST_CHECK_COMMAND)}` が終了コード {completed.returncode} で失敗しました。"
 
     tail = lines[-MAX_FAILURE_LINES:]
     message = "\n".join(tail).strip()
@@ -380,14 +380,14 @@ AGENT_PROFILES: dict[str, AgentProfile] = {
     "claude": AgentProfile(
         name="claude",
         label="Claude",
-        hook_lock_path=Path(".claude/dylint-hook.lock"),
+        hook_lock_path=Path(".claude/rust-check-hook.lock"),
         extract_rust_paths=extract_rust_paths_claude,
         block=block_claude,
     ),
     "codex": AgentProfile(
         name="codex",
         label="Codex",
-        hook_lock_path=Path(".codex/dylint-hook.lock"),
+        hook_lock_path=Path(".codex/rust-check-hook.lock"),
         extract_rust_paths=extract_rust_paths_codex,
         block=block_codex,
     ),

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/bin/python3 \"$CLAUDE_PROJECT_DIR/.agents/hooks/run_dylint_after_rust_edit.py\" --agent claude",
+            "command": "/usr/bin/python3 \"$CLAUDE_PROJECT_DIR/.agents/hooks/run_rust_checks_after_edit.py\" --agent claude",
             "timeout": 1800
           }
         ]

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -44,9 +44,9 @@ matcher = "^(apply_patch|Edit|Write)$"
 
 [[hooks.PostToolUse.hooks]]
 type = "command"
-command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.agents/hooks/run_dylint_after_rust_edit.py" --agent codex'
+command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.agents/hooks/run_rust_checks_after_edit.py" --agent codex'
 timeout = 1800
-statusMessage = "Rust 変更後の dylint を確認中"
+statusMessage = "Rust 変更後の fmt / dylint / clippy を確認中"
 
 [projects."/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs"]
 trust_level = "trusted"

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,10 @@ Cargo.lock
 /.claude/settings.local.json
 /.claude/scheduled_tasks.lock
 /.claude/dylint-hook.lock
+/.claude/rust-check-hook.lock
 
 /.codex*/dylint-hook.lock
+/.codex*/rust-check-hook.lock
 /.codex*/cache/
 /.codex*/log/
 /.codex*/auth.json

--- a/docs/plan/2026-04-27-rust-edit-hook-quality-checks.md
+++ b/docs/plan/2026-04-27-rust-edit-hook-quality-checks.md
@@ -1,0 +1,28 @@
+# Rust 編集後フックの品質チェック拡張
+
+更新日: 2026-04-27
+
+## 目的
+
+Rust ファイル編集後の自動フックが `dylint` のみを実行しており、`cargo fmt` の未実行や `clippy` エラーを後段で見落としやすい状態になっている。
+
+この変更では、既存の `scripts/ci-check.sh` は改修せず、フック側の責務だけを見直して、Rust 編集直後に `fmt` / `dylint` / `clippy` を自動実行する。
+
+あわせて、ファイル名やメッセージも `dylint` 専用前提から、Rust 品質チェック全体を表す名前へ整理する。
+
+## 方針
+
+1. `.agents/hooks/run_dylint_after_rust_edit.py` を、責務に即した新しい名前へ改名する。
+2. フックが起動するコマンドを `./scripts/ci-check.sh ai fmt dylint clippy` に変更する。
+3. docstring、失敗メッセージ、ロックファイル名、hook のステータスメッセージを `dylint` 専用表現から更新する。
+4. `.claude/settings.json` と `.codex/config.toml` の参照先を新ファイル名へ追従させる。
+
+## 変更しないもの
+
+- `scripts/ci-check.sh` の既存コマンド定義
+- Rust ファイル編集の検出ロジック
+- `target/.ci-check.lock` / `target/.ci-check.coordination.lock` による排他制御方針
+
+## 確認
+
+実装後は、対象ファイルの整合確認に加えて、最後に `./scripts/ci-check.sh ai all` を実行して全体確認する。


### PR DESCRIPTION
## 概要
Rust 編集後の PostToolUse hook を `dylint` 専用から、`fmt` / `dylint` / `clippy` をまとめて実行する品質チェック hook に整理しました。

## 変更内容
- `run_dylint_after_rust_edit.py` を `run_rust_checks_after_edit.py` へ改名
- hook が実行するコマンドを `./scripts/ci-check.sh ai fmt dylint clippy` に変更
- `.claude/settings.json` と `.codex/config.toml` の参照先・ステータスメッセージを更新
- 実装方針を `docs/plan/2026-04-27-rust-edit-hook-quality-checks.md` に記録

## 背景
`dylint` だけでは、Rust 編集後に `cargo fmt` の未実行や `clippy` エラーを見落としやすい状態でした。既存の `ci-check.sh` には各入口が揃っていたため、スクリプト本体は変えずに hook 側の責務を広げています。

## 影響
Rust ファイルを編集した直後に、整形漏れ・カスタム lint 違反・clippy warning をより早く検出できるようになります。

## 検証
- `rtk ./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to AI agent hook wiring and messaging, but it will run additional Rust checks after edits which may block workflows more often or increase hook runtime.
> 
> **Overview**
> Rust PostToolUse hook is broadened from running only `dylint` to running a fuller Rust quality gate: `./scripts/ci-check.sh ai fmt dylint clippy`.
> 
> The hook script and lockfiles are renamed from `dylint`-specific to generic Rust checks, and both `.claude/settings.json` and `.codex/config.toml` are updated to point to the new hook and reflect the expanded status/error messages. A short plan document is added describing the intent and what is/isn’t being changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1e0ab877fdb69454110857ddf9e08e8ecb6d89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->