### PR TITLE
[codex] CI の Codecov 対象を stream-* クレートまで拡張

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
 
   # カバレッジレポート
   #
-  # `scripts/coverage.sh` は actor 系 package の Unit / Contract /
+  # `scripts/coverage.sh` は actor / stream 系 package の Unit / Contract /
   # Integration / E2E をまとめて計測し、HTML レポートを生成する。
   # PR / main push / schedule で成果物として確認できるよう、
   # 通常テストとは別ジョブで実行して artifact に保存する。
@@ -188,13 +188,13 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: coverage
-      - name: Generate actor coverage reports
+      - name: Generate actor and stream coverage reports
         run: ./scripts/coverage.sh --tool llvm-cov --format html-lcov --output target/coverage
-      - name: Upload actor coverage HTML report
+      - name: Upload actor and stream coverage HTML report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: actor-coverage-html
+          name: actor-stream-coverage-html
           path: target/coverage/html
           if-no-files-found: warn
           retention-days: 14
@@ -205,8 +205,8 @@ jobs:
           use_oidc: true
           files: target/coverage/lcov.info
           disable_search: true
-          flags: actor
-          name: actor-coverage
+          flags: actor-stream
+          name: actor-stream-coverage
           fail_ci_if_error: true
 
   # Documentation build

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -45,7 +45,7 @@ usage() {
   scripts/coverage.sh --open
 
 計測対象:
-  actor 系 package の lib / bins と tests / examples を分割実行し、
+  actor / stream 系 package の lib / bins と tests / examples を分割実行し、
   Unit / Contract / Integration / E2E のプロファイルを1つのレポートに統合します。
 EOF
 }
@@ -57,7 +57,9 @@ log_step() {
 coverage_packages() {
   printf '%s\n' \
     "fraktor-actor-core-rs" \
-    "fraktor-actor-adaptor-std-rs"
+    "fraktor-actor-adaptor-std-rs" \
+    "fraktor-stream-core-rs" \
+    "fraktor-stream-adaptor-std-rs"
 }
 
 coverage_features() {


### PR DESCRIPTION
## 概要
CI の coverage upload が actor 系クレートだけを対象にしていたため、`stream-*` クレートも同じレポートへ含めるように拡張しました。

## 変更内容
- `scripts/coverage.sh` の対象 package に `fraktor-stream-core-rs` と `fraktor-stream-adaptor-std-rs` を追加
- coverage スクリプトのヘルプ文言を `actor / stream` 対象へ更新
- `.github/workflows/ci.yml` の coverage job コメントと step 名を実態に合わせて更新
- Codecov upload 名と artifact 名を `actor-stream` ベースへ更新

## 背景
現状の Codecov upload は `actor-*` のみを対象にしており、`modules/stream-*` の coverage が CI から可視化されていませんでした。

## 影響
- CI の coverage report / Codecov upload に `stream-core` と `stream-adaptor-std` が含まれます
- actor 側の既存 coverage も同じ combined レポート内に引き続き含まれます

## 検証
- `rtk ./scripts/coverage.sh --tool llvm-cov --format json --output target/coverage/actor-stream-smoke`
- `rtk ./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: CI-only coverage configuration updates; main impact is longer coverage runs or potential misconfiguration of package lists/artifact naming.
> 
> **Overview**
> Extends the coverage job to include `stream-*` crates in the combined coverage report by adding `fraktor-stream-core-rs` and `fraktor-stream-adaptor-std-rs` to `scripts/coverage.sh` package selection.
> 
> Updates the CI coverage workflow naming and Codecov/artifact identifiers from actor-only to **actor+stream** (step names, artifact name, and Codecov `flags`/`name`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed0fec071276945bb15338ad63106e76b35d24f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * コードカバレッジレポートの範囲を拡大し、複数のパッケージを対象に含めるようにしました。
  * CI/CDワークフローのメタデータと構成を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->