### PR TITLE
[codex] add std showcase index

### DIFF
--- a/docs/plan/showcases-std-readme-index.md
+++ b/docs/plan/showcases-std-readme-index.md
@@ -1,0 +1,56 @@
+# showcases/std README インデックス追加計画
+
+## 概要
+
+`showcases/std` に、日本語のサンプルコードインデックス用 `README.md` を追加する。
+既存の `showcases/std/Cargo.toml` の `[[example]]` 定義を正とし、各 example の目的、実行コマンド、完了/未完了状態が一覧で分かる構成にする。
+概念名として `classic` は使わず、該当領域は `kernel` と表記する。
+
+## 実装内容
+
+- `showcases/std/README.md` を新規作成する。
+- README は `fraktor-showcases-std` crate に集約された実行可能サンプルの一覧として記述する。
+- 実行方法として、通常 example と `advanced` feature 必須 example のコマンドを分けて明記する。
+- インデックス表は `状態 / サンプル / 対象領域 / 内容 / 実行コマンド` の列で構成する。
+- 完了扱いは `showcases/std/Cargo.toml` に `[[example]]` として登録済み、かつ対応する `showcases/std/<name>/main.rs` が存在するものに限定する。
+- `classic_logging` と `classic_timers` は example 名は既存のまま載せるが、説明・対象領域では `kernel` API のサンプルとして記述する。
+- 未完了扱いは、現時点で example 未登録だが網羅観点として将来追加すべき候補を載せる。
+
+## インデックス対象
+
+完了として掲載する example は以下の 16 件にする。
+
+- `getting_started`
+- `request_reply`
+- `state_management`
+- `child_lifecycle`
+- `timers`
+- `routing`
+- `stash`
+- `serialization`
+- `stream_pipeline`
+- `stream_authoring_apis`
+- `classic_logging`（対象領域は `kernel`）
+- `classic_timers`（対象領域は `kernel`）
+- `typed_event_stream`
+- `typed_receptionist_router`
+- `remote_lifecycle`
+- `persistent_actor`
+
+`remote_lifecycle` と `persistent_actor` は `advanced` feature 必須として、実行コマンドを `cargo run -p fraktor-showcases-std --features advanced --example <name>` にする。
+それ以外は `cargo run -p fraktor-showcases-std --example <name>` にする。
+
+未完了候補として、既存 README / OpenSpec で示唆されている `remote_messaging`、`cluster_membership`、`persistence_effector` を掲載する。
+
+## 検証
+
+- `rtk git diff -- showcases/std/README.md docs/plan/showcases-std-readme-index.md` で意図しない変更がないことを確認する。
+- ソースコードは編集しないため、`./scripts/ci-check.sh ai all` は実行しない。
+- Rust ソースや `Cargo.toml` を編集した場合のみ、最後に `rtk ./scripts/ci-check.sh ai all` を実行して完了を待つ。
+
+## 前提
+
+- `Cargo.toml` の `[[example]]` 定義を、現時点の完了済みサンプル一覧の唯一の正とする。
+- README 追加のみを対象とし、サンプルコード本体や Cargo 設定は変更しない。
+- `classic` は既存 example 名に残っている場合のみ文字列として扱い、README 上の概念説明では `kernel` を使う。
+- `CHANGELOG.md` は編集しない。

--- a/showcases/std/README.md
+++ b/showcases/std/README.md
@@ -1,0 +1,51 @@
+# std showcases
+
+`fraktor-showcases-std` は、`std` 環境で実行できる fraktor-rs のサンプルコードを集約する crate です。
+この README は、現在実装済みのサンプルと、今後網羅すべき未実装サンプルのインデックスです。
+
+## 実行方法
+
+通常の example は次の形式で実行します。
+
+```bash
+cargo run -p fraktor-showcases-std --example getting_started
+```
+
+`advanced` feature が必要な example は次の形式で実行します。
+
+```bash
+cargo run -p fraktor-showcases-std --features advanced --example remote_lifecycle
+```
+
+## サンプルインデックス
+
+状態は、`showcases/std/Cargo.toml` に `[[example]]` として登録され、対応する `main.rs` が存在するものを `完了` としています。
+
+| 状態 | サンプル | 対象領域 | 内容 | 実行コマンド |
+|------|----------|----------|------|--------------|
+| 完了 | `getting_started` | typed actor | typed API で actor system を作成し、guardian にメッセージを送信する最小構成 | `cargo run -p fraktor-showcases-std --example getting_started` |
+| 完了 | `request_reply` | typed actor | `ask` と reply actor を使った request-reply パターン | `cargo run -p fraktor-showcases-std --example request_reply` |
+| 完了 | `state_management` | typed actor | Behavior 遷移による immutable counter と state machine | `cargo run -p fraktor-showcases-std --example state_management` |
+| 完了 | `child_lifecycle` | typed actor | 子 actor の生成、監視、終了通知、supervision restart | `cargo run -p fraktor-showcases-std --example child_lifecycle` |
+| 完了 | `timers` | typed actor | one-shot timer、periodic timer、timer cancellation | `cargo run -p fraktor-showcases-std --example timers` |
+| 完了 | `routing` | typed actor | pool router と round-robin による work distribution | `cargo run -p fraktor-showcases-std --example routing` |
+| 完了 | `stash` | typed actor | `StashBuffer` による一時退避と unstash による再処理 | `cargo run -p fraktor-showcases-std --example stash` |
+| 完了 | `serialization` | serialization | `Serializer` と `SerializerWithStringManifest` の登録と利用 | `cargo run -p fraktor-showcases-std --example serialization` |
+| 完了 | `stream_pipeline` | stream | `Source`、`Map`、`FlatMapConcat`、`Fold`、`Sink` による stream pipeline | `cargo run -p fraktor-showcases-std --example stream_pipeline` |
+| 完了 | `stream_authoring_apis` | stream | `GraphStage`、`GraphDsl`、`StreamRefs` などの stream authoring API | `cargo run -p fraktor-showcases-std --example stream_authoring_apis` |
+| 完了 | `classic_logging` | kernel actor | kernel actor の logging facade、diagnostic logging、event stream 連携 | `cargo run -p fraktor-showcases-std --example classic_logging` |
+| 完了 | `classic_timers` | kernel actor | kernel actor の timer API による single timer の起動と受信 | `cargo run -p fraktor-showcases-std --example classic_timers` |
+| 完了 | `typed_event_stream` | typed actor | typed API から event stream へ subscribe / publish する流れ | `cargo run -p fraktor-showcases-std --example typed_event_stream` |
+| 完了 | `typed_receptionist_router` | typed actor | `Receptionist` 登録と group router による service discovery routing | `cargo run -p fraktor-showcases-std --example typed_receptionist_router` |
+| 完了 | `remote_lifecycle` | remote | remote transport の起動、address 確認、shutdown、lifecycle event の観測 | `cargo run -p fraktor-showcases-std --features advanced --example remote_lifecycle` |
+| 完了 | `persistent_actor` | persistence | `PersistentActor`、journal、snapshot store による event sourced actor | `cargo run -p fraktor-showcases-std --features advanced --example persistent_actor` |
+
+## 未完了・追加候補
+
+| 状態 | サンプル候補 | 対象領域 | 網羅したい内容 |
+|------|--------------|----------|----------------|
+| 未完了 | `remote_messaging` | remote | ネットワーク越しの actor 通信と message delivery |
+| 未完了 | `cluster_membership` | cluster | cluster 参加、membership 変更、lifecycle event の観測 |
+| 未完了 | `persistence_effector` | persistence | typed API から永続化 effector を扱うサンプル |
+
+未完了候補を追加するときは、`showcases/std/<example-name>/main.rs` を作成し、`showcases/std/Cargo.toml` の `[[example]]` に登録してください。


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because it only adds new documentation files and does not change Rust code or build configuration.
> 
> **Overview**
> Adds a new `showcases/std/README.md` that serves as a Japanese index of runnable `fraktor-showcases-std` examples, including per-example purpose, target area, and exact `cargo run` commands (with `--features advanced` called out where required).
> 
> Also adds a planning doc (`docs/plan/showcases-std-readme-index.md`) describing the indexing rules (source of truth is `showcases/std/Cargo.toml` `[[example]]` entries, and `classic_*` examples are described as `kernel` samples) and listing a few future, not-yet-implemented example candidates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 063c94bd5922d067b2aad13ffb38e18670e75852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * `showcases/std` のサンプルコード実行方法と概要をまとめたREADMEを追加しました。完成済みのサンプルをドメイン別に整理し、実行コマンドを明記しています。新しいサンプル追加時の手順も記載されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->