### PR TITLE
[codex] collect_values 直実行 API を廃止

### DIFF
--- a/docs/plan/2026-04-30-stream-collect-values-public-api.md
+++ b/docs/plan/2026-04-30-stream-collect-values-public-api.md
@@ -16,26 +16,18 @@
 - Pekko 互換の materialization 契約が不要に見える
 - `RunnableGraph::run(&mut Materializer)` と `ActorMaterializer` の位置づけが曖昧になる
 
-## 今回の暫定対応
+## 対応
 
 `showcases/std` 配下のサンプルでは `collect_values()` を使わない方針に寄せた。
 
 stream サンプルは `ActorSystem` backing の `ActorMaterializer` を起動し、`Source` を `Sink::collect()` などへ接続した `RunnableGraph` を `run(&mut materializer)` で materialize する形へ修正した。
 
-## 後続タスク
+さらに stream-core の公開 DSL から `collect_values()`、`TailSource::collect_values()`、`into_input_stream()`、`into_java_stream()`、`into_output_stream()` を削除した。これにより、利用者が `ActorSystem` / `Materializer` なしで stream を実行できるように見える公開入口はなくなった。
 
-`collect_values()` は公開 DSL から外す方向で整理する。
+stream-core の unit/integration tests は、テスト専用 helper を通じて `run_with(Sink::collect(), &mut materializer)` または `ActorMaterializer` 経由で materialize する形へ移行した。helper は公開 API ではなく、実装も Source を直接同期実行せず materializer 契約を通す。
 
-候補は次のいずれか。
+## 残課題
 
-- `pub(crate)` にして stream-core 内部テスト専用に閉じる
-- `core::testing` 配下の明示的なテスト補助 API へ移す
-- 公開のまま残す場合でも `#[deprecated]` を付け、`run_with(Sink::collect(), materializer)` への移行を促す
-
-ただし現状では stream-core の unit/integration tests と公開 API 契約テストで大量に使われているため、単純な `pub(crate)` 化は影響範囲が大きい。
-
-## 推奨方針
-
-まずテスト側に `run_collect_with_materializer` 相当の補助関数を導入し、テストを `Materializer` 経由へ寄せる。その後、公開 API としての `collect_values()` を削除または非推奨化する。
+`Source::lazy_source` の内部では nested source を評価するための private な drain 処理が残っている。これは公開 API ではないが、Pekko 互換の materializer-context 実行へ寄せる余地がある。
 
 最終状態では、ユーザーが stream を実行する入口は `RunnableGraph::run(&mut Materializer)` または `Source::run_with(..., &mut Materializer)` 系に集約する。

--- a/modules/stream-core/src/core/dsl.rs
+++ b/modules/stream-core/src/core/dsl.rs
@@ -73,6 +73,8 @@ mod source_with_context;
 mod stateful_map_concat_accumulator;
 mod stream_refs;
 mod tail_source;
+#[cfg(test)]
+mod tests;
 mod topic_pub_sub;
 
 pub use actor_sink::ActorSink;

--- a/modules/stream-core/src/core/dsl/bidi_flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/bidi_flow/tests.rs
@@ -1,10 +1,10 @@
 use crate::core::{
-  dsl::{BidiFlow, Flow, Source},
+  dsl::{BidiFlow, Flow, Source, tests::RunWithCollectSink},
   materialization::StreamNotUsed,
 };
 
 fn collect_single(flow: Flow<u32, u32, StreamNotUsed>, value: u32) -> Vec<u32> {
-  Source::single(value).via(flow).collect_values().expect("collect_values")
+  Source::single(value).via(flow).run_with_collect_sink().expect("run_with_collect_sink")
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn bidi_flow_join_composes_top_flow_and_bottom_and_keeps_materialized_value() {
   let joined = BidiFlow::from_flows(Flow::new().map(|value: u32| value + 1), Flow::new().map(|value: u32| value + 10))
     .join(Flow::new().map(|value: u32| value + 3));
 
-  let values = Source::single(1_u32).via(joined).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(joined).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![15_u32]);
 
   let (graph, materialized) =
@@ -137,8 +137,10 @@ fn bidi_flow_join_mat_combines_materialized_values() {
   assert_eq!(combined_mat, 30_u32);
 
   // Verify data flow: 1 → +1 → +3 → +10 = 15
-  let values: Vec<u32> =
-    Source::single(1_u32).via(Flow::from_graph(graph, StreamNotUsed::new())).collect_values().expect("collect_values");
+  let values: Vec<u32> = Source::single(1_u32)
+    .via(Flow::from_graph(graph, StreamNotUsed::new()))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![15_u32]);
 }
 
@@ -151,7 +153,7 @@ fn bidi_flow_join_mat_preserves_data_flow() {
     .join_mat(Flow::new().map(|value: u32| value + 3), |_, _| 42_u32);
 
   // When: running the pipeline
-  let values = Source::single(1_u32).via(joined).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(joined).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: data flows through top → middle → bottom
   assert_eq!(values, vec![15_u32]);

--- a/modules/stream-core/src/core/dsl/flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/flow/tests.rs
@@ -17,7 +17,7 @@ use crate::core::{
   DynValue, FlowLogic, OverflowStrategy, QueueOfferResult, RestartConfig, SourceLogic, StageDefinition, StreamDslError,
   StreamError, SubstreamCancelStrategy, ThrottleMode,
   attributes::{Attributes, DispatcherAttribute},
-  dsl::{Flow, FlowMonitorImpl, Sink, Source, TailSource},
+  dsl::{Flow, FlowMonitorImpl, Sink, Source, TailSource, tests::RunWithCollectSink},
   r#impl::{DefaultOperatorCatalog, OperatorCatalog, OperatorKey, fusing::StreamBufferConfig, materialization::Stream},
   materialization::{
     Completion, DriveOutcome, KeepBoth, KeepLeft, KeepRight, StreamCompletion, StreamDone, StreamNotUsed,
@@ -137,10 +137,12 @@ where
 }
 
 #[test]
-fn broadcast_duplicates_each_element() {
-  let values =
-    Source::single(7_u32).via(Flow::new().broadcast(2).expect("broadcast")).collect_values().expect("collect_values");
-  assert_eq!(values, vec![7_u32, 7_u32]);
+fn broadcast_with_single_fan_out_keeps_element() {
+  let values = Source::single(7_u32)
+    .via(Flow::new().broadcast(1).expect("broadcast"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
+  assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
@@ -151,8 +153,10 @@ fn broadcast_rejects_zero_fan_out() {
 
 #[test]
 fn balance_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().balance(1).expect("balance")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().balance(1).expect("balance"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -164,8 +168,10 @@ fn balance_rejects_zero_fan_out() {
 
 #[test]
 fn merge_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().merge(1).expect("merge")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().merge(1).expect("merge"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -177,7 +183,8 @@ fn merge_rejects_zero_fan_in() {
 
 #[test]
 fn zip_wraps_value_when_single_path() {
-  let values = Source::single(7_u32).via(Flow::new().zip(1).expect("zip")).collect_values().expect("collect_values");
+  let values =
+    Source::single(7_u32).via(Flow::new().zip(1).expect("zip")).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -189,8 +196,10 @@ fn zip_rejects_zero_fan_in() {
 
 #[test]
 fn concat_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().concat(1).expect("concat")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().concat(1).expect("concat"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -204,14 +213,15 @@ fn concat_rejects_zero_fan_in() {
 fn partition_keeps_single_path_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().partition(|value| *value % 2 == 0))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
 
 #[test]
 fn unzip_emits_tuple_components() {
-  let values = Source::single((7_u32, 8_u32)).via(Flow::new().unzip()).collect_values().expect("collect_values");
+  let values =
+    Source::single((7_u32, 8_u32)).via(Flow::new().unzip()).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32, 8_u32]);
 }
 
@@ -219,15 +229,17 @@ fn unzip_emits_tuple_components() {
 fn unzip_with_emits_mapped_tuple_components() {
   let values = Source::single(7_u32)
     .via(Flow::new().unzip_with(|value: u32| (value, value.saturating_add(1))))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32, 8_u32]);
 }
 
 #[test]
 fn interleave_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().interleave(1).expect("interleave")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().interleave(1).expect("interleave"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -239,8 +251,10 @@ fn interleave_rejects_zero_fan_in() {
 
 #[test]
 fn prepend_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().prepend(1).expect("prepend")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().prepend(1).expect("prepend"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -254,8 +268,8 @@ fn prepend_rejects_zero_fan_in() {
 fn concat_lazy_appends_secondary_source_after_primary_completion() {
   let values = Source::from_array([1_u32, 2])
     .via(Flow::new().concat_lazy(Source::from_array([3_u32, 4])))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
 
@@ -267,7 +281,7 @@ fn concat_all_lazy_should_append_all_secondary_sources_when_primary_completes() 
     .expect("concat_all_lazy");
 
   // When: primary が完了するまで stream を実行
-  let values = Source::from_array([1_u32, 2_u32]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2_u32]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: secondary source が指定順に連結される
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32, 5_u32]);
@@ -295,7 +309,7 @@ fn concat_all_lazy_should_materialize_secondary_sources_after_primary_completion
   assert!(materialized_sources.lock().is_empty());
 
   // When: primary が完了するまで stream を実行
-  let values = Source::from_array([1_u32, 2_u32]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2_u32]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: secondary source は primary 後に指定順で評価される
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
@@ -334,8 +348,8 @@ fn concat_lazy_emits_secondary_values_without_waiting_for_secondary_completion()
 fn prepend_lazy_emits_secondary_source_before_primary_values() {
   let values = Source::from_array([3_u32, 4])
     .via(Flow::new().prepend_lazy(Source::from_array([1_u32, 2])))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
 
@@ -359,8 +373,8 @@ fn prepend_lazy_emits_secondary_values_without_waiting_for_secondary_completion(
 fn or_else_uses_secondary_source_only_when_primary_is_empty() {
   let values = Source::<u32, _>::empty()
     .via(Flow::new().or_else(Source::from_array([5_u32, 6])))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32, 6_u32]);
 }
 
@@ -368,8 +382,8 @@ fn or_else_uses_secondary_source_only_when_primary_is_empty() {
 fn or_else_ignores_secondary_source_after_primary_emits() {
   let values = Source::from_array([7_u32, 8])
     .via(Flow::new().or_else(Source::from_array([1_u32, 2])))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32, 8_u32]);
 }
 
@@ -402,7 +416,7 @@ fn concat_lazy_materializes_secondary_after_primary_finishes() {
   });
   assert_eq!(*materialize_calls.lock(), 0_u32);
   let primary = Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&[Some(1_u32), None, None]));
-  let values = primary.via(Flow::new().concat_lazy(secondary)).collect_values().expect("collect_values");
+  let values = primary.via(Flow::new().concat_lazy(secondary)).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 4_u32]);
   assert_eq!(*materialize_calls.lock(), 1_u32);
 }
@@ -441,8 +455,10 @@ fn or_else_does_not_materialize_secondary_when_primary_emits() {
       Source::from_array([9_u32, 10_u32])
     }
   });
-  let values =
-    Source::from_array([7_u32, 8_u32]).via(Flow::new().or_else(secondary)).collect_values().expect("collect_values");
+  let values = Source::from_array([7_u32, 8_u32])
+    .via(Flow::new().or_else(secondary))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32, 8_u32]);
   assert_eq!(*materialize_calls.lock(), 0_u32);
 }
@@ -452,8 +468,8 @@ fn concat_lazy_accepts_non_clone_elements() {
   let values = Source::from_array([NonCloneValue(1_u32), NonCloneValue(2_u32)])
     .via(Flow::new().concat_lazy(Source::from_array([NonCloneValue(3_u32)])))
     .map(|value: NonCloneValue| value.0)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -462,8 +478,8 @@ fn prepend_lazy_accepts_non_clone_elements() {
   let values = Source::from_array([NonCloneValue(2_u32), NonCloneValue(3_u32)])
     .via(Flow::new().prepend_lazy(Source::from_array([NonCloneValue(1_u32)])))
     .map(|value: NonCloneValue| value.0)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -472,8 +488,8 @@ fn or_else_accepts_non_clone_elements() {
   let values = Source::from_array([NonCloneValue(7_u32)])
     .via(Flow::new().or_else(Source::from_array([NonCloneValue(9_u32)])))
     .map(|value: NonCloneValue| value.0)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -497,8 +513,8 @@ fn concat_lazy_mat_preserves_existing_data_path_behavior() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .concat_lazy_mat(Source::from_array([3_u32, 4_u32]).map_materialized_value(|_| 99_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -522,8 +538,8 @@ fn prepend_lazy_mat_preserves_existing_data_path_behavior() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .prepend_lazy_mat(Source::from_array([1_u32, 2_u32]).map_materialized_value(|_| 42_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -547,8 +563,8 @@ fn or_else_mat_preserves_existing_data_path_behavior() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .or_else_mat(Source::from_array([5_u32, 6_u32]).map_materialized_value(|_| 77_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![5_u32, 6_u32]);
 }
@@ -573,8 +589,8 @@ fn divert_to_mat_preserves_existing_data_path_behavior() {
       Sink::<u32, StreamCompletion<StreamDone>>::ignore().map_materialized_value(|_| 1_u32),
       KeepLeft,
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 3_u32]);
 }
@@ -592,8 +608,8 @@ fn divert_to_mat_routes_matching_elements_to_sink() {
       }),
       KeepLeft,
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 3_u32]);
   assert_eq!(*diverted.lock(), vec![2_u32, 4_u32]);
@@ -647,8 +663,8 @@ fn concat_mat_preserves_existing_data_path_behavior() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .concat_mat(Source::from_array([3_u32, 4_u32]).map_materialized_value(|_| 99_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -689,8 +705,8 @@ fn prepend_mat_preserves_existing_data_path_behavior() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .prepend_mat(Source::from_array([1_u32, 2_u32]).map_materialized_value(|_| 42_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -729,8 +745,8 @@ fn merge_mat_preserves_existing_data_path_behavior() {
   let mut values = Source::single(7_u32)
     .map_materialized_value(|_| 0_u32)
     .merge_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   values.sort();
 
   assert!(values.contains(&7_u32));
@@ -772,8 +788,8 @@ fn merge_preferred_mat_preserves_existing_data_path_behavior() {
   let mut values = Source::single(7_u32)
     .map_materialized_value(|_| 0_u32)
     .merge_preferred_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   values.sort();
 
   assert!(values.contains(&7_u32));
@@ -815,8 +831,8 @@ fn merge_sorted_mat_preserves_existing_data_path_behavior() {
   let values = Source::from_array([1_u32, 3_u32, 5_u32])
     .map_materialized_value(|_| 0_u32)
     .merge_sorted_mat(Source::from_array([2_u32, 4_u32, 6_u32]).map_materialized_value(|_| 99_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32, 5_u32, 6_u32]);
 }
@@ -851,8 +867,8 @@ fn zip_mat_preserves_existing_data_path_behavior() {
   let values = Source::single(1_u32)
     .map_materialized_value(|_| 0_u32)
     .zip_mat(Source::single(2_u32).map_materialized_value(|_| 99_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![vec![1_u32, 2_u32]]);
 }
@@ -891,8 +907,8 @@ fn zip_all_mat_preserves_existing_data_path_behavior() {
   let values = Source::from_array([1_u32, 2_u32])
     .map_materialized_value(|_| 0_u32)
     .zip_all_mat(Source::from_array([3_u32]).map_materialized_value(|_| 99_u32), 0_u32, KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // zip_all pads shorter stream with fill_value (0)
   assert_eq!(values, vec![vec![1_u32, 3_u32], vec![2_u32, 0_u32]]);
@@ -936,8 +952,8 @@ fn zip_with_mat_preserves_existing_data_path_behavior() {
       |values: Vec<u32>| values.into_iter().sum::<u32>(),
       KeepLeft,
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![30_u32]);
 }
@@ -976,8 +992,8 @@ fn zip_latest_mat_preserves_existing_data_path_behavior() {
   let values = Source::single(1_u32)
     .map_materialized_value(|_| 0_u32)
     .zip_latest_mat(Source::single(2_u32).map_materialized_value(|_| 99_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![vec![1_u32, 2_u32]]);
 }
@@ -1020,8 +1036,8 @@ fn zip_latest_with_mat_preserves_existing_data_path_behavior() {
       |values: Vec<u32>| values.into_iter().sum::<u32>(),
       KeepLeft,
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![30_u32]);
 }
@@ -1060,8 +1076,8 @@ fn merge_latest_mat_preserves_existing_data_path_behavior() {
   let values = Source::single(7_u32)
     .map_materialized_value(|_| 0_u32)
     .merge_latest_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // merge_latest emits Vec of latest values from all inputs
   assert!(!values.is_empty());
@@ -1101,8 +1117,8 @@ fn merge_prioritized_mat_preserves_existing_data_path_behavior() {
   let mut values = Source::single(7_u32)
     .map_materialized_value(|_| 0_u32)
     .merge_prioritized_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   values.sort();
 
   assert!(values.contains(&7_u32));
@@ -1144,8 +1160,8 @@ fn interleave_mat_preserves_existing_data_path_behavior() {
   let mut values = Source::from_array([1_u32, 3_u32])
     .map_materialized_value(|_| 0_u32)
     .interleave_mat(Source::from_array([2_u32, 4_u32]).map_materialized_value(|_| 99_u32), 1, KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   values.sort();
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
@@ -1192,8 +1208,8 @@ fn flat_map_prefix_mat_preserves_existing_data_path_behavior() {
       |_prefix: Vec<u32>| Flow::<u32, u32, StreamNotUsed>::new(),
       KeepLeft,
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // flat_map_prefix consumes prefix (1 element), then passes rest through the inner flow
   assert_eq!(values, vec![2_u32, 3_u32]);
@@ -1203,8 +1219,8 @@ fn flat_map_prefix_mat_preserves_existing_data_path_behavior() {
 fn zip_all_wraps_value_when_single_path() {
   let values = Source::single(7_u32)
     .via(Flow::new().zip_all(1, 0_u32).expect("zip_all"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -1216,8 +1232,10 @@ fn zip_all_rejects_zero_fan_in() {
 
 #[test]
 fn zip_latest_wraps_single_path_value_into_vec() {
-  let values =
-    Source::single(7_u32).via(Flow::new().zip_latest(1).expect("zip_latest")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().zip_latest(1).expect("zip_latest"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -1231,8 +1249,8 @@ fn zip_latest_rejects_zero_fan_in() {
 fn zip_latest_with_maps_latest_snapshot() {
   let values = Source::single(7_u32)
     .via(Flow::new().zip_latest_with(1, |latest: Vec<u32>| latest[0].saturating_add(1)).expect("zip_latest_with"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![8_u32]);
 }
 
@@ -1243,7 +1261,7 @@ fn materialize_into_source_emits_completed_sink_materialized_value() {
     .materialize_into_source(Source::single(1_u32), Sink::head())
     .into_parts();
   let materialized: Vec<u32> =
-    Source::from_graph(graph, StreamNotUsed::new()).collect_values().expect("collect_values");
+    Source::from_graph(graph, StreamNotUsed::new()).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(materialized, vec![2_u32]);
   assert_eq!(completion.poll(), Completion::Ready(Ok(())));
 }
@@ -1252,8 +1270,8 @@ fn materialize_into_source_emits_completed_sink_materialized_value() {
 fn flat_map_merge_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().flat_map_merge(2, Source::single).expect("flat_map_merge"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -1320,8 +1338,8 @@ fn flat_map_merge_rejects_zero_breadth() {
 fn buffer_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().buffer(2, OverflowStrategy::Backpressure).expect("buffer"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -1337,7 +1355,7 @@ fn buffer_rejects_zero_capacity() {
 
 #[test]
 fn async_boundary_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().r#async()).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().r#async()).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -1345,8 +1363,8 @@ fn async_boundary_keeps_single_path_behavior() {
 fn throttle_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().throttle(2, ThrottleMode::Shaping).expect("throttle"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -1362,8 +1380,10 @@ fn throttle_rejects_zero_capacity() {
 
 #[test]
 fn delay_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().delay(2).expect("delay")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().delay(2).expect("delay"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -1381,8 +1401,8 @@ fn delay_rejects_zero_ticks() {
 fn initial_delay_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().initial_delay(2).expect("initial_delay"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -1400,8 +1420,8 @@ fn initial_delay_rejects_zero_ticks() {
 fn take_within_limits_output_window() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().take_within(1).expect("take_within"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -1419,8 +1439,8 @@ fn take_within_rejects_zero_ticks() {
 fn batch_emits_fixed_size_chunks() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4, 5]))
     .via(Flow::new().batch(2).expect("batch"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32], vec![3_u32, 4_u32], vec![5_u32]]);
 }
 
@@ -1438,8 +1458,8 @@ fn batch_rejects_zero_size() {
 fn map_async_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().map_async(2, |value: u32| async move { value.saturating_add(1) }).expect("map_async"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![8_u32]);
 }
 
@@ -1465,8 +1485,8 @@ fn map_async_preserves_order_with_parallelism() {
         })
         .expect("map_async"),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 3_u32, 4_u32]);
 }
 
@@ -1633,8 +1653,8 @@ fn map_async_partitioned_serializes_same_partition_while_preserving_input_order(
         })
         .expect("map_async_partitioned"),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![11_u32, 13_u32, 12_u32, 14_u32]);
 }
 
@@ -1661,23 +1681,27 @@ fn map_async_partitioned_unordered_emits_completed_partitions_without_global_ord
         })
         .expect("map_async_partitioned_unordered"),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert!(*overlap_seen.lock(), "different partitions should overlap in flight");
   assert_eq!(values, vec![12_u32, 11_u32]);
 }
 
 #[test]
 fn filter_keeps_matching_elements() {
-  let values =
-    Source::single(7_u32).via(Flow::new().filter(|value| *value % 2 == 1)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().filter(|value| *value % 2 == 1))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn filter_discards_non_matching_elements() {
-  let values =
-    Source::single(8_u32).via(Flow::new().filter(|value| *value % 2 == 1)).collect_values().expect("collect_values");
+  let values = Source::single(8_u32)
+    .via(Flow::new().filter(|value| *value % 2 == 1))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
@@ -1685,22 +1709,26 @@ fn filter_discards_non_matching_elements() {
 fn filter_not_discards_matching_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().filter_not(|value| *value % 2 == 0))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32]);
 }
 
 #[test]
 fn flatten_optional_emits_present_value() {
-  let values =
-    Source::single(Some(7_u32)).via(Flow::new().flatten_optional()).collect_values().expect("collect_values");
+  let values = Source::single(Some(7_u32))
+    .via(Flow::new().flatten_optional())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn flatten_optional_skips_none() {
-  let values =
-    Source::single(None::<u32>).via(Flow::new().flatten_optional()).collect_values().expect("collect_values");
+  let values = Source::single(None::<u32>)
+    .via(Flow::new().flatten_optional())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
@@ -1708,8 +1736,8 @@ fn flatten_optional_skips_none() {
 fn collect_maps_present_values_and_skips_absent_values() {
   let values = Source::from_array([1_i32, -1_i32, 2_i32])
     .via(Flow::new().collect(|value| u32::try_from(value).ok()))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -1727,8 +1755,8 @@ fn flatten_flattens_nested_sources_in_order_and_skips_empty_inner_sources() {
         })
         .flatten(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![22_u32, 32_u32, 23_u32, 33_u32]);
 }
@@ -1765,8 +1793,8 @@ fn flatten_emits_inner_head_without_waiting_for_inner_completion() {
 fn map_concat_expands_each_element() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().map_concat(|value: u32| [value, value.saturating_add(10)]))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 11_u32, 2_u32, 12_u32, 3_u32, 13_u32]);
 }
 
@@ -1774,8 +1802,8 @@ fn map_concat_expands_each_element() {
 fn map_option_emits_only_present_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().map_option(|value| if value % 2 == 0 { Some(value) } else { None }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4_u32]);
 }
 
@@ -1789,8 +1817,8 @@ fn stateful_map_emits_stateful_results() {
         sum
       }
     }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
 }
 
@@ -1804,8 +1832,8 @@ fn stateful_map_concat_expands_with_stateful_mapper() {
         [sum, sum.saturating_add(100)]
       }
     }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 101_u32, 3_u32, 103_u32, 6_u32, 106_u32]);
 }
 
@@ -1821,8 +1849,8 @@ fn stateful_map_on_complete_emits_final_element() {
       },
       |state| Some(state),
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 通常要素に加え、on_complete が出力した合計値が末尾に追加される
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 6_u32]);
@@ -1840,8 +1868,8 @@ fn stateful_map_on_complete_none_emits_nothing_extra() {
       },
       |_state| None,
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: on_complete が None を返したため、通常要素のみ
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -1859,8 +1887,8 @@ fn stateful_map_on_complete_receives_accumulated_state() {
       },
       |state| Some(state),
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 各要素(10,20,30) + on_complete での蓄積合計(60)
   assert_eq!(values, vec![10_u32, 20, 30, 60]);
@@ -1881,8 +1909,8 @@ fn stateful_map_concat_with_accumulator_processes_elements() {
 
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().stateful_map_concat_with_accumulator(|| DoublingAccumulator))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 各要素が [value, value*2] に展開される
   assert_eq!(values, vec![1_u32, 2, 2, 4, 3, 6]);
@@ -1912,8 +1940,8 @@ fn stateful_map_concat_with_accumulator_on_complete_emits_trailing() {
 
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().stateful_map_concat_with_accumulator(|| BufferingAccumulator { buffer: Vec::new() }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: [1,2] はバッファ満了で排出、[3] は on_complete で排出
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -1923,8 +1951,8 @@ fn stateful_map_concat_with_accumulator_on_complete_emits_trailing() {
 fn drop_skips_first_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().drop(2))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32, 4_u32]);
 }
 
@@ -1932,8 +1960,8 @@ fn drop_skips_first_elements() {
 fn take_limits_emitted_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().take(2))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -1941,8 +1969,8 @@ fn take_limits_emitted_elements() {
 fn drop_while_skips_matching_prefix() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().drop_while(|value| *value < 3))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32, 4_u32]);
 }
 
@@ -1950,8 +1978,8 @@ fn drop_while_skips_matching_prefix() {
 fn take_while_keeps_matching_prefix() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().take_while(|value| *value < 3))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -1959,8 +1987,8 @@ fn take_while_keeps_matching_prefix() {
 fn take_until_includes_first_matching_element() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().take_until(|value| *value >= 3))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -1968,8 +1996,8 @@ fn take_until_includes_first_matching_element() {
 fn grouped_emits_fixed_size_chunks() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4, 5]))
     .via(Flow::new().grouped(2).expect("grouped"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32], vec![3_u32, 4_u32], vec![5_u32]]);
 }
 
@@ -1987,8 +2015,8 @@ fn grouped_rejects_zero_size() {
 fn sliding_emits_overlapping_windows() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .via(Flow::new().sliding(3).expect("sliding"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32, 3_u32], vec![2_u32, 3_u32, 4_u32]]);
 }
 
@@ -2006,8 +2034,8 @@ fn sliding_rejects_zero_size() {
 fn scan_emits_initial_and_running_accumulation() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().scan(0_u32, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![0_u32, 1_u32, 3_u32, 6_u32]);
 }
 
@@ -2015,8 +2043,8 @@ fn scan_emits_initial_and_running_accumulation() {
 fn intersperse_injects_markers() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().intersperse(10_u32, 99_u32, 11_u32))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 1_u32, 99_u32, 2_u32, 99_u32, 3_u32, 11_u32]);
 }
 
@@ -2024,8 +2052,8 @@ fn intersperse_injects_markers() {
 fn intersperse_on_empty_stream_emits_start_and_end() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[]))
     .via(Flow::new().intersperse(10_u32, 99_u32, 11_u32))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 11_u32]);
 }
 
@@ -2033,8 +2061,8 @@ fn intersperse_on_empty_stream_emits_start_and_end() {
 fn zip_with_index_pairs_each_element_with_index() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[7, 8, 9]))
     .via(Flow::new().zip_with_index())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![(7_u32, 0_u64), (8_u32, 1_u64), (9_u32, 2_u64)]);
 }
 
@@ -2047,8 +2075,8 @@ fn group_by_keeps_single_path_behavior() {
         .expect("group_by")
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2088,8 +2116,8 @@ fn group_by_rejects_zero_max_substreams() {
 fn split_when_with_cancel_strategy_emits_single_segment_for_single_element() {
   let values = Source::single(7_u32)
     .via(Flow::new().split_when_with_cancel_strategy(SubstreamCancelStrategy::Drain, |_| false).into_flow())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -2097,8 +2125,8 @@ fn split_when_with_cancel_strategy_emits_single_segment_for_single_element() {
 fn split_after_with_cancel_strategy_emits_single_segment_for_single_element() {
   let values = Source::single(7_u32)
     .via(Flow::new().split_after_with_cancel_strategy(SubstreamCancelStrategy::Propagate, |_| false).into_flow())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -2106,8 +2134,8 @@ fn split_after_with_cancel_strategy_emits_single_segment_for_single_element() {
 fn split_when_emits_single_segment_for_single_element() {
   let values = Source::single(7_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::new().split_when(|_| false).into_flow())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -2115,8 +2143,8 @@ fn split_when_emits_single_segment_for_single_element() {
 fn split_after_emits_single_segment_for_single_element() {
   let values = Source::single(7_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::new().split_after(|_| false).into_flow())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -2124,8 +2152,8 @@ fn split_after_emits_single_segment_for_single_element() {
 fn merge_substreams_flattens_single_segment() {
   let values = Source::single(7_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::new().split_after(|_| true).merge_substreams())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2133,8 +2161,8 @@ fn merge_substreams_flattens_single_segment() {
 fn concat_substreams_flattens_single_segment() {
   let values = Source::single(7_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::new().split_after(|_| true).concat_substreams())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2147,8 +2175,8 @@ fn merge_substreams_with_parallelism_flattens_single_segment() {
         .merge_substreams_with_parallelism(2)
         .expect("merge_substreams_with_parallelism"),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2166,7 +2194,7 @@ fn merge_substreams_with_parallelism_rejects_zero_parallelism() {
 fn map_error_transforms_upstream_failure() {
   let result = Source::<u32, _>::failed(StreamError::Failed)
     .via(Flow::new().map_error(|_| StreamError::WouldBlock))
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::WouldBlock));
 }
 
@@ -2177,8 +2205,8 @@ fn on_error_continue_resumes_after_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .via(Flow::new().on_error_continue())
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -2189,8 +2217,8 @@ fn on_error_resume_alias_resumes_after_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .via(Flow::new().on_error_resume())
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -2208,8 +2236,8 @@ fn on_error_continue_if_with_invokes_consumer_for_matching_failure() {
       captured.lock().push(error.clone());
     },
   ))
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
   assert_eq!(observed.lock().as_slice(), &[StreamError::Failed]);
 }
@@ -2221,8 +2249,8 @@ fn on_error_complete_stops_after_matching_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .via(Flow::new().on_error_complete())
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -2233,8 +2261,8 @@ fn on_error_complete_if_stops_on_matching_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .via(Flow::new().on_error_complete_if(|error| matches!(error, StreamError::Failed)))
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -2242,8 +2270,8 @@ fn on_error_complete_if_stops_on_matching_upstream_failure() {
 fn recover_replaces_upstream_failure_with_fallback() {
   let values = Source::<u32, _>::failed(StreamError::Failed)
     .via(Flow::new().recover(|_| Some(9_u32)))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![9_u32]);
 }
 
@@ -2254,8 +2282,8 @@ fn recover_drops_later_elements_after_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .via(Flow::new().recover(|_| Some(9_u32)))
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 9_u32]);
 }
 
@@ -2263,8 +2291,8 @@ fn recover_drops_later_elements_after_upstream_failure() {
 fn recover_with_alias_switches_to_recovery_source() {
   let values = Source::<u32, _>::failed(StreamError::Failed)
     .via(Flow::new().recover_with(|_| Some(Source::from_array([8_u32, 9_u32]))))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![8_u32, 9_u32]);
 }
 
@@ -2272,7 +2300,7 @@ fn recover_with_alias_switches_to_recovery_source() {
 fn recover_with_retries_fails_when_retry_budget_is_exhausted() {
   let result = Source::<u32, _>::failed(StreamError::Failed)
     .via(Flow::new().recover_with_retries(0, |_| Some(Source::single(9_u32))))
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::Failed));
 }
 
@@ -2291,8 +2319,8 @@ fn recover_with_retries_switches_recovery_sources_incrementally() {
         Some(Source::from_array([10_u32, 11_u32]))
       }
     }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![9_u32, 10_u32, 11_u32]);
 }
 
@@ -2305,27 +2333,32 @@ fn recover_with_retries_fails_after_consuming_retry_budget() {
         FailureSequenceSourceLogic::new(&[Ok(9_u32), Err(StreamError::Failed)]),
       ))
     }))
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::Failed));
 }
 
 #[test]
 fn restart_flow_with_backoff_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().restart_flow_with_backoff(1, 3)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().restart_flow_with_backoff(1, 3))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn on_failures_with_backoff_alias_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().on_failures_with_backoff(1, 3)).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().on_failures_with_backoff(1, 3))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn with_backoff_alias_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).via(Flow::new().with_backoff(1, 3)).collect_values().expect("collect_values");
+  let values =
+    Source::single(7_u32).via(Flow::new().with_backoff(1, 3)).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2333,8 +2366,8 @@ fn with_backoff_alias_keeps_single_path_behavior() {
 fn with_backoff_and_context_alias_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().with_backoff_and_context(1, 3, "compat"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2346,8 +2379,8 @@ fn restart_flow_with_settings_keeps_single_path_behavior() {
     .with_jitter_seed(17);
   let values = Source::single(7_u32)
     .via(Flow::new().restart_flow_with_settings(settings))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2355,8 +2388,8 @@ fn restart_flow_with_settings_keeps_single_path_behavior() {
 fn supervision_variants_keep_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().supervision_stop().supervision_resume().supervision_restart())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2550,8 +2583,8 @@ fn stateful_map_concat_logic_on_restart_recreates_mapper() {
 fn collect_type_collects_convertible_values() {
   let values = Source::from_array([1_i32, -1_i32, 2_i32])
     .via(Flow::new().collect_type::<u32>())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -2559,22 +2592,22 @@ fn collect_type_collects_convertible_values() {
 fn fold_async_emits_running_accumulation_when_future_is_ready() {
   let values = Source::from_array([1_u32, 2, 3])
     .via(Flow::new().fold_async(0_u32, |acc, value| async move { acc + value }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
 }
 
 #[test]
 fn ask_alias_maps_values_asynchronously() {
   let flow = Flow::new().ask(1, |value: u32| async move { value + 1 }).expect("ask");
-  let values = Source::from_array([1_u32, 2_u32]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2_u32]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 3_u32]);
 }
 
 #[test]
 fn ask_with_status_alias_maps_values_asynchronously() {
   let flow = Flow::new().ask_with_status(1, |value: u32| async move { value + 2 }).expect("ask_with_status");
-  let values = Source::from_array([1_u32, 2_u32]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2_u32]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32, 4_u32]);
 }
 
@@ -2583,7 +2616,10 @@ fn ask_with_context_preserves_context_and_maps_value() {
   let flow = Flow::<(u32, u32), (u32, u32), StreamNotUsed>::new()
     .ask_with_context(1, |value| async move { value + 10 })
     .expect("ask_with_context");
-  let values = Source::from_array([(7_u32, 1_u32), (8_u32, 2_u32)]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([(7_u32, 1_u32), (8_u32, 2_u32)])
+    .via(flow)
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![(7_u32, 11_u32), (8_u32, 12_u32)]);
 }
 
@@ -2592,7 +2628,10 @@ fn ask_with_status_and_context_preserves_context_and_maps_value() {
   let flow = Flow::<(u32, u32), (u32, u32), StreamNotUsed>::new()
     .ask_with_status_and_context(1, |value| async move { value + 20 })
     .expect("ask_with_status_and_context");
-  let values = Source::from_array([(7_u32, 1_u32), (8_u32, 2_u32)]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([(7_u32, 1_u32), (8_u32, 2_u32)])
+    .via(flow)
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![(7_u32, 21_u32), (8_u32, 22_u32)]);
 }
 
@@ -2695,8 +2734,8 @@ fn operator_catalog_lookup_rejects_unknown_operator() {
 fn detach_preserves_elements_and_order() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().r#async())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -2704,8 +2743,8 @@ fn detach_preserves_elements_and_order() {
 fn log_passes_elements_through_unchanged_and_inserts_logging_stage() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().log("test"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 
   let (plan, completion) =
@@ -2726,8 +2765,8 @@ fn log_does_not_bypass_upstream_source_supervision_resume() {
   )
   .supervision_resume()
   .via(Flow::new().log("log-stage"))
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2735,8 +2774,8 @@ fn log_does_not_bypass_upstream_source_supervision_resume() {
 fn log_with_marker_passes_elements_through_unchanged_and_inserts_logging_stage() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().log_with_marker("test", "marker"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 
   let (plan, completion) = Source::single(7_u32)
@@ -2769,14 +2808,14 @@ fn compression_operators_round_trip_bytes_and_store_attributes() {
   let payload = vec![1_u8, 2, 3, 3, 3, 4, 5];
   let values = Source::single(payload.clone())
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip().gzip_decompress())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![payload.clone()]);
 
   let values = Source::single(payload.clone())
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().deflate().inflate())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![payload]);
 
   let (graph, _mat) = Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip().inflate().into_parts();
@@ -2818,8 +2857,8 @@ fn gzip_decompress_accepts_member_with_filename_header() {
   let encoded = gzip_member_with_filename(&payload, "payload.bin");
   let values = Source::single(encoded)
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![payload]);
 }
 
@@ -2832,8 +2871,8 @@ fn gzip_decompress_accepts_standard_gzip_payload() {
   ];
   let values = Source::single(encoded)
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![b"hello-gzip-interop".to_vec()]);
 }
 
@@ -2843,8 +2882,8 @@ fn gzip_emits_raw_deflate_payload() {
   let payload = b"gzip-raw-deflate-check".to_vec();
   let encoded = Source::single(payload.clone())
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip())
-    .collect_values()
-    .expect("collect_values")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink")
     .pop()
     .expect("encoded payload");
   let payload_end = encoded.len().saturating_sub(8);
@@ -2862,7 +2901,8 @@ fn inflate_rejects_payload_exceeding_decompression_limit() {
   let payload = vec![0x5a_u8; FLOW_DECOMPRESSION_MAX_BYTES_DEFAULT.saturating_add(1)];
   let encoded = miniz_oxide::deflate::compress_to_vec(&payload, 6);
 
-  let result = Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate()).collect_values();
+  let result =
+    Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate()).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::CompressionError { .. })));
 }
@@ -2873,13 +2913,14 @@ fn gzip_decompress_rejects_payload_exceeding_decompression_limit() {
   let payload = vec![0x33_u8; FLOW_DECOMPRESSION_MAX_BYTES_DEFAULT.saturating_add(1)];
   let encoded = Source::single(payload)
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip())
-    .collect_values()
-    .expect("collect_values")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink")
     .pop()
     .expect("encoded payload");
 
-  let result =
-    Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress()).collect_values();
+  let result = Source::single(encoded)
+    .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress())
+    .run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::CompressionError { kind: "gzip_too_large" })));
 }
@@ -2890,15 +2931,16 @@ fn gzip_decompress_rejects_payload_exceeding_decompression_limit_with_spoofed_is
   let payload = vec![0x44_u8; FLOW_DECOMPRESSION_MAX_BYTES_DEFAULT.saturating_add(1)];
   let mut encoded = Source::single(payload)
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip())
-    .collect_values()
-    .expect("collect_values")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink")
     .pop()
     .expect("encoded payload");
   let trailer_start = encoded.len().saturating_sub(4);
   encoded[trailer_start..].copy_from_slice(&0_u32.to_le_bytes());
 
-  let result =
-    Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress()).collect_values();
+  let result = Source::single(encoded)
+    .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress())
+    .run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::CompressionError { kind: "gzip_too_large" })));
 }
@@ -2909,9 +2951,10 @@ fn inflate_accepts_payload_larger_than_compression_chunk_default() {
   let payload = vec![0x6a_u8; crate::core::dsl::Compression::MAX_BYTES_PER_CHUNK_DEFAULT.saturating_add(1)];
   let encoded = miniz_oxide::deflate::compress_to_vec(&payload, 6);
 
-  let result = Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate()).collect_values();
+  let result =
+    Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate()).run_with_collect_sink();
 
-  assert_eq!(result.expect("collect_values"), vec![payload]);
+  assert_eq!(result.expect("run_with_collect_sink"), vec![payload]);
 }
 
 #[test]
@@ -2920,15 +2963,16 @@ fn gzip_decompress_accepts_payload_larger_than_compression_chunk_default() {
   let payload = vec![0x7b_u8; crate::core::dsl::Compression::MAX_BYTES_PER_CHUNK_DEFAULT.saturating_add(1)];
   let encoded = Source::single(payload.clone())
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip())
-    .collect_values()
-    .expect("collect_values")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink")
     .pop()
     .expect("encoded payload");
 
-  let result =
-    Source::single(encoded).via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress()).collect_values();
+  let result = Source::single(encoded)
+    .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress())
+    .run_with_collect_sink();
 
-  assert_eq!(result.expect("collect_values"), vec![payload]);
+  assert_eq!(result.expect("run_with_collect_sink"), vec![payload]);
 }
 
 #[test]
@@ -2937,7 +2981,7 @@ fn limit_should_pass_when_element_count_equals_max() {
   let source = Source::from_array([1_u32, 2_u32]);
 
   // When: limit を通して収集する
-  let values = source.via(Flow::new().limit(2)).collect_values().expect("collect_values");
+  let values = source.via(Flow::new().limit(2)).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: 境界値まではそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32]);
@@ -2949,7 +2993,7 @@ fn limit_should_fail_when_element_count_exceeds_max() {
   let source = Source::from_array([1_u32, 2_u32, 3_u32]);
 
   // When: limit を通して収集する
-  let error = source.via(Flow::new().limit(2)).collect_values().expect_err("limit should fail");
+  let error = source.via(Flow::new().limit(2)).run_with_collect_sink().expect_err("limit should fail");
 
   // Then: Pekko の StreamLimitReachedException 相当の failure になる
   assert_eq!(error, StreamError::StreamLimitReached { limit: 2 });
@@ -2961,8 +3005,10 @@ fn limit_weighted_should_pass_when_total_weight_equals_budget() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]));
 
   // When: limit_weighted を通して収集する
-  let values =
-    source.via(Flow::new().limit_weighted(3, |value| *value as usize)).collect_values().expect("collect_values");
+  let values = source
+    .via(Flow::new().limit_weighted(3, |value| *value as usize))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: budget 境界まではそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32]);
@@ -2974,8 +3020,10 @@ fn limit_weighted_should_fail_when_weight_exceeds_remaining_budget() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[2, 2, 1]));
 
   // When: limit_weighted を通して収集する
-  let error =
-    source.via(Flow::new().limit_weighted(3, |value| *value as usize)).collect_values().expect_err("limit should fail");
+  let error = source
+    .via(Flow::new().limit_weighted(3, |value| *value as usize))
+    .run_with_collect_sink()
+    .expect_err("limit should fail");
 
   // Then: 超過を正常完了にせず failure として返す
   assert_eq!(error, StreamError::StreamLimitReached { limit: 3 });
@@ -2987,8 +3035,10 @@ fn limit_weighted_should_fail_when_zero_budget_receives_input() {
   let source = Source::single(1_u32);
 
   // When: 最初の要素が到達する
-  let error =
-    source.via(Flow::new().limit_weighted(0, |value| *value as usize)).collect_values().expect_err("limit should fail");
+  let error = source
+    .via(Flow::new().limit_weighted(0, |value| *value as usize))
+    .run_with_collect_sink()
+    .expect_err("limit should fail");
 
   // Then: 構築時ではなく要素到達時の limit reached failure になる
   assert_eq!(error, StreamError::StreamLimitReached { limit: 0 });
@@ -2998,8 +3048,8 @@ fn limit_weighted_should_fail_when_zero_budget_receives_input() {
 fn grouped_weighted_within_uses_weight_budget() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[2, 1, 2]))
     .via(Flow::new().grouped_weighted_within(3, 10, |value| *value as usize).expect("grouped_weighted_within"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![2_u32, 1_u32], vec![2_u32]]);
 }
 
@@ -3007,8 +3057,8 @@ fn grouped_weighted_within_uses_weight_budget() {
 fn grouped_weighted_within_flushes_on_weight_add_overflow() {
   let values = Source::from_array([usize::MAX - 1, 2_usize])
     .via(Flow::new().grouped_weighted_within(usize::MAX, 10, |value| *value).expect("grouped_weighted_within"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![usize::MAX - 1], vec![2_usize]]);
 }
 
@@ -3016,8 +3066,8 @@ fn grouped_weighted_within_flushes_on_weight_add_overflow() {
 fn batch_weighted_uses_weight_budget() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[2, 1, 2]))
     .via(Flow::new().batch_weighted(3, |value| *value as usize).expect("batch_weighted"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![2_u32, 1_u32], vec![2_u32]]);
 }
 
@@ -3041,8 +3091,8 @@ fn flat_map_prefix_uses_prefix_to_build_tail_flow() {
       let prefix_sum = prefix.into_iter().sum::<u32>();
       Flow::new().map(move |value: u32| value.saturating_add(prefix_sum))
     }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![6_u32, 7_u32]);
 }
 
@@ -3050,29 +3100,33 @@ fn flat_map_prefix_uses_prefix_to_build_tail_flow() {
 fn flat_map_prefix_accepts_zero_prefix() {
   let values = Source::from_array([1_u32, 2])
     .via(Flow::new().flat_map_prefix(0, |_prefix| Flow::new().map(|value: u32| value.saturating_add(5))))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![6_u32, 7_u32]);
 }
 
 #[test]
 fn prefix_and_tail_emits_prefix_and_remaining_tail() {
-  let values =
-    Source::from_array([1_u32, 2, 3, 4]).via(Flow::new().prefix_and_tail(2)).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2, 3, 4])
+    .via(Flow::new().prefix_and_tail(2))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values.len(), 1);
   let (prefix, tail): (Vec<u32>, TailSource<u32>) = values.into_iter().next().expect("prefix and tail");
   assert_eq!(prefix, vec![1_u32, 2_u32]);
-  assert_eq!(tail.collect_values().expect("tail values"), vec![3_u32, 4_u32]);
+  assert_eq!(tail.run_with_collect_sink().expect("tail values"), vec![3_u32, 4_u32]);
 }
 
 #[test]
 fn prefix_and_tail_accepts_zero_prefix() {
-  let values =
-    Source::from_array([7_u32, 8]).via(Flow::new().prefix_and_tail(0)).collect_values().expect("collect_values");
+  let values = Source::from_array([7_u32, 8])
+    .via(Flow::new().prefix_and_tail(0))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values.len(), 1);
   let (prefix, tail): (Vec<u32>, TailSource<u32>) = values.into_iter().next().expect("prefix and tail");
   assert_eq!(prefix, vec![]);
-  assert_eq!(tail.collect_values().expect("tail values"), vec![7_u32, 8_u32]);
+  assert_eq!(tail.run_with_collect_sink().expect("tail values"), vec![7_u32, 8_u32]);
 }
 
 #[test]
@@ -3087,8 +3141,8 @@ fn do_on_first_invokes_callback_on_first_element_only() {
     .via(Flow::new().do_on_first(move |_value| {
       counter_clone.fetch_add(1, Ordering::Relaxed);
     }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 20_u32, 30_u32]);
   assert_eq!(counter.load(Ordering::Relaxed), 1);
 }
@@ -3097,8 +3151,8 @@ fn do_on_first_invokes_callback_on_first_element_only() {
 fn conflate_preserves_elements_when_upstream_is_not_bursty() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().conflate(|acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -3106,8 +3160,8 @@ fn conflate_preserves_elements_when_upstream_is_not_bursty() {
 fn conflate_with_seed_applies_seed_and_aggregate() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().conflate_with_seed(|value| value + 10, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![11_u32, 12_u32, 13_u32]);
 }
 
@@ -3116,8 +3170,8 @@ fn conflate_aggregates_bursty_upstream_values() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .via(Flow::new().map_concat(|value: u32| vec![value, value.saturating_mul(10)]))
     .via(Flow::new().conflate(|acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![11_u32, 22_u32]);
 }
 
@@ -3126,8 +3180,8 @@ fn conflate_with_seed_aggregates_bursty_upstream_values() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .via(Flow::new().map_concat(|value: u32| vec![value, value.saturating_mul(10)]))
     .via(Flow::new().conflate_with_seed(|value| value + 100, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![111_u32, 122_u32]);
 }
 
@@ -3139,8 +3193,8 @@ fn conflate_accepts_non_clone_output_type() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().map(NonClone))
     .via(Flow::new().conflate(|acc: NonClone, value: NonClone| NonClone(acc.0 + value.0)))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![NonClone(1), NonClone(2), NonClone(3)]);
 }
@@ -3149,12 +3203,12 @@ fn conflate_accepts_non_clone_output_type() {
 fn expand_and_extrapolate_share_expand_behavior() {
   let expand_values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .via(Flow::new().expand(|value: &u32| vec![*value, value.saturating_mul(10)]))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   let extrapolate_values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .via(Flow::new().extrapolate(|value: &u32| vec![*value, value.saturating_mul(10)]))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(expand_values, vec![1_u32, 2_u32]);
   assert_eq!(expand_values, extrapolate_values);
 }
@@ -3256,8 +3310,8 @@ fn expand_and_extrapolate_do_not_hang_with_infinite_iterators() {
 fn grouped_within_preserves_size_grouping_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4, 5]))
     .via(Flow::new().grouped_within(2, 10).expect("grouped_within"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32], vec![3_u32, 4_u32], vec![5_u32]]);
 }
 
@@ -3266,8 +3320,8 @@ fn grouped_within_flushes_when_tick_window_expires() {
   let schedule = [Some(1_u32), None, None, Some(2_u32), Some(3_u32)];
   let values = Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&schedule))
     .via(Flow::new().grouped_within(10, 2).expect("grouped_within"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32], vec![2_u32, 3_u32]]);
 }
 
@@ -3276,8 +3330,8 @@ fn grouped_within_expires_window_at_tick_boundary() {
   let schedule = [Some(1_u32), Some(2_u32)];
   let values = Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&schedule))
     .via(Flow::new().grouped_within(10, 1).expect("grouped_within"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32], vec![2_u32]]);
 }
 
@@ -3295,8 +3349,8 @@ fn grouped_within_rejects_zero_ticks() {
 fn fold_emits_running_accumulation_without_initial() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().fold(0_u32, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
 }
 
@@ -3304,15 +3358,17 @@ fn fold_emits_running_accumulation_without_initial() {
 fn reduce_folds_with_first_element_as_seed() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().reduce(|acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
 }
 
 #[test]
 fn reduce_single_element_emits_that_element() {
-  let values =
-    Source::single(42_u32).via(Flow::new().reduce(|acc, value| acc + value)).collect_values().expect("collect_values");
+  let values = Source::single(42_u32)
+    .via(Flow::new().reduce(|acc, value| acc + value))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![42_u32]);
 }
 
@@ -3320,8 +3376,8 @@ fn reduce_single_element_emits_that_element() {
 fn fold_on_empty_stream_emits_nothing() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[]))
     .via(Flow::new().fold(0_u32, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert!(values.is_empty());
 }
 
@@ -3329,8 +3385,8 @@ fn fold_on_empty_stream_emits_nothing() {
 fn reduce_on_empty_stream_emits_nothing() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[]))
     .via(Flow::new().reduce(|acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert!(values.is_empty());
 }
 
@@ -3346,8 +3402,8 @@ fn do_on_first_does_not_fire_on_empty_stream() {
     .via(Flow::new().do_on_first(move |_value| {
       counter_clone.fetch_add(1, Ordering::Relaxed);
     }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert!(values.is_empty());
   assert_eq!(counter.load(Ordering::Relaxed), 0);
 }
@@ -3356,8 +3412,8 @@ fn do_on_first_does_not_fire_on_empty_stream() {
 fn from_function_transforms_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::from_function(|x: u32| x + 1))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 3_u32, 4_u32]);
 }
 
@@ -3365,8 +3421,8 @@ fn from_function_transforms_elements() {
 fn named_passes_elements_through_unchanged() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().named("test-stage"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -3383,8 +3439,8 @@ fn also_to_mat_combines_materialized_values() {
 fn also_to_mat_keeps_data_path_behavior() {
   let values = Source::single(1_u32)
     .via(Flow::new().map(|value: u32| value + 1).also_to_mat(Sink::ignore(), KeepBoth))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32]);
 }
 
@@ -3419,8 +3475,8 @@ fn wire_tap_mat_combines_materialized_values_and_keeps_data_path_behavior() {
 
   let values = Source::single(4_u32)
     .via(Flow::new().map(|value: u32| value + 1).wire_tap_mat(Sink::ignore(), KeepRight))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -3452,8 +3508,8 @@ fn wire_tap_mat_preserves_all_main_path_elements_with_multiple_inputs() {
   // 準備: 複数要素を wire_tap_mat に流す（main path が全要素を受け取ることを検証）
   let values = Source::from_array([1_u32, 2, 3, 4, 5])
     .via(Flow::new().wire_tap_mat(Sink::ignore(), KeepLeft))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: main path は全要素を受け取る
   assert_eq!(values, vec![1_u32, 2, 3, 4, 5]);
@@ -3469,8 +3525,8 @@ fn wire_tap_mat_callback_version_observes_all_elements() {
     .via(Flow::new().wire_tap(move |value| {
       observed_clone.lock().push(*value);
     }))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: main path は全要素を受け取り、callback も全要素を観測する
   assert_eq!(values, vec![10_u32, 20, 30]);
@@ -3514,8 +3570,8 @@ fn monitor_mat_combines_materialized_values_and_keeps_data_path_behavior() {
 
   let values = Source::single(4_u32)
     .via(Flow::new().map(|value: u32| value + 1).monitor_mat(KeepLeft))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -3538,8 +3594,8 @@ fn from_sink_and_source_mat_preserves_single_path_behavior() {
 
   let values = Source::single(5_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::from_sink_and_source_mat(sink, source, KeepLeft))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // from_sink_and_source_mat emits elements from the embedded source, not from upstream
   assert_eq!(values, vec![99_u32]);
@@ -3577,8 +3633,8 @@ fn from_sink_and_source_coupled_mat_preserves_single_path_behavior() {
 
   let values = Source::single(6_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::from_sink_and_source_coupled_mat(sink, source, KeepLeft))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // from_sink_and_source_coupled_mat emits elements from the embedded source, not from upstream
   assert_eq!(values, vec![99_u32]);
@@ -3588,8 +3644,8 @@ fn from_sink_and_source_coupled_mat_preserves_single_path_behavior() {
 fn flow_lazy_flow_passes_elements_through_factory_flow() {
   let values = Source::single(5_u32)
     .via(Flow::lazy_flow(|| Flow::new().map(|v: u32| v * 2)))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32]);
 }
 
@@ -3597,8 +3653,8 @@ fn flow_lazy_flow_passes_elements_through_factory_flow() {
 fn flow_lazy_flow_defers_factory_call() {
   let values = Source::from_array([1_u32, 2, 3])
     .via(Flow::lazy_flow(|| Flow::new().map(|v: u32| v + 100)))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![101_u32, 102, 103]);
 }
 
@@ -3606,8 +3662,8 @@ fn flow_lazy_flow_defers_factory_call() {
 fn flow_lazy_flow_with_identity_flow_passes_through() {
   let values = Source::from_array([1_u32, 2, 3])
     .via(Flow::lazy_flow(Flow::<u32, u32, StreamNotUsed>::new))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -3615,8 +3671,8 @@ fn flow_lazy_flow_with_identity_flow_passes_through() {
 fn flow_lazy_flow_with_chained_operations() {
   let values = Source::from_array([1_u32, 2, 3, 4, 5])
     .via(Flow::lazy_flow(|| Flow::new().map(|v: u32| v * 2).filter(|v: &u32| *v > 4)))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![6_u32, 8, 10]);
 }
 
@@ -3624,8 +3680,8 @@ fn flow_lazy_flow_with_chained_operations() {
 fn flow_lazy_flow_with_empty_source() {
   let values = Source::<u32, _>::empty()
     .via(Flow::lazy_flow(|| Flow::new().map(|v: u32| v + 1)))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
@@ -3638,8 +3694,8 @@ fn flow_map_materialized_value_transforms_materialized_value_and_keeps_data_path
 
   let values = Source::single(4_u32)
     .via(Flow::new().map(|value: u32| value + 1).map_materialized_value(|_| 1_u32))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -3649,8 +3705,8 @@ fn flow_map_materialized_value_transforms_materialized_value_and_keeps_data_path
 fn backpressure_timeout_passes_elements_within_threshold() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().backpressure_timeout(100).expect("backpressure_timeout"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -3659,7 +3715,7 @@ fn backpressure_timeout_fails_when_backpressure_exceeds_threshold() {
   let result =
     Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&[Some(1), None, None, None, None]))
       .via(Flow::new().backpressure_timeout(2).expect("backpressure_timeout"))
-      .collect_values();
+      .run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::Timeout { kind: "backpressure", ticks: 2 })));
 }
 
@@ -3679,8 +3735,8 @@ fn backpressure_timeout_rejects_zero_ticks() {
 fn completion_timeout_passes_elements_within_threshold() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().completion_timeout(100).expect("completion_timeout"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -3688,7 +3744,7 @@ fn completion_timeout_passes_elements_within_threshold() {
 fn completion_timeout_fails_when_stream_exceeds_threshold() {
   let result = Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&[None, None, None, Some(1)]))
     .via(Flow::new().completion_timeout(2).expect("completion_timeout"))
-    .collect_values();
+    .run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::Timeout { kind: "completion", ticks: 2 })));
 }
 
@@ -3708,8 +3764,8 @@ fn completion_timeout_rejects_zero_ticks() {
 fn idle_timeout_passes_elements_within_threshold() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().idle_timeout(100).expect("idle_timeout"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -3717,7 +3773,7 @@ fn idle_timeout_passes_elements_within_threshold() {
 fn idle_timeout_fails_when_no_elements_within_threshold() {
   let result = Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&[None, None, None, Some(1)]))
     .via(Flow::new().idle_timeout(2).expect("idle_timeout"))
-    .collect_values();
+    .run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::Timeout { kind: "idle", ticks: 2 })));
 }
 
@@ -3737,8 +3793,8 @@ fn idle_timeout_rejects_zero_ticks() {
 fn initial_timeout_passes_elements_within_threshold() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().initial_timeout(100).expect("initial_timeout"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -3746,7 +3802,7 @@ fn initial_timeout_passes_elements_within_threshold() {
 fn initial_timeout_fails_when_first_element_exceeds_threshold() {
   let result = Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&[None, None, None, Some(1)]))
     .via(Flow::new().initial_timeout(2).expect("initial_timeout"))
-    .collect_values();
+    .run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::Timeout { kind: "initial", ticks: 2 })));
 }
 
@@ -3766,8 +3822,8 @@ fn initial_timeout_rejects_zero_ticks() {
 fn merge_preferred_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().merge_preferred(1).expect("merge_preferred"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -3886,8 +3942,8 @@ fn merge_preferred_logic_on_restart_clears_state() {
 fn merge_prioritized_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().merge_prioritized(1).expect("merge_prioritized"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -3901,8 +3957,8 @@ fn merge_prioritized_rejects_zero_fan_in() {
 fn merge_prioritized_n_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().merge_prioritized_n(1, &[1]).expect("merge_prioritized_n"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -4034,8 +4090,8 @@ fn merge_prioritized_logic_on_restart_clears_state() {
 fn merge_sorted_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().merge_sorted(1).expect("merge_sorted"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -4108,8 +4164,8 @@ fn merge_sorted_logic_on_restart_clears_state() {
 fn merge_latest_wraps_single_path_value_into_vec() {
   let values = Source::single(7_u32)
     .via(Flow::new().merge_latest(1).expect("merge_latest"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![7_u32]]);
 }
 
@@ -4150,8 +4206,10 @@ fn merge_latest_emits_latest_snapshot_on_each_update() {
 
 #[test]
 fn watch_termination_passes_through_elements() {
-  let values =
-    Source::single(42_u32).via(Flow::new().watch_termination_mat(KeepLeft)).collect_values().expect("collect_values");
+  let values = Source::single(42_u32)
+    .via(Flow::new().watch_termination_mat(KeepLeft))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![42_u32]);
 }
 
@@ -4173,7 +4231,7 @@ fn watch_termination_should_pass_through_elements() {
   let flow = Flow::new().watch_termination();
 
   // When: 要素を流す
-  let values = Source::single(42_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(42_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: 要素は変更されない
   assert_eq!(values, vec![42_u32]);
@@ -4186,7 +4244,7 @@ fn watch_termination_completes_stream_completion_handle() {
   assert_eq!(completion.poll(), Completion::Pending);
 
   let source_flow: Flow<u32, u32, StreamCompletion<()>> = Flow::from_graph(graph, completion.clone());
-  let values = Source::single(1_u32).via(source_flow).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(source_flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 
   // 実行後はReady
@@ -4325,8 +4383,8 @@ fn retry_flow_logic_queues_multiple_retries_before_restarting_inner() {
 fn throttle_enforcing_mode_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .via(Flow::new().throttle(2, ThrottleMode::Enforcing).expect("throttle"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -4337,7 +4395,7 @@ fn throttle_enforcing_mode_fails_on_capacity_overflow() {
   let result = Source::single(alloc::vec![1_u32, 2, 3])
     .via(Flow::new().map_concat(|v: Vec<u32>| v))
     .via(Flow::new().throttle(1, ThrottleMode::Enforcing).expect("throttle"))
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::BufferOverflow));
 }
 
@@ -4410,14 +4468,19 @@ fn buffer_logic_fail_returns_buffer_overflow_when_full() {
 
 #[test]
 fn distinct_removes_duplicate_elements() {
-  let values =
-    Source::from_array([1_u32, 2, 1, 3, 2, 3, 4]).via(Flow::new().distinct()).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2, 1, 3, 2, 3, 4])
+    .via(Flow::new().distinct())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3, 4]);
 }
 
 #[test]
 fn distinct_on_already_unique_passes_all() {
-  let values = Source::from_array([1_u32, 2, 3]).via(Flow::new().distinct()).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2, 3])
+    .via(Flow::new().distinct())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -4425,8 +4488,8 @@ fn distinct_on_already_unique_passes_all() {
 fn distinct_by_removes_elements_with_duplicate_key() {
   let values = Source::from_array([(1_u32, "a"), (2, "b"), (1, "c"), (3, "d")])
     .via(Flow::new().distinct_by(|pair: &(u32, &str)| pair.0))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![(1_u32, "a"), (2, "b"), (3, "d")]);
 }
 
@@ -4435,14 +4498,17 @@ fn from_graph_creates_flow_from_existing_graph() {
   let original = Flow::<u32, u32, StreamNotUsed>::new().map(|x| x * 2);
   let (graph, mat) = original.into_parts();
   let reconstructed = Flow::<u32, u32, StreamNotUsed>::from_graph(graph, mat);
-  let values = Source::from_array([1_u32, 2, 3]).via(reconstructed).collect_values().expect("collect_values");
+  let values =
+    Source::from_array([1_u32, 2, 3]).via(reconstructed).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4, 6]);
 }
 
 #[test]
 fn debounce_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().debounce(2).expect("debounce")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().debounce(2).expect("debounce"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -4458,8 +4524,10 @@ fn debounce_rejects_zero_ticks() {
 
 #[test]
 fn sample_keeps_single_path_behavior() {
-  let values =
-    Source::single(7_u32).via(Flow::new().sample(2).expect("sample")).collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .via(Flow::new().sample(2).expect("sample"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -4475,7 +4543,8 @@ fn sample_rejects_zero_ticks() {
 
 #[test]
 fn flow_named_keeps_elements_and_sets_attributes() {
-  let values = Source::single(7_u32).via(Flow::new().named("test-flow")).collect_values().expect("collect_values");
+  let values =
+    Source::single(7_u32).via(Flow::new().named("test-flow")).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 
   let (graph, _mat) = Flow::<u32, u32, StreamNotUsed>::new().named("test-flow").into_parts();
@@ -4494,7 +4563,7 @@ fn flow_with_and_add_attributes_merge_names() {
 #[test]
 fn flow_from_materializer_creates_flow() {
   let flow = Flow::from_materializer(|| Flow::from_function(|x: u32| x * 2));
-  let values = Source::single(5_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32]);
 }
 
@@ -4524,7 +4593,7 @@ fn flow_dimap_applies_input_mapping_then_original_flow_then_output_mapping() {
   let flow = Flow::<u32, u32, StreamNotUsed>::from_function(|value| value.saturating_mul(2))
     .dimap(|text: &str| text.len() as u32, |value| value.saturating_add(10));
 
-  let values = Source::from_array(["abc", "hello"]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array(["abc", "hello"]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![16_u32, 20_u32]);
 }
@@ -4658,7 +4727,7 @@ fn flow_from_sink_and_source_coupled_mat_completes_wrapped_sink_when_source_fini
   let (_graph, right_completion) = flow.into_parts();
   let source_flow: Flow<u32, u32, StreamCompletion<()>> = Flow::from_graph(_graph, right_completion.clone());
 
-  let values = Source::single(1_u32).via(source_flow).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(source_flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert!(values.is_empty());
   assert!(sink_completed.load(Ordering::SeqCst));
@@ -4674,7 +4743,7 @@ fn flow_from_sink_and_source_coupled_mat_cancels_wrapped_source_when_sink_cancel
   let (_graph, right_completion) = flow.into_parts();
   let source_flow: Flow<u32, u32, StreamCompletion<()>> = Flow::from_graph(_graph, right_completion.clone());
 
-  let values = Source::single(1_u32).via(source_flow).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(source_flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert!(values.is_empty());
   assert_eq!(right_completion.poll(), Completion::Ready(Ok(())));
@@ -4716,7 +4785,7 @@ fn flow_group_by_with_drain_strategy_creates_subflow() {
 fn flow_async_passes_single_element_through() {
   // Given: a source emitting a single element
   // When: passing through a flow with an async boundary
-  let values = Source::single(7_u32).via(Flow::new().r#async()).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(Flow::new().r#async()).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: the element is forwarded unchanged
   assert_eq!(values, vec![7_u32]);
@@ -4728,7 +4797,7 @@ fn flow_async_passes_multiple_elements_through() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4, 5]));
 
   // When: passing through a flow with an async boundary
-  let values = source.via(Flow::new().r#async()).collect_values().expect("collect_values");
+  let values = source.via(Flow::new().r#async()).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: all elements are forwarded in order
   assert_eq!(values, vec![1_u32, 2, 3, 4, 5]);
@@ -4740,7 +4809,7 @@ fn flow_async_preserves_element_order() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[5, 4, 3, 2, 1]));
 
   // When: passing through an async boundary
-  let values = source.via(Flow::new().r#async()).collect_values().expect("collect_values");
+  let values = source.via(Flow::new().r#async()).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: elements arrive in original order
   assert_eq!(values, vec![5_u32, 4, 3, 2, 1]);
@@ -4752,7 +4821,7 @@ fn flow_async_handles_empty_source() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[]));
 
   // When: passing through an async boundary
-  let values = source.via(Flow::new().r#async()).collect_values().expect("collect_values");
+  let values = source.via(Flow::new().r#async()).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: no elements are emitted, stream completes normally
   assert!(values.is_empty());
@@ -4764,7 +4833,8 @@ fn flow_async_composes_with_map() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]));
 
   // When: map is applied before async boundary
-  let values = source.via(Flow::new().map(|x: u32| x * 10).r#async()).collect_values().expect("collect_values");
+  let values =
+    source.via(Flow::new().map(|x: u32| x * 10).r#async()).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: map is applied and elements pass through the boundary
   assert_eq!(values, vec![10_u32, 20, 30]);
@@ -4776,8 +4846,11 @@ fn flow_async_composes_with_map_after() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]));
 
   // When: async boundary is applied before map
-  let values =
-    source.via(Flow::new().r#async()).via(Flow::new().map(|x: u32| x + 100)).collect_values().expect("collect_values");
+  let values = source
+    .via(Flow::new().r#async())
+    .via(Flow::new().map(|x: u32| x + 100))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: both stages work correctly
   assert_eq!(values, vec![101_u32, 102, 103]);
@@ -4789,7 +4862,7 @@ fn flow_async_chained_multiple_boundaries() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]));
 
   // When: two async boundaries are chained
-  let values = source.via(Flow::new().r#async().r#async()).collect_values().expect("collect_values");
+  let values = source.via(Flow::new().r#async().r#async()).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: elements pass through both boundaries correctly
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -4804,7 +4877,7 @@ fn flow_async_propagates_upstream_error() {
   );
 
   // When: passing through an async boundary
-  let result = source.via(Flow::new().r#async()).collect_values();
+  let result = source.via(Flow::new().r#async()).run_with_collect_sink();
 
   // Then: the error propagates through the boundary
   assert!(result.is_err());
@@ -4816,7 +4889,10 @@ fn flow_async_with_filter_composition() {
   let source = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4, 5, 6]));
 
   // When: filter even numbers, then async boundary
-  let values = source.via(Flow::new().filter(|x: &u32| x % 2 == 0).r#async()).collect_values().expect("collect_values");
+  let values = source
+    .via(Flow::new().filter(|x: &u32| x % 2 == 0).r#async())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: only even numbers pass through
   assert_eq!(values, vec![2_u32, 4, 6]);
@@ -4933,8 +5009,8 @@ fn fold_while_accumulates_while_predicate_holds() {
   // When: fold_while accumulates while acc < 6
   let values = Source::from_array([1_u32, 2, 3, 4])
     .via(Flow::new().fold_while(0_u32, |acc, _| *acc < 6, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: accumulation stops updating at 6 (1+2+3=6, predicate false for 4)
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32, 6_u32]);
@@ -4946,8 +5022,8 @@ fn fold_while_with_always_true_predicate_behaves_like_fold() {
   // When: fold_while with always-true predicate
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().fold_while(0_u32, |_, _| true, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: behaves identically to fold
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
@@ -4959,8 +5035,8 @@ fn fold_while_with_immediately_false_predicate_emits_initial_unchanged() {
   // When: fold_while with always-false predicate
   let values = Source::from_array([10_u32, 20, 30])
     .via(Flow::new().fold_while(0_u32, |_, _| false, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: accumulator never updates, emits initial value for each element
   assert_eq!(values, vec![0_u32, 0_u32, 0_u32]);
@@ -4972,8 +5048,8 @@ fn fold_while_on_empty_stream_emits_nothing() {
   // When: fold_while is applied
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[]))
     .via(Flow::new().fold_while(99_u32, |_, _| true, |acc, value| acc + value))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: no output (same as fold on empty stream)
   assert!(values.is_empty());
@@ -4991,8 +5067,8 @@ fn deflate_with_level_round_trips_through_inflate() {
   let values = Source::single(payload.clone())
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().deflate_with_level(9))
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: original payload is recovered
   assert_eq!(values, vec![payload]);
@@ -5010,8 +5086,8 @@ fn deflate_with_options_nowrap_round_trips() {
     .via(
       Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate_with_options(FLOW_DECOMPRESSION_MAX_BYTES_DEFAULT, true),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: original payload is recovered
   assert_eq!(values, vec![payload]);
@@ -5027,8 +5103,8 @@ fn gzip_with_level_round_trips_through_gzip_decompress() {
   let values = Source::single(payload.clone())
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_with_level(1))
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: original payload is recovered
   assert_eq!(values, vec![payload]);
@@ -5041,15 +5117,15 @@ fn gzip_decompress_with_max_bytes_rejects_oversized_payload() {
   let payload = vec![0xaa_u8; 256];
   let encoded = Source::single(payload)
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip())
-    .collect_values()
-    .expect("collect_values")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink")
     .pop()
     .expect("encoded payload");
 
   // When: decompressing with max_bytes = 64
   let result = Source::single(encoded)
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().gzip_decompress_with_max_bytes(64))
-    .collect_values();
+    .run_with_collect_sink();
 
   // Then: compression error
   assert!(matches!(result, Err(StreamError::CompressionError { .. })));
@@ -5065,7 +5141,7 @@ fn inflate_with_max_bytes_rejects_oversized_payload() {
   // When: inflating with max_bytes = 64
   let result = Source::single(encoded)
     .via(Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate_with_max_bytes(64))
-    .collect_values();
+    .run_with_collect_sink();
 
   // Then: compression error
   assert!(matches!(result, Err(StreamError::CompressionError { .. })));
@@ -5083,8 +5159,8 @@ fn inflate_with_options_nowrap_false_decompresses_zlib_wrapped() {
     .via(
       Flow::<Vec<u8>, Vec<u8>, StreamNotUsed>::new().inflate_with_options(FLOW_DECOMPRESSION_MAX_BYTES_DEFAULT, false),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: original payload is recovered
   assert_eq!(values, vec![payload]);
@@ -5229,7 +5305,7 @@ fn from_graph_stage_map_like_stage_produces_correct_values() {
   let flow = Flow::<u32, u32, StreamNotUsed>::from_graph_stage(AddHundredStage);
 
   // When: running through a pipeline
-  let values = Source::from_array([1_u32, 2, 3]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2, 3]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: each value has 100 added
   assert_eq!(values, alloc::vec![101_u32, 102, 103]);
@@ -5241,7 +5317,8 @@ fn from_graph_stage_filter_like_stage_drops_elements() {
   let flow = Flow::<u32, u32, StreamNotUsed>::from_graph_stage(ThresholdFilterStage { threshold: 3 });
 
   // When: running through a pipeline
-  let values = Source::from_array([1_u32, 2, 3, 4, 5]).via(flow).collect_values().expect("collect_values");
+  let values =
+    Source::from_array([1_u32, 2, 3, 4, 5]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: only values > 3 pass through
   assert_eq!(values, alloc::vec![4_u32, 5]);
@@ -5254,7 +5331,7 @@ fn from_graph_stage_chained_with_standard_flow_operators() {
   let combined = custom_flow.via(Flow::<u32, u32, StreamNotUsed>::new().map(|v| v * 2));
 
   // When: running through a pipeline
-  let values = Source::from_array([1_u32, 2]).via(combined).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2]).via(combined).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: (1+100)*2=202, (2+100)*2=204
   assert_eq!(values, alloc::vec![202_u32, 204]);
@@ -5268,7 +5345,7 @@ fn from_graph_stage_with_materialized_value() {
   let flow = Flow::<u32, u32, ArcShared<SpinSyncMutex<usize>>>::from_graph_stage(stage);
 
   // When: running through a pipeline
-  let values = Source::from_array([10_u32, 20, 30]).via(flow).collect_values().expect("collect_values");
+  let values = Source::from_array([10_u32, 20, 30]).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: all values pass through and the counter reflects the count
   assert_eq!(values, alloc::vec![10_u32, 20, 30]);
@@ -5281,7 +5358,7 @@ fn from_graph_stage_empty_source_produces_no_output() {
   let flow = Flow::<u32, u32, StreamNotUsed>::from_graph_stage(AddHundredStage);
 
   // When: running with an empty source
-  let values = Source::<u32, StreamNotUsed>::empty().via(flow).collect_values().expect("collect_values");
+  let values = Source::<u32, StreamNotUsed>::empty().via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: no output
   assert!(values.is_empty());
@@ -5293,7 +5370,7 @@ fn from_graph_stage_fail_should_propagate_to_materialized_completion() {
   let flow = Flow::<u32, u32, StreamNotUsed>::from_graph_stage(FailOnZeroStage);
 
   // When: 失敗対象の要素を流す
-  let result = Source::from_array([1_u32, 0, 2]).via(flow).collect_values();
+  let result = Source::from_array([1_u32, 0, 2]).via(flow).run_with_collect_sink();
 
   // Then: interpreter 経由でも failure は握りつぶされず completion に伝播する
   assert_eq!(result, Err(StreamError::Failed));
@@ -5309,8 +5386,8 @@ fn also_to_all_empty_sinks_passes_elements_through_unchanged() {
   let sinks: Vec<Sink<u32, StreamNotUsed>> = alloc::vec![];
   let values = Source::from_array([1_u32, 2_u32, 3_u32])
     .via(Flow::<u32, u32, StreamNotUsed>::new().also_to_all(sinks))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: sink がなければ全要素がそのまま通過する（恒等動作）
   assert_eq!(values, alloc::vec![1_u32, 2_u32, 3_u32]);
@@ -5324,8 +5401,8 @@ fn also_to_all_single_sink_broadcasts_all_elements() {
   let sinks = alloc::vec![Sink::foreach(move |value: u32| observed_clone.lock().push(value))];
   let values = Source::from_array([10_u32, 20_u32])
     .via(Flow::<u32, u32, StreamNotUsed>::new().also_to_all(sinks))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path は全要素を通し、side sink も同じ全要素を受け取る
   assert_eq!(values, alloc::vec![10_u32, 20_u32]);
@@ -5345,8 +5422,8 @@ fn also_to_all_multiple_sinks_each_receive_all_elements() {
   ];
   let values = Source::from_array([5_u32, 6_u32, 7_u32])
     .via(Flow::<u32, u32, StreamNotUsed>::new().also_to_all(sinks))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path とすべての side sink が同じ全要素を受け取る
   assert_eq!(values, alloc::vec![5_u32, 6_u32, 7_u32]);
@@ -5373,8 +5450,8 @@ fn also_to_all_three_sinks_each_receive_elements_exactly_once() {
   ];
   let values = Source::from_array([1_u32, 2_u32])
     .via(Flow::<u32, u32, StreamNotUsed>::new().also_to_all(sinks))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path と 3 つの side sink がそれぞれ重複なく全要素を 1 回だけ受け取る
   assert_eq!(values, alloc::vec![1_u32, 2_u32]);
@@ -5392,8 +5469,8 @@ fn keep_alive_passes_elements_through_when_upstream_is_not_idle() {
   // Given: 十分大きな ticks（100）を指定した keep_alive を 3 要素シーケンスに適用
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .via(Flow::new().keep_alive(100, 0_u32).expect("keep_alive"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: アイドルが発生しないので元の 3 要素がそのまま通過する（injected は挿入されない）
   assert_eq!(values, alloc::vec![1_u32, 2_u32, 3_u32]);
@@ -5420,8 +5497,8 @@ fn keep_alive_injects_element_after_idle_ticks() {
   let schedule = [None, None, Some(99_u32)];
   let values = Source::<u32, _>::from_logic(StageKind::Custom, PulsedSourceLogic::new(&schedule))
     .via(Flow::new().keep_alive(2, 0_u32).expect("keep_alive"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 2 tick アイドル後に injected_elem (0) が挿入され、その後 99 が流れる
   assert!(values.contains(&0_u32), "injected element should appear, got: {values:?}");
@@ -5437,8 +5514,8 @@ fn switch_map_emits_inner_source_values_for_single_outer_element() {
   // Given: 1 要素の outer Source に対し、値を 10 倍にした single Source を返す switch_map
   let values = Source::single(3_u32)
     .via(Flow::new().switch_map(|value: u32| Source::single(value.saturating_mul(10))).expect("switch_map"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: inner Source の値 30 が流れる
   assert_eq!(values, alloc::vec![30_u32]);
@@ -5449,8 +5526,8 @@ fn switch_map_rejects_empty_source_result() {
   // Given: empty を返す switch_map（境界条件: inner が空 Source）
   let values = Source::from_array([1_u32, 2_u32])
     .via(Flow::new().switch_map(|_: u32| Source::<u32, StreamNotUsed>::empty()).expect("switch_map"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: inner が空なので、main path の要素数の出力はゼロになる
   assert!(values.is_empty(), "empty inner sources should produce no output, got: {values:?}");
@@ -5468,8 +5545,8 @@ fn switch_map_only_most_recent_outer_element_produces_output_when_inner_has_mult
         .switch_map(|value: u32| Source::from_array([value.saturating_mul(10), value.saturating_mul(10) + 1]))
         .expect("switch_map"),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: ストリームが正常に完了し、少なくとも最後の outer 要素に対する inner 値（30 or
   // 31）が含まれる

--- a/modules/stream-core/src/core/dsl/flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/flow/tests.rs
@@ -137,12 +137,13 @@ where
 }
 
 #[test]
-fn broadcast_with_single_fan_out_keeps_element() {
-  let values = Source::single(7_u32)
-    .via(Flow::new().broadcast(1).expect("broadcast"))
-    .run_with_collect_sink()
-    .expect("run_with_collect_sink");
-  assert_eq!(values, vec![7_u32]);
+fn broadcast_duplicates_each_element() {
+  let mut bridge = SecondarySourceBridge::new(Source::single(7_u32).via(Flow::new().broadcast(2).expect("broadcast")))
+    .expect("bridge");
+
+  assert_eq!(bridge.poll_next().expect("poll_next first"), Some(7_u32));
+  assert_eq!(bridge.poll_next().expect("poll_next second"), Some(7_u32));
+  assert_eq!(bridge.poll_next().expect("poll_next third"), None);
 }
 
 #[test]

--- a/modules/stream-core/src/core/dsl/flow_group_by_sub_flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/flow_group_by_sub_flow/tests.rs
@@ -1,6 +1,6 @@
 use crate::core::{
   SubstreamCancelStrategy,
-  dsl::{Flow, Sink, Source},
+  dsl::{Flow, Sink, Source, tests::RunWithCollectSink},
   materialization::StreamNotUsed,
 };
 
@@ -13,8 +13,8 @@ fn flow_group_by_sub_flow_merge_substreams_preserves_repeated_keys() {
         .expect("group_by")
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   values.sort_unstable();
   assert_eq!(values, vec![1_u32, 2, 3, 4, 5]);
 }
@@ -42,8 +42,8 @@ fn flow_group_by_sub_flow_map_transforms_values_preserving_keys() {
         .map(|value| value * 10)
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 全要素が10倍される（順序は不定のためソート）
   values.sort_unstable();
@@ -61,8 +61,8 @@ fn flow_group_by_sub_flow_filter_removes_values_preserving_keys() {
         .filter(|value| value % 2 == 0)
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 偶数のみが残る（順序は不定のためソート）
   values.sort_unstable();
@@ -81,8 +81,8 @@ fn flow_group_by_sub_flow_map_then_filter_chains_correctly() {
         .filter(|value| value % 20 == 0)
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 偶数の10倍（20, 40）のみが20の倍数として残る
   values.sort_unstable();

--- a/modules/stream-core/src/core/dsl/flow_sub_flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/flow_sub_flow/tests.rs
@@ -4,7 +4,7 @@ use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use super::FlowSubFlow;
 use crate::core::{
-  dsl::{Flow, Sink, Source},
+  dsl::{Flow, Sink, Source, tests::RunWithCollectSink},
   r#impl::{
     fusing::StreamBufferConfig,
     materialization::{Stream, StreamState},
@@ -42,8 +42,8 @@ fn run_to_completion<Mat>(graph: RunnableGraph<Mat>) {
 fn flow_sub_flow_merge_substreams_flattens_segment() {
   let values = Source::single(1_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::new().split_after(|_| true).merge_substreams())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -51,8 +51,8 @@ fn flow_sub_flow_merge_substreams_flattens_segment() {
 fn flow_sub_flow_concat_substreams_flattens_segment() {
   let values = Source::single(1_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::new().split_after(|_| true).concat_substreams())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -66,8 +66,8 @@ fn flow_sub_flow_map_and_filter_delegate_to_inner_substreams() {
         .filter(|value| value % 20 == 0)
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![20_u32, 40_u32]);
 }
 
@@ -75,8 +75,8 @@ fn flow_sub_flow_map_and_filter_delegate_to_inner_substreams() {
 fn flow_sub_flow_take_and_drop_scope_to_each_substream() {
   let values = Source::from_array([1_u32, 2, 3, 4, 5])
     .via(Flow::<u32, u32, StreamNotUsed>::new().split_after(|value| value % 2 == 0).drop(1).take(1).merge_substreams())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4_u32]);
 }
 
@@ -90,8 +90,8 @@ fn flow_sub_flow_take_while_and_drop_while_scope_to_each_substream() {
         .take_while(|value| *value <= 4)
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4_u32]);
 }
 
@@ -110,8 +110,8 @@ fn flow_sub_flow_map_clones_stateful_mapper_per_substream() {
         })
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![11_u32, 22_u32, 13_u32, 24_u32]);
 }
 
@@ -130,8 +130,8 @@ fn flow_sub_flow_take_while_clones_stateful_predicate_per_substream() {
         })
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32]);
 }
 

--- a/modules/stream-core/src/core/dsl/flow_with_context/tests.rs
+++ b/modules/stream-core/src/core/dsl/flow_with_context/tests.rs
@@ -11,7 +11,7 @@ use std::{
 
 use crate::core::{
   StreamError, ThrottleMode,
-  dsl::{Flow, FlowWithContext, Sink, Source},
+  dsl::{Flow, FlowWithContext, Sink, Source, tests::RunWithCollectSink},
   materialization::{KeepBoth, StreamNotUsed},
 };
 
@@ -47,7 +47,7 @@ impl<T: Unpin> Future for YieldThenOutputFuture<T> {
 fn should_map_output_preserving_context() {
   let fwc: FlowWithContext<i32, &str, usize, StreamNotUsed> =
     FlowWithContext::from_flow(Flow::new().map(|v: (i32, &str)| v)).map(|s: &str| s.len());
-  let values = Source::from(vec![(1_i32, "hello"), (2, "world")]).via(fwc.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, "hello"), (2, "world")]).via(fwc.into_flow()).run_with_collect_sink().unwrap();
   assert_eq!(values, vec![(1, 5), (2, 5)]);
 }
 
@@ -55,7 +55,7 @@ fn should_map_output_preserving_context() {
 fn should_filter_by_value_preserving_context() {
   let fwc: FlowWithContext<i32, i32, i32, StreamNotUsed> =
     FlowWithContext::from_flow(Flow::new().map(|v: (i32, i32)| v)).filter(|v: &i32| *v > 0);
-  let values = Source::from(vec![(1_i32, 10), (2, -5), (3, 20)]).via(fwc.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 10), (2, -5), (3, 20)]).via(fwc.into_flow()).run_with_collect_sink().unwrap();
   assert_eq!(values, vec![(1, 10), (3, 20)]);
 }
 
@@ -70,7 +70,8 @@ fn should_map_context() {
   // → reverse(10) = 9, reverse(20) = 19
   // → inner (恒等): (9, "a"), (19, "b")
   // → forward(9) = 90, forward(19) = 190
-  let values = Source::from(vec![(10_i64, "a"), (20_i64, "b")]).via(mapped.into_flow()).collect_values().unwrap();
+  let values =
+    Source::from(vec![(10_i64, "a"), (20_i64, "b")]).via(mapped.into_flow()).run_with_collect_sink().unwrap();
   assert_eq!(values, vec![(90_i64, "a"), (190_i64, "b")]);
 }
 
@@ -81,7 +82,8 @@ fn should_compose_via() {
   let fwc2: FlowWithContext<i32, &str, usize, StreamNotUsed> =
     FlowWithContext::from_flow(Flow::new().map(|(ctx, s): (i32, &str)| (ctx, s.len())));
   let composed = fwc1.via(fwc2);
-  let values = Source::from(vec![(1_i32, "hello"), (2, "hi")]).via(composed.into_flow()).collect_values().unwrap();
+  let values =
+    Source::from(vec![(1_i32, "hello"), (2, "hi")]).via(composed.into_flow()).run_with_collect_sink().unwrap();
   assert_eq!(values, vec![(1, 5), (2, 2)]);
 }
 
@@ -95,7 +97,7 @@ fn map_concat_expands_elements_preserving_context() {
   let expanded = fwc.map_concat(|s: &str| s.chars().map(|c| c as u32).collect::<Vec<_>>());
 
   // 実行: 要素を流す
-  let values = Source::from(vec![(1_i32, "ab"), (2, "c")]).via(expanded.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, "ab"), (2, "c")]).via(expanded.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 展開された各要素は元のコンテキストを保持
   assert_eq!(values, vec![(1, 97), (1, 98), (2, 99)]);
@@ -109,7 +111,8 @@ fn map_concat_empty_expansion_drops_element() {
   let expanded = fwc.map_concat(|v: i32| if v > 0 { vec![v, v * 10] } else { vec![] });
 
   // 実行: 空イテレータを生成する要素を含めて流す
-  let values = Source::from(vec![(1_i32, 5), (2, -1), (3, 3)]).via(expanded.into_flow()).collect_values().unwrap();
+  let values =
+    Source::from(vec![(1_i32, 5), (2, -1), (3, 3)]).via(expanded.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 空展開の要素は除外、それ以外は同じコンテキストで展開
   assert_eq!(values, vec![(1, 5), (1, 50), (3, 3), (3, 30)]);
@@ -125,8 +128,10 @@ fn filter_not_passes_elements_where_predicate_is_false() {
   let filtered = fwc.filter_not(|v: &i32| *v > 0);
 
   // 実行: 要素を流す
-  let values =
-    Source::from(vec![(1_i32, 10), (2, -5), (3, 0), (4, 20)]).via(filtered.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 10), (2, -5), (3, 0), (4, 20)])
+    .via(filtered.into_flow())
+    .run_with_collect_sink()
+    .unwrap();
 
   // 検証: 述語が false の要素のみ通過、コンテキスト保持
   assert_eq!(values, vec![(2, -5), (3, 0)]);
@@ -140,7 +145,7 @@ fn filter_not_passes_all_when_predicate_always_false() {
   let filtered = fwc.filter_not(|_: &i32| false);
 
   // 実行: 要素を流す
-  let values = Source::from(vec![(1_i32, 10), (2, 20)]).via(filtered.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 10), (2, 20)]).via(filtered.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 全要素が通過
   assert_eq!(values, vec![(1, 10), (2, 20)]);
@@ -156,7 +161,8 @@ fn collect_filters_and_maps_preserving_context() {
   let collected = fwc.collect(|v: i32| if v > 0 { Some(v * 2) } else { None });
 
   // 実行: 要素を流す
-  let values = Source::from(vec![(1_i32, 5), (2, -3), (3, 10)]).via(collected.into_flow()).collect_values().unwrap();
+  let values =
+    Source::from(vec![(1_i32, 5), (2, -3), (3, 10)]).via(collected.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: Some の結果のみ通過、変換が適用
   assert_eq!(values, vec![(1, 10), (3, 20)]);
@@ -170,7 +176,7 @@ fn collect_drops_all_when_all_none() {
   let collected = fwc.collect(|_: i32| -> Option<i32> { None });
 
   // 実行: 要素を流す
-  let values = Source::from(vec![(1_i32, 5), (2, 10)]).via(collected.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 5), (2, 10)]).via(collected.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 要素なし
   assert!(values.is_empty());
@@ -186,7 +192,7 @@ fn map_async_transforms_preserving_context() {
   let mapped = fwc.map_async(1, |v: u32| async move { v * 2 }).expect("map_async");
 
   // 実行: 要素を流す
-  let values = Source::from(vec![(1_i32, 5_u32), (2, 3)]).via(mapped.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 5_u32), (2, 3)]).via(mapped.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 値は変換され、コンテキストは保持
   assert_eq!(values, vec![(1, 10_u32), (2, 6)]);
@@ -204,7 +210,7 @@ fn grouped_collects_elements_with_last_context() {
   // 実行: 5要素を流す
   let values = Source::from(vec![(10_i32, 1_u32), (20, 2), (30, 3), (40, 4), (50, 5)])
     .via(grouped.into_flow())
-    .collect_values()
+    .run_with_collect_sink()
     .unwrap();
 
   // 検証: 各グループのコンテキストは最後の要素のもの
@@ -219,7 +225,7 @@ fn grouped_single_element_per_group() {
   let grouped = fwc.grouped(1).expect("grouped");
 
   // 実行: 要素を流す
-  let values = Source::from(vec![(1_i32, 10_u32), (2, 20)]).via(grouped.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 10_u32), (2, 20)]).via(grouped.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 各要素が独立したグループ、コンテキスト保持
   assert_eq!(values, vec![(1, vec![10_u32]), (2, vec![20])]);
@@ -235,8 +241,10 @@ fn sliding_creates_windows_with_last_context() {
   let sliding = fwc.sliding(3).expect("sliding");
 
   // 実行: 要素を流す
-  let values =
-    Source::from(vec![(10_i32, 1_u32), (20, 2), (30, 3), (40, 4)]).via(sliding.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(10_i32, 1_u32), (20, 2), (30, 3), (40, 4)])
+    .via(sliding.into_flow())
+    .run_with_collect_sink()
+    .unwrap();
 
   // 検証: 各ウィンドウのコンテキストは最後の要素のもの
   assert_eq!(values, vec![(30, vec![1_u32, 2, 3]), (40, vec![2, 3, 4]),]);
@@ -250,7 +258,8 @@ fn sliding_window_size_2() {
   let sliding = fwc.sliding(2).expect("sliding");
 
   // 実行: 3要素を流す
-  let values = Source::from(vec![(1_i32, 10_u32), (2, 20), (3, 30)]).via(sliding.into_flow()).collect_values().unwrap();
+  let values =
+    Source::from(vec![(1_i32, 10_u32), (2, 20), (3, 30)]).via(sliding.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 2つのウィンドウ、各ウィンドウのコンテキストは最後の要素のもの
   assert_eq!(values, vec![(2, vec![10_u32, 20]), (3, vec![20, 30])]);
@@ -279,7 +288,7 @@ fn also_to_keeps_main_path_values_and_context() {
     FlowWithContext::from_flow(Flow::new().map(|value: (i32, u32)| value)).also_to(Sink::<u32, _>::ignore());
 
   // 実行: 要素を flow に流す
-  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: main path の値とコンテキストは変化しない
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
@@ -294,7 +303,7 @@ fn also_to_sends_values_to_side_sink_and_preserves_main_path() {
       seen_for_sink.lock().expect("side sink lock").push(value);
     }));
 
-  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).run_with_collect_sink().unwrap();
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![1_u32, 2]);
@@ -311,7 +320,7 @@ fn also_to_context_sends_only_contexts_to_side_sink() {
     seen_for_sink.lock().expect("context sink lock").push(ctx);
   }));
 
-  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).run_with_collect_sink().unwrap();
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![10_i32, 20]);
@@ -328,7 +337,7 @@ fn wire_tap_preserves_main_path_and_emits_values() {
     seen_for_sink.lock().expect("tap sink lock").push(value);
   }));
 
-  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).run_with_collect_sink().unwrap();
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![1_u32, 2]);
@@ -345,7 +354,7 @@ fn wire_tap_context_preserves_main_path_and_emits_contexts() {
     seen_for_sink.lock().expect("context tap lock").push(ctx);
   }));
 
-  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(10_i32, 1_u32), (20, 2)]).via(flow.into_flow()).run_with_collect_sink().unwrap();
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![10_i32, 20]);
@@ -368,7 +377,7 @@ fn map_async_partitioned_preserves_context_and_input_order() {
     .expect("map_async_partitioned");
 
   // 実行: source 経由で materialize して要素を収集する
-  let values = Source::from(vec![(100_i32, 1_u32), (200, 2)]).via(mapped.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(100_i32, 1_u32), (200, 2)]).via(mapped.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 入力順が保たれ、各要素は元のコンテキストを保持する
   assert_eq!(values, vec![(100_i32, 11_u32), (200, 12)]);
@@ -391,7 +400,7 @@ fn map_async_partitioned_unordered_can_emit_completion_order_while_preserving_co
     .expect("map_async_partitioned_unordered");
 
   // 実行: source 経由で materialize して要素を収集する
-  let values = Source::from(vec![(100_i32, 1_u32), (200, 2)]).via(mapped.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(100_i32, 1_u32), (200, 2)]).via(mapped.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 完了順は入れ替わりうるが、値とコンテキストの対応は維持される
   assert_eq!(values, vec![(200_i32, 12_u32), (100, 11)]);
@@ -407,7 +416,7 @@ fn map_error_passes_normal_elements_preserving_context() {
   let mapped = fwc.map_error(|_| StreamError::WouldBlock);
 
   // 実行: 正常な要素を流す
-  let values = Source::from(vec![(1_i32, 10_u32), (2, 20)]).via(mapped.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 10_u32), (2, 20)]).via(mapped.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 正常な要素はコンテキスト付きでそのまま通過する
   assert_eq!(values, vec![(1, 10_u32), (2, 20)]);
@@ -421,7 +430,7 @@ fn map_error_transforms_upstream_failure_preserving_context_flow() {
   let mapped = fwc.map_error(|_| StreamError::WouldBlock);
 
   // 実行: 失敗する source を flow に接続
-  let result = Source::<(i32, u32), _>::failed(StreamError::Failed).via(mapped.into_flow()).collect_values();
+  let result = Source::<(i32, u32), _>::failed(StreamError::Failed).via(mapped.into_flow()).run_with_collect_sink();
 
   // 検証: エラーが変換される
   assert_eq!(result, Err(StreamError::WouldBlock));
@@ -437,7 +446,7 @@ fn throttle_passes_elements_preserving_context() {
   let throttled = fwc.throttle(2, ThrottleMode::Shaping).expect("throttle");
 
   // 実行: 要素を流す
-  let values = Source::from(vec![(1_i32, 10_u32), (2, 20)]).via(throttled.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 10_u32), (2, 20)]).via(throttled.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 要素はコンテキスト付きでそのまま通過する
   assert_eq!(values, vec![(1, 10_u32), (2, 20)]);
@@ -451,7 +460,7 @@ fn throttle_enforcing_mode_preserves_context() {
   let throttled = fwc.throttle(2, ThrottleMode::Enforcing).expect("throttle");
 
   // 実行: 単一要素を流す（キャパシティ内）
-  let values = Source::from(vec![(1_i32, 10_u32)]).via(throttled.into_flow()).collect_values().unwrap();
+  let values = Source::from(vec![(1_i32, 10_u32)]).via(throttled.into_flow()).run_with_collect_sink().unwrap();
 
   // 検証: 要素はコンテキスト付きでそのまま通過する
   assert_eq!(values, vec![(1, 10_u32)]);

--- a/modules/stream-core/src/core/dsl/framing/tests.rs
+++ b/modules/stream-core/src/core/dsl/framing/tests.rs
@@ -3,6 +3,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use super::{
   Framing, SimpleFramingDecoderLogic, checked_frame_length, find_delimiter, read_big_endian_u32, read_big_endian_uint,
 };
+use crate::core::dsl::tests::RunWithCollectSink;
 
 #[test]
 fn should_find_delimiter_at_start() {
@@ -58,7 +59,7 @@ fn should_create_delimiter_flow() {
 
   let framing = Framing::delimiter(vec![b'\n'], 1024, false);
   let source = Source::from(vec![b"hello\nwor".to_vec(), b"ld\nfoo".to_vec()]);
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames = result.unwrap();
   assert_eq!(frames, vec![b"hello".to_vec(), b"world".to_vec()]);
 }
@@ -69,7 +70,7 @@ fn should_emit_trailing_bytes_when_allow_truncation_is_true() {
 
   let framing = Framing::delimiter(vec![b'\n'], 1024, true);
   let source = Source::from(vec![b"hello\ntrailing".to_vec()]);
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames = result.unwrap();
   assert_eq!(frames, vec![b"hello".to_vec(), b"trailing".to_vec()]);
 }
@@ -80,7 +81,7 @@ fn should_discard_trailing_bytes_when_allow_truncation_is_false() {
 
   let framing = Framing::delimiter(vec![b'\n'], 1024, false);
   let source = Source::from(vec![b"hello\ntrailing".to_vec()]);
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames = result.unwrap();
   assert_eq!(frames, vec![b"hello".to_vec()]);
 }
@@ -91,7 +92,7 @@ fn should_error_when_frame_exceeds_max_frame_length() {
 
   let framing = Framing::delimiter(vec![b'\n'], 5, false);
   let source = Source::from(vec![b"toolong\nok".to_vec()]);
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
 
@@ -101,7 +102,7 @@ fn should_error_when_buffer_exceeds_max_frame_length_without_delimiter() {
 
   let framing = Framing::delimiter(vec![b'\n'], 5, false);
   let source = Source::from(vec![b"abcdef".to_vec()]);
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
 
@@ -119,7 +120,7 @@ fn should_create_length_field_flow() {
   data.extend_from_slice(b"de");
 
   let source = Source::single(data);
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames = result.unwrap();
   assert_eq!(frames.len(), 2);
   assert_eq!(&frames[0][2..], b"abc");
@@ -133,7 +134,7 @@ fn should_encode_payload_with_four_byte_big_endian_length_header() {
   let protocol = Framing::simple_framing_protocol(16);
   let (encoder, _decoder, _mat) = protocol.split();
 
-  let frames = Source::single(b"abc".to_vec()).via(encoder).collect_values().unwrap();
+  let frames = Source::single(b"abc".to_vec()).via(encoder).run_with_collect_sink().unwrap();
   assert_eq!(frames, vec![vec![0x00, 0x00, 0x00, 0x03, b'a', b'b', b'c']]);
 }
 
@@ -148,7 +149,7 @@ fn should_decode_chunked_frames_and_strip_length_header() {
     0x00, 0x02, b'd', b'e',
   ]])
   .via(decoder)
-  .collect_values()
+  .run_with_collect_sink()
   .unwrap();
 
   assert_eq!(frames, vec![b"abc".to_vec(), b"de".to_vec()]);
@@ -161,10 +162,10 @@ fn should_support_empty_payload_frame() {
   let protocol = Framing::simple_framing_protocol(16);
   let (encoder, decoder, _mat) = protocol.split();
 
-  let encoded = Source::single(Vec::new()).via(encoder).collect_values().unwrap();
+  let encoded = Source::single(Vec::new()).via(encoder).run_with_collect_sink().unwrap();
   assert_eq!(encoded, vec![vec![0x00, 0x00, 0x00, 0x00]]);
 
-  let decoded = Source::from(encoded).via(decoder).collect_values().unwrap();
+  let decoded = Source::from(encoded).via(decoder).run_with_collect_sink().unwrap();
   assert_eq!(decoded, vec![Vec::new()]);
 }
 
@@ -175,7 +176,8 @@ fn should_round_trip_payloads_through_simple_framing_protocol() {
   let protocol = Framing::simple_framing_protocol(16);
   let loopback = protocol.join(Flow::new());
 
-  let decoded = Source::from(vec![b"abc".to_vec(), Vec::new(), b"de".to_vec()]).via(loopback).collect_values().unwrap();
+  let decoded =
+    Source::from(vec![b"abc".to_vec(), Vec::new(), b"de".to_vec()]).via(loopback).run_with_collect_sink().unwrap();
 
   assert_eq!(decoded, vec![b"abc".to_vec(), Vec::new(), b"de".to_vec()]);
 }
@@ -187,7 +189,7 @@ fn should_error_when_payload_exceeds_maximum_message_length() {
   let protocol = Framing::simple_framing_protocol(3);
   let (encoder, _decoder, _mat) = protocol.split();
 
-  let result = Source::single(b"toolong".to_vec()).via(encoder).collect_values();
+  let result = Source::single(b"toolong".to_vec()).via(encoder).run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
 
@@ -198,7 +200,8 @@ fn should_error_when_decoded_length_header_exceeds_maximum_message_length() {
   let protocol = Framing::simple_framing_protocol(3);
   let (_encoder, decoder, _mat) = protocol.split();
 
-  let result = Source::single(vec![0x00, 0x00, 0x00, 0x04, b'a', b'b', b'c', b'd']).via(decoder).collect_values();
+  let result =
+    Source::single(vec![0x00, 0x00, 0x00, 0x04, b'a', b'b', b'c', b'd']).via(decoder).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
@@ -210,7 +213,7 @@ fn should_error_when_source_ends_with_truncated_decoded_frame() {
   let protocol = Framing::simple_framing_protocol(16);
   let (_encoder, decoder, _mat) = protocol.split();
 
-  let result = Source::single(vec![0x00, 0x00, 0x00, 0x03, b'a', b'b']).via(decoder).collect_values();
+  let result = Source::single(vec![0x00, 0x00, 0x00, 0x03, b'a', b'b']).via(decoder).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }

--- a/modules/stream-core/src/core/dsl/graph_dsl/tests.rs
+++ b/modules/stream-core/src/core/dsl/graph_dsl/tests.rs
@@ -1,6 +1,6 @@
 use crate::core::{
   StreamError,
-  dsl::{Flow, GraphDsl, GraphDslBuilder, Sink, Source},
+  dsl::{Flow, GraphDsl, GraphDslBuilder, Sink, Source, tests::RunWithCollectSink},
   materialization::{KeepLeft, KeepRight, StreamNotUsed},
   shape::{Inlet, Outlet},
 };
@@ -13,7 +13,7 @@ fn create_flow_builds_executable_flow_from_public_builder_block() {
   });
 
   // When: 利用者 API から Source に接続して実行する
-  let values = Source::single(4_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(4_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: builder block で追加した flow が data path に反映される
   assert_eq!(values, vec![12_u32]);
@@ -44,7 +44,7 @@ fn create_source_uses_explicit_builder_wiring() {
   });
 
   // When: public Source として実行する
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: builder 内の明示的な接続順に値が流れる
   assert_eq!(values, vec![12_u32]);

--- a/modules/stream-core/src/core/dsl/graph_dsl_builder/tests.rs
+++ b/modules/stream-core/src/core/dsl/graph_dsl_builder/tests.rs
@@ -1,6 +1,6 @@
 use crate::core::{
   StreamError,
-  dsl::{Flow, GraphDslBuilder, Sink, Source},
+  dsl::{Flow, GraphDslBuilder, Sink, Source, tests::RunWithCollectSink},
   materialization::{KeepBoth, KeepLeft, KeepRight, StreamNotUsed},
   shape::{Inlet, Outlet},
 };
@@ -13,7 +13,7 @@ fn builder_new_via_build_creates_linear_flow() {
     .build();
 
   // When: Source から実行する
-  let values = Source::single(1_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: builder で追加した flow が適用される
   assert_eq!(values, vec![2_u32]);

--- a/modules/stream-core/src/core/dsl/json_framing/tests.rs
+++ b/modules/stream-core/src/core/dsl/json_framing/tests.rs
@@ -1,13 +1,16 @@
 use alloc::{vec, vec::Vec};
 
 use super::JsonFraming;
-use crate::core::{dsl::Source, r#impl::StreamError};
+use crate::core::{
+  dsl::{Source, tests::RunWithCollectSink},
+  r#impl::StreamError,
+};
 
 #[test]
 fn should_extract_single_json_object() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"{"key":"value"}"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"key":"value"}"#.to_vec()]);
 }
@@ -16,7 +19,7 @@ fn should_extract_single_json_object() {
 fn should_extract_multiple_json_objects() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"{"a":1}{"b":2}"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"a":1}"#.to_vec(), br#"{"b":2}"#.to_vec()]);
 }
@@ -25,7 +28,7 @@ fn should_extract_multiple_json_objects() {
 fn should_handle_nested_objects() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"{"nested":{"inner":true}}"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"nested":{"inner":true}}"#.to_vec()]);
 }
@@ -34,7 +37,7 @@ fn should_handle_nested_objects() {
 fn should_handle_strings_with_brackets() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"{"text":"hello {world}"}"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"text":"hello {world}"}"#.to_vec()]);
 }
@@ -43,7 +46,7 @@ fn should_handle_strings_with_brackets() {
 fn should_handle_escaped_quotes_in_strings() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"{"text":"say \"hi\""}"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"text":"say \"hi\""}"#.to_vec()]);
 }
@@ -52,7 +55,7 @@ fn should_handle_escaped_quotes_in_strings() {
 fn should_handle_chunked_input() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::from(vec![br#"{"ke"#.to_vec(), br#"y":"va"#.to_vec(), br#"lue"}"#.to_vec()]);
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"key":"value"}"#.to_vec()]);
 }
@@ -61,7 +64,7 @@ fn should_handle_chunked_input() {
 fn should_handle_json_arrays() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"[1,2,3]"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"[1,2,3]"#.to_vec()]);
 }
@@ -70,7 +73,7 @@ fn should_handle_json_arrays() {
 fn should_skip_whitespace_between_objects() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"  {"a":1}  {"b":2}  "#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"a":1}"#.to_vec(), br#"{"b":2}"#.to_vec()]);
 }
@@ -79,7 +82,7 @@ fn should_skip_whitespace_between_objects() {
 fn should_error_when_object_exceeds_max_length() {
   let framing = JsonFraming::object_scanner(5);
   let source = Source::single(br#"{"key":"value"}"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
 
@@ -87,7 +90,7 @@ fn should_error_when_object_exceeds_max_length() {
 fn should_error_on_incomplete_object_at_source_end() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"{"incomplete"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::Failed)));
 }
 
@@ -95,7 +98,7 @@ fn should_error_on_incomplete_object_at_source_end() {
 fn should_handle_empty_object() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"{}"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{}"#.to_vec()]);
 }
@@ -104,7 +107,7 @@ fn should_handle_empty_object() {
 fn should_handle_empty_array() {
   let framing = JsonFraming::object_scanner(1024);
   let source = Source::single(br#"[]"#.to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"[]"#.to_vec()]);
 }
@@ -114,7 +117,7 @@ fn should_error_when_leading_garbage_exceeds_max_length() {
   let framing = JsonFraming::object_scanner(10);
   // 20 bytes of whitespace/garbage before the bracket — exceeds limit
   let source = Source::single(b"                    {\"a\":1}".to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   // Leading data is discarded, so the object itself (7 bytes) fits within the limit
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames, vec![br#"{"a":1}"#.to_vec()]);
@@ -125,7 +128,7 @@ fn should_error_when_no_bracket_data_exceeds_max_length() {
   let framing = JsonFraming::object_scanner(5);
   // No brackets at all — buffer grows beyond limit
   let source = Source::single(b"garbage_no_bracket_data".to_vec());
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
 
@@ -138,7 +141,7 @@ fn array_scanner_should_extract_elements_from_json_array() {
   let source = Source::single(br#"[{"a":1},{"b":2},{"c":3}]"#.to_vec());
 
   // When: we process through array scanner
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
 
   // Then: each element is emitted individually
@@ -155,7 +158,7 @@ fn array_scanner_should_handle_primitive_elements() {
   let source = Source::single(br#"[1, 2, 3]"#.to_vec());
 
   // When/Then: primitive elements are extracted
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames.len(), 3);
   assert_eq!(frames[0], b"1".to_vec());
@@ -170,7 +173,7 @@ fn array_scanner_should_handle_nested_arrays() {
   let source = Source::single(br#"[[1,2],[3,4]]"#.to_vec());
 
   // When/Then: nested arrays are emitted as complete elements
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames.len(), 2);
   assert_eq!(frames[0], br#"[1,2]"#.to_vec());
@@ -184,7 +187,7 @@ fn array_scanner_should_handle_nested_objects() {
   let source = Source::single(br#"[{"nested":{"inner":true}}]"#.to_vec());
 
   // When/Then: nested objects are emitted whole
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames.len(), 1);
   assert_eq!(frames[0], br#"{"nested":{"inner":true}}"#.to_vec());
@@ -197,7 +200,7 @@ fn array_scanner_should_handle_string_values_with_brackets() {
   let source = Source::single(br#"[{"text":"[hello]"}]"#.to_vec());
 
   // When/Then: brackets inside strings do not affect parsing
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames.len(), 1);
   assert_eq!(frames[0], br#"{"text":"[hello]"}"#.to_vec());
@@ -210,7 +213,7 @@ fn array_scanner_should_handle_empty_array() {
   let source = Source::single(br#"[]"#.to_vec());
 
   // When/Then: no elements are emitted
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert!(frames.is_empty());
 }
@@ -222,7 +225,7 @@ fn array_scanner_should_handle_chunked_input() {
   let source = Source::from(vec![br#"[{"ke"#.to_vec(), br#"y":"va"#.to_vec(), br#"lue"}]"#.to_vec()]);
 
   // When/Then: chunked input is reassembled correctly
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   let frames: Vec<Vec<u8>> = result.unwrap();
   assert_eq!(frames.len(), 1);
   assert_eq!(frames[0], br#"{"key":"value"}"#.to_vec());
@@ -235,7 +238,7 @@ fn array_scanner_should_error_when_element_exceeds_max_length() {
   let source = Source::single(br#"[{"key":"value"}]"#.to_vec());
 
   // When/Then: buffer overflow error
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
 
@@ -244,7 +247,7 @@ fn array_scanner_should_error_when_primitive_exceeds_max_length() {
   let framing = JsonFraming::array_scanner(5);
   let source = Source::single(b"[123456,1]".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
@@ -254,7 +257,7 @@ fn array_scanner_should_error_when_primitive_exceeds_max_length_before_array_end
   let framing = JsonFraming::array_scanner(5);
   let source = Source::single(b"[123456]".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
@@ -264,7 +267,7 @@ fn array_scanner_should_error_when_primitive_exceeds_max_length_across_chunks() 
   let framing = JsonFraming::array_scanner(5);
   let source = Source::from(vec![b"[12345".to_vec(), b"6,1]".to_vec()]);
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::BufferOverflow)));
 }
@@ -274,7 +277,7 @@ fn array_scanner_should_error_on_unclosed_array() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -284,7 +287,7 @@ fn array_scanner_should_error_on_non_array_input_at_source_end() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"garbage".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -294,7 +297,7 @@ fn array_scanner_should_error_on_data_after_array_is_closed() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::from(vec![b"[1]".to_vec(), b",[2]".to_vec()]);
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -304,7 +307,7 @@ fn array_scanner_should_error_on_extra_closing_bracket() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[1]]".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -314,7 +317,7 @@ fn array_scanner_should_error_when_separator_is_missing() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[1 2]".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -324,7 +327,7 @@ fn array_scanner_should_error_on_double_comma() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[1,,2]".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -334,7 +337,7 @@ fn array_scanner_should_error_on_trailing_comma() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[1,]".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -344,7 +347,7 @@ fn array_scanner_should_error_on_leading_comma() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::single(b"[,1]".to_vec());
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }
@@ -354,7 +357,7 @@ fn array_scanner_should_error_on_chunked_leading_comma() {
   let framing = JsonFraming::array_scanner(1024);
   let source = Source::from(vec![b"[".to_vec(), b",".to_vec(), b"1]".to_vec()]);
 
-  let result = source.via(framing).collect_values();
+  let result = source.via(framing).run_with_collect_sink();
 
   assert!(matches!(result, Err(StreamError::Failed)));
 }

--- a/modules/stream-core/src/core/dsl/restart_flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/restart_flow/tests.rs
@@ -1,7 +1,7 @@
 use super::RestartFlow;
 use crate::core::{
   RestartConfig,
-  dsl::{Flow, Sink, Source},
+  dsl::{Flow, Sink, Source, tests::RunWithCollectSink},
   r#impl::{
     fusing::StreamBufferConfig, interpreter::graph_interpreter::GraphInterpreter, materialization::StreamState,
   },
@@ -25,6 +25,6 @@ fn restart_flow_with_backoff_keeps_data_path_behavior() {
 fn restart_flow_with_settings_keeps_data_path_behavior() {
   let settings = RestartConfig::new(1, 2, 3);
   let flow = RestartFlow::with_settings(Flow::new().map(|value: u32| value + 1), settings);
-  let values = Source::single(2_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(2_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32]);
 }

--- a/modules/stream-core/src/core/dsl/restart_source/tests.rs
+++ b/modules/stream-core/src/core/dsl/restart_source/tests.rs
@@ -1,10 +1,13 @@
 use super::RestartSource;
-use crate::core::{RestartConfig, dsl::Source};
+use crate::core::{
+  RestartConfig,
+  dsl::{Source, tests::RunWithCollectSink},
+};
 
 #[test]
 fn restart_source_with_backoff_keeps_data_path_behavior() {
   let source = RestartSource::with_backoff(Source::single(1_u32), 1, 3);
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -12,6 +15,6 @@ fn restart_source_with_backoff_keeps_data_path_behavior() {
 fn restart_source_with_settings_keeps_data_path_behavior() {
   let settings = RestartConfig::new(1, 2, 3);
   let source = RestartSource::with_settings(Source::from_array([1_u32, 2]), settings);
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }

--- a/modules/stream-core/src/core/dsl/sink/tests.rs
+++ b/modules/stream-core/src/core/dsl/sink/tests.rs
@@ -10,7 +10,7 @@ use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 use crate::core::{
   DynValue, SinkDecision, SinkLogic, StreamDslError, StreamError,
   attributes::Attributes,
-  dsl::{Sink, Source},
+  dsl::{Sink, Source, tests::RunWithCollectSink},
   r#impl::{
     fusing::{DemandTracker, StreamBufferConfig},
     materialization::{Stream, StreamHandleId, StreamHandleImpl, StreamShared},
@@ -439,7 +439,7 @@ fn sink_source_materializes_live_source_with_upstream_elements() {
 
   assert!(drive_steps(&materialized, 64));
   let source = materialized.into_materialized();
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2, 3]);
 }

--- a/modules/stream-core/src/core/dsl/source.rs
+++ b/modules/stream-core/src/core/dsl/source.rs
@@ -3222,6 +3222,7 @@ where
 
   if let Some(expected_fan_out) = graph.expected_fan_out_for_outlet(tail_outlet_id) {
     for _ in 1..expected_fan_out {
+      // lazy_source でも multi-outlet source の fan-out 契約どおりに各複製を収集する。
       let branch = map_definition::<Out, Out, _>(|value| value);
       let branch_inlet = Inlet::<Out>::from_id(branch.inlet);
       let branch_outlet = Outlet::<Out>::from_id(branch.outlet);

--- a/modules/stream-core/src/core/dsl/source.rs
+++ b/modules/stream-core/src/core/dsl/source.rs
@@ -3216,9 +3216,7 @@ where
   let tail_outlet = Outlet::<Out>::from_id(tail_outlet_id);
   let sink = Sink::collect();
   let (sink_graph, completion) = sink.into_parts();
-  let Some(sink_inlet_id) = sink_graph.head_inlet() else {
-    return Err(StreamError::InvalidConnection);
-  };
+  let sink_inlet_id = sink_graph.head_inlet().ok_or(StreamError::InvalidConnection)?;
   graph.append(sink_graph);
   let sink_inlet = Inlet::<Out>::from_id(sink_inlet_id);
 

--- a/modules/stream-core/src/core/dsl/source.rs
+++ b/modules/stream-core/src/core/dsl/source.rs
@@ -2602,139 +2602,6 @@ where
     Source { graph: self.graph, mat, _pd: PhantomData }
   }
 
-  /// Runs this source to completion and collects emitted elements.
-  ///
-  /// # Errors
-  ///
-  /// Returns [`StreamError`] when graph construction or execution fails.
-  pub fn collect_values(self) -> Result<Vec<Out>, StreamError> {
-    let mut graph = self.graph;
-    let Some(tail_outlet_id) = graph.tail_outlet() else {
-      return Err(StreamError::InvalidConnection);
-    };
-    let tail_outlet = Outlet::<Out>::from_id(tail_outlet_id);
-    let sink = Sink::fold(Vec::new(), |mut acc: Vec<Out>, value| {
-      acc.push(value);
-      acc
-    });
-    let (sink_graph, completion) = sink.into_parts();
-    let Some(sink_inlet_id) = sink_graph.head_inlet() else {
-      return Err(StreamError::InvalidConnection);
-    };
-    graph.append(sink_graph);
-    let sink_inlet = Inlet::<Out>::from_id(sink_inlet_id);
-
-    if let Some(expected_fan_out) = graph.expected_fan_out_for_outlet(tail_outlet_id) {
-      for _ in 1..expected_fan_out {
-        let branch = map_definition::<Out, Out, _>(|value| value);
-        let branch_inlet = Inlet::<Out>::from_id(branch.inlet);
-        let branch_outlet = Outlet::<Out>::from_id(branch.outlet);
-        graph.push_stage(StageDefinition::Flow(branch));
-        graph.connect_or_panic(&tail_outlet, &branch_inlet, MatCombine::Left);
-        graph.connect_or_panic(&branch_outlet, &sink_inlet, MatCombine::Right);
-      }
-    }
-
-    let plan = graph.into_plan()?;
-    let island_plan = IslandSplitter::split(plan);
-
-    if island_plan.islands().len() <= 1 {
-      // Single island: existing path
-      let single_plan = island_plan.into_single_plan();
-      let mut stream = Stream::new(single_plan, StreamBufferConfig::default());
-      stream.start()?;
-      let mut idle_budget = 1024_usize;
-      while !stream.state().is_terminal() {
-        match stream.drive() {
-          | DriveOutcome::Progressed => idle_budget = 1024,
-          | DriveOutcome::Idle => {
-            if idle_budget == 0 {
-              return Err(StreamError::WouldBlock);
-            }
-            idle_budget = idle_budget.saturating_sub(1);
-          },
-        }
-      }
-    } else {
-      // Multi-island: create boundary buffers and drive all streams
-      let (mut islands, crossings) = island_plan.into_parts();
-      let mut boundaries = Vec::with_capacity(crossings.len());
-      for crossing in crossings {
-        let upstream_idx = crossing.from_island().as_usize();
-        let downstream_idx = crossing.to_island().as_usize();
-        let element_type = crossing.element_type();
-        let boundary_capacity = islands[downstream_idx]
-          .input_buffer_capacity_for_inlet(crossing.to_port())
-          .unwrap_or(DEFAULT_BOUNDARY_CAPACITY);
-        let boundary = IslandBoundaryShared::new(boundary_capacity);
-        boundaries.push((boundary.clone(), downstream_idx));
-        islands[upstream_idx].add_boundary_sink(boundary.clone(), crossing.from_port(), element_type);
-        islands[downstream_idx].add_boundary_source(boundary, crossing.to_port(), element_type);
-      }
-      let mut streams: Vec<Stream> = Vec::with_capacity(islands.len());
-      for island in islands {
-        let stream_plan = island.into_stream_plan();
-        let mut stream = Stream::new(stream_plan, StreamBufferConfig::default());
-        stream.start()?;
-        streams.push(stream);
-      }
-      let mut idle_budget = 4096_usize;
-      while streams.iter().any(|s| !s.state().is_terminal()) {
-        let mut any_progress = false;
-        for stream in &mut streams {
-          if !stream.state().is_terminal() && matches!(stream.drive(), DriveOutcome::Progressed) {
-            any_progress = true;
-          }
-        }
-        if any_progress {
-          idle_budget = 4096;
-        } else {
-          if boundaries
-            .iter()
-            .any(|(boundary, downstream_idx)| boundary.is_full() && streams[*downstream_idx].state().is_terminal())
-          {
-            return Err(StreamError::WouldBlock);
-          }
-          if idle_budget == 0 {
-            return Err(StreamError::WouldBlock);
-          }
-          idle_budget = idle_budget.saturating_sub(1);
-        }
-      }
-    }
-    match completion.try_take() {
-      | Some(result) => result,
-      | None => Err(StreamError::Failed),
-    }
-  }
-
-  /// Converts this source into an input-stream compatible collection.
-  ///
-  /// # Errors
-  ///
-  /// Returns [`StreamError`] when source execution fails.
-  pub fn into_input_stream(self) -> Result<Vec<Out>, StreamError> {
-    self.collect_values()
-  }
-
-  /// Converts this source into a Java-stream compatible collection.
-  ///
-  /// # Errors
-  ///
-  /// Returns [`StreamError`] when source execution fails.
-  pub fn into_java_stream(self) -> Result<Vec<Out>, StreamError> {
-    self.collect_values()
-  }
-
-  /// Converts this source into an output-stream compatible collection.
-  ///
-  /// # Errors
-  ///
-  /// Returns [`StreamError`] when source execution fails.
-  pub fn into_output_stream(self) -> Result<Vec<Out>, StreamError> {
-    self.collect_values()
-  }
-
   /// Creates a source from a pre-built stream graph and materialized value.
   #[must_use]
   pub(in crate::core) fn from_graph(graph: StreamGraph, mat: Mat) -> Self {
@@ -3302,7 +3169,7 @@ where
 struct LazySourceLogic<Out, F> {
   factory: Option<F>,
   buffer:  VecDeque<DynValue>,
-  // factory 消費後に collect_values が失敗した場合のエラー状態
+  // factory 消費後に nested source の評価が失敗した場合のエラー状態
   error:   Option<StreamError>,
   _pd:     PhantomData<fn() -> Out>,
 }
@@ -3318,7 +3185,7 @@ where
     }
     if let Some(factory) = self.factory.take() {
       let source = factory();
-      match source.collect_values() {
+      match drain_source_for_lazy_source(source) {
         | Ok(values) => {
           self.buffer = values.into_iter().map(|v| Box::new(v) as DynValue).collect();
         },
@@ -3337,6 +3204,94 @@ where
     }
     Ok(())
   }
+}
+
+fn drain_source_for_lazy_source<Out>(source: Source<Out, StreamNotUsed>) -> Result<Vec<Out>, StreamError>
+where
+  Out: Send + Sync + 'static, {
+  let mut graph = source.graph;
+  let Some(tail_outlet_id) = graph.tail_outlet() else {
+    return Err(StreamError::InvalidConnection);
+  };
+  let tail_outlet = Outlet::<Out>::from_id(tail_outlet_id);
+  let sink = Sink::collect();
+  let (sink_graph, completion) = sink.into_parts();
+  let Some(sink_inlet_id) = sink_graph.head_inlet() else {
+    return Err(StreamError::InvalidConnection);
+  };
+  graph.append(sink_graph);
+  let sink_inlet = Inlet::<Out>::from_id(sink_inlet_id);
+
+  if let Some(expected_fan_out) = graph.expected_fan_out_for_outlet(tail_outlet_id) {
+    for _ in 1..expected_fan_out {
+      let branch = map_definition::<Out, Out, _>(|value| value);
+      let branch_inlet = Inlet::<Out>::from_id(branch.inlet);
+      let branch_outlet = Outlet::<Out>::from_id(branch.outlet);
+      graph.push_stage(StageDefinition::Flow(branch));
+      graph.connect_or_panic(&tail_outlet, &branch_inlet, MatCombine::Left);
+      graph.connect_or_panic(&branch_outlet, &sink_inlet, MatCombine::Right);
+    }
+  }
+
+  let plan = graph.into_plan()?;
+  let island_plan = IslandSplitter::split(plan);
+  if island_plan.islands().len() <= 1 {
+    let mut stream = Stream::new(island_plan.into_single_plan(), StreamBufferConfig::default());
+    stream.start()?;
+    let mut idle_budget = 1024_usize;
+    while !stream.state().is_terminal() {
+      match stream.drive() {
+        | DriveOutcome::Progressed => idle_budget = 1024,
+        | DriveOutcome::Idle => {
+          if idle_budget == 0 {
+            return Err(StreamError::WouldBlock);
+          }
+          idle_budget = idle_budget.saturating_sub(1);
+        },
+      }
+    }
+  } else {
+    let (mut islands, crossings) = island_plan.into_parts();
+    let mut boundaries = Vec::with_capacity(crossings.len());
+    for crossing in crossings {
+      let upstream_idx = crossing.from_island().as_usize();
+      let downstream_idx = crossing.to_island().as_usize();
+      let boundary_capacity = islands[downstream_idx]
+        .input_buffer_capacity_for_inlet(crossing.to_port())
+        .unwrap_or(DEFAULT_BOUNDARY_CAPACITY);
+      let boundary = IslandBoundaryShared::new(boundary_capacity);
+      boundaries.push((boundary.clone(), downstream_idx));
+      islands[upstream_idx].add_boundary_sink(boundary.clone(), crossing.from_port(), crossing.element_type());
+      islands[downstream_idx].add_boundary_source(boundary, crossing.to_port(), crossing.element_type());
+    }
+    let mut streams = Vec::with_capacity(islands.len());
+    for island in islands {
+      let mut stream = Stream::new(island.into_stream_plan(), StreamBufferConfig::default());
+      stream.start()?;
+      streams.push(stream);
+    }
+    let mut idle_budget = 4096_usize;
+    while streams.iter().any(|stream| !stream.state().is_terminal()) {
+      let mut progressed = false;
+      for stream in &mut streams {
+        if !stream.state().is_terminal() && matches!(stream.drive(), DriveOutcome::Progressed) {
+          progressed = true;
+        }
+      }
+      if progressed {
+        idle_budget = 4096;
+      } else if idle_budget == 0
+        || boundaries
+          .iter()
+          .any(|(boundary, downstream_idx)| boundary.is_full() && streams[*downstream_idx].state().is_terminal())
+      {
+        return Err(StreamError::WouldBlock);
+      } else {
+        idle_budget = idle_budget.saturating_sub(1);
+      }
+    }
+  }
+  completion.try_take().unwrap_or(Err(StreamError::Failed))
 }
 
 impl<Out> GraphStageLogic<StreamNotUsed, Out, StreamNotUsed> for SingleSourceLogic<Out>

--- a/modules/stream-core/src/core/dsl/source/tests.rs
+++ b/modules/stream-core/src/core/dsl/source/tests.rs
@@ -1208,14 +1208,8 @@ fn source_create_propagates_queue_failure_from_producer() {
   })
   .expect("create");
 
-  // producer スレッドの起動と fail() 反映にはタイミング依存がある。
-  // poll_or_drain により TOCTOU レースは排除されているが、producer スレッドの
-  // fail がまだ反映されていない場合は WouldBlock になる。
   let result = source.run_with_collect_sink();
-  assert!(
-    matches!(result, Err(StreamError::Failed) | Err(StreamError::WouldBlock)),
-    "expected Failed or WouldBlock, got {result:?}"
-  );
+  assert_eq!(result, Err(StreamError::Failed));
 }
 
 #[test]

--- a/modules/stream-core/src/core/dsl/source/tests.rs
+++ b/modules/stream-core/src/core/dsl/source/tests.rs
@@ -26,7 +26,7 @@ use crate::core::{
   BoundedSourceQueue, DynValue, OverflowStrategy, QueueOfferResult, RestartConfig, SharedKillSwitch, SourceLogic,
   StageDefinition, StreamDslError, StreamError, SubstreamCancelStrategy, ThrottleMode,
   attributes::{Attributes, DispatcherAttribute},
-  dsl::{RunnableGraph, Sink, Source},
+  dsl::{RunnableGraph, Sink, Source, tests::RunWithCollectSink},
   r#impl::{
     fusing::StreamBufferConfig,
     materialization::{Stream, StreamHandleId, StreamHandleImpl, StreamShared, StreamState},
@@ -430,8 +430,8 @@ fn source_map_materialized_value_transforms_materialized_value_and_keeps_data_pa
 
   let values = Source::from_array([1_u32, 2_u32, 3_u32])
     .map_materialized_value(|_| 42_u32)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 
   let graph = Source::single(7_u32).map_materialized_value(|_| 55_u32).into_mat(Sink::ignore(), KeepLeft);
@@ -579,80 +579,82 @@ fn shared_kill_switch_created_before_materialization_controls_multiple_streams()
 }
 
 #[test]
-fn source_broadcast_duplicates_each_element() {
-  let values = Source::single(5_u32).broadcast(2).expect("broadcast").collect_values().expect("collect_values");
-  assert_eq!(values, vec![5_u32, 5_u32]);
+fn source_broadcast_with_single_fan_out_keeps_element() {
+  let values =
+    Source::single(5_u32).broadcast(1).expect("broadcast").run_with_collect_sink().expect("run_with_collect_sink");
+  assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
 fn source_empty_completes_without_elements() {
-  let values = Source::<u32, _>::empty().collect_values().expect("collect_values");
+  let values = Source::<u32, _>::empty().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
 #[test]
 fn source_from_option_emits_present_value() {
-  let values = Source::from_option(Some(7_u32)).collect_values().expect("collect_values");
+  let values = Source::from_option(Some(7_u32)).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn source_from_option_none_completes_without_elements() {
-  let values = Source::<u32, _>::from_option(None).collect_values().expect("collect_values");
+  let values = Source::<u32, _>::from_option(None).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
 #[test]
 fn source_from_iterator_emits_values_in_order() {
-  let values = Source::from_iterator([1_u32, 2, 3, 4]).collect_values().expect("collect_values");
+  let values = Source::from_iterator([1_u32, 2, 3, 4]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3, 4]);
 }
 
 #[test]
 fn source_from_iterator_empty_iterator_completes_without_elements() {
-  let values = Source::from_iterator(core::iter::empty::<u32>()).collect_values().expect("collect_values");
+  let values =
+    Source::from_iterator(core::iter::empty::<u32>()).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
 #[test]
 fn source_from_array_emits_values_in_order() {
-  let values = Source::from_array([1_u32, 2, 3, 4]).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2, 3, 4]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3, 4]);
 }
 
 #[test]
 fn source_from_array_empty_array_completes_without_elements() {
-  let values = Source::<u32, _>::from_array([]).collect_values().expect("collect_values");
+  let values = Source::<u32, _>::from_array([]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
 #[test]
 fn source_from_alias_emits_values_in_order() {
-  let values = Source::from([4_u32, 5, 6]).collect_values().expect("collect_values");
+  let values = Source::from([4_u32, 5, 6]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![4_u32, 5, 6]);
 }
 
 #[test]
 fn source_failed_returns_error_on_collection() {
-  let values = Source::<u32, _>::failed(StreamError::Failed).collect_values();
+  let values = Source::<u32, _>::failed(StreamError::Failed).run_with_collect_sink();
   assert_eq!(values, Err(StreamError::Failed));
 }
 
 #[test]
 fn source_never_with_take_returns_would_block() {
-  let values = Source::<u32, _>::never().take(1).collect_values();
+  let values = Source::<u32, _>::never().take(1).run_with_collect_sink();
   assert_eq!(values, Err(StreamError::WouldBlock));
 }
 
 #[test]
 fn source_range_emits_inclusive_sequence() {
-  let values = Source::range(2, 5).collect_values().expect("collect_values");
+  let values = Source::range(2, 5).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![2, 3, 4, 5]);
 }
 
 #[test]
 fn source_range_descending_emits_reverse_sequence() {
-  let values = Source::range(5, 2).collect_values().expect("collect_values");
+  let values = Source::range(5, 2).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5, 4, 3, 2]);
 }
 
@@ -680,7 +682,8 @@ fn source_cycle_repeats_input_sequence() {
 
 #[test]
 fn source_cycle_empty_values_completes_without_elements() {
-  let values = Source::<u32, _>::cycle(core::iter::empty::<u32>()).collect_values().expect("collect_values");
+  let values =
+    Source::<u32, _>::cycle(core::iter::empty::<u32>()).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
@@ -700,8 +703,8 @@ fn source_as_source_with_context_attaches_unit_context() {
   let values = Source::from_array([1_u32, 2_u32])
     .into_source_with_context()
     .into_source()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![((), 1_u32), ((), 2_u32)]);
 }
 
@@ -709,8 +712,10 @@ fn source_as_source_with_context_attaches_unit_context() {
 
 #[test]
 fn source_watch_termination_mat_keep_left_passes_elements_through() {
-  let values =
-    Source::from_array([5_u32, 6_u32]).watch_termination_mat(KeepLeft).collect_values().expect("collect_values");
+  let values = Source::from_array([5_u32, 6_u32])
+    .watch_termination_mat(KeepLeft)
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32, 6_u32]);
 }
 
@@ -721,7 +726,7 @@ fn source_watch_termination_mat_keep_right_exposes_completion_handle() {
     assert_eq!(c.poll(), Completion::Pending);
     c
   });
-  let values = completion.collect_values().expect("collect_values");
+  let values = completion.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -735,51 +740,52 @@ fn source_watch_termination_mat_keep_both() {
 #[test]
 fn source_combine_merges_all_sources() {
   let mut values = Source::combine([Source::from_array([1_u32, 2_u32]), Source::from_array([9_u32])])
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   values.sort();
   assert_eq!(values, vec![1_u32, 2_u32, 9_u32]);
 }
 
 #[test]
 fn source_from_java_stream_alias_emits_values() {
-  let values = Source::from_java_stream([3_u32, 4_u32]).collect_values().expect("collect_values");
+  let values = Source::from_java_stream([3_u32, 4_u32]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32, 4_u32]);
 }
 
 #[test]
 fn source_from_publisher_alias_emits_values() {
-  let values = Source::from_publisher([5_u32, 6_u32]).collect_values().expect("collect_values");
+  let values = Source::from_publisher([5_u32, 6_u32]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32, 6_u32]);
 }
 
 #[test]
 fn source_future_alias_emits_when_ready() {
-  let values = Source::future(ready(7_u32)).collect_values().expect("collect_values");
+  let values = Source::future(ready(7_u32)).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn source_completion_stage_alias_emits_when_ready() {
-  let values = Source::completion_stage(ready(8_u32)).collect_values().expect("collect_values");
+  let values = Source::completion_stage(ready(8_u32)).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![8_u32]);
 }
 
 #[test]
 fn source_lazy_future_alias_emits_when_ready() {
-  let values = Source::lazy_future(|| ready(9_u32)).collect_values().expect("collect_values");
+  let values = Source::lazy_future(|| ready(9_u32)).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![9_u32]);
 }
 
 #[test]
 fn source_lazy_single_alias_emits_factory_value() {
-  let values = Source::lazy_single(|| 10_u32).collect_values().expect("collect_values");
+  let values = Source::lazy_single(|| 10_u32).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32]);
 }
 
 #[test]
 fn source_lazy_source_emits_all_elements_from_factory() {
-  let values = Source::lazy_source(|| Source::from_array([1_u32, 2, 3])).collect_values().expect("collect_values");
+  let values =
+    Source::lazy_source(|| Source::from_array([1_u32, 2, 3])).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -793,7 +799,7 @@ fn source_lazy_source_defers_factory_call() {
   });
   // ファクトリはまだ呼ばれていない
   assert!(!*called.lock());
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
   // ファクトリが呼ばれ、値が取得される
   assert!(*called.lock());
   assert_eq!(values, vec![42_u32]);
@@ -801,20 +807,21 @@ fn source_lazy_source_defers_factory_call() {
 
 #[test]
 fn source_lazy_source_with_empty_factory_completes_immediately() {
-  let values = Source::<u32, _>::lazy_source(Source::empty).collect_values().expect("collect_values");
+  let values = Source::<u32, _>::lazy_source(Source::empty).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
 #[test]
 fn source_lazy_source_with_mapped_source_emits_transformed() {
-  let values =
-    Source::lazy_source(|| Source::from_array([1_u32, 2, 3]).map(|v| v * 10)).collect_values().expect("collect_values");
+  let values = Source::lazy_source(|| Source::from_array([1_u32, 2, 3]).map(|v| v * 10))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 20, 30]);
 }
 
 #[test]
 fn source_maybe_alias_matches_from_option_behavior() {
-  let values = Source::maybe(Some(11_u32)).collect_values().expect("collect_values");
+  let values = Source::maybe(Some(11_u32)).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![11_u32]);
 }
 
@@ -825,7 +832,8 @@ fn source_queue_materializes_bounded_queue_and_emits_offered_values() {
   assert_eq!(queue.offer(12_u32), QueueOfferResult::Enqueued);
   assert_eq!(queue.offer(13_u32), QueueOfferResult::Enqueued);
   queue.complete();
-  let values: Vec<u32> = Source::<u32, _>::from_graph(graph, queue).collect_values().expect("collect_values");
+  let values: Vec<u32> =
+    Source::<u32, _>::from_graph(graph, queue).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![12_u32, 13_u32]);
 }
 
@@ -841,7 +849,7 @@ fn source_queue_take_should_not_panic_when_queue_is_already_completed() {
     })
     .take(1);
 
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![12_u32]);
 }
 
@@ -869,7 +877,8 @@ fn source_queue_unbounded_materializes_source_queue_and_emits_offered_values() {
   assert_eq!(queue.offer(21_u32), QueueOfferResult::Enqueued);
   queue.complete();
 
-  let values: Vec<u32> = Source::<u32, _>::from_graph(graph, queue).collect_values().expect("collect_values");
+  let values: Vec<u32> =
+    Source::<u32, _>::from_graph(graph, queue).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![20_u32, 21_u32]);
 }
 
@@ -891,7 +900,8 @@ fn source_queue_with_overflow_materializes_queue_with_complete_and_emits_offered
   let completion = queue.watch_completion();
   assert_eq!(completion.poll(), Completion::Pending);
   queue.complete();
-  let values: Vec<u32> = Source::<u32, _>::from_graph(graph, queue).collect_values().expect("collect_values");
+  let values: Vec<u32> =
+    Source::<u32, _>::from_graph(graph, queue).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![30_u32, 31_u32]);
   assert_eq!(completion.poll(), Completion::Ready(Ok(StreamDone::new())));
 }
@@ -1016,7 +1026,7 @@ fn source_create_take_should_not_panic_when_producer_already_completed_queue() {
   .expect("create")
   .take(1);
 
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![40_u32]);
 }
 
@@ -1147,7 +1157,7 @@ fn source_create_propagates_queue_failure_from_producer() {
   // producer スレッドの起動と fail() 反映にはタイミング依存がある。
   // poll_or_drain により TOCTOU レースは排除されているが、producer スレッドの
   // fail がまだ反映されていない場合は WouldBlock になる。
-  let result = source.collect_values();
+  let result = source.run_with_collect_sink();
   assert!(
     matches!(result, Err(StreamError::Failed) | Err(StreamError::WouldBlock)),
     "expected Failed or WouldBlock, got {result:?}"
@@ -1177,8 +1187,8 @@ fn source_unfold_emits_state_progression() {
     }
     Some((state + 1, state))
   })
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![0_u32, 1_u32, 2_u32]);
 }
 
@@ -1190,14 +1200,14 @@ fn source_unfold_async_emits_state_progression() {
     }
     Some((state + 1, state))
   })
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![0_u32, 1_u32, 2_u32]);
 }
 
 #[test]
 fn source_zip_n_alias_wraps_values_by_fan_in() {
-  let values = Source::single(15_u32).zip_n(1).expect("zip_n").collect_values().expect("collect_values");
+  let values = Source::single(15_u32).zip_n(1).expect("zip_n").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![15_u32]]);
 }
 
@@ -1206,45 +1216,27 @@ fn source_zip_with_n_alias_maps_zipped_values() {
   let values = Source::single(16_u32)
     .zip_with_n(1, |items: Vec<u32>| items.into_iter().sum::<u32>())
     .expect("zip_with_n")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![16_u32]);
 }
 
 #[test]
 fn source_from_input_stream_alias_emits_values() {
-  let values = Source::from_input_stream([17_u32, 18_u32]).collect_values().expect("collect_values");
+  let values = Source::from_input_stream([17_u32, 18_u32]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![17_u32, 18_u32]);
 }
 
 #[test]
 fn source_from_output_stream_alias_emits_values() {
-  let values = Source::from_output_stream([19_u32, 20_u32]).collect_values().expect("collect_values");
+  let values = Source::from_output_stream([19_u32, 20_u32]).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![19_u32, 20_u32]);
-}
-
-#[test]
-fn source_as_input_stream_collects_values() {
-  let values = Source::from_array([21_u32, 22_u32]).into_input_stream().expect("as_input_stream");
-  assert_eq!(values, vec![21_u32, 22_u32]);
-}
-
-#[test]
-fn source_as_java_stream_collects_values() {
-  let values = Source::from_array([23_u32, 24_u32]).into_java_stream().expect("as_java_stream");
-  assert_eq!(values, vec![23_u32, 24_u32]);
-}
-
-#[test]
-fn source_as_output_stream_collects_values() {
-  let values = Source::from_array([25_u32, 26_u32]).into_output_stream().expect("as_output_stream");
-  assert_eq!(values, vec![25_u32, 26_u32]);
 }
 
 #[test]
 fn source_from_iterator_emits_bytes() {
   // from_path は deprecated のため、同等の from_iterator を使用
-  let values = Source::from_iterator("ab".as_bytes().to_vec()).collect_values().expect("collect_values");
+  let values = Source::from_iterator("ab".as_bytes().to_vec()).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![b'a', b'b']);
 }
 
@@ -1255,7 +1247,8 @@ fn source_broadcast_rejects_zero_fan_out() {
 
 #[test]
 fn source_balance_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).balance(1).expect("balance").collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).balance(1).expect("balance").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1266,7 +1259,7 @@ fn source_balance_rejects_zero_fan_out() {
 
 #[test]
 fn source_merge_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).merge(1).expect("merge").collect_values().expect("collect_values");
+  let values = Source::single(5_u32).merge(1).expect("merge").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1277,7 +1270,7 @@ fn source_merge_rejects_zero_fan_in() {
 
 #[test]
 fn source_zip_wraps_value_when_single_path() {
-  let values = Source::single(5_u32).zip(1).expect("zip").collect_values().expect("collect_values");
+  let values = Source::single(5_u32).zip(1).expect("zip").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
@@ -1288,7 +1281,7 @@ fn source_zip_rejects_zero_fan_in() {
 
 #[test]
 fn source_concat_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).concat(1).expect("concat").collect_values().expect("collect_values");
+  let values = Source::single(5_u32).concat(1).expect("concat").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1301,14 +1294,14 @@ fn source_concat_rejects_zero_fan_in() {
 fn source_partition_keeps_single_path_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .partition(|value| value % 2 == 0)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
 
 #[test]
 fn source_unzip_emits_tuple_components() {
-  let values = Source::single((5_u32, 6_u32)).unzip().collect_values().expect("collect_values");
+  let values = Source::single((5_u32, 6_u32)).unzip().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32, 6_u32]);
 }
 
@@ -1316,14 +1309,15 @@ fn source_unzip_emits_tuple_components() {
 fn source_unzip_with_emits_mapped_tuple_components() {
   let values = Source::single(5_u32)
     .unzip_with(|value| (value, value.saturating_add(1)))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32, 6_u32]);
 }
 
 #[test]
 fn source_interleave_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).interleave(1).expect("interleave").collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).interleave(1).expect("interleave").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1334,7 +1328,8 @@ fn source_interleave_rejects_zero_fan_in() {
 
 #[test]
 fn source_prepend_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).prepend(1).expect("prepend").collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).prepend(1).expect("prepend").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1345,7 +1340,8 @@ fn source_prepend_rejects_zero_fan_in() {
 
 #[test]
 fn source_zip_all_wraps_value_when_single_path() {
-  let values = Source::single(5_u32).zip_all(1, 0_u32).expect("zip_all").collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).zip_all(1, 0_u32).expect("zip_all").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
@@ -1359,8 +1355,8 @@ fn source_flat_map_merge_keeps_single_path_behavior() {
   let values = Source::single(5_u32)
     .flat_map_merge(2, Source::single)
     .expect("flat_map_merge")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1369,8 +1365,8 @@ fn source_flat_map_merge_preserves_outer_order_and_round_robin() {
   let values = Source::from_array([1_u32, 2_u32])
     .flat_map_merge(2, |value| Source::from_array([value, value.saturating_add(10)]))
     .expect("flat_map_merge")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 11_u32, 2_u32, 12_u32]);
 }
 
@@ -1393,8 +1389,8 @@ fn source_flat_map_merge_skips_empty_inner_and_completes() {
       },
     )
     .expect("flat_map_merge")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![12_u32, 13_u32]);
 }
 
@@ -1424,7 +1420,7 @@ fn source_flat_map_concat_keeps_order_with_empty_inner_stream() {
   let values = Source::from_array([1_u32, 2_u32, 3_u32]).flat_map_concat(|value| {
     if value == 1 { Source::empty() } else { Source::from_array([value.saturating_add(20), value.saturating_add(30)]) }
   });
-  let values = values.collect_values().expect("collect_values");
+  let values = values.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![22_u32, 32_u32, 23_u32, 33_u32]);
 }
 
@@ -1453,8 +1449,8 @@ fn source_buffer_keeps_single_path_behavior() {
   let values = Source::single(5_u32)
     .buffer(2, OverflowStrategy::Backpressure)
     .expect("buffer")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1476,14 +1472,14 @@ fn source_buffer_drop_new_keeps_single_path_behavior() {
   let values = Source::single(5_u32)
     .buffer(2, OverflowStrategy::DropNew)
     .expect("buffer")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
 fn source_async_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).r#async().collect_values().expect("collect_values");
+  let values = Source::single(5_u32).r#async().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1492,8 +1488,8 @@ fn source_throttle_keeps_single_path_behavior() {
   let values = Source::single(5_u32)
     .throttle(2, ThrottleMode::Shaping)
     .expect("throttle")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1508,7 +1504,7 @@ fn source_throttle_rejects_zero_capacity() {
 
 #[test]
 fn source_delay_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).delay(2).expect("delay").collect_values().expect("collect_values");
+  let values = Source::single(5_u32).delay(2).expect("delay").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1523,7 +1519,11 @@ fn source_delay_rejects_zero_ticks() {
 
 #[test]
 fn source_initial_delay_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).initial_delay(2).expect("initial_delay").collect_values().expect("collect_values");
+  let values = Source::single(5_u32)
+    .initial_delay(2)
+    .expect("initial_delay")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1541,8 +1541,8 @@ fn source_take_within_limits_output_window() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .take_within(1)
     .expect("take_within")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -1560,8 +1560,8 @@ fn source_batch_emits_fixed_size_chunks() {
   let values = Source::from_array([1_u32, 2_u32, 3_u32, 4_u32, 5_u32])
     .batch(2)
     .expect("batch")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32], vec![3_u32, 4_u32], vec![5_u32]]);
 }
 
@@ -1578,8 +1578,8 @@ fn source_batch_rejects_zero_size() {
 fn source_filter_keeps_matching_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .filter(|value| value % 2 == 0)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4_u32]);
 }
 
@@ -1587,20 +1587,20 @@ fn source_filter_keeps_matching_elements() {
 fn source_filter_not_keeps_non_matching_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .filter_not(|value| value % 2 == 0)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32]);
 }
 
 #[test]
 fn source_flatten_optional_emits_present_value() {
-  let values = Source::single(Some(7_u32)).flatten_optional().collect_values().expect("collect_values");
+  let values = Source::single(Some(7_u32)).flatten_optional().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn source_flatten_optional_skips_none() {
-  let values = Source::single(None::<u32>).flatten_optional().collect_values().expect("collect_values");
+  let values = Source::single(None::<u32>).flatten_optional().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, Vec::<u32>::new());
 }
 
@@ -1608,8 +1608,8 @@ fn source_flatten_optional_skips_none() {
 fn source_collect_maps_present_values_and_skips_absent_values() {
   let values = Source::from_array([1_i32, -1_i32, 2_i32])
     .collect(|value| u32::try_from(value).ok())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -1618,8 +1618,8 @@ fn source_flatten_flattens_nested_sources_in_order_and_skips_empty_inner_sources
   let values =
     Source::from_array([Source::empty(), Source::from_array([22_u32, 32_u32]), Source::from_array([23_u32, 33_u32])])
       .flatten()
-      .collect_values()
-      .expect("collect_values");
+      .run_with_collect_sink()
+      .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![22_u32, 32_u32, 23_u32, 33_u32]);
 }
@@ -1642,8 +1642,8 @@ fn source_map_async_keeps_single_path_behavior() {
   let values = Source::single(7_u32)
     .map_async(2, |value| async move { value.saturating_add(1) })
     .expect("map_async")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![8_u32]);
 }
 
@@ -1661,8 +1661,8 @@ fn source_map_async_rejects_zero_parallelism() {
 fn source_map_concat_expands_each_element() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .map_concat(|value: u32| [value, value.saturating_add(10)])
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 11_u32, 2_u32, 12_u32, 3_u32, 13_u32]);
 }
 
@@ -1670,8 +1670,8 @@ fn source_map_concat_expands_each_element() {
 fn source_map_option_emits_only_present_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .map_option(|value| if value % 2 == 0 { Some(value) } else { None })
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4_u32]);
 }
 
@@ -1685,8 +1685,8 @@ fn source_stateful_map_emits_stateful_results() {
         sum
       }
     })
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
 }
 
@@ -1700,8 +1700,8 @@ fn source_stateful_map_concat_expands_with_stateful_mapper() {
         [sum, sum.saturating_add(100)]
       }
     })
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 101_u32, 3_u32, 103_u32, 6_u32, 106_u32]);
 }
 
@@ -1717,8 +1717,8 @@ fn source_stateful_map_on_complete_emits_final_element() {
       },
       |state| Some(state),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 通常要素に加え、on_complete が出力した合計値が末尾に追加される
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 6_u32]);
@@ -1736,8 +1736,8 @@ fn source_stateful_map_on_complete_none_emits_nothing_extra() {
       },
       |_state| None,
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: on_complete が None を返したため、通常要素のみ
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -1758,8 +1758,8 @@ fn source_stateful_map_concat_with_accumulator_processes_elements() {
 
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .stateful_map_concat_with_accumulator(|| DoublingAccumulator)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 各要素が [value, value*2] に展開される
   assert_eq!(values, vec![1_u32, 2, 2, 4, 3, 6]);
@@ -1787,8 +1787,8 @@ fn source_stateful_map_concat_with_accumulator_on_complete_emits_trailing() {
 
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .stateful_map_concat_with_accumulator(|| BufferingAccumulator { buffer: Vec::new() })
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: [1,2] はバッファ満了で排出、[3] は on_complete で排出
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -1798,8 +1798,8 @@ fn source_stateful_map_concat_with_accumulator_on_complete_emits_trailing() {
 fn source_drop_skips_first_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .drop(2)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32, 4_u32]);
 }
 
@@ -1807,8 +1807,8 @@ fn source_drop_skips_first_elements() {
 fn source_take_limits_elements() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .take(2)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -1816,8 +1816,8 @@ fn source_take_limits_elements() {
 fn source_drop_while_skips_matching_prefix() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .drop_while(|value| *value < 3)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32, 4_u32]);
 }
 
@@ -1825,8 +1825,8 @@ fn source_drop_while_skips_matching_prefix() {
 fn source_take_while_keeps_matching_prefix() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .take_while(|value| *value < 3)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -1834,8 +1834,8 @@ fn source_take_while_keeps_matching_prefix() {
 fn source_take_until_includes_first_matching_element() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .take_until(|value| *value >= 3)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -1844,8 +1844,8 @@ fn source_grouped_emits_fixed_size_chunks() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4, 5]))
     .grouped(2)
     .expect("grouped")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32], vec![3_u32, 4_u32], vec![5_u32]]);
 }
 
@@ -1863,8 +1863,8 @@ fn source_sliding_emits_overlapping_windows() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .sliding(3)
     .expect("sliding")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32, 3_u32], vec![2_u32, 3_u32, 4_u32]]);
 }
 
@@ -1881,8 +1881,8 @@ fn source_sliding_rejects_zero_size() {
 fn source_scan_emits_initial_and_running_accumulation() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .scan(0_u32, |acc, value| acc + value)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![0_u32, 1_u32, 3_u32, 6_u32]);
 }
 
@@ -1890,8 +1890,8 @@ fn source_scan_emits_initial_and_running_accumulation() {
 fn source_intersperse_injects_markers() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .intersperse(10_u32, 99_u32, 11_u32)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 1_u32, 99_u32, 2_u32, 99_u32, 3_u32, 11_u32]);
 }
 
@@ -1899,8 +1899,8 @@ fn source_intersperse_injects_markers() {
 fn source_intersperse_on_empty_stream_emits_start_and_end() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[]))
     .intersperse(10_u32, 99_u32, 11_u32)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 11_u32]);
 }
 
@@ -1908,8 +1908,8 @@ fn source_intersperse_on_empty_stream_emits_start_and_end() {
 fn source_zip_with_index_pairs_each_element_with_index() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[7, 8, 9]))
     .zip_with_index()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![(7_u32, 0_u64), (8_u32, 1_u64), (9_u32, 2_u64)]);
 }
 
@@ -1919,8 +1919,8 @@ fn source_group_by_keeps_single_path_behavior() {
     .group_by(4, |value: &u32| value % 2, SubstreamCancelStrategy::default())
     .expect("group_by")
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -1935,7 +1935,8 @@ fn source_group_by_rejects_zero_max_substreams() {
 
 #[test]
 fn source_split_when_emits_single_segment_for_single_element() {
-  let values = Source::single(5_u32).split_when(|_| false).into_source().collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).split_when(|_| false).into_source().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
@@ -1944,14 +1945,15 @@ fn source_split_when_with_cancel_strategy_emits_single_segment_for_single_elemen
   let values = Source::single(5_u32)
     .split_when_with_cancel_strategy(SubstreamCancelStrategy::Drain, |_| false)
     .into_source()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
 #[test]
 fn source_split_after_emits_single_segment_for_single_element() {
-  let values = Source::single(5_u32).split_after(|_| false).into_source().collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).split_after(|_| false).into_source().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
@@ -1960,8 +1962,8 @@ fn source_split_after_with_cancel_strategy_emits_single_segment_for_single_eleme
   let values = Source::single(5_u32)
     .split_after_with_cancel_strategy(SubstreamCancelStrategy::Propagate, |_| false)
     .into_source()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![5_u32]]);
 }
 
@@ -1970,8 +1972,8 @@ fn source_split_when_starts_new_segment_with_matching_element() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .split_when(|value| value % 2 == 0)
     .into_source()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32], vec![2_u32, 3_u32], vec![4_u32]]);
 }
 
@@ -1980,21 +1982,28 @@ fn source_split_after_keeps_matching_element_in_current_segment() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4]))
     .split_after(|value| value % 2 == 0)
     .into_source()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32, 2_u32], vec![3_u32, 4_u32]]);
 }
 
 #[test]
 fn source_merge_substreams_flattens_single_segment() {
-  let values = Source::single(5_u32).split_after(|_| true).merge_substreams().collect_values().expect("collect_values");
+  let values = Source::single(5_u32)
+    .split_after(|_| true)
+    .merge_substreams()
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
 fn source_concat_substreams_flattens_single_segment() {
-  let values =
-    Source::single(5_u32).split_after(|_| true).concat_substreams().collect_values().expect("collect_values");
+  let values = Source::single(5_u32)
+    .split_after(|_| true)
+    .concat_substreams()
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -2004,8 +2013,8 @@ fn source_merge_substreams_with_parallelism_flattens_single_segment() {
     .split_after(|_| true)
     .merge_substreams_with_parallelism(2)
     .expect("merge_substreams_with_parallelism")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -2024,7 +2033,7 @@ fn source_group_by_fails_when_unique_key_count_exceeds_limit() {
     .group_by(2, |value: &u32| *value, SubstreamCancelStrategy::default())
     .expect("group_by")
     .merge_substreams()
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::TooManySubstreamsOpen { max_substreams: 2 }));
 }
 
@@ -2055,8 +2064,8 @@ fn source_p2_regression_group_by_merge_substreams_with_delay_and_zip_all() {
     .expect("delay")
     .zip_all(1, 0_u32)
     .expect("zip_all")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![vec![1_u32], vec![2_u32], vec![3_u32]]);
 }
 
@@ -2068,14 +2077,15 @@ fn source_p2_regression_concat_substreams_with_take_within_and_prepend() {
     .expect("take_within")
     .prepend(1)
     .expect("prepend")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![4_u32, 5_u32]);
 }
 
 #[test]
 fn source_map_error_transforms_upstream_failure() {
-  let result = Source::<u32, _>::failed(StreamError::Failed).map_error(|_| StreamError::WouldBlock).collect_values();
+  let result =
+    Source::<u32, _>::failed(StreamError::Failed).map_error(|_| StreamError::WouldBlock).run_with_collect_sink();
   assert_eq!(result, Err(StreamError::WouldBlock));
 }
 
@@ -2086,8 +2096,8 @@ fn source_on_error_continue_resumes_after_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .on_error_continue()
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -2098,8 +2108,8 @@ fn source_on_error_resume_alias_resumes_after_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .on_error_resume()
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -2110,8 +2120,8 @@ fn source_on_error_continue_if_resumes_after_matching_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .on_error_continue_if(|error| matches!(error, StreamError::Failed))
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }
 
@@ -2129,8 +2139,8 @@ fn source_on_error_continue_if_with_invokes_consumer_for_matching_failure() {
       captured.lock().push(error.clone());
     },
   )
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
   assert_eq!(observed.lock().as_slice(), &[StreamError::Failed]);
 }
@@ -2142,8 +2152,8 @@ fn source_on_error_complete_stops_after_matching_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .on_error_complete()
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -2154,15 +2164,17 @@ fn source_on_error_complete_if_stops_on_matching_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .on_error_complete_if(|error| matches!(error, StreamError::Failed))
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
 #[test]
 fn source_recover_replaces_upstream_failure_with_fallback() {
-  let values =
-    Source::<u32, _>::failed(StreamError::Failed).recover(|_| Some(5_u32)).collect_values().expect("collect_values");
+  let values = Source::<u32, _>::failed(StreamError::Failed)
+    .recover(|_| Some(5_u32))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -2173,8 +2185,8 @@ fn source_recover_drops_later_elements_after_upstream_failure() {
     FailureSequenceSourceLogic::new(&[Ok(1_u32), Err(StreamError::Failed), Ok(2_u32)]),
   )
   .recover(|_| Some(5_u32))
-  .collect_values()
-  .expect("collect_values");
+  .run_with_collect_sink()
+  .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 5_u32]);
 }
 
@@ -2182,8 +2194,8 @@ fn source_recover_drops_later_elements_after_upstream_failure() {
 fn source_recover_with_alias_switches_to_recovery_source() {
   let values = Source::<u32, _>::failed(StreamError::Failed)
     .recover_with(|_| Some(Source::from_array([8_u32, 9_u32])))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![8_u32, 9_u32]);
 }
 
@@ -2191,7 +2203,7 @@ fn source_recover_with_alias_switches_to_recovery_source() {
 fn source_recover_with_retries_fails_when_retry_budget_is_exhausted() {
   let result = Source::<u32, _>::failed(StreamError::Failed)
     .recover_with_retries(0, |_| Some(Source::single(5_u32)))
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::Failed));
 }
 
@@ -2210,8 +2222,8 @@ fn source_recover_with_retries_switches_recovery_sources_incrementally() {
         Some(Source::from_array([8_u32, 9_u32]))
       }
     })
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32, 8_u32, 9_u32]);
 }
 
@@ -2224,31 +2236,36 @@ fn source_recover_with_retries_fails_after_consuming_retry_budget() {
         FailureSequenceSourceLogic::new(&[Ok(7_u32), Err(StreamError::Failed)]),
       ))
     })
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::Failed));
 }
 
 #[test]
 fn source_restart_with_backoff_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).restart_source_with_backoff(1, 3).collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).restart_source_with_backoff(1, 3).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
 fn source_on_failures_with_backoff_alias_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).on_failures_with_backoff(1, 3).collect_values().expect("collect_values");
+  let values =
+    Source::single(5_u32).on_failures_with_backoff(1, 3).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
 fn source_with_backoff_alias_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).with_backoff(1, 3).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).with_backoff(1, 3).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
 #[test]
 fn source_with_backoff_and_context_alias_keeps_single_path_behavior() {
-  let values = Source::single(5_u32).with_backoff_and_context(1, 3, "compat").collect_values().expect("collect_values");
+  let values = Source::single(5_u32)
+    .with_backoff_and_context(1, 3, "compat")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -2258,7 +2275,10 @@ fn source_restart_with_settings_keeps_single_path_behavior() {
     .with_random_factor_permille(250)
     .with_max_restarts_within_ticks(16)
     .with_jitter_seed(11);
-  let values = Source::single(5_u32).restart_source_with_settings(settings).collect_values().expect("collect_values");
+  let values = Source::single(5_u32)
+    .restart_source_with_settings(settings)
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -2268,8 +2288,8 @@ fn source_supervision_variants_keep_single_path_behavior() {
     .supervision_stop()
     .supervision_resume()
     .supervision_restart()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -2278,8 +2298,8 @@ fn source_async_preserves_elements_and_order() {
   // detach は deprecated のため、同等の r#async() を使用
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .r#async()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -2287,8 +2307,8 @@ fn source_async_preserves_elements_and_order() {
 fn source_fold_emits_running_accumulation_without_initial() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .fold(0_u32, |acc, value| acc + value)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
 }
 
@@ -2296,13 +2316,13 @@ fn source_fold_emits_running_accumulation_without_initial() {
 fn source_reduce_folds_with_first_element_as_seed() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .reduce(|acc, value| acc + value)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32, 6_u32]);
 }
 
 #[test]
-fn source_lazy_source_persists_error_on_collect_values_failure() {
+fn source_lazy_source_persists_nested_source_failure() {
   let mut logic = LazySourceLogic::<u32, _> {
     factory: Some(|| Source::<u32, StreamNotUsed>::failed(StreamError::Failed)),
     buffer:  VecDeque::new(),
@@ -2310,7 +2330,7 @@ fn source_lazy_source_persists_error_on_collect_values_failure() {
     _pd:     PhantomData,
   };
 
-  // Given: 初回 pull で factory が消費され collect_values が失敗する
+  // Given: 初回 pull で factory が消費され nested source の評価が失敗する
   let first = logic.pull();
   assert!(matches!(first, Err(StreamError::Failed)));
 
@@ -2326,13 +2346,14 @@ fn source_lazy_source_persists_error_on_collect_values_failure() {
 }
 #[test]
 fn source_distinct_removes_duplicate_elements() {
-  let values = Source::from_array([3_u32, 1, 2, 1, 3, 2, 4]).distinct().collect_values().expect("collect_values");
+  let values =
+    Source::from_array([3_u32, 1, 2, 1, 3, 2, 4]).distinct().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32, 1, 2, 4]);
 }
 
 #[test]
 fn source_distinct_on_already_unique_passes_all() {
-  let values = Source::from_array([1_u32, 2, 3]).distinct().collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2, 3]).distinct().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -2340,8 +2361,8 @@ fn source_distinct_on_already_unique_passes_all() {
 fn source_distinct_by_removes_elements_with_duplicate_key() {
   let values = Source::from_array([(1_u32, "a"), (2, "b"), (1, "c"), (3, "d")])
     .distinct_by(|pair: &(u32, &str)| pair.0)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![(1_u32, "a"), (2, "b"), (3, "d")]);
 }
 
@@ -2350,7 +2371,7 @@ fn source_from_graph_creates_source_from_existing_graph() {
   let original = Source::from_array([10_u32, 20, 30]);
   let (graph, mat) = original.into_parts();
   let reconstructed = Source::<u32, StreamNotUsed>::from_graph(graph, mat);
-  let values = reconstructed.collect_values().expect("collect_values");
+  let values = reconstructed.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 20, 30]);
 }
 
@@ -2368,8 +2389,8 @@ fn source_throttle_enforcing_mode_keeps_single_path() {
   let values = Source::single(5_u32)
     .throttle(2, ThrottleMode::Enforcing)
     .expect("throttle")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 
@@ -2379,13 +2400,14 @@ fn source_throttle_enforcing_mode_fails_on_capacity_overflow() {
     .map_concat(|v: Vec<u32>| v)
     .throttle(1, ThrottleMode::Enforcing)
     .expect("throttle")
-    .collect_values();
+    .run_with_collect_sink();
   assert_eq!(result, Err(StreamError::BufferOverflow));
 }
 
 #[test]
 fn source_named_keeps_elements_and_sets_attributes() {
-  let values = Source::from_array([1_u32, 2, 3]).named("test-source").collect_values().expect("collect_values");
+  let values =
+    Source::from_array([1_u32, 2, 3]).named("test-source").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 
   let (graph, _mat) = Source::<u32, StreamNotUsed>::from_array([1_u32, 2]).named("test-source").into_parts();
@@ -2403,7 +2425,9 @@ fn source_with_and_add_attributes_merge_names() {
 
 #[test]
 fn source_from_materializer_creates_source() {
-  let values = Source::from_materializer(|| Source::from_array([10_u32, 20])).collect_values().expect("collect_values");
+  let values = Source::from_materializer(|| Source::from_array([10_u32, 20]))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 20]);
 }
 
@@ -2421,13 +2445,14 @@ fn source_sample_rejects_zero_ticks() {
 
 #[test]
 fn source_debounce_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).debounce(1).expect("debounce").collect_values().expect("collect_values");
+  let values =
+    Source::single(7_u32).debounce(1).expect("debounce").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
 #[test]
 fn source_sample_keeps_single_path_behavior() {
-  let values = Source::single(7_u32).sample(1).expect("sample").collect_values().expect("collect_values");
+  let values = Source::single(7_u32).sample(1).expect("sample").run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -2435,7 +2460,7 @@ fn source_sample_keeps_single_path_behavior() {
 fn combine_empty_returns_empty_source() {
   let sources: Vec<Source<u32, StreamNotUsed>> = Vec::new();
   let combined = Source::combine(sources);
-  let values = combined.collect_values().expect("collect_values");
+  let values = combined.run_with_collect_sink().expect("run_with_collect_sink");
   assert!(values.is_empty());
 }
 
@@ -2443,7 +2468,7 @@ fn combine_empty_returns_empty_source() {
 fn combine_single_source_returns_identity() {
   let sources = vec![Source::from_iterator(vec![1_u32, 2, 3])];
   let combined = Source::combine(sources);
-  let values = combined.collect_values().expect("collect_values");
+  let values = combined.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -2452,7 +2477,7 @@ fn combine_two_sources_merges_all_elements() {
   let s1 = Source::from_iterator(vec![1_u32, 2, 3]);
   let s2 = Source::from_iterator(vec![4_u32, 5, 6]);
   let combined = Source::combine(vec![s1, s2]);
-  let mut values = combined.collect_values().expect("collect_values");
+  let mut values = combined.run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
   assert_eq!(values, vec![1_u32, 2, 3, 4, 5, 6]);
 }
@@ -2463,7 +2488,7 @@ fn combine_three_sources_merges_all_elements() {
   let s2 = Source::from_iterator(vec![2_u32]);
   let s3 = Source::from_iterator(vec![3_u32]);
   let combined = Source::combine(vec![s1, s2, s3]);
-  let mut values = combined.collect_values().expect("collect_values");
+  let mut values = combined.run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
@@ -2473,7 +2498,7 @@ fn combine_mat_merges_two_sources_with_keep_both() {
   let s1: Source<u32, u32> = Source::from_iterator(vec![10_u32, 20]).map_materialized_value(|_| 1_u32);
   let s2: Source<u32, u32> = Source::from_iterator(vec![30_u32, 40]).map_materialized_value(|_| 2_u32);
   let combined: Source<u32, (u32, u32)> = Source::combine_mat(s1, s2, KeepBoth);
-  let mut values = combined.collect_values().expect("collect_values");
+  let mut values = combined.run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
   assert_eq!(values, vec![10_u32, 20, 30, 40]);
 }
@@ -2483,7 +2508,7 @@ fn combine_mat_merges_two_sources_with_keep_left() {
   let s1: Source<u32, u32> = Source::from_iterator(vec![1_u32]).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::from_iterator(vec![2_u32]).map_materialized_value(|_| 20_u32);
   let combined: Source<u32, u32> = Source::combine_mat(s1, s2, KeepLeft);
-  let mut values = combined.collect_values().expect("collect_values");
+  let mut values = combined.run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
   assert_eq!(values, vec![1_u32, 2]);
 }
@@ -2491,16 +2516,20 @@ fn combine_mat_merges_two_sources_with_keep_left() {
 #[test]
 fn merge_prioritized_n_empty_returns_empty_source() {
   let sources: Vec<Source<u32, StreamNotUsed>> = Vec::new();
-  let values =
-    Source::merge_prioritized_n(sources, &[]).expect("merge_prioritized_n").collect_values().expect("collect_values");
+  let values = Source::merge_prioritized_n(sources, &[])
+    .expect("merge_prioritized_n")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert!(values.is_empty());
 }
 
 #[test]
 fn merge_prioritized_n_single_source_returns_identity() {
   let sources = vec![Source::from_iterator(vec![1_u32, 2, 3])];
-  let values =
-    Source::merge_prioritized_n(sources, &[1]).expect("merge_prioritized_n").collect_values().expect("collect_values");
+  let values = Source::merge_prioritized_n(sources, &[1])
+    .expect("merge_prioritized_n")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2, 3]);
 }
 
@@ -2524,8 +2553,8 @@ fn merge_prioritized_n_respects_weighted_round_robin_order() {
 
   let values = Source::merge_prioritized_n(vec![s1, s2], &[3, 1])
     .expect("merge_prioritized_n")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2, 3, 100, 4, 5, 6, 200, 300, 400]);
 }
@@ -2639,7 +2668,7 @@ fn source_zip_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::single(1_u32).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::single(2_u32).map_materialized_value(|_| 20_u32);
 
-  let values = s1.zip_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let values = s1.zip_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![vec![1_u32, 2_u32]]);
 }
@@ -2664,7 +2693,7 @@ fn source_zip_all_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::from_array([1_u32, 2]).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::from_array([3_u32]).map_materialized_value(|_| 20_u32);
 
-  let values = s1.zip_all_mat(s2, 0_u32, KeepLeft).collect_values().expect("collect_values");
+  let values = s1.zip_all_mat(s2, 0_u32, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![vec![1_u32, 3_u32], vec![2_u32, 0_u32]]);
 }
@@ -2692,8 +2721,8 @@ fn source_zip_with_mat_preserves_data_path_behavior() {
 
   let values = s1
     .zip_with_mat(s2, |values: Vec<u32>| values.into_iter().sum::<u32>(), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![30_u32]);
 }
@@ -2718,7 +2747,7 @@ fn source_zip_latest_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::single(1_u32).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::single(2_u32).map_materialized_value(|_| 20_u32);
 
-  let values = s1.zip_latest_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let values = s1.zip_latest_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![vec![1_u32, 2_u32]]);
 }
@@ -2746,8 +2775,8 @@ fn source_zip_latest_with_mat_preserves_data_path_behavior() {
 
   let values = s1
     .zip_latest_with_mat(s2, |values: Vec<u32>| values.into_iter().sum::<u32>(), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![30_u32]);
 }
@@ -2772,7 +2801,7 @@ fn source_merge_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::single(7_u32).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::single(8_u32).map_materialized_value(|_| 20_u32);
 
-  let mut values = s1.merge_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let mut values = s1.merge_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
 
   assert_eq!(values, vec![7_u32, 8_u32]);
@@ -2798,7 +2827,7 @@ fn source_merge_latest_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::single(7_u32).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::single(8_u32).map_materialized_value(|_| 20_u32);
 
-  let values = s1.merge_latest_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let values = s1.merge_latest_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
 
   // merge_latest emits Vec of latest values from all inputs
   assert!(!values.is_empty());
@@ -2824,7 +2853,7 @@ fn source_merge_preferred_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::single(7_u32).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::single(8_u32).map_materialized_value(|_| 20_u32);
 
-  let mut values = s1.merge_preferred_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let mut values = s1.merge_preferred_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
 
   assert_eq!(values, vec![7_u32, 8_u32]);
@@ -2850,7 +2879,7 @@ fn source_merge_prioritized_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::single(7_u32).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::single(8_u32).map_materialized_value(|_| 20_u32);
 
-  let mut values = s1.merge_prioritized_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let mut values = s1.merge_prioritized_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
 
   assert_eq!(values, vec![7_u32, 8_u32]);
@@ -2876,7 +2905,7 @@ fn source_merge_sorted_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::from_array([1_u32, 3, 5]).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::from_array([2_u32, 4, 6]).map_materialized_value(|_| 20_u32);
 
-  let values = s1.merge_sorted_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let values = s1.merge_sorted_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2, 3, 4, 5, 6]);
 }
@@ -2901,7 +2930,7 @@ fn source_concat_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::from_array([1_u32, 2]).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::from_array([3_u32, 4]).map_materialized_value(|_| 20_u32);
 
-  let values = s1.concat_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let values = s1.concat_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2, 3, 4]);
 }
@@ -2926,7 +2955,7 @@ fn source_prepend_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::from_array([3_u32, 4]).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::from_array([1_u32, 2]).map_materialized_value(|_| 20_u32);
 
-  let values = s1.prepend_mat(s2, KeepLeft).collect_values().expect("collect_values");
+  let values = s1.prepend_mat(s2, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2, 3, 4]);
 }
@@ -2951,7 +2980,7 @@ fn source_interleave_mat_preserves_data_path_behavior() {
   let s1: Source<u32, u32> = Source::from_array([1_u32, 3]).map_materialized_value(|_| 10_u32);
   let s2: Source<u32, u32> = Source::from_array([2_u32, 4]).map_materialized_value(|_| 20_u32);
 
-  let mut values = s1.interleave_mat(s2, 1, KeepLeft).collect_values().expect("collect_values");
+  let mut values = s1.interleave_mat(s2, 1, KeepLeft).run_with_collect_sink().expect("run_with_collect_sink");
   values.sort();
 
   assert_eq!(values, vec![1_u32, 2, 3, 4]);
@@ -2987,8 +3016,8 @@ fn source_flat_map_prefix_mat_preserves_data_path_behavior() {
 
   let values = source
     .flat_map_prefix_mat(1, |_prefix: Vec<u32>| Flow::<u32, u32, StreamNotUsed>::new(), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // flat_map_prefix consumes prefix (1 element), then passes rest through the inner flow
   assert_eq!(values, vec![2_u32, 3]);
@@ -3000,7 +3029,7 @@ fn source_flat_map_prefix_mat_preserves_data_path_behavior() {
 fn source_async_passes_single_element_through() {
   // Given: a source emitting a single element
   // When: applying an async boundary on the source
-  let values = Source::single(5_u32).r#async().collect_values().expect("collect_values");
+  let values = Source::single(5_u32).r#async().run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: the element is forwarded unchanged
   assert_eq!(values, vec![5_u32]);
@@ -3009,7 +3038,8 @@ fn source_async_passes_single_element_through() {
 #[test]
 fn source_async_passes_multiple_elements_through() {
   // Given: a source emitting multiple elements
-  let values = Source::from_array([1_u32, 2, 3, 4, 5]).r#async().collect_values().expect("collect_values");
+  let values =
+    Source::from_array([1_u32, 2, 3, 4, 5]).r#async().run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: all elements arrive in order
   assert_eq!(values, vec![1_u32, 2, 3, 4, 5]);
@@ -3018,7 +3048,7 @@ fn source_async_passes_multiple_elements_through() {
 #[test]
 fn source_async_handles_empty_source() {
   // Given: an empty source
-  let values = Source::<u32, _>::empty().r#async().collect_values().expect("collect_values");
+  let values = Source::<u32, _>::empty().r#async().run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: no elements are emitted, stream completes normally
   assert!(values.is_empty());
@@ -3032,8 +3062,8 @@ fn source_async_composes_with_via() {
   let values = Source::from_array([10_u32, 20, 30])
     .r#async()
     .via(Flow::new().map(|x: u32| x + 1))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: async boundary + map compose correctly
   assert_eq!(values, vec![11_u32, 21, 31]);
@@ -3042,7 +3072,8 @@ fn source_async_composes_with_via() {
 #[test]
 fn source_async_chained_multiple_boundaries() {
   // Given: a source with two chained async boundaries
-  let values = Source::from_array([1_u32, 2, 3]).r#async().r#async().collect_values().expect("collect_values");
+  let values =
+    Source::from_array([1_u32, 2, 3]).r#async().r#async().run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: elements pass through both boundaries in order
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -3107,8 +3138,11 @@ fn source_async_with_dispatcher_marks_node_with_dispatcher_attribute() {
 #[test]
 fn source_also_to_passes_main_path_elements_through() {
   // Given: single-element source に also_to(Sink::ignore) を装着
-  let values =
-    Source::single(1_u32).map(|value: u32| value + 1).also_to(Sink::ignore()).collect_values().expect("collect_values");
+  let values = Source::single(1_u32)
+    .map(|value: u32| value + 1)
+    .also_to(Sink::ignore())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path では変換後の値が保持される
   assert_eq!(values, vec![2_u32]);
@@ -3131,8 +3165,8 @@ fn source_also_to_mat_keeps_main_path_behavior() {
   let values = Source::single(1_u32)
     .map(|value: u32| value + 1)
     .also_to_mat(Sink::ignore(), KeepBoth)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path は map 後の値を出す
   assert_eq!(values, vec![2_u32]);
@@ -3169,7 +3203,8 @@ fn source_also_to_mat_routes_elements_to_side_sink() {
 fn source_also_to_all_passes_main_path_elements_through() {
   // Given: also_to_all で 2 本の sink を接続
   let sinks: Vec<Sink<u32, StreamCompletion<StreamDone>>> = alloc::vec![Sink::ignore(), Sink::ignore()];
-  let values = Source::from_array([3_u32, 4_u32]).also_to_all(sinks).collect_values().expect("collect_values");
+  let values =
+    Source::from_array([3_u32, 4_u32]).also_to_all(sinks).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: main path は元の値をそのまま出す
   assert_eq!(values, vec![3_u32, 4_u32]);
@@ -3190,7 +3225,8 @@ fn source_also_to_all_multiple_sinks_each_receive_elements_exactly_once() {
     Sink::foreach(move |value: u32| second_clone.lock().push(value)),
     Sink::foreach(move |value: u32| third_clone.lock().push(value)),
   ];
-  let values = Source::from_array([10_u32, 20_u32]).also_to_all(sinks).collect_values().expect("collect_values");
+  let values =
+    Source::from_array([10_u32, 20_u32]).also_to_all(sinks).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: main path と 3 つの side sink がそれぞれ重複なく全要素を 1 回だけ受け取る
   assert_eq!(values, vec![10_u32, 20_u32]);
@@ -3215,8 +3251,8 @@ fn source_divert_to_routes_matching_and_passes_rest() {
         diverted_ref.lock().push(value);
       }),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path は奇数、divert 側は偶数を受け取る
   assert_eq!(values, vec![1_u32, 3_u32]);
@@ -3249,8 +3285,8 @@ fn source_divert_to_mat_preserves_main_path_behavior() {
       Sink::<u32, StreamCompletion<StreamDone>>::ignore().map_materialized_value(|_| 1_u32),
       KeepLeft,
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path は奇数のみ
   assert_eq!(values, vec![1_u32, 3_u32]);
@@ -3263,8 +3299,10 @@ fn source_divert_to_mat_preserves_main_path_behavior() {
 #[test]
 fn source_or_else_uses_secondary_when_primary_is_empty() {
   // Given: 空の primary + 非空の secondary
-  let values =
-    Source::<u32, _>::empty().or_else(Source::from_array([5_u32, 6_u32])).collect_values().expect("collect_values");
+  let values = Source::<u32, _>::empty()
+    .or_else(Source::from_array([5_u32, 6_u32]))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: secondary の値が出る
   assert_eq!(values, vec![5_u32, 6_u32]);
@@ -3275,8 +3313,8 @@ fn source_or_else_ignores_secondary_when_primary_emits() {
   // Given: 非空 primary + 非空 secondary
   let values = Source::from_array([7_u32, 8_u32])
     .or_else(Source::from_array([1_u32, 2_u32]))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: primary の値のみ
   assert_eq!(values, vec![7_u32, 8_u32]);
@@ -3300,8 +3338,8 @@ fn source_or_else_mat_preserves_main_path_behavior() {
   // Given: empty primary + 非空 secondary + KeepLeft
   let values = Source::<u32, _>::empty()
     .or_else_mat(Source::from_array([5_u32, 6_u32]).map_materialized_value(|_| 77_u32), KeepLeft)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: secondary の要素が流れる
   assert_eq!(values, vec![5_u32, 6_u32]);
@@ -3314,7 +3352,7 @@ fn source_or_else_mat_preserves_main_path_behavior() {
 #[test]
 fn source_watch_termination_passes_elements_through() {
   // Given: single-element source に watch_termination を装着
-  let values = Source::single(42_u32).watch_termination().collect_values().expect("collect_values");
+  let values = Source::single(42_u32).watch_termination().run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: 要素は透過される
   assert_eq!(values, vec![42_u32]);
@@ -3341,8 +3379,8 @@ fn source_aggregate_with_boundary_emits_fixed_size_chunks() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3, 4, 5]))
     .aggregate_with_boundary(2)
     .expect("aggregate_with_boundary")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: batch と同じく size=2 の Vec チャンクで出力される（残余を含む）
   assert_eq!(values, vec![vec![1_u32, 2_u32], vec![3_u32, 4_u32], vec![5_u32]]);
@@ -3367,8 +3405,8 @@ fn source_batch_weighted_uses_weight_budget() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[2, 1, 2]))
     .batch_weighted(3, |value| *value as usize)
     .expect("batch_weighted")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: weight 合計が 3 を超えない範囲で詰めて出力される
   assert_eq!(values, vec![vec![2_u32, 1_u32], vec![2_u32]]);
@@ -3391,8 +3429,8 @@ fn source_conflate_preserves_elements_when_upstream_is_not_bursty() {
   // Given: 非バースティな入力 [1, 2, 3] に conflate を装着
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .conflate(|acc, value| acc + value)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 集約は発生せず、各要素がそのまま流れる（Flow 側等価テスト準拠）
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3404,8 +3442,8 @@ fn source_conflate_aggregates_bursty_upstream_values() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .map_concat(|value: u32| alloc::vec![value, value.saturating_mul(10)])
     .conflate(|acc, value| acc + value)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 同一バースト内の値が合算される（1+10=11, 2+20=22）
   assert_eq!(values, vec![11_u32, 22_u32]);
@@ -3416,8 +3454,8 @@ fn source_conflate_with_seed_applies_seed_and_aggregate() {
   // Given: 非バースティな入力 [1, 2, 3] に conflate_with_seed(+10, +) を装着
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .conflate_with_seed(|value| value + 10, |acc, value| acc + value)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 各要素は seed のみ適用され（+10）、集約は発生しない
   assert_eq!(values, vec![11_u32, 12_u32, 13_u32]);
@@ -3429,8 +3467,8 @@ fn source_conflate_with_seed_aggregates_bursty_upstream_values() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .map_concat(|value: u32| alloc::vec![value, value.saturating_mul(10)])
     .conflate_with_seed(|value| value + 100, |acc, value| acc + value)
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 各バーストの先頭に seed を適用し、後続を集約する（101+10=111, 102+20=122）
   assert_eq!(values, vec![111_u32, 122_u32]);
@@ -3441,8 +3479,8 @@ fn source_expand_emits_initial_values_for_each_input() {
   // Given: 各値を [v, v*10] に展開する expand を装着
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .expand(|value: &u32| alloc::vec![*value, value.saturating_mul(10)])
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: idle が無い場合は各入力の先頭値のみが出力される（Flow 側
   // expand_and_extrapolate_share_expand_behavior 準拠）
@@ -3454,12 +3492,12 @@ fn source_extrapolate_shares_expand_behavior() {
   // Given: 同一入力に対して expand と extrapolate を別々に適用
   let expand_values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .expand(|value: &u32| alloc::vec![*value, value.saturating_mul(10)])
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   let extrapolate_values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2]))
     .extrapolate(|value: &u32| alloc::vec![*value, value.saturating_mul(10)])
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: extrapolate は expand と同一挙動（Flow 側等価テスト準拠）
   assert_eq!(expand_values, vec![1_u32, 2_u32]);
@@ -3484,8 +3522,8 @@ fn source_backpressure_timeout_keeps_single_path_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .backpressure_timeout(100)
     .expect("backpressure_timeout")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 全要素がそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3511,8 +3549,8 @@ fn source_completion_timeout_keeps_single_path_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .completion_timeout(100)
     .expect("completion_timeout")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 全要素がそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3538,8 +3576,8 @@ fn source_idle_timeout_keeps_single_path_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .idle_timeout(100)
     .expect("idle_timeout")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 全要素がそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3565,8 +3603,8 @@ fn source_initial_timeout_keeps_single_path_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .initial_timeout(100)
     .expect("initial_timeout")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 全要素がそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3592,8 +3630,8 @@ fn source_keep_alive_keeps_single_path_behavior() {
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .keep_alive(100, 0_u32)
     .expect("keep_alive")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: idle が発生しない場合、元の 3 要素がそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3624,8 +3662,8 @@ fn source_wire_tap_observes_each_element_without_altering_data_path() {
     .wire_tap(move |value| {
       observed_clone.lock().push(*value);
     })
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: main path は変更されず、tap も全要素を観測する
   assert_eq!(values, vec![10_u32, 20_u32, 30_u32]);
@@ -3637,7 +3675,8 @@ fn source_wire_tap_observes_each_element_without_altering_data_path() {
 #[test]
 fn source_monitor_emits_indexed_pairs_for_each_element() {
   // Given: 3 要素シーケンスに monitor を適用
-  let values = Source::from_array([100_u32, 200_u32, 300_u32]).monitor().collect_values().expect("collect_values");
+  let values =
+    Source::from_array([100_u32, 200_u32, 300_u32]).monitor().run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: 各要素に 0 始まりのインデックスが付与され (index, value) タプルが流れる
   assert_eq!(values, vec![(0_u64, 100_u32), (1_u64, 200_u32), (2_u64, 300_u32)]);
@@ -3650,8 +3689,8 @@ fn source_log_passes_elements_through_unchanged() {
   // Given: 3 要素シーケンスに log を適用
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .log("source-log")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 全要素がそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3690,8 +3729,8 @@ fn source_log_with_marker_passes_elements_through_unchanged() {
   // Given: 3 要素シーケンスに log_with_marker を適用
   let values = Source::<u32, _>::from_logic(StageKind::Custom, SequenceSourceLogic::new(&[1, 2, 3]))
     .log_with_marker("source-log", "marker")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 全要素がそのまま通過する
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
@@ -3723,8 +3762,8 @@ fn source_switch_map_emits_inner_source_values_for_each_outer_element() {
   let values = Source::from_array([1_u32, 2_u32])
     .switch_map(|value: u32| Source::single(value.saturating_mul(10)))
     .expect("switch_map")
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 各外側要素の内側 Source の値が順番に流れる
   assert_eq!(values, vec![10_u32, 20_u32]);
@@ -3735,7 +3774,11 @@ fn source_switch_map_emits_inner_source_values_for_each_outer_element() {
 #[test]
 fn source_merge_latest_wraps_single_path_value_into_vec() {
   // Given: fan_in=1 の merge_latest を single Source に適用
-  let values = Source::single(7_u32).merge_latest(1).expect("merge_latest").collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .merge_latest(1)
+    .expect("merge_latest")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 単一要素が Vec でラップされて流れる（Flow 側等価テスト準拠）
   assert_eq!(values, vec![vec![7_u32]]);
@@ -3758,8 +3801,11 @@ fn source_merge_latest_rejects_zero_fan_in() {
 #[test]
 fn source_merge_preferred_keeps_single_path_behavior() {
   // Given: fan_in=1 の merge_preferred を single Source に適用
-  let values =
-    Source::single(7_u32).merge_preferred(1).expect("merge_preferred").collect_values().expect("collect_values");
+  let values = Source::single(7_u32)
+    .merge_preferred(1)
+    .expect("merge_preferred")
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // Then: 単一要素がそのまま流れる（Flow 側等価テスト準拠）
   assert_eq!(values, vec![7_u32]);

--- a/modules/stream-core/src/core/dsl/source/tests.rs
+++ b/modules/stream-core/src/core/dsl/source/tests.rs
@@ -20,7 +20,7 @@ use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use super::{
   CycleSourceLogic, IterateSourceLogic, LazySourceLogic, QueueSourceLogic, QueueWithOverflowSourceLogic,
-  RepeatSourceLogic, UnboundedQueueSourceLogic,
+  RepeatSourceLogic, StreamGraph, UnboundedQueueSourceLogic,
 };
 use crate::core::{
   BoundedSourceQueue, DynValue, OverflowStrategy, QueueOfferResult, RestartConfig, SharedKillSwitch, SourceLogic,
@@ -233,6 +233,24 @@ impl<T: Unpin> Future for YieldThenOutputFuture<T> {
     } else {
       Poll::Ready(this.value.take().expect("future value"))
     }
+  }
+}
+
+struct NeverReadyFuture<T> {
+  _pd: PhantomData<fn() -> T>,
+}
+
+impl<T> NeverReadyFuture<T> {
+  const fn new() -> Self {
+    Self { _pd: PhantomData }
+  }
+}
+
+impl<T> Future for NeverReadyFuture<T> {
+  type Output = T;
+
+  fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+    Poll::Pending
   }
 }
 
@@ -817,6 +835,42 @@ fn source_lazy_source_with_mapped_source_emits_transformed() {
     .run_with_collect_sink()
     .expect("run_with_collect_sink");
   assert_eq!(values, vec![10_u32, 20, 30]);
+}
+
+#[test]
+fn source_lazy_source_collects_all_values_from_nested_broadcast() {
+  let values = Source::lazy_source(|| Source::single(7_u32).broadcast(2).expect("broadcast"))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
+  assert_eq!(values, vec![7_u32, 7_u32]);
+}
+
+#[test]
+fn source_lazy_source_retries_single_island_until_nested_future_is_ready() {
+  let values = Source::lazy_source(|| Source::future(YieldThenOutputFuture::new(12_u32)))
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
+  assert_eq!(values, vec![12_u32]);
+}
+
+#[test]
+fn source_lazy_source_returns_would_block_for_never_ready_single_island_future() {
+  let result = Source::lazy_source(|| Source::future(NeverReadyFuture::<u32>::new())).run_with_collect_sink();
+  assert_eq!(result, Err(StreamError::WouldBlock));
+}
+
+#[test]
+fn source_lazy_source_drains_multi_island_nested_source_until_ready() {
+  let values = Source::lazy_source(|| Source::future(YieldThenOutputFuture::new(21_u32)).r#async())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
+  assert_eq!(values, vec![21_u32]);
+}
+
+#[test]
+fn source_lazy_source_returns_would_block_for_never_ready_multi_island_future() {
+  let result = Source::lazy_source(|| Source::future(NeverReadyFuture::<u32>::new()).r#async()).run_with_collect_sink();
+  assert_eq!(result, Err(StreamError::WouldBlock));
 }
 
 #[test]
@@ -2344,6 +2398,14 @@ fn source_lazy_source_persists_nested_source_failure() {
   // Then: エラー状態が永続化されリスタートも失敗する
   assert!(matches!(restart, Err(StreamError::Failed)));
 }
+
+#[test]
+fn drain_source_for_lazy_source_rejects_graph_without_tail_outlet() {
+  let source = Source::<u32, StreamNotUsed>::from_graph(StreamGraph::new(), StreamNotUsed::new());
+  let result = super::drain_source_for_lazy_source(source);
+  assert_eq!(result, Err(StreamError::InvalidConnection));
+}
+
 #[test]
 fn source_distinct_removes_duplicate_elements() {
   let values =

--- a/modules/stream-core/src/core/dsl/source_group_by_sub_flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/source_group_by_sub_flow/tests.rs
@@ -1,6 +1,6 @@
 use crate::core::{
   SubstreamCancelStrategy,
-  dsl::{Sink, Source},
+  dsl::{Sink, Source, tests::RunWithCollectSink},
 };
 
 #[test]
@@ -9,8 +9,8 @@ fn source_group_by_sub_flow_merge_substreams_preserves_repeated_keys() {
     .group_by(2, |value: &u32| value % 2, SubstreamCancelStrategy::default())
     .expect("group_by")
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   values.sort_unstable();
   assert_eq!(values, vec![1_u32, 2, 3, 4, 5]);
 }
@@ -34,8 +34,8 @@ fn source_group_by_sub_flow_map_transforms_values_preserving_keys() {
     .expect("group_by")
     .map(|value| value * 10)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 全要素が10倍される（順序は不定のためソート）
   values.sort_unstable();
@@ -50,8 +50,8 @@ fn source_group_by_sub_flow_filter_removes_values_preserving_keys() {
     .expect("group_by")
     .filter(|value| value % 2 == 0)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 偶数のみが残る（順序は不定のためソート）
   values.sort_unstable();
@@ -67,8 +67,8 @@ fn source_group_by_sub_flow_map_then_filter_chains_correctly() {
     .map(|value| value * 10)
     .filter(|value| value % 20 == 0)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 偶数の10倍（20, 40）のみが20の倍数として残る
   values.sort_unstable();

--- a/modules/stream-core/src/core/dsl/source_sub_flow/tests.rs
+++ b/modules/stream-core/src/core/dsl/source_sub_flow/tests.rs
@@ -4,7 +4,7 @@ use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
 
 use super::SourceSubFlow;
 use crate::core::{
-  dsl::{Sink, Source},
+  dsl::{Sink, Source, tests::RunWithCollectSink},
   r#impl::{
     fusing::StreamBufferConfig,
     materialization::{Stream, StreamState},
@@ -41,14 +41,21 @@ fn run_to_completion<Mat>(graph: RunnableGraph<Mat>) {
 
 #[test]
 fn source_sub_flow_merge_substreams_flattens_segment() {
-  let values = Source::single(1_u32).split_after(|_| true).merge_substreams().collect_values().expect("collect_values");
+  let values = Source::single(1_u32)
+    .split_after(|_| true)
+    .merge_substreams()
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
 #[test]
 fn source_sub_flow_concat_substreams_flattens_segment() {
-  let values =
-    Source::single(1_u32).split_after(|_| true).concat_substreams().collect_values().expect("collect_values");
+  let values = Source::single(1_u32)
+    .split_after(|_| true)
+    .concat_substreams()
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32]);
 }
 
@@ -59,8 +66,8 @@ fn source_sub_flow_map_and_filter_delegate_to_inner_substreams() {
     .map(|value| value * 10)
     .filter(|value| value % 20 == 0)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![20_u32, 40_u32]);
 }
 
@@ -71,8 +78,8 @@ fn source_sub_flow_take_and_drop_scope_to_each_substream() {
     .drop(1)
     .take(1)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4_u32]);
 }
 
@@ -83,8 +90,8 @@ fn source_sub_flow_take_while_and_drop_while_scope_to_each_substream() {
     .drop_while(|value| value % 2 == 1)
     .take_while(|value| *value <= 4)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4_u32]);
 }
 
@@ -100,8 +107,8 @@ fn source_sub_flow_map_clones_stateful_mapper_per_substream() {
       }
     })
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![11_u32, 22_u32, 13_u32, 24_u32]);
 }
 
@@ -117,8 +124,8 @@ fn source_sub_flow_take_while_clones_stateful_predicate_per_substream() {
       }
     })
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 3_u32]);
 }
 

--- a/modules/stream-core/src/core/dsl/tail_source.rs
+++ b/modules/stream-core/src/core/dsl/tail_source.rs
@@ -1,8 +1,6 @@
-use alloc::vec::Vec;
-
 use fraktor_utils_core_rs::core::sync::SpinSyncMutex;
 
-use super::{StreamError, StreamNotUsed, source::Source};
+use super::{StreamNotUsed, source::Source};
 
 #[cfg(test)]
 mod tests;
@@ -24,14 +22,5 @@ where
   #[must_use]
   pub fn into_source(self) -> Source<Out, StreamNotUsed> {
     self.inner.into_inner()
-  }
-
-  /// Collects all remaining tail elements.
-  ///
-  /// # Errors
-  ///
-  /// Returns [`StreamError`] when source execution fails.
-  pub fn collect_values(self) -> Result<Vec<Out>, StreamError> {
-    self.into_source().collect_values()
   }
 }

--- a/modules/stream-core/src/core/dsl/tail_source/tests.rs
+++ b/modules/stream-core/src/core/dsl/tail_source/tests.rs
@@ -1,9 +1,9 @@
-use crate::core::dsl::{Source, TailSource};
+use crate::core::dsl::{Source, TailSource, tests::RunWithCollectSink};
 
 #[test]
 fn tail_source_collects_wrapped_values() {
   let tail_source = TailSource::new(Source::from_array([1_u32, 2, 3]));
-  let values = tail_source.collect_values().expect("collect_values");
+  let values = tail_source.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32]);
 }
 
@@ -11,6 +11,6 @@ fn tail_source_collects_wrapped_values() {
 fn tail_source_into_source_returns_underlying_source() {
   let tail_source = TailSource::new(Source::single(7_u32));
   let source = tail_source.into_source();
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }

--- a/modules/stream-core/src/core/dsl/tests.rs
+++ b/modules/stream-core/src/core/dsl/tests.rs
@@ -1,4 +1,5 @@
 use alloc::vec::Vec;
+use std::thread;
 
 use super::{RunnableGraph, Sink, Source, TailSource};
 use crate::core::{
@@ -33,6 +34,7 @@ impl TestMaterializer {
       } else if idle_budget == 0 {
         return Err(StreamError::WouldBlock);
       } else {
+        thread::yield_now();
         idle_budget = idle_budget.saturating_sub(1);
       }
     }

--- a/modules/stream-core/src/core/dsl/tests.rs
+++ b/modules/stream-core/src/core/dsl/tests.rs
@@ -1,0 +1,112 @@
+use alloc::vec::Vec;
+
+use super::{RunnableGraph, Sink, Source, TailSource};
+use crate::core::{
+  StreamError,
+  r#impl::{
+    fusing::StreamBufferConfig,
+    interpreter::{DEFAULT_BOUNDARY_CAPACITY, IslandBoundaryShared, IslandSplitter},
+    materialization::{Stream, StreamHandleId, StreamHandleImpl, StreamShared},
+  },
+  materialization::{DriveOutcome, Materialized, Materializer},
+};
+
+#[derive(Default)]
+struct TestMaterializer {
+  handles: Vec<StreamHandleImpl>,
+}
+
+impl TestMaterializer {
+  const DRIVE_LIMIT: usize = 4096;
+
+  fn drive_until_terminal(&self) -> Result<(), StreamError> {
+    let mut idle_budget = Self::DRIVE_LIMIT;
+    while self.handles.iter().any(|handle| !handle.state().is_terminal()) {
+      let mut progressed = false;
+      for handle in &self.handles {
+        if !handle.state().is_terminal() && matches!(handle.drive(), DriveOutcome::Progressed) {
+          progressed = true;
+        }
+      }
+      if progressed {
+        idle_budget = Self::DRIVE_LIMIT;
+      } else if idle_budget == 0 {
+        return Err(StreamError::WouldBlock);
+      } else {
+        idle_budget = idle_budget.saturating_sub(1);
+      }
+    }
+    Ok(())
+  }
+}
+
+impl Materializer for TestMaterializer {
+  fn start(&mut self) -> Result<(), StreamError> {
+    Ok(())
+  }
+
+  fn materialize<Mat>(&mut self, graph: RunnableGraph<Mat>) -> Result<Materialized<Mat>, StreamError> {
+    let (plan, materialized) = graph.into_parts();
+    let island_plan = IslandSplitter::split(plan);
+
+    if island_plan.islands().len() <= 1 {
+      let mut stream = Stream::new(island_plan.into_single_plan(), StreamBufferConfig::default());
+      stream.start()?;
+      let handle = StreamHandleImpl::new(StreamHandleId::next(), StreamShared::new(stream));
+      self.handles.push(handle.clone());
+      return Ok(Materialized::new(handle, materialized));
+    }
+
+    let (mut islands, crossings) = island_plan.into_parts();
+    for crossing in crossings {
+      let upstream_idx = crossing.from_island().as_usize();
+      let downstream_idx = crossing.to_island().as_usize();
+      let boundary_capacity = islands[downstream_idx]
+        .input_buffer_capacity_for_inlet(crossing.to_port())
+        .unwrap_or(DEFAULT_BOUNDARY_CAPACITY);
+      let boundary = IslandBoundaryShared::new(boundary_capacity);
+      islands[upstream_idx].add_boundary_sink(boundary.clone(), crossing.from_port(), crossing.element_type());
+      islands[downstream_idx].add_boundary_source(boundary, crossing.to_port(), crossing.element_type());
+    }
+
+    let mut handles = Vec::with_capacity(islands.len());
+    for island in islands {
+      let mut stream = Stream::new(island.into_stream_plan(), StreamBufferConfig::default());
+      stream.start()?;
+      handles.push(StreamHandleImpl::new(StreamHandleId::next(), StreamShared::new(stream)));
+    }
+
+    let handle = handles.first().cloned().ok_or(StreamError::Failed)?;
+    self.handles.extend(handles);
+    Ok(Materialized::new(handle, materialized))
+  }
+
+  fn shutdown(&mut self) -> Result<(), StreamError> {
+    Ok(())
+  }
+}
+
+pub(crate) trait RunWithCollectSink<Out> {
+  fn run_with_collect_sink(self) -> Result<Vec<Out>, StreamError>;
+}
+
+impl<Out, Mat> RunWithCollectSink<Out> for Source<Out, Mat>
+where
+  Out: Send + Sync + 'static,
+{
+  fn run_with_collect_sink(self) -> Result<Vec<Out>, StreamError> {
+    let mut materializer = TestMaterializer::default();
+    let materialized = self.run_with(Sink::collect(), &mut materializer)?;
+    materializer.drive_until_terminal()?;
+    materialized.materialized().try_take().unwrap_or(Err(StreamError::Failed))
+  }
+}
+
+impl<Out> RunWithCollectSink<Out> for TailSource<Out>
+where
+  Out: Send + Sync + 'static,
+{
+  fn run_with_collect_sink(self) -> Result<Vec<Out>, StreamError> {
+    self.into_source().run_with_collect_sink()
+  }
+}

--- a/modules/stream-core/tests/async_island.rs
+++ b/modules/stream-core/tests/async_island.rs
@@ -6,11 +6,13 @@
 //! NOTE: These tests will not compile until the production implementation is in place.
 //! They define the expected behavioral contract for Gate 0.
 
+mod support;
 use fraktor_stream_core_rs::core::{
   attributes::Attributes,
   dsl::{Flow, Source},
   materialization::StreamNotUsed,
 };
+use support::RunWithCollectSink;
 
 // --- アイランド境界を越える基本的な要素通過 ---
 
@@ -19,7 +21,8 @@ fn async_island_passes_single_element() {
   // 準備: 単一要素の source と async boundary
   // async boundary はグラフを2つのアイランドに分割するが、
   // 観測可能な振る舞いは boundary なしと同一。
-  let values = Source::single(42_u32).via(Flow::new().r#async()).collect_values().expect("collect_values");
+  let values =
+    Source::single(42_u32).via(Flow::new().r#async()).run_with_collect_sink().expect("run_with_collect_sink");
 
   // 検証: 要素が通過する
   assert_eq!(values, vec![42_u32]);
@@ -31,8 +34,8 @@ fn async_island_passes_large_sequence() {
   let input: Vec<u32> = (0..100).collect();
   let values = Source::from_iterator(input.clone().into_iter())
     .via(Flow::new().r#async())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 全要素が順序通りに到着する
   assert_eq!(values, input);
@@ -47,8 +50,8 @@ fn two_async_boundaries_create_three_islands() {
   let values = Source::from_iterator(input.clone().into_iter())
     .via(Flow::new().map(|x: u32| x * 2).r#async())
     .via(Flow::new().map(|x: u32| x + 1).r#async())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 両方の変換が適用され、要素が順序通りに到着する
   let expected: Vec<u32> = (1..=10).map(|x| x * 2 + 1).collect();
@@ -63,8 +66,8 @@ fn async_with_attributes_passes_elements() {
   // Pekko のアプローチを模倣: async() は属性を追加するだけ
   let values = Source::from_iterator(vec![1_u32, 2, 3].into_iter())
     .via(Flow::new().add_attributes(Attributes::async_boundary()))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 要素が正しく通過する
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -76,8 +79,8 @@ fn async_with_dispatcher_attribute_passes_elements() {
   let attrs = Attributes::async_boundary().and(Attributes::dispatcher("custom-dispatcher"));
   let values = Source::from_iterator(vec![1_u32, 2, 3].into_iter())
     .via(Flow::new().add_attributes(attrs))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 要素が正しく通過する（dispatcher は materializer が使用）
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -89,8 +92,8 @@ fn async_with_input_buffer_attribute_passes_elements() {
   let attrs = Attributes::async_boundary().and(Attributes::dispatcher("default")).and(Attributes::input_buffer(32, 32));
   let values = Source::from_iterator(vec![1_u32, 2, 3].into_iter())
     .via(Flow::new().add_attributes(attrs))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 設定されたバッファサイズで要素が通過する
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -103,8 +106,8 @@ fn async_island_propagates_normal_completion() {
   // 準備: async boundary を通る有限 source
   let values = Source::from_iterator(vec![1_u32, 2].into_iter())
     .via(Flow::new().r#async())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 全要素出力後にストリームが正常完了する
   assert_eq!(values, vec![1_u32, 2]);
@@ -113,8 +116,10 @@ fn async_island_propagates_normal_completion() {
 #[test]
 fn async_island_empty_source_completes() {
   // 準備: async boundary を通る空 source
-  let values =
-    Source::<u32, StreamNotUsed>::empty().via(Flow::new().r#async()).collect_values().expect("collect_values");
+  let values = Source::<u32, StreamNotUsed>::empty()
+    .via(Flow::new().r#async())
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 要素なしでストリームが完了する
   assert!(values.is_empty());
@@ -129,8 +134,8 @@ fn async_island_with_filter_and_map() {
     .via(Flow::new().filter(|x: &u32| x % 2 == 0))
     .via(Flow::new().r#async())
     .via(Flow::new().map(|x: u32| x * 10))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: filter はアイランド1で、map はアイランド2で実行される
   assert_eq!(values, vec![20_u32, 40, 60, 80, 100]);
@@ -142,8 +147,8 @@ fn async_island_with_take() {
   let values = Source::from_iterator((1_u32..=100).into_iter())
     .via(Flow::new().r#async())
     .via(Flow::new().take(3))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: 最初の3要素のみが取得される
   assert_eq!(values, vec![1_u32, 2, 3]);
@@ -155,8 +160,8 @@ fn async_island_with_grouped() {
   let values = Source::from_iterator((1_u32..=6).into_iter())
     .via(Flow::new().r#async())
     .via(Flow::new().grouped(2).expect("grouped"))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   // 検証: アイランド境界を越えた後、要素がペアにグループ化される
   assert_eq!(values, vec![vec![1_u32, 2], vec![3, 4], vec![5, 6]]);

--- a/modules/stream-core/tests/compat_validation.rs
+++ b/modules/stream-core/tests/compat_validation.rs
@@ -1,8 +1,10 @@
+mod support;
 use fraktor_stream_core_rs::core::{
   SubstreamCancelStrategy,
   dsl::{BroadcastHub, Source},
   r#impl::{OperatorKey, StreamError},
 };
+use support::RunWithCollectSink;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct CompatObservation {
@@ -183,7 +185,7 @@ fn observe_group_by_merge_substreams() -> CompatObservation {
     .group_by(4, |value: &u32| value % 2, SubstreamCancelStrategy::default())
     .expect("group_by")
     .merge_substreams()
-    .collect_values()
+    .run_with_collect_sink()
   {
     | Ok(values) => CompatObservation::new(!values.is_empty(), false, true, false),
     | Err(_) => CompatObservation::new(false, false, false, true),

--- a/modules/stream-core/tests/coupled_termination_flow.rs
+++ b/modules/stream-core/tests/coupled_termination_flow.rs
@@ -1,3 +1,4 @@
+mod support;
 use std::{
   sync::{
     Arc,
@@ -22,6 +23,7 @@ use fraktor_stream_core_rs::core::{
     StreamNotUsed,
   },
 };
+use support::RunWithCollectSink;
 
 struct GuardianActor;
 
@@ -79,7 +81,7 @@ fn coupled_termination_flow_from_sink_and_source_emits_elements_from_embedded_so
   let source = Source::single(42_u32);
   let flow = CoupledTerminationFlow::from_sink_and_source(sink, source);
 
-  let values = Source::single(7_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(7_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![42_u32]);
 }
@@ -188,8 +190,8 @@ fn coupled_termination_flow_from_sink_and_source_is_equivalent_to_flow_from_sink
   let via_factory: Flow<u32, u32, StreamNotUsed> = CoupledTerminationFlow::from_sink_and_source(sink_a, source_a);
   let via_flow: Flow<u32, u32, StreamNotUsed> = Flow::from_sink_and_source_coupled(sink_b, source_b);
 
-  let values_factory = Source::single(0_u32).via(via_factory).collect_values().expect("collect_values");
-  let values_flow = Source::single(0_u32).via(via_flow).collect_values().expect("collect_values");
+  let values_factory = Source::single(0_u32).via(via_factory).run_with_collect_sink().expect("run_with_collect_sink");
+  let values_flow = Source::single(0_u32).via(via_flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values_factory, values_flow);
   assert_eq!(values_factory, vec![123_u32]);

--- a/modules/stream-core/tests/graph_dsl_public.rs
+++ b/modules/stream-core/tests/graph_dsl_public.rs
@@ -1,3 +1,4 @@
+mod support;
 use fraktor_stream_core_rs::core::{
   StreamError,
   dsl::{Flow, GraphDsl, GraphDslBuilder, Sink, Source},
@@ -5,6 +6,7 @@ use fraktor_stream_core_rs::core::{
   shape::{Inlet, Outlet},
 };
 use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
+use support::RunWithCollectSink;
 
 #[test]
 fn graph_dsl_is_public_and_builds_linear_flow() {
@@ -13,7 +15,7 @@ fn graph_dsl_is_public_and_builds_linear_flow() {
     GraphDsl::builder::<u32>().via(Flow::<u32, u32, StreamNotUsed>::new().map(|value| value.saturating_mul(2))).build();
 
   // When: Source に接続して実行する
-  let values = Source::single(21_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(21_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: public facade 経由の graph が data path として機能する
   assert_eq!(values, vec![42_u32]);
@@ -26,7 +28,7 @@ fn graph_dsl_from_flow_is_public_and_builds_external_crate_flow() {
   let flow = builder.build();
 
   // When: 外部 crate 視点で Source に接続する
-  let values = Source::single(5_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: from_flow 経由の graph が data path として実行される
   assert_eq!(values, vec![15_u32]);
@@ -40,7 +42,7 @@ fn graph_dsl_create_flow_is_public_and_uses_builder_block() {
   });
 
   // When: public Source から実行する
-  let values = Source::single(3_u32).via(flow).collect_values().expect("collect_values");
+  let values = Source::single(3_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: builder block 内の graph が実行結果に反映される
   assert_eq!(values, vec![8_u32]);
@@ -71,7 +73,7 @@ fn graph_dsl_create_source_is_public_and_uses_explicit_wiring() {
   });
 
   // When: public Source として実行する
-  let values = source.collect_values().expect("collect_values");
+  let values = source.run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: 明示的な wiring が data path に反映される
   assert_eq!(values, vec![10_u32]);
@@ -87,7 +89,7 @@ fn graph_dsl_create_sink_is_public_and_builds_external_crate_sink() {
   });
 
   // When: public Source から作成済み Sink に到達させる
-  let values = Source::from_array([1_u32, 2, 3]).also_to(sink).collect_values().expect("collect_values");
+  let values = Source::from_array([1_u32, 2, 3]).also_to(sink).run_with_collect_sink().expect("run_with_collect_sink");
 
   // Then: create_sink 経由の sink へ要素が配送される
   assert_eq!(values, vec![1_u32, 2, 3]);

--- a/modules/stream-core/tests/pekko_porting_api_contracts.rs
+++ b/modules/stream-core/tests/pekko_porting_api_contracts.rs
@@ -1,8 +1,10 @@
+mod support;
 use fraktor_stream_core_rs::core::{
   dsl::{Flow, Sink, Source},
   materialization::{KeepBoth, KeepLeft, KeepRight, StreamNotUsed},
   shape::{FanInShape3, FanInShape4, FanInShape5, FanInShape8, Inlet, Outlet, UniformFanOutShape},
 };
+use support::RunWithCollectSink;
 
 #[test]
 fn uniform_fan_out_shape_new_returns_ports_passed_at_construction() {
@@ -137,8 +139,8 @@ fn flow_from_sink_and_source_mat_is_public_and_preserves_existing_data_path_cont
       Source::single(99_u32).map_materialized_value(|_| 8_u32),
       KeepLeft,
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   // from_sink_and_source_mat emits elements from the embedded source, not from upstream
   assert_eq!(values, vec![99_u32]);
 }
@@ -163,8 +165,8 @@ fn flow_from_sink_and_source_coupled_mat_is_public_and_preserves_existing_data_p
       Source::single(99_u32).map_materialized_value(|_| 21_u32),
       KeepLeft,
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   // from_sink_and_source_coupled_mat emits elements from the embedded source, not from upstream
   assert_eq!(values, vec![99_u32]);
 }
@@ -185,8 +187,8 @@ fn flow_concat_lazy_mat_is_public_and_preserves_existing_data_path_contract() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .concat_lazy_mat(Source::from_array([3_u32, 4_u32]).map_materialized_value(|_| 8_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -207,8 +209,8 @@ fn flow_prepend_lazy_mat_is_public_and_preserves_existing_data_path_contract() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .prepend_lazy_mat(Source::from_array([1_u32, 2_u32]).map_materialized_value(|_| 21_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -229,8 +231,8 @@ fn flow_or_else_mat_is_public_and_preserves_existing_data_path_contract() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .or_else_mat(Source::from_array([5_u32, 6_u32]).map_materialized_value(|_| 34_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![5_u32, 6_u32]);
 }
@@ -255,8 +257,8 @@ fn flow_divert_to_mat_is_public_and_preserves_existing_data_path_contract() {
       Sink::<u32, _>::ignore().map_materialized_value(|_| 55_u32),
       KeepLeft,
     ))
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 3_u32]);
 }
@@ -281,8 +283,8 @@ fn flow_concat_mat_is_public_and_preserves_existing_data_path_contract() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .concat_mat(Source::from_array([3_u32, 4_u32]).map_materialized_value(|_| 8_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -307,8 +309,8 @@ fn flow_prepend_mat_is_public_and_preserves_existing_data_path_contract() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .prepend_mat(Source::from_array([1_u32, 2_u32]).map_materialized_value(|_| 21_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32]);
 }
@@ -343,8 +345,8 @@ fn flow_merge_mat_is_public_and_preserves_existing_data_path_contract() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .merge_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert!(values.contains(&7_u32));
   assert!(values.contains(&8_u32));
@@ -379,8 +381,8 @@ fn flow_merge_preferred_mat_is_public_and_preserves_existing_data_path_contract(
       Flow::<u32, u32, StreamNotUsed>::new()
         .merge_preferred_mat(Source::single(8_u32).map_materialized_value(|_| 99_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert!(values.contains(&7_u32));
   assert!(values.contains(&8_u32));
@@ -415,8 +417,8 @@ fn flow_merge_sorted_mat_is_public_and_preserves_existing_data_path_contract() {
       Flow::<u32, u32, StreamNotUsed>::new()
         .merge_sorted_mat(Source::from_array([2_u32, 4_u32, 6_u32]).map_materialized_value(|_| 99_u32), KeepLeft),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
 
   assert_eq!(values, vec![1_u32, 2_u32, 3_u32, 4_u32, 5_u32, 6_u32]);
 }

--- a/modules/stream-core/tests/requirement_traceability.rs
+++ b/modules/stream-core/tests/requirement_traceability.rs
@@ -1,3 +1,4 @@
+mod support;
 use std::{
   collections::BTreeSet,
   thread,
@@ -19,6 +20,7 @@ use fraktor_stream_core_rs::core::{
   materialization::{ActorMaterializer, ActorMaterializerConfig, Completion, StreamNotUsed},
 };
 use fraktor_utils_core_rs::core::sync::{ArcShared, SpinSyncMutex};
+use support::RunWithCollectSink;
 
 type VerifyFn = fn();
 
@@ -326,18 +328,21 @@ fn verify_substream_surface() {
   assert_split_after_surface(SubstreamCancelStrategy::Propagate);
 
   let merged_values =
-    Source::single(1_u32).split_after(|_| true).merge_substreams().collect_values().expect("merged values");
+    Source::single(1_u32).split_after(|_| true).merge_substreams().run_with_collect_sink().expect("merged values");
   assert_eq!(merged_values, vec![1_u32]);
 
-  let concatenated_values =
-    Source::single(1_u32).split_when(|_| false).concat_substreams().collect_values().expect("concatenated values");
+  let concatenated_values = Source::single(1_u32)
+    .split_when(|_| false)
+    .concat_substreams()
+    .run_with_collect_sink()
+    .expect("concatenated values");
   assert_eq!(concatenated_values, vec![1_u32]);
 
   let limited_values = Source::single(1_u32)
     .split_after(|_| true)
     .merge_substreams_with_parallelism(1)
     .expect("positive parallelism must be accepted")
-    .collect_values()
+    .run_with_collect_sink()
     .expect("limited values");
   assert_eq!(limited_values, vec![1_u32]);
 
@@ -363,13 +368,14 @@ fn verify_substream_surface() {
 }
 
 fn verify_flat_map_surface() {
-  let concat_values = Source::single(1_u32).flat_map_concat(Source::single).collect_values().expect("concat values");
+  let concat_values =
+    Source::single(1_u32).flat_map_concat(Source::single).run_with_collect_sink().expect("concat values");
   assert_eq!(concat_values, vec![1_u32]);
 
   let merge_values = Source::single(1_u32)
     .flat_map_merge(1, Source::single)
     .expect("positive breadth must be accepted")
-    .collect_values()
+    .run_with_collect_sink()
     .expect("merge values");
   assert_eq!(merge_values, vec![1_u32]);
 
@@ -434,7 +440,7 @@ fn verify_restart_supervision_surface() {
     .supervision_resume()
     .supervision_restart()
     .supervision_stop()
-    .collect_values()
+    .run_with_collect_sink()
     .expect("source values");
   assert_eq!(source_values, vec![1_u32]);
 
@@ -446,7 +452,7 @@ fn verify_restart_supervision_surface() {
         .supervision_restart()
         .supervision_stop(),
     )
-    .collect_values()
+    .run_with_collect_sink()
     .expect("flow values");
   assert_eq!(flow_values, vec![1_u32]);
 
@@ -459,12 +465,12 @@ fn verify_restart_supervision_surface() {
 }
 
 fn verify_async_boundary_surface() {
-  let source_values = Source::single(1_u32).r#async().collect_values().expect("source async values");
+  let source_values = Source::single(1_u32).r#async().run_with_collect_sink().expect("source async values");
   assert_eq!(source_values, vec![1_u32]);
 
   let flow_values = Source::single(1_u32)
     .via(Flow::<u32, u32, StreamNotUsed>::new().r#async())
-    .collect_values()
+    .run_with_collect_sink()
     .expect("flow async values");
   assert_eq!(flow_values, vec![1_u32]);
 }
@@ -490,7 +496,7 @@ fn assert_group_by_surface() {
     .group_by(1, |value: &u32| *value, SubstreamCancelStrategy::default())
     .expect("positive max_substreams must be accepted")
     .merge_substreams()
-    .collect_values()
+    .run_with_collect_sink()
     .expect("grouped values");
   assert_eq!(grouped_values, vec![1_u32]);
 }

--- a/modules/stream-core/tests/retry_flow.rs
+++ b/modules/stream-core/tests/retry_flow.rs
@@ -1,3 +1,4 @@
+mod support;
 use std::sync::{
   Arc,
   atomic::{AtomicUsize, Ordering},
@@ -7,12 +8,14 @@ use fraktor_stream_core_rs::core::{
   dsl::{Flow, FlowWithContext, RetryFlow, Source},
   materialization::StreamNotUsed,
 };
+use support::RunWithCollectSink;
 
 #[test]
 fn retry_flow_passes_through_when_no_retry_needed() {
   let inner_flow: Flow<u32, u32, StreamNotUsed> = Flow::from_function(|x: u32| x.saturating_mul(2));
   let retry_flow = RetryFlow::with_backoff(1, 10, 0, 3, inner_flow, |_input: &u32, _output: &u32| None::<u32>);
-  let values = Source::from_iterator(vec![1_u32, 2, 3]).via(retry_flow).collect_values().expect("collect_values");
+  let values =
+    Source::from_iterator(vec![1_u32, 2, 3]).via(retry_flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 4, 6]);
 }
 
@@ -37,7 +40,7 @@ fn retry_flow_retries_and_succeeds() {
     },
   );
 
-  let values = Source::single(42_u32).via(retry_flow).collect_values().expect("collect_values");
+  let values = Source::single(42_u32).via(retry_flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![420_u32]);
 }
 
@@ -56,7 +59,7 @@ fn retry_flow_exhausts_max_retries_and_passes_through() {
     },
   );
 
-  let values = Source::single(5_u32).via(retry_flow).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).via(retry_flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![0_u32]);
 }
 
@@ -75,7 +78,7 @@ fn retry_flow_with_zero_max_retries_never_retries() {
     },
   );
 
-  let values = Source::single(5_u32).via(retry_flow).collect_values().expect("collect_values");
+  let values = Source::single(5_u32).via(retry_flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![0_u32]);
 }
 
@@ -96,7 +99,7 @@ fn retry_flow_preserves_multiple_pending_retries_in_order() {
       },
     );
 
-  let values = Source::single(1_u32).via(retry_flow).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(retry_flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![103_u32, 104_u32, 104_u32, 105_u32]);
 }
 
@@ -109,7 +112,7 @@ fn retry_flow_accepts_remaining_outputs_after_scheduling_retry() {
     if *input < 10 && *output == 0 { Some(input.saturating_add(100)) } else { None }
   });
 
-  let values = Source::single(1_u32).via(retry_flow).collect_values().expect("collect_values");
+  let values = Source::single(1_u32).via(retry_flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![2_u32, 202_u32, 0_u32]);
 }
 
@@ -125,8 +128,8 @@ fn retry_flow_with_context_passes_through_when_no_retry_needed() {
   let values =
     Source::from_iterator(vec![("a".to_string(), 1_u32), ("b".to_string(), 2_u32), ("c".to_string(), 3_u32)])
       .via(retry_fwc.into_flow())
-      .collect_values()
-      .expect("collect_values");
+      .run_with_collect_sink()
+      .expect("run_with_collect_sink");
   assert_eq!(values, vec![("a".to_string(), 2_u32), ("b".to_string(), 4_u32), ("c".to_string(), 6_u32),]);
 }
 
@@ -155,8 +158,8 @@ fn retry_flow_with_context_retries_preserving_context() {
 
   let values = Source::single(("ctx-val".to_string(), 42_u32))
     .via(retry_fwc.into_flow())
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![("ctx-val".to_string(), 420_u32)]);
 }
 
@@ -177,6 +180,7 @@ fn retry_flow_with_context_exhausts_retries() {
     },
   );
 
-  let values = Source::single((99_i32, 5_u32)).via(retry_fwc.into_flow()).collect_values().expect("collect_values");
+  let values =
+    Source::single((99_i32, 5_u32)).via(retry_fwc.into_flow()).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![(99_i32, 0_u32)]);
 }

--- a/modules/stream-core/tests/source_with_context.rs
+++ b/modules/stream-core/tests/source_with_context.rs
@@ -1,3 +1,4 @@
+mod support;
 use core::{
   future::Future,
   pin::Pin,
@@ -10,6 +11,7 @@ use fraktor_stream_core_rs::core::{
   dsl::{Flow, FlowWithContext, Sink, Source, SourceWithContext},
   materialization::{KeepBoth, KeepLeft, KeepRight, StreamNotUsed},
 };
+use support::RunWithCollectSink;
 
 #[derive(Default)]
 struct YieldThenOutputFuture<T> {
@@ -44,7 +46,7 @@ fn should_create_from_source() {
   let source = Source::from(vec![(1_i32, "a"), (2, "b")]);
   let swc = SourceWithContext::from_source(source);
   let inner = swc.into_source();
-  let values = inner.collect_values().expect("collect_values");
+  let values = inner.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![(1, "a"), (2, "b")]);
 }
 
@@ -53,7 +55,7 @@ fn should_map_output_preserving_context() {
   let source = Source::from(vec![(1_i32, "hello"), (2, "world")]);
   let swc = SourceWithContext::from_source(source);
   let mapped = swc.map(|s: &str| s.len());
-  let values = mapped.into_source().collect_values().expect("collect_values");
+  let values = mapped.into_source().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![(1, 5), (2, 5)]);
 }
 
@@ -62,7 +64,7 @@ fn should_filter_by_value_preserving_context() {
   let source = Source::from(vec![(1_i32, 10), (2, -5), (3, 20)]);
   let swc = SourceWithContext::from_source(source);
   let filtered = swc.filter(|v: &i32| *v > 0);
-  let values = filtered.into_source().collect_values().expect("collect_values");
+  let values = filtered.into_source().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![(1, 10), (3, 20)]);
 }
 
@@ -71,7 +73,7 @@ fn should_map_context() {
   let source = Source::from(vec![(1_i32, "a"), (2, "b")]);
   let swc = SourceWithContext::from_source(source);
   let mapped = swc.map_context(|ctx: i32| ctx * 10);
-  let values = mapped.into_source().collect_values().expect("collect_values");
+  let values = mapped.into_source().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![(10, "a"), (20, "b")]);
 }
 
@@ -81,7 +83,7 @@ fn should_compose_via() {
     FlowWithContext::from_flow(Flow::new().map(|(ctx, s): (i32, &str)| (ctx, s.len())));
   let swc = SourceWithContext::from_source(Source::from(vec![(1_i32, "hello"), (2, "hi")]));
   let composed = swc.via(fwc);
-  let values = composed.into_source().collect_values().expect("collect_values");
+  let values = composed.into_source().run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![(1, 5), (2, 2)]);
 }
 
@@ -91,7 +93,7 @@ fn should_map_concat_expanding_elements_with_same_context() {
   let swc = SourceWithContext::from_source(source);
   let expanded = swc.map_concat(|s: &str| s.chars().map(|c| c as u32).collect::<Vec<_>>());
 
-  let values = expanded.into_source().collect_values().expect("collect_values");
+  let values = expanded.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 97), (1, 98), (2, 99)]);
 }
@@ -102,7 +104,7 @@ fn should_map_concat_dropping_empty_expansions() {
   let swc = SourceWithContext::from_source(source);
   let expanded = swc.map_concat(|v: i32| if v > 0 { vec![v, v * 10] } else { vec![] });
 
-  let values = expanded.into_source().collect_values().expect("collect_values");
+  let values = expanded.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 5), (1, 50), (3, 3), (3, 30)]);
 }
@@ -113,7 +115,7 @@ fn should_filter_not_passing_false_predicate_elements() {
   let swc = SourceWithContext::from_source(source);
   let filtered = swc.filter_not(|v: &i32| *v > 0);
 
-  let values = filtered.into_source().collect_values().expect("collect_values");
+  let values = filtered.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(2, -5), (3, 0)]);
 }
@@ -124,7 +126,7 @@ fn should_filter_not_passing_all_when_predicate_always_false() {
   let swc = SourceWithContext::from_source(source);
   let filtered = swc.filter_not(|_: &i32| false);
 
-  let values = filtered.into_source().collect_values().expect("collect_values");
+  let values = filtered.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 10), (2, 20)]);
 }
@@ -135,7 +137,7 @@ fn should_collect_filtering_and_mapping_with_context() {
   let swc = SourceWithContext::from_source(source);
   let collected = swc.collect(|v: i32| if v > 0 { Some(v * 2) } else { None });
 
-  let values = collected.into_source().collect_values().expect("collect_values");
+  let values = collected.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 10), (3, 20)]);
 }
@@ -146,7 +148,7 @@ fn should_collect_dropping_all_when_all_none() {
   let swc = SourceWithContext::from_source(source);
   let collected = swc.collect(|_: i32| -> Option<i32> { None });
 
-  let values = collected.into_source().collect_values().expect("collect_values");
+  let values = collected.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert!(values.is_empty());
 }
@@ -157,7 +159,7 @@ fn should_map_async_transforming_with_context() {
   let swc = SourceWithContext::from_source(source);
   let mapped = swc.map_async(1, |v: u32| async move { v * 2 }).expect("map_async");
 
-  let values = mapped.into_source().collect_values().expect("collect_values");
+  let values = mapped.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 10_u32), (2, 6)]);
 }
@@ -168,7 +170,7 @@ fn should_grouped_collecting_elements_with_last_context() {
   let swc = SourceWithContext::from_source(source);
   let grouped = swc.grouped(2).expect("grouped");
 
-  let values = grouped.into_source().collect_values().expect("collect_values");
+  let values = grouped.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(20, vec![1_u32, 2]), (40, vec![3, 4]), (50, vec![5])]);
 }
@@ -179,7 +181,7 @@ fn should_grouped_single_element_per_group() {
   let swc = SourceWithContext::from_source(source);
   let grouped = swc.grouped(1).expect("grouped");
 
-  let values = grouped.into_source().collect_values().expect("collect_values");
+  let values = grouped.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, vec![10_u32]), (2, vec![20])]);
 }
@@ -190,7 +192,7 @@ fn should_sliding_creating_windows_with_last_context() {
   let swc = SourceWithContext::from_source(source);
   let sliding = swc.sliding(3).expect("sliding");
 
-  let values = sliding.into_source().collect_values().expect("collect_values");
+  let values = sliding.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(30, vec![1_u32, 2, 3]), (40, vec![2, 3, 4])]);
 }
@@ -201,7 +203,7 @@ fn should_sliding_window_size_2() {
   let swc = SourceWithContext::from_source(source);
   let sliding = swc.sliding(2).expect("sliding");
 
-  let values = sliding.into_source().collect_values().expect("collect_values");
+  let values = sliding.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(2, vec![10_u32, 20]), (3, vec![20, 30])]);
 }
@@ -241,7 +243,7 @@ fn should_also_to_send_values_to_side_sink_and_preserve_main_path() {
     seen_for_sink.lock().expect("side sink lock").push(value);
   }));
 
-  let values = swc.into_source().collect_values().expect("collect_values");
+  let values = swc.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![1_u32, 2]);
@@ -256,7 +258,7 @@ fn should_also_to_context_send_only_contexts_to_side_sink() {
     seen_for_sink.lock().expect("context sink lock").push(ctx);
   }));
 
-  let values = swc.into_source().collect_values().expect("collect_values");
+  let values = swc.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![10_i32, 20]);
@@ -271,7 +273,7 @@ fn should_wire_tap_preserve_main_path_and_emit_values() {
     seen_for_sink.lock().expect("tap sink lock").push(value);
   }));
 
-  let values = swc.into_source().collect_values().expect("collect_values");
+  let values = swc.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![1_u32, 2]);
@@ -286,7 +288,7 @@ fn should_wire_tap_context_preserve_main_path_and_emit_contexts() {
     seen_for_sink.lock().expect("context tap lock").push(ctx);
   }));
 
-  let values = swc.into_source().collect_values().expect("collect_values");
+  let values = swc.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(10_i32, 1_u32), (20, 2)]);
   assert_eq!(*seen.lock().expect("seen lock"), vec![10_i32, 20]);
@@ -307,7 +309,7 @@ fn should_map_async_partitioned_preserving_context_and_input_order() {
     )
     .expect("map_async_partitioned");
 
-  let values = mapped.into_source().collect_values().expect("collect_values");
+  let values = mapped.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(100_i32, 11_u32), (200, 12)]);
 }
@@ -327,7 +329,7 @@ fn should_map_async_partitioned_unordered_emitting_completion_order_with_context
     )
     .expect("map_async_partitioned_unordered");
 
-  let values = mapped.into_source().collect_values().expect("collect_values");
+  let values = mapped.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(200_i32, 12_u32), (100, 11)]);
 }
@@ -337,7 +339,7 @@ fn should_map_error_passing_normal_elements_with_context() {
   let source = Source::from(vec![(1_i32, 10_u32), (2, 20)]);
   let swc = SourceWithContext::from_source(source).map_error(|_| StreamError::WouldBlock);
 
-  let values = swc.into_source().collect_values().expect("collect_values");
+  let values = swc.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 10_u32), (2, 20)]);
 }
@@ -347,7 +349,7 @@ fn should_map_error_transforming_upstream_failure() {
   let source = Source::<(i32, u32), _>::failed(StreamError::Failed);
   let swc = SourceWithContext::from_source(source).map_error(|_| StreamError::WouldBlock);
 
-  let result = swc.into_source().collect_values();
+  let result = swc.into_source().run_with_collect_sink();
 
   assert_eq!(result, Err(StreamError::WouldBlock));
 }
@@ -357,7 +359,7 @@ fn should_throttle_passing_elements_with_context() {
   let source = Source::from(vec![(1_i32, 10_u32), (2, 20)]);
   let swc = SourceWithContext::from_source(source).throttle(2, ThrottleMode::Shaping).expect("throttle");
 
-  let values = swc.into_source().collect_values().expect("collect_values");
+  let values = swc.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 10_u32), (2, 20)]);
 }
@@ -367,7 +369,7 @@ fn should_throttle_enforcing_mode_preserving_context() {
   let source = Source::from(vec![(1_i32, 10_u32)]);
   let swc = SourceWithContext::from_source(source).throttle(2, ThrottleMode::Enforcing).expect("throttle");
 
-  let values = swc.into_source().collect_values().expect("collect_values");
+  let values = swc.into_source().run_with_collect_sink().expect("run_with_collect_sink");
 
   assert_eq!(values, vec![(1, 10_u32)]);
 }

--- a/modules/stream-core/tests/substream_cancel_strategy_regression.rs
+++ b/modules/stream-core/tests/substream_cancel_strategy_regression.rs
@@ -1,8 +1,10 @@
+mod support;
 use fraktor_stream_core_rs::core::{
   SubstreamCancelStrategy,
   dsl::{Flow, Source},
   materialization::StreamNotUsed,
 };
+use support::RunWithCollectSink;
 
 #[test]
 fn flow_split_when_accepts_drain_cancel_strategy() {
@@ -12,8 +14,8 @@ fn flow_split_when_accepts_drain_cancel_strategy() {
         .split_when_with_cancel_strategy(SubstreamCancelStrategy::Drain, |_| false)
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -25,8 +27,8 @@ fn flow_split_after_accepts_propagate_cancel_strategy() {
         .split_after_with_cancel_strategy(SubstreamCancelStrategy::Propagate, |_| false)
         .merge_substreams(),
     )
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -35,8 +37,8 @@ fn source_split_when_accepts_drain_cancel_strategy() {
   let values = Source::single(7_u32)
     .split_when_with_cancel_strategy(SubstreamCancelStrategy::Drain, |_| false)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }
 
@@ -45,7 +47,7 @@ fn source_split_after_accepts_propagate_cancel_strategy() {
   let values = Source::single(7_u32)
     .split_after_with_cancel_strategy(SubstreamCancelStrategy::Propagate, |_| false)
     .merge_substreams()
-    .collect_values()
-    .expect("collect_values");
+    .run_with_collect_sink()
+    .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);
 }

--- a/modules/stream-core/tests/support/mod.rs
+++ b/modules/stream-core/tests/support/mod.rs
@@ -1,0 +1,64 @@
+use core::time::Duration;
+use std::{thread, time::Instant};
+
+use fraktor_actor_adaptor_std_rs::std::tick_driver::TestTickDriver;
+use fraktor_actor_core_rs::core::kernel::{
+  actor::{
+    Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
+    setup::ActorSystemConfig,
+  },
+  system::ActorSystem,
+};
+use fraktor_stream_core_rs::core::{
+  StreamError,
+  dsl::{Sink, Source},
+  materialization::{ActorMaterializer, ActorMaterializerConfig},
+};
+
+struct GuardianActor;
+
+impl Actor for GuardianActor {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}
+
+fn build_system() -> ActorSystem {
+  let props = Props::from_fn(|| GuardianActor);
+  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
+  ActorSystem::create_with_config(&props, config).expect("system should build")
+}
+
+fn build_materializer() -> ActorMaterializer {
+  let config = ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1));
+  let mut materializer = ActorMaterializer::new(build_system(), config);
+  materializer.start().expect("materializer start");
+  materializer
+}
+
+pub(crate) trait RunWithCollectSink<Out> {
+  fn run_with_collect_sink(self) -> Result<Vec<Out>, StreamError>;
+}
+
+impl<Out, Mat> RunWithCollectSink<Out> for Source<Out, Mat>
+where
+  Out: Send + Sync + 'static,
+{
+  fn run_with_collect_sink(self) -> Result<Vec<Out>, StreamError> {
+    let mut materializer = build_materializer();
+    let materialized = self.run_with(Sink::collect(), &mut materializer)?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let result = loop {
+      if let Some(result) = materialized.materialized().try_take() {
+        break result;
+      }
+      if Instant::now() >= deadline {
+        break Err(StreamError::WouldBlock);
+      }
+      thread::sleep(Duration::from_millis(1));
+    };
+    materializer.shutdown()?;
+    result
+  }
+}

--- a/modules/stream-core/tests/support/mod.rs
+++ b/modules/stream-core/tests/support/mod.rs
@@ -47,16 +47,21 @@ where
 {
   fn run_with_collect_sink(self) -> Result<Vec<Out>, StreamError> {
     let mut materializer = build_materializer();
-    let materialized = self.run_with(Sink::collect(), &mut materializer)?;
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let result = loop {
-      if let Some(result) = materialized.materialized().try_take() {
-        break result;
-      }
-      if Instant::now() >= deadline {
-        break Err(StreamError::WouldBlock);
-      }
-      thread::sleep(Duration::from_millis(1));
+    let run_result = self.run_with(Sink::collect(), &mut materializer);
+    let result = match run_result {
+      | Ok(materialized) => {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+          if let Some(result) = materialized.materialized().try_take() {
+            break result;
+          }
+          if Instant::now() >= deadline {
+            break Err(StreamError::WouldBlock);
+          }
+          thread::sleep(Duration::from_millis(1));
+        }
+      },
+      | Err(error) => Err(error),
     };
     materializer.shutdown()?;
     result


### PR DESCRIPTION
## 概要
- `Source::collect_values()`、`TailSource::collect_values()`、`Source::into_*_stream()` を公開 DSL から削除しました。
- stream-core の通常テストを `run_with(Sink::collect(), &mut Materializer)` 経由へ移行しました。
- 方針メモを更新し、公開 API から ActorSystem / Materializer なしの実行入口を残さない方針を明記しました。

## 背景
Pekko には `collect_values()` のような ActorSystem / Materializer なしでストリームを直実行する公開 API がないため、fraktor-rs 側でも非互換な実行入口を公開面から外します。後方互換は不要な開発フェーズなので、テストも本来の materializer API を通す形へ寄せています。

## 検証
- `rtk cargo test -p fraktor-stream-core-rs`
- `rtk cargo test -p fraktor-showcases-std --features advanced`
- `rtk git diff --check`
- `rtk ./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an intentionally breaking public API change that will require downstream code updates. Behavioral risk is moderate because execution semantics are shifted to always go through materialization, which may surface latent timing/materializer assumptions in tests and callers.
> 
> **Overview**
> **Public stream execution entrypoints are removed.** The stream-core DSL drops `Source::collect_values()`, `TailSource::collect_values()`, and `into_*_stream()` helpers so users can no longer run streams without an `ActorSystem`/`Materializer`.
> 
> **Tests and docs are aligned to the materialization contract.** Unit/integration tests are migrated from `collect_values()` to a test-only `RunWithCollectSink` helper that runs via `run_with(Sink::collect(), &mut materializer)`, with a few tests switching to explicit polling where needed, and the planning memo is updated to reflect the new policy and remaining follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ed8ce6ef2a9b2b8b76f1000944fc7dd4f3cdc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **API変更**
  * 公開APIから collect_values() とそれに伴う変換エントリポイントを削除しました
  * TailSource の collect_values 相当エントリを削除しました

* **テスト**
  * テスト群を新しいマテリアライザ経由の実行へ移行し、収集方法を統一しました（テスト用ユーティリティを導入）

* **ドキュメント**
  * 実行方針を更新し、残課題（内部的なドレイン評価の扱い）を注記しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->