### PR TITLE
[codex] add remote artery settings parity surface

### DIFF
--- a/modules/remote-adaptor-std/src/std/association_runtime.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime.rs
@@ -32,6 +32,7 @@ mod effect_application;
 mod handshake_driver;
 mod inbound_dispatch;
 mod inbound_quarantine_check;
+mod monotonic_millis;
 mod outbound_loop;
 mod peer_address_match;
 mod reconnect_backoff_policy;
@@ -44,6 +45,9 @@ pub(crate) use effect_application::apply_effects_in_place;
 pub use handshake_driver::HandshakeDriver;
 pub use inbound_dispatch::{run_inbound_dispatch, run_inbound_task_with_restart_budget};
 pub use inbound_quarantine_check::InboundQuarantineCheck;
+pub(crate) use monotonic_millis::{
+  duration_millis_saturated, std_instant_elapsed_millis, tokio_instant_elapsed_millis,
+};
 pub use outbound_loop::{run_outbound_loop, run_outbound_loop_with_reconnect};
 pub use reconnect_backoff_policy::ReconnectBackoffPolicy;
 pub use restart_counter::RestartCounter;

--- a/modules/remote-adaptor-std/src/std/association_runtime.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime.rs
@@ -42,7 +42,7 @@ pub use association_registry::AssociationRegistry;
 pub use association_shared::AssociationShared;
 pub(crate) use effect_application::apply_effects_in_place;
 pub use handshake_driver::HandshakeDriver;
-pub use inbound_dispatch::run_inbound_dispatch;
+pub use inbound_dispatch::{run_inbound_dispatch, run_inbound_task_with_restart_budget};
 pub use inbound_quarantine_check::InboundQuarantineCheck;
 pub use outbound_loop::{run_outbound_loop, run_outbound_loop_with_reconnect};
 pub use reconnect_backoff_policy::ReconnectBackoffPolicy;

--- a/modules/remote-adaptor-std/src/std/association_runtime/handshake_driver.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/handshake_driver.rs
@@ -12,7 +12,9 @@ use fraktor_remote_core_rs::core::{
 };
 use tokio::task::JoinHandle;
 
-use crate::std::association_runtime::{apply_effects_in_place, association_shared::AssociationShared};
+use crate::std::association_runtime::{
+  apply_effects_in_place, association_shared::AssociationShared, duration_millis_saturated, std_instant_elapsed_millis,
+};
 
 /// Drives handshake control tasks for one `Association`.
 ///
@@ -68,7 +70,7 @@ impl HandshakeDriver {
     }
     let task = tokio::spawn(async move {
       tokio::time::sleep(timeout).await;
-      let now_ms = monotonic_millis_since(started_at);
+      let now_ms = std_instant_elapsed_millis(started_at);
       shared.with_write(|assoc| {
         let effects = assoc.handshake_timed_out(now_ms, None);
         // Discarding `effects` here would silently drop the `Gated`
@@ -140,7 +142,7 @@ impl HandshakeDriver {
       let mut send_handshake = send_handshake;
       // u128 -> u64 のロッシーキャストを `monotonic_millis_since` と同じ防御パターンで揃え、
       // 極端な Duration が来ても silent な値変動を起こさないようにする。
-      let interval_ms = interval.as_millis().min(u128::from(u64::MAX)) as u64;
+      let interval_ms = duration_millis_saturated(interval);
       loop {
         tokio::time::sleep(interval).await;
         let now_ms = now_ms_provider();
@@ -166,14 +168,6 @@ impl HandshakeDriver {
       handle.abort();
     }
   }
-}
-
-/// Computes the monotonic millis elapsed between `started_at` and `now`.
-///
-/// This is the **only** place in the adapter that materialises an
-/// `Instant`-derived `u64` for the pure core layer (per design Decision 7).
-fn monotonic_millis_since(started_at: Instant) -> u64 {
-  started_at.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
 }
 
 fn spawn_periodic_handshake_sender<F, P>(

--- a/modules/remote-adaptor-std/src/std/association_runtime/inbound_dispatch.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/inbound_dispatch.rs
@@ -1,22 +1,51 @@
 //! Inbound dispatch loop: feeds incoming wire frames into the matching
 //! `Association`.
 
+use core::{future::Future, time::Duration};
+
 use fraktor_remote_core_rs::core::{
   address::{Address, UniqueAddress},
+  config::RemoteConfig,
   extension::EventPublisher,
   transport::TransportError,
   watcher::WatcherCommand,
   wire::{ControlPdu, HandshakePdu, HandshakeReq, HandshakeRsp},
 };
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::{sync::mpsc::UnboundedReceiver, time::Instant};
 
 use crate::std::{
   association_runtime::{
-    apply_effects_in_place, association_registry::AssociationRegistry,
+    RestartCounter, apply_effects_in_place, association_registry::AssociationRegistry,
     inbound_quarantine_check::InboundQuarantineCheck, peer_address_match::peer_matches_address,
   },
   tcp_transport::{InboundFrameEvent, WireFrame},
 };
+
+/// Re-runs an inbound task until it succeeds or the configured restart budget
+/// is exhausted.
+///
+/// # Errors
+///
+/// Returns the last task error once the configured inbound restart budget is
+/// consumed inside the active restart-timeout window.
+pub async fn run_inbound_task_with_restart_budget<F, Fut, E>(config: &RemoteConfig, mut run_task: F) -> Result<(), E>
+where
+  F: FnMut() -> Fut,
+  Fut: Future<Output = Result<(), E>>, {
+  let started_at = Instant::now();
+  let mut restart_counter = RestartCounter::new(config.inbound_max_restarts(), config.inbound_restart_timeout());
+
+  loop {
+    match run_task().await {
+      | Ok(()) => return Ok(()),
+      | Err(err) => {
+        if !restart_counter.restart(elapsed_ms(started_at)) {
+          return Err(err);
+        }
+      },
+    }
+  }
+}
 
 /// Reads inbound frames from the TCP transport's inbound channel and
 /// dispatches them into the matching `Association`.
@@ -280,4 +309,12 @@ fn dispatch_handshake_response(
       tracing::warn!(peer = %peer, ?err, "discarding invalid handshake response");
     },
   });
+}
+
+fn elapsed_ms(started_at: Instant) -> u64 {
+  duration_millis(started_at.elapsed())
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+  duration.as_millis().min(u128::from(u64::MAX)) as u64
 }

--- a/modules/remote-adaptor-std/src/std/association_runtime/inbound_dispatch.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/inbound_dispatch.rs
@@ -1,7 +1,7 @@
 //! Inbound dispatch loop: feeds incoming wire frames into the matching
 //! `Association`.
 
-use core::{future::Future, time::Duration};
+use core::future::Future;
 use std::sync::{Arc, Mutex};
 
 use fraktor_remote_core_rs::core::{
@@ -18,6 +18,7 @@ use crate::std::{
   association_runtime::{
     RestartCounter, apply_effects_in_place, association_registry::AssociationRegistry,
     inbound_quarantine_check::InboundQuarantineCheck, peer_address_match::peer_matches_address,
+    tokio_instant_elapsed_millis,
   },
   tcp_transport::{InboundFrameEvent, WireFrame},
 };
@@ -57,7 +58,7 @@ where
     match run_task().await {
       | Ok(()) => return Ok(()),
       | Err(err) => {
-        if !restart_counter.restart(elapsed_ms(started_at)) {
+        if !restart_counter.restart(tokio_instant_elapsed_millis(started_at)) {
           return Err(err);
         }
       },
@@ -393,12 +394,4 @@ fn dispatch_handshake_response(
       tracing::warn!(peer = %peer, ?err, "discarding invalid handshake response");
     },
   });
-}
-
-fn elapsed_ms(started_at: Instant) -> u64 {
-  duration_millis(started_at.elapsed())
-}
-
-fn duration_millis(duration: Duration) -> u64 {
-  duration.as_millis().min(u128::from(u64::MAX)) as u64
 }

--- a/modules/remote-adaptor-std/src/std/association_runtime/inbound_dispatch.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/inbound_dispatch.rs
@@ -2,6 +2,7 @@
 //! `Association`.
 
 use core::{future::Future, time::Duration};
+use std::sync::{Arc, Mutex};
 
 use fraktor_remote_core_rs::core::{
   address::{Address, UniqueAddress},
@@ -20,6 +21,23 @@ use crate::std::{
   },
   tcp_transport::{InboundFrameEvent, WireFrame},
 };
+
+struct InboundDispatchState<HS, CS, WS> {
+  inbound_rx:              UnboundedReceiver<InboundFrameEvent>,
+  send_handshake_response: HS,
+  send_control_response:   CS,
+  submit_watcher_command:  WS,
+}
+
+struct InboundDispatchContext<'a, Now, HS, CS, WS> {
+  registry:                &'a AssociationRegistry,
+  now_ms_provider:         &'a Now,
+  event_publisher:         &'a EventPublisher,
+  local:                   &'a UniqueAddress,
+  send_handshake_response: &'a mut HS,
+  send_control_response:   &'a mut CS,
+  submit_watcher_command:  &'a mut WS,
+}
 
 /// Re-runs an inbound task until it succeeds or the configured restart budget
 /// is exhausted.
@@ -49,36 +67,105 @@ where
 
 /// Reads inbound frames from the TCP transport's inbound channel and
 /// dispatches them into the matching `Association`.
-pub async fn run_inbound_dispatch(
-  mut inbound_rx: UnboundedReceiver<InboundFrameEvent>,
+///
+/// # Errors
+///
+/// Returns the last transport send error when handshake/control response
+/// delivery keeps failing until the configured inbound restart budget is
+/// exhausted.
+pub async fn run_inbound_dispatch<HS, CS, WS>(
+  config: &RemoteConfig,
+  inbound_rx: UnboundedReceiver<InboundFrameEvent>,
   registry: AssociationRegistry,
   now_ms_provider: impl Fn() -> u64 + Send + 'static,
   event_publisher: EventPublisher,
-  sinks: (
-    UniqueAddress,
-    impl FnMut(&Address, HandshakePdu) -> Result<(), TransportError> + Send + 'static,
-    impl FnMut(&Address, ControlPdu) -> Result<(), TransportError> + Send + 'static,
-    impl FnMut(WatcherCommand) -> Result<(), Box<WatcherCommand>> + Send + 'static,
-  ),
-) {
-  let (local, mut send_handshake_response, mut send_control_response, mut submit_watcher_command) = sinks;
+  sinks: (UniqueAddress, HS, CS, WS),
+) -> Result<(), TransportError>
+where
+  HS: FnMut(&Address, HandshakePdu) -> Result<(), TransportError> + Send + 'static,
+  CS: FnMut(&Address, ControlPdu) -> Result<(), TransportError> + Send + 'static,
+  WS: FnMut(WatcherCommand) -> Result<(), Box<WatcherCommand>> + Send + 'static, {
+  let (local, send_handshake_response, send_control_response, submit_watcher_command) = sinks;
+  let state = Arc::new(Mutex::new(Some(InboundDispatchState {
+    inbound_rx,
+    send_handshake_response,
+    send_control_response,
+    submit_watcher_command,
+  })));
+  let registry = Arc::new(registry);
+  let now_ms_provider = Arc::new(now_ms_provider);
+  run_inbound_task_with_restart_budget(config, {
+    let state = Arc::clone(&state);
+    let registry = Arc::clone(&registry);
+    let now_ms_provider = Arc::clone(&now_ms_provider);
+    let event_publisher = event_publisher.clone();
+    let local = local.clone();
+    move || {
+      let state = Arc::clone(&state);
+      let registry = Arc::clone(&registry);
+      let now_ms_provider = Arc::clone(&now_ms_provider);
+      let event_publisher = event_publisher.clone();
+      let local = local.clone();
+      async move {
+        let mut dispatch_state = {
+          let mut guard = match state.lock() {
+            | Ok(guard) => guard,
+            | Err(poisoned) => poisoned.into_inner(),
+          };
+          match guard.take() {
+            | Some(state) => state,
+            | None => unreachable!("inbound dispatch state must be available before restart attempt"),
+          }
+        };
+        let ctx = InboundDispatchContext {
+          registry:                registry.as_ref(),
+          now_ms_provider:         now_ms_provider.as_ref(),
+          event_publisher:         &event_publisher,
+          local:                   &local,
+          send_handshake_response: &mut dispatch_state.send_handshake_response,
+          send_control_response:   &mut dispatch_state.send_control_response,
+          submit_watcher_command:  &mut dispatch_state.submit_watcher_command,
+        };
+        let result = run_inbound_dispatch_once(&mut dispatch_state.inbound_rx, ctx).await;
+        let mut guard = match state.lock() {
+          | Ok(guard) => guard,
+          | Err(poisoned) => poisoned.into_inner(),
+        };
+        *guard = Some(dispatch_state);
+        result
+      }
+    }
+  })
+  .await
+}
+
+async fn run_inbound_dispatch_once<Now, HS, CS, WS>(
+  inbound_rx: &mut UnboundedReceiver<InboundFrameEvent>,
+  ctx: InboundDispatchContext<'_, Now, HS, CS, WS>,
+) -> Result<(), TransportError>
+where
+  Now: Fn() -> u64,
+  HS: FnMut(&Address, HandshakePdu) -> Result<(), TransportError>,
+  CS: FnMut(&Address, ControlPdu) -> Result<(), TransportError>,
+  WS: FnMut(WatcherCommand) -> Result<(), Box<WatcherCommand>>, {
+  let InboundDispatchContext {
+    registry,
+    now_ms_provider,
+    event_publisher,
+    local,
+    send_handshake_response,
+    send_control_response,
+    submit_watcher_command,
+  } = ctx;
   while let Some(event) = inbound_rx.recv().await {
-    if !InboundQuarantineCheck::allows(&registry, &event) {
+    if !InboundQuarantineCheck::allows(registry, &event) {
       tracing::debug!(peer = %event.peer, "dropping inbound frame from quarantined association");
       continue;
     }
     match event.frame {
       | WireFrame::Handshake(pdu) => {
         let now = now_ms_provider();
-        dispatch_handshake_pdu(
-          &event.peer,
-          &pdu,
-          &registry,
-          now,
-          &event_publisher,
-          &local,
-          &mut send_handshake_response,
-        );
+        dispatch_handshake_pdu(&event.peer, &pdu, registry, now, event_publisher, local, send_handshake_response)?;
       },
       | WireFrame::Envelope(_pdu) => {
         // Local actor delivery is a separate provider integration contract.
@@ -86,21 +173,14 @@ pub async fn run_inbound_dispatch(
       },
       | WireFrame::Control(pdu) => {
         let now = now_ms_provider();
-        dispatch_control_pdu(
-          &event.peer,
-          &pdu,
-          &registry,
-          now,
-          &local,
-          &mut send_control_response,
-          &mut submit_watcher_command,
-        );
+        dispatch_control_pdu(&event.peer, &pdu, registry, now, local, send_control_response, submit_watcher_command)?;
       },
       | WireFrame::Ack(_pdu) => {
         tracing::debug!(peer = %event.peer, "inbound ack frame received");
       },
     }
   }
+  Ok(())
 }
 
 fn dispatch_control_pdu(
@@ -111,7 +191,7 @@ fn dispatch_control_pdu(
   local: &UniqueAddress,
   send_control_response: &mut impl FnMut(&Address, ControlPdu) -> Result<(), TransportError>,
   submit_watcher_command: &mut impl FnMut(WatcherCommand) -> Result<(), Box<WatcherCommand>>,
-) {
+) -> Result<(), TransportError> {
   match pdu {
     | ControlPdu::Heartbeat { authority } => {
       dispatch_heartbeat_request(
@@ -122,7 +202,7 @@ fn dispatch_control_pdu(
         local,
         send_control_response,
         submit_watcher_command,
-      );
+      )?;
     },
     | ControlPdu::HeartbeatResponse { authority, uid } => {
       dispatch_heartbeat_response(peer, authority, *uid, registry, now_ms, submit_watcher_command);
@@ -134,6 +214,7 @@ fn dispatch_control_pdu(
       tracing::debug!(peer = %peer, "inbound shutdown control frame received");
     },
   }
+  Ok(())
 }
 
 fn dispatch_heartbeat_request(
@@ -144,9 +225,9 @@ fn dispatch_heartbeat_request(
   local: &UniqueAddress,
   send_control_response: &mut impl FnMut(&Address, ControlPdu) -> Result<(), TransportError>,
   submit_watcher_command: &mut impl FnMut(WatcherCommand) -> Result<(), Box<WatcherCommand>>,
-) {
+) -> Result<(), TransportError> {
   let Some(remote_address) = registered_remote_address(peer, authority, registry, "heartbeat request") else {
-    return;
+    return Ok(());
   };
   // 受信した heartbeat 自身を liveness signal として watcher に流し込み、応答送信に
   // 失敗・遅延したケースでも片方向疎通を検出できるようにする。
@@ -159,9 +240,10 @@ fn dispatch_heartbeat_request(
   }
   let response = ControlPdu::HeartbeatResponse { authority: local.address().to_string(), uid: local.uid() };
   match send_control_response(&remote_address, response) {
-    | Ok(()) => {},
+    | Ok(()) => Ok(()),
     | Err(err) => {
       tracing::warn!(peer = %peer, origin = %remote_address, ?err, "heartbeat response send failed");
+      Err(err)
     },
   }
 }
@@ -236,13 +318,14 @@ fn dispatch_handshake_pdu(
   event_publisher: &EventPublisher,
   local: &UniqueAddress,
   send_handshake_response: &mut impl FnMut(&Address, HandshakePdu) -> Result<(), TransportError>,
-) {
+) -> Result<(), TransportError> {
   match pdu {
     | HandshakePdu::Req(req) => {
-      dispatch_handshake_request(peer, req, registry, now_ms, event_publisher, local, send_handshake_response);
+      dispatch_handshake_request(peer, req, registry, now_ms, event_publisher, local, send_handshake_response)?;
     },
     | HandshakePdu::Rsp(rsp) => dispatch_handshake_response(peer, rsp, registry, now_ms, event_publisher),
   }
+  Ok(())
 }
 
 fn dispatch_handshake_request(
@@ -253,7 +336,7 @@ fn dispatch_handshake_request(
   event_publisher: &EventPublisher,
   local: &UniqueAddress,
   send_handshake_response: &mut impl FnMut(&Address, HandshakePdu) -> Result<(), TransportError>,
-) {
+) -> Result<(), TransportError> {
   let remote_address = req.from().address();
   let Some(target) = registry.get_by_remote_address(remote_address).cloned() else {
     tracing::warn!(
@@ -261,7 +344,7 @@ fn dispatch_handshake_request(
       origin = %remote_address,
       "discarding handshake request for an unregistered association",
     );
-    return;
+    return Ok(());
   };
   // Lock 区間内で外部 I/O (send_handshake_response) を呼ぶと、send 側が再帰的に同じ
   // registry/association を参照するパスを持っていたとき deadlock し得る。受理判定と
@@ -278,12 +361,13 @@ fn dispatch_handshake_request(
   });
   match response {
     | Some(response) => match send_handshake_response(remote_address, response) {
-      | Ok(()) => {},
+      | Ok(()) => Ok(()),
       | Err(err) => {
         tracing::warn!(peer = %peer, origin = %remote_address, ?err, "handshake response send failed");
+        Err(err)
       },
     },
-    | None => {},
+    | None => Ok(()),
   }
 }
 

--- a/modules/remote-adaptor-std/src/std/association_runtime/monotonic_millis.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/monotonic_millis.rs
@@ -1,0 +1,24 @@
+//! Shared monotonic time conversion helpers for association runtime tasks.
+
+use core::time::Duration;
+use std::time::Instant as StdInstant;
+
+use tokio::time::Instant as TokioInstant;
+
+/// Converts elapsed monotonic time since `started_at` into saturated millis.
+#[must_use]
+pub fn std_instant_elapsed_millis(started_at: StdInstant) -> u64 {
+  duration_millis_saturated(started_at.elapsed())
+}
+
+/// Converts elapsed tokio monotonic time since `started_at` into saturated millis.
+#[must_use]
+pub fn tokio_instant_elapsed_millis(started_at: TokioInstant) -> u64 {
+  duration_millis_saturated(started_at.elapsed())
+}
+
+/// Converts a duration into saturated millis.
+#[must_use]
+pub fn duration_millis_saturated(duration: Duration) -> u64 {
+  duration.as_millis().min(u128::from(u64::MAX)) as u64
+}

--- a/modules/remote-adaptor-std/src/std/association_runtime/outbound_loop.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/outbound_loop.rs
@@ -12,8 +12,8 @@ use fraktor_utils_core_rs::core::sync::SharedLock;
 use tokio::time::{Instant, sleep, timeout};
 
 use crate::std::association_runtime::{
-  apply_effects_in_place, association_shared::AssociationShared, reconnect_backoff_policy::ReconnectBackoffPolicy,
-  restart_counter::RestartCounter,
+  apply_effects_in_place, association_shared::AssociationShared, duration_millis_saturated,
+  reconnect_backoff_policy::ReconnectBackoffPolicy, restart_counter::RestartCounter, tokio_instant_elapsed_millis,
 };
 
 /// Polling interval used by the outbound drain loop.
@@ -104,14 +104,14 @@ where
             // (next_outbound が Some を返した時点で Active のため、実際の戻り先は send_queue)
             // に戻して shutdown 後の再起動で再送できるようにする。
             shared.with_write(|assoc| {
-              let now_ms = elapsed_ms(started_at);
+              let now_ms = tokio_instant_elapsed_millis(started_at);
               let effects = assoc.enqueue(envelope_for_retry, now_ms);
               apply_effects_in_place(assoc, effects, &event_publisher, now_ms);
             });
             return Ok(());
           },
           | Err(err) => {
-            gate_for_reconnect(&shared, &policy, elapsed_ms(started_at), &event_publisher);
+            gate_for_reconnect(&shared, &policy, tokio_instant_elapsed_millis(started_at), &event_publisher);
             let ctx =
               RecoverContext { shared: &shared, policy: &policy, event_publisher: &event_publisher, started_at };
             recover_with_restart_budget(ctx, &mut reconnect, remote, &mut restart_counter, err).await?;
@@ -119,7 +119,7 @@ where
             // envelope を再投入する。これは Pekko Artery の AckedDeliveryQueue 相当の最低限
             // の振る舞いで、ack ベースの再送は別レイヤの責務として残してある。
             shared.with_write(|assoc| {
-              let now_ms = elapsed_ms(started_at);
+              let now_ms = tokio_instant_elapsed_millis(started_at);
               let effects = assoc.enqueue(envelope_for_retry, now_ms);
               apply_effects_in_place(assoc, effects, &event_publisher, now_ms);
             });
@@ -160,7 +160,7 @@ where
   Fut: Future<Output = Result<TransportEndpoint, TransportError>>, {
   let mut last_error = first_error;
   loop {
-    if !restart_counter.restart(elapsed_ms(ctx.started_at)) {
+    if !restart_counter.restart(tokio_instant_elapsed_millis(ctx.started_at)) {
       return Err(last_error);
     }
     match reconnect_after_backoff(ctx.policy, reconnect, remote.clone()).await {
@@ -170,7 +170,7 @@ where
         // 流す。これにより observability (Connected lifecycle 等) が reconnect 経路でも
         // 維持される。
         ctx.shared.with_write(|assoc| {
-          let now_ms = elapsed_ms(ctx.started_at);
+          let now_ms = tokio_instant_elapsed_millis(ctx.started_at);
           let effects = assoc.recover(Some(endpoint), now_ms);
           apply_effects_in_place(assoc, effects, ctx.event_publisher, now_ms);
         });
@@ -193,7 +193,7 @@ fn gate_for_reconnect(
   now_ms: u64,
   event_publisher: &EventPublisher,
 ) {
-  let backoff_ms = duration_millis(policy.backoff());
+  let backoff_ms = duration_millis_saturated(policy.backoff());
   // gate() が返す PublishLifecycle(Gated) / DiscardEnvelopes を event stream へ流すため、
   // log_association_effects ではなく apply_effects_in_place を使う。
   shared.with_write(|assoc| {
@@ -218,17 +218,8 @@ where
   match timeout(policy.timeout(), reconnect(remote)).await {
     | Ok(result) => result,
     | Err(_elapsed) => {
-      tracing::warn!(remote = %remote_for_log, timeout_ms = duration_millis(policy.timeout()), "reconnect attempt timed out");
+      tracing::warn!(remote = %remote_for_log, timeout_ms = duration_millis_saturated(policy.timeout()), "reconnect attempt timed out");
       Err(TransportError::ConnectionClosed)
     },
   }
-}
-
-fn elapsed_ms(started_at: Instant) -> u64 {
-  duration_millis(started_at.elapsed())
-}
-
-fn duration_millis(duration: Duration) -> u64 {
-  // handshake_driver::monotonic_millis_since と同じ saturating キャスト形式に揃える。
-  duration.as_millis().min(u128::from(u64::MAX)) as u64
 }

--- a/modules/remote-adaptor-std/src/std/association_runtime/tests.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/tests.rs
@@ -1,7 +1,7 @@
-use core::time::Duration;
+use core::{num::NonZeroUsize, time::Duration};
 use std::time::Instant;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use fraktor_actor_core_rs::core::kernel::{
   actor::{actor_path::ActorPathParser, messaging::AnyMessage},
   event::stream::{CorrelationId, EventStreamEvent, RemotingLifecycleEvent},
@@ -9,25 +9,29 @@ use fraktor_actor_core_rs::core::kernel::{
 use fraktor_remote_core_rs::core::{
   address::{Address, RemoteNodeId, UniqueAddress},
   association::{Association, AssociationEffect, AssociationState, QuarantineReason},
-  config::RemoteConfig,
+  config::{LargeMessageDestinationPattern, LargeMessageDestinations, RemoteCompressionConfig, RemoteConfig},
   envelope::{OutboundEnvelope, OutboundPriority},
   transport::{RemoteTransport, TransportEndpoint, TransportError},
   watcher::WatcherCommand,
-  wire::{AckPdu, ControlPdu, EnvelopePdu, HandshakePdu, HandshakeReq, HandshakeRsp},
+  wire::{AckPdu, ControlPdu, EnvelopePdu, HandshakePdu, HandshakeReq, HandshakeRsp, KIND_CONTROL, WIRE_VERSION_1},
 };
 use fraktor_utils_core_rs::core::sync::{DefaultMutex, SharedLock};
 use tokio::sync::{
   mpsc::{self, UnboundedReceiver},
   oneshot::{self, Sender},
 };
+use tokio_util::codec::Encoder;
 
 use crate::std::{
   association_runtime::{
-    InboundQuarantineCheck, RestartCounter, apply_effects_in_place, association_registry::AssociationRegistry,
-    association_shared::AssociationShared, handshake_driver::HandshakeDriver, inbound_dispatch::run_inbound_dispatch,
+    InboundQuarantineCheck, RestartCounter, apply_effects_in_place,
+    association_registry::AssociationRegistry,
+    association_shared::AssociationShared,
+    handshake_driver::HandshakeDriver,
+    inbound_dispatch::{run_inbound_dispatch, run_inbound_task_with_restart_budget},
     system_message_delivery::SystemMessageDeliveryState,
   },
-  tcp_transport::{InboundFrameEvent, WireFrame},
+  tcp_transport::{InboundFrameEvent, WireFrame, WireFrameCodec},
   tests::test_support::EventHarness,
 };
 
@@ -1104,6 +1108,106 @@ async fn outbound_loop_treats_not_started_as_shutdown_without_reconnect() {
   shared.with_write(|assoc| {
     assert!(assoc.state().is_active(), "shutdown must not gate an otherwise active association");
   });
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn inbound_restart_budget_allows_restarts_within_configured_budget() {
+  let config = RemoteConfig::new("localhost")
+    .with_inbound_restart_timeout(Duration::from_millis(100))
+    .with_inbound_max_restarts(2);
+  let attempts = SharedLock::new_with_driver::<DefaultMutex<_>>(0_u32);
+  let attempts_for_task = attempts.clone();
+
+  let result = run_inbound_task_with_restart_budget(&config, move || {
+    let attempts = attempts_for_task.clone();
+    async move {
+      let attempt = attempts.with_lock(|count| {
+        *count += 1;
+        *count
+      });
+      if attempt < 3 { Err(TransportError::ConnectionClosed) } else { Ok(()) }
+    }
+  })
+  .await;
+
+  assert_eq!(result, Ok(()));
+  assert_eq!(attempts.with_lock(|count| *count), 3, "two failures within budget should allow a third successful run");
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn inbound_restart_budget_resets_after_timeout_window_expires() {
+  let config = RemoteConfig::new("localhost")
+    .with_inbound_restart_timeout(Duration::from_millis(100))
+    .with_inbound_max_restarts(1);
+  let attempts = SharedLock::new_with_driver::<DefaultMutex<_>>(0_u32);
+  let attempts_for_task = attempts.clone();
+
+  let result = run_inbound_task_with_restart_budget(&config, move || {
+    let attempts = attempts_for_task.clone();
+    async move {
+      let attempt = attempts.with_lock(|count| {
+        *count += 1;
+        *count
+      });
+      if attempt == 2 {
+        tokio::time::advance(Duration::from_millis(101)).await;
+      }
+      if attempt < 3 { Err(TransportError::ConnectionClosed) } else { Ok(()) }
+    }
+  })
+  .await;
+
+  assert_eq!(result, Ok(()));
+  assert_eq!(attempts.with_lock(|count| *count), 3, "restart budget should reopen after the timeout window expires");
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn inbound_restart_budget_returns_error_when_exhausted() {
+  let config = RemoteConfig::new("localhost")
+    .with_inbound_restart_timeout(Duration::from_millis(100))
+    .with_inbound_max_restarts(1);
+  let attempts = SharedLock::new_with_driver::<DefaultMutex<_>>(0_u32);
+  let attempts_for_task = attempts.clone();
+
+  let result = run_inbound_task_with_restart_budget(&config, move || {
+    let attempts = attempts_for_task.clone();
+    async move {
+      attempts.with_lock(|count| *count += 1);
+      Err::<(), _>(TransportError::ConnectionClosed)
+    }
+  })
+  .await;
+
+  assert_eq!(result, Err(TransportError::ConnectionClosed));
+  assert_eq!(attempts.with_lock(|count| *count), 2, "one retry plus the initial failure should exhaust the budget");
+}
+
+#[test]
+fn advanced_settings_surface_remains_readable_without_altering_wire_frame_shape() {
+  let destinations = LargeMessageDestinations::new()
+    .with_pattern(LargeMessageDestinationPattern::new("/user/large"))
+    .with_pattern(LargeMessageDestinationPattern::new("/temp/session-ask-actor*"));
+  let compression = RemoteCompressionConfig::new()
+    .with_actor_ref_max(Some(NonZeroUsize::new(32).expect("non-zero limit")))
+    .with_manifest_max(None);
+  let config = RemoteConfig::new("localhost")
+    .with_outbound_large_message_queue_size(16)
+    .with_large_message_destinations(destinations.clone())
+    .with_compression_config(compression);
+
+  assert_eq!(config.outbound_large_message_queue_size(), 16);
+  assert_eq!(config.large_message_destinations(), &destinations);
+  assert!(config.large_message_destinations().matches_relative_path("/user/large"));
+  assert_eq!(config.compression_config(), compression);
+
+  let mut codec = WireFrameCodec::with_maximum_frame_size(config.maximum_frame_size());
+  let mut buf = BytesMut::new();
+  codec
+    .encode(WireFrame::Control(ControlPdu::Heartbeat { authority: "local-sys@127.0.0.1:2551".into() }), &mut buf)
+    .expect("control frame encode should succeed");
+
+  assert_eq!(buf[4], WIRE_VERSION_1, "wire version must remain the existing fraktor header version");
+  assert_eq!(buf[5], KIND_CONTROL, "large-message/compression settings must not change the control frame kind");
 }
 
 struct FailingTransport {

--- a/modules/remote-adaptor-std/src/std/association_runtime/tests.rs
+++ b/modules/remote-adaptor-std/src/std/association_runtime/tests.rs
@@ -176,9 +176,11 @@ async fn run_inbound_dispatch_with_response_probe(
   harness: &EventHarness,
   sent: SentHandshakes,
 ) {
+  let config = RemoteConfig::new("localhost");
   let sent_controls = new_sent_controls();
   let submitted_commands = new_submitted_watcher_commands();
   run_inbound_dispatch(
+    &config,
     rx,
     registry,
     move || now_ms,
@@ -190,7 +192,8 @@ async fn run_inbound_dispatch_with_response_probe(
       watcher_submit_probe(submitted_commands),
     ),
   )
-  .await;
+  .await
+  .expect("inbound dispatch should complete without transport send failure");
 }
 
 async fn run_inbound_dispatch_with_control_probes(
@@ -201,7 +204,9 @@ async fn run_inbound_dispatch_with_control_probes(
   sent_controls: SentControls,
   submitted_commands: SubmittedWatcherCommands,
 ) {
+  let config = RemoteConfig::new("localhost");
   run_inbound_dispatch(
+    &config,
     rx,
     registry,
     move || now_ms,
@@ -213,7 +218,8 @@ async fn run_inbound_dispatch_with_control_probes(
       watcher_submit_probe(submitted_commands),
     ),
   )
-  .await;
+  .await
+  .expect("inbound dispatch should complete without transport send failure");
 }
 
 async fn run_inbound_dispatch_with_all_probes(
@@ -225,7 +231,9 @@ async fn run_inbound_dispatch_with_all_probes(
   sent_controls: SentControls,
   submitted_commands: SubmittedWatcherCommands,
 ) {
+  let config = RemoteConfig::new("localhost");
   run_inbound_dispatch(
+    &config,
     rx,
     registry,
     move || now_ms,
@@ -237,7 +245,8 @@ async fn run_inbound_dispatch_with_all_probes(
       watcher_submit_probe(submitted_commands),
     ),
   )
-  .await;
+  .await
+  .expect("inbound dispatch should complete without transport send failure");
 }
 
 fn has_remoting_lifecycle_event(
@@ -1182,6 +1191,61 @@ async fn inbound_restart_budget_returns_error_when_exhausted() {
   assert_eq!(attempts.with_lock(|count| *count), 2, "one retry plus the initial failure should exhaust the budget");
 }
 
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn inbound_dispatch_uses_restart_budget_for_control_response_send_failures() {
+  let harness = EventHarness::new();
+  let remote = remote_address("remote-sys", "10.0.0.1", 2552);
+  let registry = registry_with(remote.clone(), active_association_for(remote.clone()));
+  let attempts = SharedLock::new_with_driver::<DefaultMutex<_>>(0_u32);
+  let attempts_for_closure = attempts.clone();
+  let sent_controls = new_sent_controls();
+  let sent_controls_for_closure = sent_controls.clone();
+  let submitted_commands = new_submitted_watcher_commands();
+  let config = RemoteConfig::new("localhost")
+    .with_inbound_restart_timeout(Duration::from_millis(100))
+    .with_inbound_max_restarts(2);
+  let (tx, rx) = mpsc::unbounded_channel();
+
+  for _ in 0..3 {
+    tx.send(inbound_event_from(&remote, WireFrame::Control(ControlPdu::Heartbeat { authority: remote.to_string() })))
+      .expect("heartbeat frame should be queued for inbound dispatch");
+  }
+  drop(tx);
+
+  let result = run_inbound_dispatch(
+    &config,
+    rx,
+    registry,
+    move || 300,
+    harness.publisher().clone(),
+    (
+      local_unique(),
+      handshake_send_probe(new_sent_handshakes()),
+      move |remote, pdu| {
+        let attempt = attempts_for_closure.with_lock(|count| {
+          *count += 1;
+          *count
+        });
+        if attempt < 3 {
+          Err(TransportError::ConnectionClosed)
+        } else {
+          sent_controls_for_closure.with_lock(|items| items.push((remote.clone(), pdu)));
+          Ok(())
+        }
+      },
+      watcher_submit_probe(submitted_commands),
+    ),
+  )
+  .await;
+
+  assert_eq!(result, Ok(()));
+  assert_eq!(attempts.with_lock(|count| *count), 3, "dispatch should consume restart budget before succeeding");
+  assert_eq!(sent_control_frames(&sent_controls), vec![(remote, ControlPdu::HeartbeatResponse {
+    authority: local_address().to_string(),
+    uid:       local_unique().uid(),
+  },)],);
+}
+
 #[test]
 fn advanced_settings_surface_remains_readable_without_altering_wire_frame_shape() {
   let destinations = LargeMessageDestinations::new()
@@ -1197,8 +1261,8 @@ fn advanced_settings_surface_remains_readable_without_altering_wire_frame_shape(
 
   assert_eq!(config.outbound_large_message_queue_size(), 16);
   assert_eq!(config.large_message_destinations(), &destinations);
-  assert!(config.large_message_destinations().matches_relative_path("/user/large"));
-  assert_eq!(config.compression_config(), compression);
+  assert!(config.large_message_destinations().matches_absolute_path("/user/large"));
+  assert_eq!(config.compression_config(), &compression);
 
   let mut codec = WireFrameCodec::with_maximum_frame_size(config.maximum_frame_size());
   let mut buf = BytesMut::new();

--- a/modules/remote-core/src/core/config.rs
+++ b/modules/remote-core/src/core/config.rs
@@ -3,8 +3,14 @@
 #[cfg(test)]
 mod tests;
 
+mod large_message_destination_pattern;
+mod large_message_destinations;
+mod remote_compression_config;
 mod remote_config;
 
+pub use large_message_destination_pattern::LargeMessageDestinationPattern;
+pub use large_message_destinations::LargeMessageDestinations;
+pub use remote_compression_config::RemoteCompressionConfig;
 pub use remote_config::RemoteConfig;
 pub(crate) use remote_config::{
   DEFAULT_OUTBOUND_CONTROL_QUEUE_SIZE, DEFAULT_OUTBOUND_MESSAGE_QUEUE_SIZE,

--- a/modules/remote-core/src/core/config/large_message_destination_pattern.rs
+++ b/modules/remote-core/src/core/config/large_message_destination_pattern.rs
@@ -1,0 +1,141 @@
+//! Typed path pattern for routing large messages.
+
+use alloc::{
+  string::{String, ToString},
+  vec::Vec,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PatternSegment {
+  Literal(String),
+  MultiSegmentWildcard,
+}
+
+/// Actor path pattern that marks a destination as large-message eligible.
+///
+/// The pattern syntax follows the relative actor-path examples used by Pekko
+/// Artery's `large-message-destinations` setting:
+///
+/// - `/user/large` for an exact path
+/// - `/user/group/*` for a single-segment wildcard
+/// - `/user/group/**` for a recursive wildcard
+/// - `/temp/session-ask-actor*` for an in-segment wildcard
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LargeMessageDestinationPattern {
+  pattern:  String,
+  segments: Vec<PatternSegment>,
+}
+
+impl LargeMessageDestinationPattern {
+  /// Creates a new path pattern.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `pattern` is not an absolute actor path.
+  #[must_use]
+  pub fn new(pattern: impl Into<String>) -> Self {
+    let pattern = pattern.into();
+    let segments = parse_pattern_segments(&pattern);
+    Self { pattern, segments }
+  }
+
+  /// Returns the original pattern string.
+  #[must_use]
+  pub fn pattern(&self) -> &str {
+    &self.pattern
+  }
+
+  /// Returns `true` when `path` matches this pattern.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `path` is not an absolute actor path.
+  #[must_use]
+  pub fn matches_relative_path(&self, path: &str) -> bool {
+    let path_segments = parse_candidate_segments(path);
+    matches_segments(&self.segments, &path_segments)
+  }
+}
+
+fn parse_pattern_segments(pattern: &str) -> Vec<PatternSegment> {
+  let segments = parse_absolute_segments(pattern, "large-message destination pattern");
+  segments
+    .into_iter()
+    .map(|segment| {
+      if segment == "**" { PatternSegment::MultiSegmentWildcard } else { PatternSegment::Literal(segment.to_string()) }
+    })
+    .collect()
+}
+
+fn parse_candidate_segments(path: &str) -> Vec<&str> {
+  parse_absolute_segments(path, "actor path")
+}
+
+fn parse_absolute_segments<'a>(path: &'a str, label: &str) -> Vec<&'a str> {
+  assert!(path.starts_with('/'), "{label} must start with '/'");
+  assert!(path != "/", "{label} must contain at least one path segment");
+  let trimmed = path.trim_end_matches('/');
+  let segments: Vec<&str> = trimmed.split('/').skip(1).collect();
+  assert!(
+    !segments.is_empty() && segments.iter().all(|segment| !segment.is_empty()),
+    "{label} must not contain empty path segments",
+  );
+  segments
+}
+
+fn matches_segments(pattern: &[PatternSegment], path: &[&str]) -> bool {
+  match pattern.split_first() {
+    | None => path.is_empty(),
+    | Some((PatternSegment::MultiSegmentWildcard, tail)) => {
+      if tail.is_empty() {
+        return true;
+      }
+      (0..=path.len()).any(|skip| matches_segments(tail, &path[skip..]))
+    },
+    | Some((PatternSegment::Literal(pattern_segment), tail)) => match path.split_first() {
+      | Some((path_segment, path_tail)) => {
+        segment_matches(pattern_segment, path_segment) && matches_segments(tail, path_tail)
+      },
+      | None => false,
+    },
+  }
+}
+
+fn segment_matches(pattern: &str, segment: &str) -> bool {
+  let pattern = pattern.as_bytes();
+  let segment = segment.as_bytes();
+  let mut pattern_index = 0;
+  let mut segment_index = 0;
+  let mut last_star = None;
+  let mut retry_segment_index = 0;
+
+  while segment_index < segment.len() {
+    if pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+      last_star = Some(pattern_index);
+      pattern_index += 1;
+      retry_segment_index = segment_index;
+      continue;
+    }
+
+    if pattern_index < pattern.len() && pattern[pattern_index] == segment[segment_index] {
+      pattern_index += 1;
+      segment_index += 1;
+      continue;
+    }
+
+    match last_star {
+      | Some(star_index) => {
+        pattern_index = star_index + 1;
+        retry_segment_index += 1;
+        segment_index = retry_segment_index;
+      },
+      | None => return false,
+    }
+  }
+
+  while pattern_index < pattern.len() && pattern[pattern_index] == b'*' {
+    pattern_index += 1;
+  }
+
+  pattern_index == pattern.len()
+}

--- a/modules/remote-core/src/core/config/large_message_destination_pattern.rs
+++ b/modules/remote-core/src/core/config/large_message_destination_pattern.rs
@@ -51,7 +51,7 @@ impl LargeMessageDestinationPattern {
   ///
   /// Panics when `path` is not an absolute actor path.
   #[must_use]
-  pub fn matches_relative_path(&self, path: &str) -> bool {
+  pub fn matches_absolute_path(&self, path: &str) -> bool {
     let path_segments = parse_candidate_segments(path);
     matches_segments(&self.segments, &path_segments)
   }

--- a/modules/remote-core/src/core/config/large_message_destinations.rs
+++ b/modules/remote-core/src/core/config/large_message_destinations.rs
@@ -55,7 +55,7 @@ impl LargeMessageDestinations {
   ///
   /// Panics when `path` is not an absolute actor path.
   #[must_use]
-  pub fn matches_relative_path(&self, path: &str) -> bool {
-    self.patterns.iter().any(|pattern| pattern.matches_relative_path(path))
+  pub fn matches_absolute_path(&self, path: &str) -> bool {
+    self.patterns.iter().any(|pattern| pattern.matches_absolute_path(path))
   }
 }

--- a/modules/remote-core/src/core/config/large_message_destinations.rs
+++ b/modules/remote-core/src/core/config/large_message_destinations.rs
@@ -1,0 +1,61 @@
+//! Collection of large-message destination patterns.
+
+use alloc::vec::Vec;
+
+use crate::core::config::LargeMessageDestinationPattern;
+
+/// Owned `no_std` collection of destination patterns that opt actors into the
+/// dedicated large-message path.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LargeMessageDestinations {
+  patterns: Vec<LargeMessageDestinationPattern>,
+}
+
+impl LargeMessageDestinations {
+  /// Creates an empty destination set.
+  #[must_use]
+  pub fn new() -> Self {
+    Self::default()
+  }
+
+  /// Creates a destination set from already-built patterns.
+  #[must_use]
+  pub const fn from_patterns(patterns: Vec<LargeMessageDestinationPattern>) -> Self {
+    Self { patterns }
+  }
+
+  /// Appends one path pattern.
+  #[must_use]
+  pub fn with_pattern(mut self, pattern: LargeMessageDestinationPattern) -> Self {
+    self.patterns.push(pattern);
+    self
+  }
+
+  /// Returns all configured patterns.
+  #[must_use]
+  pub fn patterns(&self) -> &[LargeMessageDestinationPattern] {
+    &self.patterns
+  }
+
+  /// Returns the number of configured patterns.
+  #[must_use]
+  pub const fn len(&self) -> usize {
+    self.patterns.len()
+  }
+
+  /// Returns `true` when no destination pattern is configured.
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.patterns.is_empty()
+  }
+
+  /// Returns `true` when `path` matches at least one configured pattern.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `path` is not an absolute actor path.
+  #[must_use]
+  pub fn matches_relative_path(&self, path: &str) -> bool {
+    self.patterns.iter().any(|pattern| pattern.matches_relative_path(path))
+  }
+}

--- a/modules/remote-core/src/core/config/remote_compression_config.rs
+++ b/modules/remote-core/src/core/config/remote_compression_config.rs
@@ -1,0 +1,101 @@
+//! Typed compression settings carried by `RemoteConfig`.
+
+use core::{num::NonZeroUsize, time::Duration};
+
+const DEFAULT_COMPRESSION_MAX: usize = 256;
+const DEFAULT_COMPRESSION_ADVERTISEMENT_INTERVAL: Duration = Duration::from_secs(60);
+
+const fn default_compression_max() -> NonZeroUsize {
+  // SAFETY: DEFAULT_COMPRESSION_MAX is a fixed positive literal.
+  unsafe { NonZeroUsize::new_unchecked(DEFAULT_COMPRESSION_MAX) }
+}
+
+/// Compression table settings for actor refs and serializer manifests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RemoteCompressionConfig {
+  actor_ref_max:                    Option<NonZeroUsize>,
+  actor_ref_advertisement_interval: Duration,
+  manifest_max:                     Option<NonZeroUsize>,
+  manifest_advertisement_interval:  Duration,
+}
+
+impl RemoteCompressionConfig {
+  /// Creates compression settings with Pekko-compatible defaults.
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      actor_ref_max:                    Some(default_compression_max()),
+      actor_ref_advertisement_interval: DEFAULT_COMPRESSION_ADVERTISEMENT_INTERVAL,
+      manifest_max:                     Some(default_compression_max()),
+      manifest_advertisement_interval:  DEFAULT_COMPRESSION_ADVERTISEMENT_INTERVAL,
+    }
+  }
+
+  /// Returns a copy with the actor-ref compression limit changed.
+  #[must_use]
+  pub const fn with_actor_ref_max(mut self, max: Option<NonZeroUsize>) -> Self {
+    self.actor_ref_max = max;
+    self
+  }
+
+  /// Returns a copy with the actor-ref advertisement interval changed.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `interval` is zero.
+  #[must_use]
+  pub const fn with_actor_ref_advertisement_interval(mut self, interval: Duration) -> Self {
+    assert!(!interval.is_zero(), "actor-ref advertisement interval must be greater than zero");
+    self.actor_ref_advertisement_interval = interval;
+    self
+  }
+
+  /// Returns a copy with the manifest compression limit changed.
+  #[must_use]
+  pub const fn with_manifest_max(mut self, max: Option<NonZeroUsize>) -> Self {
+    self.manifest_max = max;
+    self
+  }
+
+  /// Returns a copy with the manifest advertisement interval changed.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `interval` is zero.
+  #[must_use]
+  pub const fn with_manifest_advertisement_interval(mut self, interval: Duration) -> Self {
+    assert!(!interval.is_zero(), "manifest advertisement interval must be greater than zero");
+    self.manifest_advertisement_interval = interval;
+    self
+  }
+
+  /// Returns the actor-ref compression limit.
+  #[must_use]
+  pub const fn actor_ref_max(&self) -> Option<NonZeroUsize> {
+    self.actor_ref_max
+  }
+
+  /// Returns the actor-ref advertisement interval.
+  #[must_use]
+  pub const fn actor_ref_advertisement_interval(&self) -> Duration {
+    self.actor_ref_advertisement_interval
+  }
+
+  /// Returns the manifest compression limit.
+  #[must_use]
+  pub const fn manifest_max(&self) -> Option<NonZeroUsize> {
+    self.manifest_max
+  }
+
+  /// Returns the manifest advertisement interval.
+  #[must_use]
+  pub const fn manifest_advertisement_interval(&self) -> Duration {
+    self.manifest_advertisement_interval
+  }
+}
+
+impl Default for RemoteCompressionConfig {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/modules/remote-core/src/core/config/remote_config.rs
+++ b/modules/remote-core/src/core/config/remote_config.rs
@@ -3,6 +3,8 @@
 use alloc::string::String;
 use core::time::Duration;
 
+use crate::core::config::{LargeMessageDestinations, RemoteCompressionConfig};
+
 /// Default handshake timeout (20 seconds), matching Pekko Artery advanced defaults.
 const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -26,6 +28,9 @@ pub(crate) const DEFAULT_OUTBOUND_MESSAGE_QUEUE_SIZE: usize = 3072;
 
 /// Default outbound control queue size.
 pub(crate) const DEFAULT_OUTBOUND_CONTROL_QUEUE_SIZE: usize = 20_000;
+
+/// Default outbound large-message queue size.
+const DEFAULT_OUTBOUND_LARGE_MESSAGE_QUEUE_SIZE: usize = 256;
 
 /// Default system message resend interval.
 const DEFAULT_SYSTEM_MESSAGE_RESEND_INTERVAL: Duration = Duration::from_secs(1);
@@ -59,6 +64,12 @@ const DEFAULT_OUTBOUND_RESTART_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Default maximum outbound stream restart count.
 const DEFAULT_OUTBOUND_MAX_RESTARTS: u32 = 5;
+
+/// Default inbound stream restart timeout.
+const DEFAULT_INBOUND_RESTART_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default maximum inbound stream restart count.
+const DEFAULT_INBOUND_MAX_RESTARTS: u32 = 5;
 
 /// Default inbound lane count.
 const DEFAULT_INBOUND_LANES: usize = 4;
@@ -95,6 +106,8 @@ pub struct RemoteConfig {
   system_message_buffer_size: usize,
   outbound_message_queue_size: usize,
   outbound_control_queue_size: usize,
+  outbound_large_message_queue_size: usize,
+  large_message_destinations: LargeMessageDestinations,
   system_message_resend_interval: Duration,
   give_up_system_message_after: Duration,
   handshake_retry_interval: Duration,
@@ -106,6 +119,9 @@ pub struct RemoteConfig {
   outbound_restart_backoff: Duration,
   outbound_restart_timeout: Duration,
   outbound_max_restarts: u32,
+  inbound_restart_timeout: Duration,
+  inbound_max_restarts: u32,
+  compression_config: RemoteCompressionConfig,
   inbound_lanes: usize,
   outbound_lanes: usize,
   maximum_frame_size: usize,
@@ -134,6 +150,8 @@ impl RemoteConfig {
       system_message_buffer_size: DEFAULT_SYSTEM_MESSAGE_BUFFER_SIZE,
       outbound_message_queue_size: DEFAULT_OUTBOUND_MESSAGE_QUEUE_SIZE,
       outbound_control_queue_size: DEFAULT_OUTBOUND_CONTROL_QUEUE_SIZE,
+      outbound_large_message_queue_size: DEFAULT_OUTBOUND_LARGE_MESSAGE_QUEUE_SIZE,
+      large_message_destinations: LargeMessageDestinations::new(),
       system_message_resend_interval: DEFAULT_SYSTEM_MESSAGE_RESEND_INTERVAL,
       give_up_system_message_after: DEFAULT_GIVE_UP_SYSTEM_MESSAGE_AFTER,
       handshake_retry_interval: DEFAULT_HANDSHAKE_RETRY_INTERVAL,
@@ -145,6 +163,9 @@ impl RemoteConfig {
       outbound_restart_backoff: DEFAULT_OUTBOUND_RESTART_BACKOFF,
       outbound_restart_timeout: DEFAULT_OUTBOUND_RESTART_TIMEOUT,
       outbound_max_restarts: DEFAULT_OUTBOUND_MAX_RESTARTS,
+      inbound_restart_timeout: DEFAULT_INBOUND_RESTART_TIMEOUT,
+      inbound_max_restarts: DEFAULT_INBOUND_MAX_RESTARTS,
+      compression_config: RemoteCompressionConfig::new(),
       inbound_lanes: DEFAULT_INBOUND_LANES,
       outbound_lanes: DEFAULT_OUTBOUND_LANES,
       maximum_frame_size: DEFAULT_MAXIMUM_FRAME_SIZE,
@@ -243,6 +264,25 @@ impl RemoteConfig {
     self
   }
 
+  /// Returns a copy with the given outbound large-message queue size.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `size` is zero.
+  #[must_use]
+  pub const fn with_outbound_large_message_queue_size(mut self, size: usize) -> Self {
+    assert!(size > 0, "outbound large-message queue size must be greater than zero");
+    self.outbound_large_message_queue_size = size;
+    self
+  }
+
+  /// Returns a copy with the configured large-message destination patterns.
+  #[must_use]
+  pub fn with_large_message_destinations(mut self, destinations: LargeMessageDestinations) -> Self {
+    self.large_message_destinations = destinations;
+    self
+  }
+
   /// Returns a copy with the given system message resend interval.
   #[must_use]
   pub const fn with_system_message_resend_interval(mut self, interval: Duration) -> Self {
@@ -322,6 +362,27 @@ impl RemoteConfig {
   #[must_use]
   pub const fn with_outbound_max_restarts(mut self, max_restarts: u32) -> Self {
     self.outbound_max_restarts = max_restarts;
+    self
+  }
+
+  /// Returns a copy with the given inbound stream restart timeout.
+  #[must_use]
+  pub const fn with_inbound_restart_timeout(mut self, duration: Duration) -> Self {
+    self.inbound_restart_timeout = duration;
+    self
+  }
+
+  /// Returns a copy with the given maximum inbound stream restart count.
+  #[must_use]
+  pub const fn with_inbound_max_restarts(mut self, max_restarts: u32) -> Self {
+    self.inbound_max_restarts = max_restarts;
+    self
+  }
+
+  /// Returns a copy with the given compression settings.
+  #[must_use]
+  pub const fn with_compression_config(mut self, compression_config: RemoteCompressionConfig) -> Self {
+    self.compression_config = compression_config;
     self
   }
 
@@ -473,6 +534,18 @@ impl RemoteConfig {
     self.outbound_control_queue_size
   }
 
+  /// Returns the outbound large-message queue size.
+  #[must_use]
+  pub const fn outbound_large_message_queue_size(&self) -> usize {
+    self.outbound_large_message_queue_size
+  }
+
+  /// Returns the configured large-message destination patterns.
+  #[must_use]
+  pub const fn large_message_destinations(&self) -> &LargeMessageDestinations {
+    &self.large_message_destinations
+  }
+
   /// Returns the system message resend interval.
   #[must_use]
   pub const fn system_message_resend_interval(&self) -> Duration {
@@ -537,6 +610,24 @@ impl RemoteConfig {
   #[must_use]
   pub const fn outbound_max_restarts(&self) -> u32 {
     self.outbound_max_restarts
+  }
+
+  /// Returns the inbound stream restart timeout.
+  #[must_use]
+  pub const fn inbound_restart_timeout(&self) -> Duration {
+    self.inbound_restart_timeout
+  }
+
+  /// Returns the maximum inbound stream restart count.
+  #[must_use]
+  pub const fn inbound_max_restarts(&self) -> u32 {
+    self.inbound_max_restarts
+  }
+
+  /// Returns the compression settings surface.
+  #[must_use]
+  pub const fn compression_config(&self) -> RemoteCompressionConfig {
+    self.compression_config
   }
 
   /// Returns the inbound lane count.

--- a/modules/remote-core/src/core/config/remote_config.rs
+++ b/modules/remote-core/src/core/config/remote_config.rs
@@ -626,8 +626,8 @@ impl RemoteConfig {
 
   /// Returns the compression settings surface.
   #[must_use]
-  pub const fn compression_config(&self) -> RemoteCompressionConfig {
-    self.compression_config
+  pub const fn compression_config(&self) -> &RemoteCompressionConfig {
+    &self.compression_config
   }
 
   /// Returns the inbound lane count.

--- a/modules/remote-core/src/core/config/tests.rs
+++ b/modules/remote-core/src/core/config/tests.rs
@@ -1,13 +1,23 @@
-use core::time::Duration;
+use core::{num::NonZeroUsize, time::Duration};
 
-use crate::core::config::RemoteConfig;
+use crate::core::config::{
+  LargeMessageDestinationPattern, LargeMessageDestinations, RemoteCompressionConfig, RemoteConfig,
+};
 
 const DEFAULT_MAXIMUM_FRAME_SIZE: usize = 256 * 1024;
 const DEFAULT_BUFFER_POOL_SIZE: usize = 128;
 const DEFAULT_OUTBOUND_MESSAGE_QUEUE_SIZE: usize = 3072;
 const DEFAULT_OUTBOUND_CONTROL_QUEUE_SIZE: usize = 20_000;
+const DEFAULT_OUTBOUND_LARGE_MESSAGE_QUEUE_SIZE: usize = 256;
 const DEFAULT_REMOVE_QUARANTINED_ASSOCIATION_AFTER: Duration = Duration::from_secs(60 * 60);
+const DEFAULT_INBOUND_RESTART_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_INBOUND_MAX_RESTARTS: u32 = 5;
+const DEFAULT_COMPRESSION_ADVERTISEMENT_INTERVAL: Duration = Duration::from_secs(60);
 const MINIMUM_MAXIMUM_FRAME_SIZE: usize = 32 * 1024;
+
+fn non_zero(value: usize) -> NonZeroUsize {
+  NonZeroUsize::new(value).expect("test value must be non-zero")
+}
 
 #[test]
 fn new_uses_defaults_for_optional_fields() {
@@ -47,7 +57,15 @@ fn advanced_artery_settings_use_pekko_compatible_defaults() {
   assert_eq!(s.buffer_pool_size(), DEFAULT_BUFFER_POOL_SIZE);
   assert_eq!(s.outbound_message_queue_size(), DEFAULT_OUTBOUND_MESSAGE_QUEUE_SIZE);
   assert_eq!(s.outbound_control_queue_size(), DEFAULT_OUTBOUND_CONTROL_QUEUE_SIZE);
+  assert_eq!(s.outbound_large_message_queue_size(), DEFAULT_OUTBOUND_LARGE_MESSAGE_QUEUE_SIZE);
+  assert!(s.large_message_destinations().is_empty());
   assert_eq!(s.remove_quarantined_association_after(), DEFAULT_REMOVE_QUARANTINED_ASSOCIATION_AFTER);
+  assert_eq!(s.inbound_restart_timeout(), DEFAULT_INBOUND_RESTART_TIMEOUT);
+  assert_eq!(s.inbound_max_restarts(), DEFAULT_INBOUND_MAX_RESTARTS);
+  assert_eq!(s.compression_config().actor_ref_max(), Some(non_zero(256)));
+  assert_eq!(s.compression_config().manifest_max(), Some(non_zero(256)));
+  assert_eq!(s.compression_config().actor_ref_advertisement_interval(), DEFAULT_COMPRESSION_ADVERTISEMENT_INTERVAL);
+  assert_eq!(s.compression_config().manifest_advertisement_interval(), DEFAULT_COMPRESSION_ADVERTISEMENT_INTERVAL);
   assert!(!s.untrusted_mode());
   assert!(!s.log_received_messages());
   assert!(!s.log_sent_messages());
@@ -104,9 +122,22 @@ fn method_chain_applies_all_changes() {
 #[test]
 fn advanced_artery_settings_method_chain_applies_all_changes() {
   // Given: advanced 設定をすべて上書きした構成
+  let destinations = LargeMessageDestinations::new()
+    .with_pattern(LargeMessageDestinationPattern::new("/user/large"))
+    .with_pattern(LargeMessageDestinationPattern::new("/temp/session-ask-actor*"));
+  let compression = RemoteCompressionConfig::new()
+    .with_actor_ref_max(Some(non_zero(32)))
+    .with_actor_ref_advertisement_interval(Duration::from_secs(10))
+    .with_manifest_max(None)
+    .with_manifest_advertisement_interval(Duration::from_secs(20));
   let s = RemoteConfig::new("localhost")
     .with_bind_hostname("0.0.0.0")
     .with_bind_port(25520)
+    .with_outbound_large_message_queue_size(16)
+    .with_large_message_destinations(destinations.clone())
+    .with_inbound_restart_timeout(Duration::from_secs(7))
+    .with_inbound_max_restarts(9)
+    .with_compression_config(compression)
     .with_inbound_lanes(8)
     .with_outbound_lanes(2)
     .with_maximum_frame_size(512 * 1024)
@@ -122,6 +153,11 @@ fn advanced_artery_settings_method_chain_applies_all_changes() {
   // Then: 上書きした値を保持する
   assert_eq!(s.bind_hostname(), Some("0.0.0.0"));
   assert_eq!(s.bind_port(), Some(25520));
+  assert_eq!(s.outbound_large_message_queue_size(), 16);
+  assert_eq!(s.large_message_destinations(), &destinations);
+  assert_eq!(s.inbound_restart_timeout(), Duration::from_secs(7));
+  assert_eq!(s.inbound_max_restarts(), 9);
+  assert_eq!(s.compression_config(), compression);
   assert_eq!(s.inbound_lanes(), 8);
   assert_eq!(s.outbound_lanes(), 2);
   assert_eq!(s.maximum_frame_size(), 512 * 1024);
@@ -191,6 +227,15 @@ fn with_outbound_control_queue_size_rejects_zero() {
 }
 
 #[test]
+fn with_outbound_large_message_queue_size_rejects_zero() {
+  // When: outbound large-message queue size に 0 を指定する
+  let result = std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_outbound_large_message_queue_size(0));
+
+  // Then: 不正な queue size として拒否する
+  assert!(result.is_err());
+}
+
+#[test]
 fn with_remove_quarantined_association_after_rejects_zero() {
   // When: remove quarantined association after に 0 を指定する
   let result = std::panic::catch_unwind(|| {
@@ -210,6 +255,25 @@ fn cloning_preserves_immutability_of_original() {
 }
 
 #[test]
+fn cloning_preserves_large_message_and_compression_immutability_of_original() {
+  let a = RemoteConfig::new("localhost");
+  let compression = RemoteCompressionConfig::new().with_manifest_max(None);
+  let destinations = LargeMessageDestinations::new().with_pattern(LargeMessageDestinationPattern::new("/user/large"));
+  let b = a
+    .clone()
+    .with_outbound_large_message_queue_size(8)
+    .with_large_message_destinations(destinations.clone())
+    .with_compression_config(compression);
+
+  assert_eq!(a.outbound_large_message_queue_size(), DEFAULT_OUTBOUND_LARGE_MESSAGE_QUEUE_SIZE);
+  assert!(a.large_message_destinations().is_empty());
+  assert_ne!(a.compression_config(), compression);
+  assert_eq!(b.outbound_large_message_queue_size(), 8);
+  assert_eq!(b.large_message_destinations(), &destinations);
+  assert_eq!(b.compression_config(), compression);
+}
+
+#[test]
 fn equality_and_clone_are_consistent() {
   let a = RemoteConfig::new("localhost").with_canonical_port(1234);
   let b = a.clone();
@@ -220,4 +284,52 @@ fn equality_and_clone_are_consistent() {
 fn with_flight_recorder_capacity_respects_input() {
   let s = RemoteConfig::new("h").with_flight_recorder_capacity(1);
   assert_eq!(s.flight_recorder_capacity(), 1);
+}
+
+#[test]
+fn large_message_destinations_match_exact_and_wildcard_paths() {
+  let destinations = LargeMessageDestinations::new()
+    .with_pattern(LargeMessageDestinationPattern::new("/user/largeMessageActor"))
+    .with_pattern(LargeMessageDestinationPattern::new("/user/largeMessagesGroup/*"))
+    .with_pattern(LargeMessageDestinationPattern::new("/user/thirdGroup/**"))
+    .with_pattern(LargeMessageDestinationPattern::new("/temp/session-ask-actor*"));
+
+  assert!(destinations.matches_relative_path("/user/largeMessageActor"));
+  assert!(destinations.matches_relative_path("/user/largeMessagesGroup/actor1"));
+  assert!(destinations.matches_relative_path("/user/thirdGroup/actor3"));
+  assert!(destinations.matches_relative_path("/user/thirdGroup/actor4/actor5"));
+  assert!(destinations.matches_relative_path("/temp/session-ask-actor$abc"));
+  assert!(!destinations.matches_relative_path("/user/small"));
+}
+
+#[test]
+fn large_message_destination_pattern_rejects_relative_path_without_leading_slash() {
+  let result = std::panic::catch_unwind(|| LargeMessageDestinationPattern::new("user/large"));
+
+  assert!(result.is_err());
+}
+
+#[test]
+fn remote_compression_config_rejects_zero_advertisement_interval() {
+  let actor_ref_result =
+    std::panic::catch_unwind(|| RemoteCompressionConfig::new().with_actor_ref_advertisement_interval(Duration::ZERO));
+  let manifest_result =
+    std::panic::catch_unwind(|| RemoteCompressionConfig::new().with_manifest_advertisement_interval(Duration::ZERO));
+
+  assert!(actor_ref_result.is_err());
+  assert!(manifest_result.is_err());
+}
+
+#[test]
+fn advanced_settings_sources_keep_no_std_boundary() {
+  let sources = [
+    include_str!("remote_config.rs"),
+    include_str!("large_message_destination_pattern.rs"),
+    include_str!("large_message_destinations.rs"),
+    include_str!("remote_compression_config.rs"),
+  ];
+
+  for source in sources {
+    assert!(!source.contains("use std::"), "remote-core config advanced settings must remain no_std");
+  }
 }

--- a/modules/remote-core/src/core/config/tests.rs
+++ b/modules/remote-core/src/core/config/tests.rs
@@ -157,7 +157,7 @@ fn advanced_artery_settings_method_chain_applies_all_changes() {
   assert_eq!(s.large_message_destinations(), &destinations);
   assert_eq!(s.inbound_restart_timeout(), Duration::from_secs(7));
   assert_eq!(s.inbound_max_restarts(), 9);
-  assert_eq!(s.compression_config(), compression);
+  assert_eq!(s.compression_config(), &compression);
   assert_eq!(s.inbound_lanes(), 8);
   assert_eq!(s.outbound_lanes(), 2);
   assert_eq!(s.maximum_frame_size(), 512 * 1024);
@@ -267,10 +267,10 @@ fn cloning_preserves_large_message_and_compression_immutability_of_original() {
 
   assert_eq!(a.outbound_large_message_queue_size(), DEFAULT_OUTBOUND_LARGE_MESSAGE_QUEUE_SIZE);
   assert!(a.large_message_destinations().is_empty());
-  assert_ne!(a.compression_config(), compression);
+  assert_ne!(a.compression_config(), &compression);
   assert_eq!(b.outbound_large_message_queue_size(), 8);
   assert_eq!(b.large_message_destinations(), &destinations);
-  assert_eq!(b.compression_config(), compression);
+  assert_eq!(b.compression_config(), &compression);
 }
 
 #[test]
@@ -294,12 +294,12 @@ fn large_message_destinations_match_exact_and_wildcard_paths() {
     .with_pattern(LargeMessageDestinationPattern::new("/user/thirdGroup/**"))
     .with_pattern(LargeMessageDestinationPattern::new("/temp/session-ask-actor*"));
 
-  assert!(destinations.matches_relative_path("/user/largeMessageActor"));
-  assert!(destinations.matches_relative_path("/user/largeMessagesGroup/actor1"));
-  assert!(destinations.matches_relative_path("/user/thirdGroup/actor3"));
-  assert!(destinations.matches_relative_path("/user/thirdGroup/actor4/actor5"));
-  assert!(destinations.matches_relative_path("/temp/session-ask-actor$abc"));
-  assert!(!destinations.matches_relative_path("/user/small"));
+  assert!(destinations.matches_absolute_path("/user/largeMessageActor"));
+  assert!(destinations.matches_absolute_path("/user/largeMessagesGroup/actor1"));
+  assert!(destinations.matches_absolute_path("/user/thirdGroup/actor3"));
+  assert!(destinations.matches_absolute_path("/user/thirdGroup/actor4/actor5"));
+  assert!(destinations.matches_absolute_path("/temp/session-ask-actor$abc"));
+  assert!(!destinations.matches_absolute_path("/user/small"));
 }
 
 #[test]

--- a/openspec/changes/remote-artery-settings-parity/tasks.md
+++ b/openspec/changes/remote-artery-settings-parity/tasks.md
@@ -1,30 +1,30 @@
 ## 1. 既存パターン確認
 
-- [ ] 1.1 `RemoteConfig` の既存 builder / accessor / validation / test のパターンを確認する
-- [ ] 1.2 `association_runtime` の outbound restart 実装、`RestartCounter`、`ReconnectBackoffPolicy` の責務分離を確認する
-- [ ] 1.3 `core/wire` と `tcp_transport` が fraktor-rs 独自 wire format を維持していることを確認し、Pekko byte compatibility を実装対象に含めない境界を確認する
+- [x] 1.1 `RemoteConfig` の既存 builder / accessor / validation / test のパターンを確認する
+- [x] 1.2 `association_runtime` の outbound restart 実装、`RestartCounter`、`ReconnectBackoffPolicy` の責務分離を確認する
+- [x] 1.3 `core/wire` と `tcp_transport` が fraktor-rs 独自 wire format を維持していることを確認し、Pekko byte compatibility を実装対象に含めない境界を確認する
 
 ## 2. remote-core settings
 
-- [ ] 2.1 large-message destinations を no_std core で所有できる型として追加し、HOCON parser や regex dependency を導入しない
-- [ ] 2.2 `RemoteConfig` に outbound large-message queue size と large-message destinations のフィールド、デフォルト値、builder、accessor を追加する
-- [ ] 2.3 outbound large-message queue size が `0` の場合に拒否される validation を追加する
-- [ ] 2.4 `RemoteConfig` に inbound restart timeout と inbound max restarts のフィールド、デフォルト値、builder、accessor を追加する
-- [ ] 2.5 `RemoteConfig` に compression settings の設定 surface を追加し、wire-level compression behavior は追加しない
-- [ ] 2.6 `modules/remote-core/src/core/config/tests.rs` に defaults、builder chain、validation、immutability、no_std 境界のテストを追加する
+- [x] 2.1 large-message destinations を no_std core で所有できる型として追加し、HOCON parser や regex dependency を導入しない
+- [x] 2.2 `RemoteConfig` に outbound large-message queue size と large-message destinations のフィールド、デフォルト値、builder、accessor を追加する
+- [x] 2.3 outbound large-message queue size が `0` の場合に拒否される validation を追加する
+- [x] 2.4 `RemoteConfig` に inbound restart timeout と inbound max restarts のフィールド、デフォルト値、builder、accessor を追加する
+- [x] 2.5 `RemoteConfig` に compression settings の設定 surface を追加し、wire-level compression behavior は追加しない
+- [x] 2.6 `modules/remote-core/src/core/config/tests.rs` に defaults、builder chain、validation、immutability、no_std 境界のテストを追加する
 
 ## 3. remote-adaptor-std runtime
 
-- [ ] 3.1 std adaptor が `RemoteConfig` から inbound restart timeout と inbound max restarts を association runtime に渡す経路を追加する
-- [ ] 3.2 inbound loop の restart に既存 `RestartCounter` と同じ deadline-window budget 意味論を適用する
-- [ ] 3.3 inbound restart budget 超過時に無限 restart せず、観測可能な error path に失敗を返す
-- [ ] 3.4 restart window の判定が `Instant` ベースの monotonic millis で行われ、`SystemTime` に依存しないことを確認する
-- [ ] 3.5 large-message / compression settings を参照可能にしても、Pekko Artery TCP framing、protobuf control PDU、compression table の wire 互換処理を追加しない
-- [ ] 3.6 `modules/remote-adaptor-std/src/std/association_runtime/tests.rs` に inbound restart budget、budget reset、budget exhaustion、wire codec 非変更のテストを追加する
+- [x] 3.1 std adaptor が `RemoteConfig` から inbound restart timeout と inbound max restarts を association runtime に渡す経路を追加する
+- [x] 3.2 inbound loop の restart に既存 `RestartCounter` と同じ deadline-window budget 意味論を適用する
+- [x] 3.3 inbound restart budget 超過時に無限 restart せず、観測可能な error path に失敗を返す
+- [x] 3.4 restart window の判定が `Instant` ベースの monotonic millis で行われ、`SystemTime` に依存しないことを確認する
+- [x] 3.5 large-message / compression settings を参照可能にしても、Pekko Artery TCP framing、protobuf control PDU、compression table の wire 互換処理を追加しない
+- [x] 3.6 `modules/remote-adaptor-std/src/std/association_runtime/tests.rs` に inbound restart budget、budget reset、budget exhaustion、wire codec 非変更のテストを追加する
 
 ## 4. 検証
 
-- [ ] 4.1 `cargo test -p fraktor-remote-core-rs core::config` を実行して remote-core settings のテストを確認する
-- [ ] 4.2 `cargo test -p fraktor-remote-adaptor-std-rs association_runtime` を実行して std runtime のテストを確認する
-- [ ] 4.3 `openspec validate remote-artery-settings-parity --strict` を実行して OpenSpec delta を検証する
-- [ ] 4.4 ソースコードを編集した implementation phase の最後に `./scripts/ci-check.sh ai all` を実行し、エラーがないことを確認する
+- [x] 4.1 `cargo test -p fraktor-remote-core-rs core::config` を実行して remote-core settings のテストを確認する
+- [x] 4.2 `cargo test -p fraktor-remote-adaptor-std-rs association_runtime` を実行して std runtime のテストを確認する
+- [x] 4.3 `openspec validate remote-artery-settings-parity --strict` を実行して OpenSpec delta を検証する
+- [x] 4.4 ソースコードを編集した implementation phase の最後に `./scripts/ci-check.sh ai all` を実行し、エラーがないことを確認する


### PR DESCRIPTION
## What changed
- add typed remote-core settings for large-message destination patterns, inbound restart budgets, and compression metadata
- extend `RemoteConfig` builders/accessors and add parity-focused config tests
- add std association runtime inbound restart budget enforcement and runtime tests
- mark the OpenSpec implementation tasks complete for `remote-artery-settings-parity`

## Why
`RemoteConfig` and the std runtime were still missing part of the Artery advanced settings surface. That left large-message, inbound restart, and compression inputs undefined for later remote delivery work.

## Impact
- remote-core can now own large-message destination patterns without adding HOCON or regex dependencies
- std runtime can enforce inbound restart budgets with the same deadline-window semantics used for outbound restarts
- the existing fraktor wire codec remains unchanged even when the new settings are configured

## Root cause
The remote redesign had already split core and std responsibilities, but the advanced Artery settings parity work had not yet defined typed configuration and runtime boundaries for these remaining settings.

## Validation
- `cargo test -p fraktor-remote-core-rs core::config`
- `cargo test -p fraktor-remote-adaptor-std-rs association_runtime`
- `openspec validate remote-artery-settings-parity --strict`
- `./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new `RemoteConfig` fields/types and changes inbound dispatch to fail/retry based on restart budgets, which can alter runtime error propagation and recovery behavior. Wire format is intended to remain unchanged, but the new retry logic and config defaults warrant careful review in integration scenarios.
> 
> **Overview**
> Adds missing Artery advanced settings *configuration surface* to `remote-core`: large-message destination path patterns, outbound large-message queue sizing, inbound restart budget settings, and compression metadata (`RemoteCompressionConfig`), with defaults, builders/accessors, and validation.
> 
> Updates the std association runtime to **enforce inbound restart budgets**: `run_inbound_dispatch` now takes `RemoteConfig`, retries the inbound loop via `run_inbound_task_with_restart_budget`, and propagates handshake/control response send failures once the budget is exhausted; monotonic millis conversion is centralized in `monotonic_millis` and reused across handshake/outbound logic.
> 
> Expands tests to cover the new config surfaces (including no-`std` boundary), inbound restart budget semantics (retry, window reset, exhaustion), and asserts that configuring the new settings does *not* change the existing wire frame encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d673c1ddd4d7d4584cf6286e25ea7295a891d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 大規模メッセージのパターンベースルーティング機能を追加しました。
  * インバウンドタスク再起動の予算管理機能（タイムアウトと最大再試行回数）を追加しました。
  * リモート圧縮設定オプション（アクターリファレンスとマニフェストの圧縮制御）を追加しました。

* **テスト**
  * 新機能に関する包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->