### PR TITLE
[codex] Explain backoff option duplication

### DIFF
--- a/modules/actor-core/src/core/kernel/actor/supervision/backoff_on_failure_options.rs
+++ b/modules/actor-core/src/core/kernel/actor/supervision/backoff_on_failure_options.rs
@@ -12,6 +12,11 @@ mod tests;
 /// Options for creating a backoff supervisor that restarts its child on failure.
 ///
 /// Corresponds to Pekko's `BackoffOnFailureOptions`.
+///
+/// This intentionally mirrors [`BackoffOnStopOptions`](super::BackoffOnStopOptions)
+/// and shares storage through [`BackoffOptionsData`]. Keep the public option
+/// types separate unless future fields or behavior diverge enough to make a
+/// shared abstraction simpler than the duplicated API surface.
 #[derive(Clone)]
 pub struct BackoffOnFailureOptions {
   inner: BackoffOptionsData,

--- a/modules/actor-core/src/core/kernel/actor/supervision/backoff_on_stop_options.rs
+++ b/modules/actor-core/src/core/kernel/actor/supervision/backoff_on_stop_options.rs
@@ -12,6 +12,11 @@ mod tests;
 /// Options for creating a backoff supervisor that restarts its child on stop.
 ///
 /// Corresponds to Pekko's `BackoffOnStopOptions`.
+///
+/// This intentionally mirrors [`BackoffOnFailureOptions`](super::BackoffOnFailureOptions)
+/// and shares storage through [`BackoffOptionsData`]. Keep the public option
+/// types separate unless future fields or behavior diverge enough to make a
+/// shared abstraction simpler than the duplicated API surface.
 #[derive(Clone)]
 pub struct BackoffOnStopOptions {
   inner: BackoffOptionsData,


### PR DESCRIPTION
## 概要
- `BackoffOnFailureOptions` と `BackoffOnStopOptions` の Rustdoc に、重複が意図的であることを追記しました。
- `BackoffOptionsData` による内部ストレージ共有と、将来共通抽象へ寄せる判断基準を明記しました。

Closes #1494

## 検証
- `PATH="$HOME/.cargo/bin:$PATH" ./scripts/ci-check.sh ai all`

## 備考
- `apply_patch` 後の自動チェックは PATH 上の cargo が `+nightly-2025-12-01` を直接解釈できず一度失敗したため、rustup proxy を優先する PATH で再実行しました。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only change clarifying design intent; no functional behavior, API, or data-handling logic is modified.
> 
> **Overview**
> Adds Rustdoc notes to `BackoffOnFailureOptions` and `BackoffOnStopOptions` explaining that their duplicated public APIs are *intentional*, while both types share internal storage via `BackoffOptionsData`.
> 
> The docs also state the guideline for keeping the option types separate unless future divergence makes a shared abstraction preferable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4f2d73bcfe415057c6ecfa438314f941f90c6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->