### PR TITLE
[codex] stream island actors change proposal

### DIFF
--- a/openspec/changes/stream-island-actors/.openspec.yaml
+++ b/openspec/changes/stream-island-actors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/stream-island-actors/design.md
+++ b/openspec/changes/stream-island-actors/design.md
@@ -1,0 +1,164 @@
+## Context
+
+現在の stream async boundary は、graph construction と island splitting までは進んでいる。
+
+- `Source::async()` / `Flow::async()` は最後の graph node に `AsyncBoundaryAttr` を付ける。
+- `Source::async_with_dispatcher()` / `Flow::async_with_dispatcher()` は `AsyncBoundaryAttr` と `DispatcherAttribute` を付ける。
+- `IslandSplitter` は async stage を upstream island の最後として扱い、次 stage 以降を downstream island に分ける。
+- `SingleIslandPlan` は `dispatcher: Option<String>` を持つ。
+- `ActorMaterializer` は複数 island に分かれた graph を island ごとの `Stream` / `StreamHandleImpl` に変換する。
+
+ただし、現状の実行は Pekko の island architecture には届いていない。`ActorMaterializer::start()` は単一の `StreamDriveActor` を system actor として起動し、materialized island の全 handle をその actor に登録する。`StreamDriveActor::tick()` は自分の mailbox 内で全 handle を順番に `drive()` するため、island ごとの actor / mailbox / dispatcher は独立していない。
+
+また、`SingleIslandPlan::dispatcher()` は存在するが、`SingleIslandPlan::into_stream_plan()` 後に dispatcher 情報は失われる。したがって `async_with_dispatcher()` の dispatcher 指定は、現在の runtime では island actor 起動に使われていない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `async()` で分割された island を actor runtime 上の独立実行単位にする。
+- 各 island が独立した actor mailbox 上で `drive()` されるようにする。
+- `async_with_dispatcher()` の dispatcher を downstream island actor の `Props::with_dispatcher_id(...)` に反映する。
+- island 間 boundary の backpressure / completion / failure / cancellation の契約を actor 分離後も保持する。
+- materialized handle / materializer shutdown / snapshot が複数 island graph 全体を扱えるようにする。
+
+**Non-Goals:**
+
+- stream operator DSL の追加。
+- `Actor::receive` や actor mailbox drain contract の async 化。
+- island ごとの OS thread 固定割り当て。
+- stream 専用 mailbox selector API の追加。
+- remote stream / cluster stream の実装。
+- ActorSystem なしの stream 直実行 API の復活。
+
+## Decisions
+
+### Decision 1: island ごとに 1 actor が 1 stream handle を所有する
+
+`StreamDriveActor` が複数 handle を所有して直列 drive する構造をやめる。新しい実行単位は「1 island actor が 1 `StreamHandleImpl` を所有する」形にする。
+
+想定する内部型名は以下とする。最終的なファイル配置は既存 package 整理に合わせる。
+
+- `StreamIslandActor`
+- `StreamIslandCommand`
+- `StreamIslandHandle`
+- `MaterializedStreamGroup`
+
+これらは公開 API ではなく、`modules/stream-core` 内部の materialization 実装として扱う。
+
+```text
+現状:
+
+ActorMaterializer
+  -> StreamDriveActor
+       -> drive(island 0 handle)
+       -> drive(island 1 handle)
+       -> drive(island 2 handle)
+
+変更後:
+
+ActorMaterializer
+  -> StreamIslandActor(0) mailbox dispatcher A
+  -> StreamIslandActor(1) mailbox dispatcher B
+  -> StreamIslandActor(2) mailbox dispatcher C
+
+island 0 --boundary--> island 1 --boundary--> island 2
+```
+
+### Decision 2: tick source は分離してよいが drive は island actor 内で行う
+
+tick の供給方法は実装時に次のどちらかを選べる。
+
+- 各 island actor に scheduler job を持たせ、scheduler が直接 `StreamIslandCommand::Drive` を送る。
+- materializer ごとに tick fanout actor を持ち、fanout actor が各 island actor へ `Drive` command を送る。
+
+どちらを選んでも、fanout actor や scheduler callback が `StreamHandleImpl::drive()` を直接呼んではならない。`drive()` は必ず対象 island actor の mailbox 内で実行する。
+
+この制約により、dispatcher 分離と mailbox 分離が実行時意味論として守られる。
+
+### Decision 3: dispatcher は async boundary の downstream island に適用する
+
+`IslandSplitter` は現在、async stage の `DispatcherAttribute` を downstream stage の dispatcher candidate として扱っている。この意味論を維持し、`async_with_dispatcher("x")` は「その async boundary の下流 island を dispatcher `x` で実行する」と定義する。
+
+materialization は、`SingleIslandPlan::dispatcher()` を `into_stream_plan()` の前に読み取り、island actor 用 `Props` に反映する。
+
+```text
+source --map.async_with_dispatcher("blocking")--> sink
+
+island 0:
+  source + map
+  dispatcher: default
+
+island 1:
+  boundary source + sink
+  dispatcher: blocking
+```
+
+dispatcher id が actor system に登録されていない場合、materialization は default dispatcher にフォールバックしてはならない。Pekko と同様に設定ミスとして失敗させ、失敗は `StreamError` として観測可能にする。
+
+### Decision 4: boundary は actor 間の唯一の data channel とする
+
+island 間の data flow は boundary を通してのみ行う。初期実装では既存の `IslandBoundaryShared` を使い続けてよい。ただし、actor 分離後に必要な状態遷移を満たせない場合は、同じ contract を持つ境界型へ置き換える。
+
+boundary contract は以下とする。
+
+- upstream island は boundary full を `WouldBlock` 相当の局所 pending として扱い、要素を失わない。
+- downstream island は boundary empty かつ open を pending として扱い、busy loop しない。
+- upstream completion は pending 要素の flush 後に downstream completion として観測される。
+- upstream failure は downstream failure として観測される。
+- downstream cancel は upstream island の cancel または shutdown command へ伝播する。
+
+### Decision 5: materialized graph は composite lifecycle を持つ
+
+複数 island graph で利用者に返す handle は、先頭 island の handle だけではなく graph 全体を代表する composite handle として扱う。
+
+必要な振る舞いは以下とする。
+
+- `cancel()` は全 island actor へ cancel を伝える。
+- terminal state は全 island の terminal state と boundary terminal state から導出する。
+- snapshot は materialized graph 単位と island 単位の両方を観測できる。
+- materialization 途中で island actor 起動に失敗した場合、起動済み island actor と boundary resource を rollback する。
+
+### Decision 6: materializer shutdown は停止失敗を握りつぶさない
+
+`ActorMaterializer::shutdown()` は materializer が所有する island actor、tick resource、boundary resource を決定的に停止する。停止中の partial failure は、best-effort コメントで黙殺せず、少なくとも返り値または actor error として観測できるようにする。
+
+Drop など回復不能な best-effort 経路で戻り値を捨てる場合だけ、失敗しても契約が壊れない理由をコメントに明記する。
+
+## Risks / Trade-Offs
+
+**actor 数が増える:**
+
+async boundary ごとに actor が増えるため、非常に細かい boundary を大量に置く stream は mailbox / actor overhead が増える。これは Pekko 互換の意味論として受け入れる。単一 fused island は引き続き最小構成で動く。
+
+**boundary が lock ベースのままだと fairness が弱い可能性がある:**
+
+初期実装で `IslandBoundaryShared` を維持する場合、actor は tick 駆動で再試行する。将来 waker / signal 型 boundary に置き換える余地は残すが、本 change では busy loop しないこと、要素を失わないこと、terminal signal を落とさないことを優先する。
+
+**dispatcher test が実装依存になりやすい:**
+
+単に値が流れることだけを検証すると退行を検出できない。test-only dispatcher factory または actor snapshot を使い、island actor が期待 dispatcher に attach されたことを観測する。
+
+## Migration Plan
+
+1. `StreamDriveActor` の責務を「複数 handle を直列 drive する actor」から取り除く。
+2. `StreamIslandActor` と `StreamIslandCommand` を追加し、1 actor が 1 island handle を drive する形にする。
+3. `ActorMaterializer` の materialization で、island ごとに actor を spawn する。
+4. `SingleIslandPlan::dispatcher()` を actor `Props::with_dispatcher_id(...)` へ反映する。
+5. composite handle / materialized graph state を導入し、cancel / snapshot / shutdown を graph 全体へ適用する。
+6. boundary backpressure / completion / failure / cancellation の regression tests を追加する。
+7. showcase と stream tests を ActorSystem + Materializer 経由の実行契約へ寄せる。
+
+## Open Questions
+
+**tick fanout を actor にするか scheduler job を island ごとに持つか:**
+
+どちらでも contract は満たせる。初期実装ではシンプルさを優先し、既存 scheduler API で安全に cancel できる方を選ぶ。
+
+**snapshot の公開粒度:**
+
+materializer snapshot に island actor id / dispatcher id / terminal state を含めるか、内部 test helper に限定するかは実装時に決める。少なくとも regression test が dispatcher 反映を観測できる経路は必要である。
+
+**stream mailbox selector API:**
+
+現在 stream attribute として mailbox selector は存在しない。本 change では actor mailbox が island ごとに独立することだけを保証し、カスタム mailbox selection は別 change とする。

--- a/openspec/changes/stream-island-actors/proposal.md
+++ b/openspec/changes/stream-island-actors/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+Pekko の stream `async()` / `async(dispatcher)` は、fused graph を island に分け、island ごとに独立した actor / mailbox / dispatcher で実行するための境界である。一方、現在の fraktor-rs は `AsyncBoundaryAttr` による island 分割と boundary buffer は持っているが、materialization 後は複数 island の `StreamHandleImpl` を 1 つの `StreamDriveActor` が順番に drive している。
+
+この状態では `async_with_dispatcher()` が dispatcher 属性を付けても実行時 dispatcher の選択に反映されず、Pekko 互換サンプルやテストが「ActorSystem 上で動いているが island は分離実行されていない」状態になる。正式リリース前に、stream island を実行単位として actor runtime に接続し、async boundary の意味論を Pekko に寄せて固定する。
+
+## What Changes
+
+### 1. stream island を actor 実行単位にする
+
+`ActorMaterializer` は、`IslandSplitter` が生成した island ごとに独立した stream 実行 actor を起動する。各 actor は 1 つの island の `Stream` / `StreamHandleImpl` を所有し、自分の mailbox 上で drive / cancel / shutdown command を処理する。
+
+単一 island の stream は現在と同じ fused 実行を維持してよい。ただし `async()` により複数 island へ分かれた graph は、1 つの drive actor に全 handle を登録するのではなく、island ごとの actor 群として materialize する。
+
+### 2. dispatcher 属性を island actor 起動へ反映する
+
+`Source::async_with_dispatcher()` / `Flow::async_with_dispatcher()` が付与した dispatcher は、`IslandSplitter` の island plan に保持されるだけでなく、該当 island actor の `Props` / dispatcher selector へ反映されなければならない。
+
+dispatcher 指定がない island は actor system の default dispatcher を使う。stream 専用 mailbox 属性は現状存在しないため、本 change では「island ごとに actor mailbox が独立する」ことを対象にし、カスタム stream mailbox selector の追加は別 change とする。
+
+### 3. island 間 boundary の backpressure / terminal propagation を契約化する
+
+既存の `IslandBoundaryShared`、`BoundarySinkLogic`、`BoundarySourceLogic` を actor 間境界として使うか、同等の境界型に置き換える。どちらの場合も、以下の contract を固定する。
+
+- boundary full は upstream island の局所 backpressure として扱う。
+- boundary empty は downstream island の pending 状態として扱い、busy loop しない。
+- upstream failure / completion は downstream island へ伝播する。
+- downstream cancel は upstream island へ停止要求として伝播する。
+
+### 4. materialized handle と materializer lifecycle を composite にする
+
+複数 island の materialization では、利用者へ返す handle は全 island actor の lifecycle を代表する composite handle として振る舞う。cancel / shutdown / snapshot は、先頭 island だけでなく materialized graph 全体に作用する。
+
+`ActorMaterializer::shutdown()` は、materializer が起動した全 island actor と tick / drive resource を決定的に停止する。停止失敗は握りつぶさず、観測可能な `StreamError` または actor error として扱う。
+
+### 5. tests と showcases を Pekko 互換の意味論へ寄せる
+
+`async()` / `async_with_dispatcher()` のテストは、値が通るだけでなく、island 数、dispatcher 反映、boundary backpressure、cancel / failure propagation を検証する。showcase では ActorSystem / Materializer を通した stream 実行だけを示し、ActorSystem なしの直実行 API には戻さない。
+
+## Capabilities
+
+### New Capabilities
+
+- **`stream-island-actors`**
+  - stream async boundary は island ごとの actor 実行境界になる。
+  - island actor は独立した mailbox で drive command を処理する。
+  - `async_with_dispatcher()` の dispatcher は該当 island actor の dispatcher 選択に反映される。
+  - materialized handle は複数 island から成る graph 全体を cancel / observe できる。
+
+### Modified Capabilities
+
+- **`streams-backpressure-integrity`**
+  - island 間 boundary の backpressure / completion / failure / cancellation を actor 分離後も保持する。
+  - `WouldBlock` を同期直実行の失敗として扱わず、actor 駆動下の pending progress として検証する。
+
+## Impact
+
+**影響を受けるコード:**
+
+- `modules/stream-core/src/core/impl/interpreter/island_splitter.rs`
+- `modules/stream-core/src/core/materialization/actor_materializer.rs`
+- `modules/stream-core/src/core/impl/materialization/stream_drive_actor.rs`
+- `modules/stream-core/src/core/impl/materialization/stream_handle*.rs`
+- `modules/stream-core/src/core/impl/boundary*` または同等の island boundary 実装
+- `modules/stream-core/tests/*`
+- `showcases/std/stream/*`
+
+**公開 API 影響:**
+
+- `Source::async_with_dispatcher()` / `Flow::async_with_dispatcher()` の dispatcher 指定が実行時に意味を持つようになる。
+- ActorSystem / Materializer なしの stream 実行入口は追加しない。
+- カスタム stream mailbox selector は本 change では追加しない。
+
+**挙動影響:**
+
+- 複数 island stream は 1 actor 直列 drive ではなく、island ごとの actor mailbox で進む。
+- dispatcher を分けた island は actor runtime の dispatcher 分離を受ける。
+- async boundary は throughput / fairness / failure propagation の観測単位になる。
+
+## Non-goals
+
+- stream operator DSL の追加や Pekko operator 全量実装。
+- remote stream / cluster stream / distributed stream の実装。
+- island ごとの OS thread 固定割り当て。
+- stream 専用 mailbox selector API の追加。
+- `Actor::receive` や mailbox drain contract の async 化。
+- 旧直実行 API や ActorSystem なし execution helper の復活。

--- a/openspec/changes/stream-island-actors/specs/stream-island-actors/spec.md
+++ b/openspec/changes/stream-island-actors/specs/stream-island-actors/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: async boundary は island ごとの actor 実行境界にならなければならない
+
+stream materialization は、`async()` によって分割された各 island を独立した actor 実行単位として起動しなければならない（MUST）。複数 island graph を 1 つの actor が全 handle を順番に `drive()` する実装にしてはならない（MUST NOT）。
+
+#### Scenario: 複数 island graph は island ごとの actor で drive される
+
+- **GIVEN** `Source` / `Flow` / `Sink` graph に少なくとも 1 つの `async()` boundary がある
+- **WHEN** `ActorMaterializer` が graph を materialize する
+- **THEN** `IslandSplitter` が生成した island ごとに stream 実行 actor が起動される
+- **AND** 各 actor は自分の island の `StreamHandleImpl` だけを所有する
+- **AND** `StreamHandleImpl::drive()` は対象 island actor の mailbox 内で実行される
+
+#### Scenario: 1 つの actor が複数 island handle を直列 drive しない
+
+- **GIVEN** 3 つ以上の island に分割される graph
+- **WHEN** materialized stream が tick を受ける
+- **THEN** 1 つの actor が全 island handle を順番に `drive()` する経路は存在しない
+- **AND** 各 island の drive はそれぞれの actor mailbox を通って実行される
+
+### Requirement: async dispatcher は downstream island actor に反映されなければならない
+
+`async_with_dispatcher(dispatcher_id)` は、その async boundary の downstream island actor を指定 dispatcher で起動しなければならない（MUST）。dispatcher id が actor system に登録されていない場合、materialization は default dispatcher へフォールバックしてはならない（MUST NOT）。
+
+#### Scenario: async_with_dispatcher が downstream island の dispatcher を選ぶ
+
+- **GIVEN** `Flow::new().map(...).async_with_dispatcher("stream-blocking")` を含む graph
+- **AND** actor system に `"stream-blocking"` dispatcher が登録されている
+- **WHEN** `ActorMaterializer` が graph を materialize する
+- **THEN** async boundary の downstream island actor は `"stream-blocking"` dispatcher で起動される
+- **AND** upstream island actor は dispatcher 指定がなければ default dispatcher で起動される
+
+#### Scenario: 未登録 dispatcher は materialization failure になる
+
+- **GIVEN** `Source::single(1).async_with_dispatcher("missing-dispatcher")` を含む graph
+- **AND** actor system に `"missing-dispatcher"` dispatcher が登録されていない
+- **WHEN** `ActorMaterializer` が graph を materialize する
+- **THEN** materialization は失敗する
+- **AND** default dispatcher への暗黙フォールバックは発生しない
+- **AND** 失敗は `StreamError` として観測できる
+
+### Requirement: materialized handle は graph 全体を代表しなければならない
+
+複数 island graph の materialized handle は、先頭 island だけではなく graph 全体の lifecycle を代表しなければならない（MUST）。cancel / terminal state / snapshot は、materialized graph に属する全 island を対象にしなければならない（MUST）。
+
+#### Scenario: cancel は全 island actor に伝播する
+
+- **GIVEN** 複数 island graph が materialize 済みである
+- **WHEN** 利用者が materialized handle を cancel する
+- **THEN** materialized graph に属する全 island actor に cancel または shutdown command が送られる
+- **AND** boundary は terminal state へ遷移し、pending 要素を無言で捨てない
+
+#### Scenario: snapshot は island 単位の状態を観測できる
+
+- **GIVEN** 複数 island graph が materialize 済みである
+- **WHEN** materializer snapshot または test-only diagnostic が取得される
+- **THEN** materialized graph に属する island 数を観測できる
+- **AND** 各 island の dispatcher id または actor id を検証できる
+
+### Requirement: materializer shutdown は island actors を決定的に停止しなければならない
+
+`ActorMaterializer::shutdown()` は、materializer が起動した island actor と tick resource を停止しなければならない（MUST）。停止失敗を無言で握りつぶしてはならない（MUST NOT）。
+
+#### Scenario: shutdown は全 island actor を停止する
+
+- **GIVEN** 複数 materialized stream が存在し、それぞれが複数 island actor を持つ
+- **WHEN** `ActorMaterializer::shutdown()` が呼ばれる
+- **THEN** 全 island actor に shutdown command が送られる
+- **AND** tick resource は cancel される
+- **AND** shutdown が成功した後に island actor へ drive command は送られない
+
+#### Scenario: shutdown failure は観測できる
+
+- **GIVEN** island actor または tick resource の停止に失敗する状態がある
+- **WHEN** `ActorMaterializer::shutdown()` が呼ばれる
+- **THEN** 失敗は `StreamError` または actor error として観測できる
+- **AND** best-effort コメントだけで失敗を黙殺しない

--- a/openspec/changes/stream-island-actors/specs/streams-backpressure-integrity/spec.md
+++ b/openspec/changes/stream-island-actors/specs/streams-backpressure-integrity/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: island boundary は actor 分離後も backpressure と terminal signal を保持しなければならない
+
+stream island boundary は、island が別 actor / 別 mailbox / 別 dispatcher で実行されても、要素、backpressure、completion、failure、cancellation を失ってはならない（MUST）。boundary full / empty を同期直実行の恒久 failure として扱ってはならない（MUST NOT）。
+
+#### Scenario: boundary full は upstream island の pending として扱われる
+
+- **GIVEN** upstream island actor が downstream boundary に要素を push している
+- **AND** boundary capacity が満杯である
+- **WHEN** upstream island actor が drive される
+- **THEN** upstream island は要素を保持したまま pending になる
+- **AND** 要素は drop されない
+- **AND** downstream island が boundary を drain した後、upstream island は後続 drive で進捗できる
+
+#### Scenario: boundary empty は downstream island の pending として扱われる
+
+- **GIVEN** downstream island actor が boundary から pull している
+- **AND** boundary が empty かつ open である
+- **WHEN** downstream island actor が drive される
+- **THEN** downstream island は failure ではなく pending として扱われる
+- **AND** busy loop せず、次の drive command または boundary state transition まで待機する
+
+#### Scenario: upstream completion は pending 要素の後に downstream completion になる
+
+- **GIVEN** upstream island が completion に到達する
+- **AND** boundary に未配送要素が残っている
+- **WHEN** downstream island が boundary を drain する
+- **THEN** downstream island は残り要素を受け取る
+- **AND** 残り要素の後に completion を観測する
+
+#### Scenario: upstream failure は downstream failure になる
+
+- **GIVEN** upstream island actor が failure に到達する
+- **WHEN** boundary が failure state に遷移する
+- **THEN** downstream island actor は同じ materialized graph の failure として観測する
+- **AND** downstream island は正常 completion として扱われない
+
+#### Scenario: downstream cancellation は upstream island へ伝播する
+
+- **GIVEN** downstream island actor が cancel される
+- **WHEN** cancel が boundary に伝播する
+- **THEN** upstream island actor は cancel または shutdown command を受け取る
+- **AND** upstream island は新しい要素を boundary へ publish し続けない

--- a/openspec/changes/stream-island-actors/tasks.md
+++ b/openspec/changes/stream-island-actors/tasks.md
@@ -1,0 +1,64 @@
+## 1. 現状固定と退行テスト準備
+
+- [ ] 1.1 `Source::async()` / `Flow::async()` が stage attribute として async boundary を付与していることを確認する。
+- [ ] 1.2 `Source::async_with_dispatcher()` / `Flow::async_with_dispatcher()` が downstream island dispatcher candidate として解釈されることを `IslandSplitter` tests で固定する。
+- [ ] 1.3 `SingleIslandPlan::dispatcher()` が materialization 前に取得できることを unit test で固定する。
+- [ ] 1.4 現在の `StreamDriveActor` が複数 handle を直列 drive している箇所を洗い出し、置換対象を明確にする。
+- [ ] 1.5 dispatcher 反映を観測するための test-only dispatcher factory または actor snapshot 経路を決める。
+
+## 2. island actor 実行単位の追加
+
+- [ ] 2.1 `StreamIslandActor` を追加し、1 actor が 1 `StreamHandleImpl` だけを所有するようにする。
+- [ ] 2.2 `StreamIslandCommand` を追加し、`Drive` / `Cancel` / `Shutdown` を扱う。
+- [ ] 2.3 `StreamIslandActor` の `Drive` command が自分の mailbox 内で `handle.drive()` を呼ぶことを unit test で固定する。
+- [ ] 2.4 terminal state に到達した island actor がそれ以上 drive されないことを固定する。
+- [ ] 2.5 `StreamDriveActor` を削除または tick fanout 専用へ縮小し、複数 handle を直接 drive する責務を残さない。
+
+## 3. ActorMaterializer の materialization 変更
+
+- [ ] 3.1 `ActorMaterializer` が `IslandSplitter::split(...)` の island ごとに `StreamIslandActor` を spawn するようにする。
+- [ ] 3.2 `SingleIslandPlan::dispatcher()` を `into_stream_plan()` 前に読み取り、`Props::with_dispatcher_id(...)` に反映する。
+- [ ] 3.3 dispatcher 指定がない island は default dispatcher を使うようにする。
+- [ ] 3.4 未登録 dispatcher 指定時に materialization が失敗し、default dispatcher へフォールバックしないことを integration test で固定する。
+- [ ] 3.5 island actor spawn 途中で失敗した場合、起動済み actor / tick resource / boundary resource を rollback する。
+
+## 4. tick 供給と lifecycle 管理
+
+- [ ] 4.1 tick 供給方式を island ごとの scheduler job にするか tick fanout actor にするか決定する。
+- [ ] 4.2 どちらの方式でも `handle.drive()` が scheduler callback や fanout actor から直接呼ばれないことを実装で保証する。
+- [ ] 4.3 materialized stream ごとの island actor 集合を追跡する内部構造を追加する。
+- [ ] 4.4 `ActorMaterializer::shutdown()` が全 island actor と tick resource を停止するようにする。
+- [ ] 4.5 shutdown failure を `StreamError` または actor error として観測できるようにし、戻り値を黙殺しない。
+
+## 5. composite materialized handle
+
+- [ ] 5.1 複数 island graph 全体を代表する composite handle または同等の内部構造を追加する。
+- [ ] 5.2 `cancel()` が全 island actor へ cancel / shutdown を伝播することを integration test で固定する。
+- [ ] 5.3 terminal state が graph 全体の状態として導出されることを test で固定する。
+- [ ] 5.4 materializer snapshot または test-only diagnostic で island 数を観測できるようにする。
+- [ ] 5.5 dispatcher id または actor id を test から検証できる経路を追加する。
+
+## 6. boundary backpressure と terminal propagation
+
+- [ ] 6.1 `IslandBoundaryShared` が actor 分離後の full / empty / completed / failed / cancelled state を表現できるか確認する。
+- [ ] 6.2 表現できない場合、同じ contract を持つ boundary 型へ置き換える。
+- [ ] 6.3 boundary full 時に upstream island が要素を保持して pending になることを test で固定する。
+- [ ] 6.4 boundary empty かつ open 時に downstream island が pending になり、busy loop しないことを test で固定する。
+- [ ] 6.5 upstream completion が pending 要素の後に downstream completion として観測されることを test で固定する。
+- [ ] 6.6 upstream failure が downstream failure として観測されることを test で固定する。
+- [ ] 6.7 downstream cancellation が upstream island へ伝播することを test で固定する。
+
+## 7. DSL / showcase / 公開面の整合
+
+- [ ] 7.1 `Flow::add_attributes(Attributes::async_boundary())` が stage attribute ではなく graph attribute に留まる場合の扱いを確認し、必要なら別 task として切り出す。
+- [ ] 7.2 stream showcase は ActorSystem + ActorMaterializer + Sink 経由の実行だけを示すように維持する。
+- [ ] 7.3 ActorSystem なしの直実行 API や `collect_values()` 相当 helper を公開 API に戻さない。
+- [ ] 7.4 `async_with_dispatcher()` の rustdoc に downstream island dispatcher の意味を記載する。
+- [ ] 7.5 カスタム stream mailbox selector は本 change に含めず、必要なら別 change として整理する。
+
+## 8. 検証
+
+- [ ] 8.1 `rtk cargo test -p fraktor-stream-core-rs` を実行する。
+- [ ] 8.2 必要に応じて `rtk cargo test -p fraktor-showcases-std --features advanced` を実行する。
+- [ ] 8.3 `rtk git diff --check` を実行する。
+- [ ] 8.4 ソースコード編集後の最終確認として `rtk ./scripts/ci-check.sh ai all` を実行し、完了を待つ。


### PR DESCRIPTION
## 概要

stream async boundary を Pekko 互換の island actor 実行境界へ寄せるための OpenSpec change を追加します。

この PR は実装コードを変更せず、`openspec/changes/stream-island-actors/` の proposal / design / specs / tasks のみを追加します。

## 内容

- `async()` による island 分割を actor / mailbox / dispatcher 独立実行へ接続する方針を定義
- `async_with_dispatcher()` の dispatcher を downstream island actor に反映する契約を追加
- island boundary の backpressure / completion / failure / cancellation 契約を明文化
- 実装タスクを段階化

## 検証

- `rtk mise exec -- openspec validate stream-island-actors --strict`
- `rtk git diff --cached --check`

ソースコードは編集していないため、`./scripts/ci-check.sh ai all` は実行していません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenSpec change adding requirements/design/tasks; no runtime or API code is modified, so risk is limited to spec/process alignment.
> 
> **Overview**
> Adds a new OpenSpec change set `stream-island-actors` defining the planned shift from single `StreamDriveActor`-driven execution to **per-island stream actors** with mailbox/dispatcher isolation, aligning `async()` semantics with Pekko.
> 
> Introduces explicit requirements and scenarios for **downstream dispatcher propagation** from `async_with_dispatcher()`, boundary backpressure/terminal-signal integrity across actor boundaries, and composite materialized-handle/materializer shutdown behavior, plus a staged implementation task plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ea9f2709df8c13f7c07a169f42ded0291c7323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->