### PR TITLE
test(stream-core): remove stream handle naming remnants

### DIFF
--- a/modules/stream-core/src/core/dsl/actor_sink/tests.rs
+++ b/modules/stream-core/src/core/dsl/actor_sink/tests.rs
@@ -29,8 +29,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), crate::core::r#impl::StreamError> {

--- a/modules/stream-core/src/core/dsl/actor_source/tests.rs
+++ b/modules/stream-core/src/core/dsl/actor_source/tests.rs
@@ -23,8 +23,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {

--- a/modules/stream-core/src/core/dsl/sink/tests.rs
+++ b/modules/stream-core/src/core/dsl/sink/tests.rs
@@ -48,8 +48,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {

--- a/modules/stream-core/src/core/dsl/source/tests.rs
+++ b/modules/stream-core/src/core/dsl/source/tests.rs
@@ -141,8 +141,8 @@ impl Materializer for RecordingMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {

--- a/modules/stream-core/src/core/impl/hub/broadcast_hub/tests.rs
+++ b/modules/stream-core/src/core/impl/hub/broadcast_hub/tests.rs
@@ -34,8 +34,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {

--- a/modules/stream-core/src/core/impl/hub/merge_hub/tests.rs
+++ b/modules/stream-core/src/core/impl/hub/merge_hub/tests.rs
@@ -34,8 +34,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {

--- a/modules/stream-core/src/core/impl/hub/partition_hub/tests.rs
+++ b/modules/stream-core/src/core/impl/hub/partition_hub/tests.rs
@@ -34,8 +34,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {

--- a/modules/stream-core/src/core/stage/sub_sink_inlet/tests.rs
+++ b/modules/stream-core/src/core/stage/sub_sink_inlet/tests.rs
@@ -25,8 +25,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {

--- a/modules/stream-core/src/core/stage/sub_source_outlet/tests.rs
+++ b/modules/stream-core/src/core/stage/sub_source_outlet/tests.rs
@@ -27,8 +27,8 @@ impl Materializer for TestMaterializer {
     let (plan, materialized) = graph.into_parts();
     let mut stream = Stream::new(plan, StreamBufferConfig::default());
     stream.start()?;
-    let handle = StreamShared::new(stream);
-    Ok(Materialized::new(handle, materialized))
+    let stream = StreamShared::new(stream);
+    Ok(Materialized::new(stream, materialized))
   }
 
   fn shutdown(&mut self) -> Result<(), StreamError> {


### PR DESCRIPTION
## 概要
- StreamShared を旧設計由来の handle 変数名で扱っていたテスト helper を stream に修正
- StreamHandle 系の削除後に残った命名の残骸を整理
- 実体が handle である queue/control/completion/scheduler 系の公開契約は変更しない

## 検証
- rtk grep "let handle = StreamShared::new|Materialized::new\\(handle" modules/stream-core/src/core
- rtk env PATH="/Users/j5ik2o/.cargo/bin:/Users/j5ik2o/.local/share/mise/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/j5ik2o/.local/bin:/Users/j5ik2o/.local/share/mise/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/j5ik2o/.local/bin:/Users/j5ik2o/.nix-profile/bin:/etc/profiles/per-user/j5ik2o/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Obsidian.app/Contents/MacOS" ./scripts/ci-check.sh ai fmt
- rtk env PATH="/Users/j5ik2o/.cargo/bin:/Users/j5ik2o/.local/share/mise/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/j5ik2o/.local/bin:/Users/j5ik2o/.local/share/mise/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/j5ik2o/.local/bin:/Users/j5ik2o/.nix-profile/bin:/etc/profiles/per-user/j5ik2o/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Obsidian.app/Contents/MacOS" ./scripts/ci-check.sh ai all は実行中

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only variable renames with no logic, API, or runtime behavior changes.
> 
> **Overview**
> Cleans up `stream-core` test helpers by renaming the local `StreamShared::new(stream)` binding from `handle` to `stream` and passing that through to `Materialized::new`.
> 
> This is a *naming-only* refactor across several DSL/hub/stage test modules; no behavioral or public API changes are introduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9279b95e6fa7c5cdd878791c94abc05806ff80a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * ストリーム処理関連の複数のテストモジュール内で内部実装を整理・簡潔化し、コード構造を最適化しました。これらの変更により、テストコードの可読性と保守性が向上し、今後の開発効率が改善されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->