### PR TITLE
Examples/add affinity exector

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 node = "20"
 python = "3"
 "npm:@fission-ai/openspec" = "1.3.1"
-codex = "0.125.0"
+codex = "0.128.0"

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers.rs
@@ -41,27 +41,27 @@ use super::{
 
 /// Primary registry identifier for the default dispatcher entry.
 ///
-/// Corresponds 1:1 to Pekko `Dispatchers.DefaultDispatcherId` in
-/// `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/Dispatchers.scala:160-164`.
+/// The actual value is `"fraktor.actor.default-dispatcher"`. This uses the
+/// Fraktor namespace and no longer matches Pekko
+/// `Dispatchers.DefaultDispatcherId` (`"pekko.actor.default-dispatcher"`).
+/// Internal code should use [`DEFAULT_DISPATCHER_ID`]; external configuration
+/// should use the Fraktor literal when a literal is required.
 ///
-/// Historically fraktor-rs used `"default"` as the primary id, but change
-/// `pekko-dispatcher-primary-id-alignment` (2026-04-23) flipped the value to
-/// match Pekko. The legacy `"default"` token is no longer registered as an
-/// entry or alias; callers must use this constant (or the raw Pekko string
-/// `"pekko.actor.default-dispatcher"` when a literal is required for
-/// external configuration such as HOCON-style config files).
+/// Historically fraktor-rs used `"default"` as the primary id. The legacy
+/// `"default"` token is no longer registered as an entry or alias.
 pub const DEFAULT_DISPATCHER_ID: &str = "fraktor.actor.default-dispatcher";
 /// Reserved registry identifier for the default blocking IO dispatcher.
 ///
-/// Matches Pekko `Dispatchers.DefaultBlockingDispatcherId`.
+/// The actual value is `"fraktor.actor.default-blocking-io-dispatcher"`.
+/// This uses the Fraktor namespace and no longer matches Pekko
+/// `Dispatchers.DefaultBlockingDispatcherId`.
 pub const DEFAULT_BLOCKING_DISPATCHER_ID: &str = "fraktor.actor.default-blocking-io-dispatcher";
 
-/// Pekko-style alias for the internal dispatcher.
+/// Fraktor-style alias for the internal dispatcher.
 ///
-/// Matches Pekko `Dispatchers.InternalDispatcherId`. Registered as an alias
-/// of [`DEFAULT_DISPATCHER_ID`] by `ensure_default` so Pekko-style user code
-/// referring to the internal dispatcher resolves to the same entry.
-const PEKKO_INTERNAL_DISPATCHER_ID: &str = "fraktor.actor.internal-dispatcher";
+/// Registered as an alias of [`DEFAULT_DISPATCHER_ID`] by `ensure_default` so
+/// internal dispatcher references resolve to the same entry.
+const FRAKTOR_INTERNAL_DISPATCHER_ID: &str = "fraktor.actor.internal-dispatcher";
 
 /// Registry mapping dispatcher identifiers to configurators.
 pub struct Dispatchers {
@@ -275,11 +275,11 @@ impl Dispatchers {
     ArcShared::new(configurator)
   }
 
-  /// Registers the Pekko `InternalDispatcherId` alias pointing at
+  /// Registers the Fraktor internal dispatcher alias pointing at
   /// [`DEFAULT_DISPATCHER_ID`].
   ///
-  /// Only `pekko.actor.internal-dispatcher` is registered as an alias;
-  /// `pekko.actor.default-dispatcher` is the primary entry id itself after
+  /// Only `fraktor.actor.internal-dispatcher` is registered as an alias;
+  /// `fraktor.actor.default-dispatcher` is the primary entry id itself after
   /// change `pekko-dispatcher-primary-id-alignment` (2026-04-23), so it must
   /// not be registered as an alias. The legacy fraktor-rs `"default"` token
   /// is also not registered (completely retired by the same change).
@@ -291,7 +291,7 @@ impl Dispatchers {
     Self::register_alias_if_absent(
       &mut self.aliases,
       &self.entries,
-      PEKKO_INTERNAL_DISPATCHER_ID,
+      FRAKTOR_INTERNAL_DISPATCHER_ID,
       DEFAULT_DISPATCHER_ID,
     );
   }
@@ -317,7 +317,7 @@ impl Dispatchers {
   /// If `default` is missing, the supplied factory closure is called to
   /// produce a configurator that is then registered for both
   /// [`DEFAULT_DISPATCHER_ID`] and [`DEFAULT_BLOCKING_DISPATCHER_ID`], and the
-  /// Pekko-compatible aliases are registered against
+  /// Fraktor internal dispatcher alias is registered against
   /// [`DEFAULT_DISPATCHER_ID`].
   ///
   /// Any pre-existing alias registered under the same id is removed before

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers.rs
@@ -50,18 +50,18 @@ use super::{
 /// entry or alias; callers must use this constant (or the raw Pekko string
 /// `"pekko.actor.default-dispatcher"` when a literal is required for
 /// external configuration such as HOCON-style config files).
-pub const DEFAULT_DISPATCHER_ID: &str = "pekko.actor.default-dispatcher";
+pub const DEFAULT_DISPATCHER_ID: &str = "fraktor.actor.default-dispatcher";
 /// Reserved registry identifier for the default blocking IO dispatcher.
 ///
 /// Matches Pekko `Dispatchers.DefaultBlockingDispatcherId`.
-pub const DEFAULT_BLOCKING_DISPATCHER_ID: &str = "pekko.actor.default-blocking-io-dispatcher";
+pub const DEFAULT_BLOCKING_DISPATCHER_ID: &str = "fraktor.actor.default-blocking-io-dispatcher";
 
 /// Pekko-style alias for the internal dispatcher.
 ///
 /// Matches Pekko `Dispatchers.InternalDispatcherId`. Registered as an alias
 /// of [`DEFAULT_DISPATCHER_ID`] by `ensure_default` so Pekko-style user code
 /// referring to the internal dispatcher resolves to the same entry.
-const PEKKO_INTERNAL_DISPATCHER_ID: &str = "pekko.actor.internal-dispatcher";
+const PEKKO_INTERNAL_DISPATCHER_ID: &str = "fraktor.actor.internal-dispatcher";
 
 /// Registry mapping dispatcher identifiers to configurators.
 pub struct Dispatchers {

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers/tests.rs
@@ -60,10 +60,10 @@ fn pekko_default_dispatcher_id_resolves_as_primary_entry_after_ensure_default() 
   // alias ではなく entry 直接 lookup になることを確認する。
   let mut dispatchers = Dispatchers::new();
   dispatchers.ensure_default(|| make_default_configurator(DEFAULT_DISPATCHER_ID));
-  let resolved = dispatchers.resolve("faktor.actor.default-dispatcher").expect("resolve primary entry");
+  let resolved = dispatchers.resolve("fraktor.actor.default-dispatcher").expect("resolve primary entry");
   assert_eq!(resolved.id(), DEFAULT_DISPATCHER_ID);
   // canonical_id も同じ id を返す (alias chain を辿らず即時 entry 一致)。
-  assert_eq!(dispatchers.canonical_id("faktor.actor.default-dispatcher").expect("canonical"), DEFAULT_DISPATCHER_ID);
+  assert_eq!(dispatchers.canonical_id("fraktor.actor.default-dispatcher").expect("canonical"), DEFAULT_DISPATCHER_ID);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn pekko_internal_dispatcher_id_resolves_via_alias_registered_by_ensure_default(
   // (Pekko `InternalDispatcherId` 互換のため)。
   let mut dispatchers = Dispatchers::new();
   dispatchers.ensure_default(|| make_default_configurator(DEFAULT_DISPATCHER_ID));
-  let resolved = dispatchers.resolve("faktor.actor.internal-dispatcher").expect("resolve internal");
+  let resolved = dispatchers.resolve("fraktor.actor.internal-dispatcher").expect("resolve internal");
   assert_eq!(resolved.id(), DEFAULT_DISPATCHER_ID);
 }
 
@@ -101,7 +101,7 @@ fn ensure_default_inline_registers_only_internal_dispatcher_alias() {
   // aliases map には internal-dispatcher の 1 件のみ存在 (legacy "default" は登録されない)。
   assert_eq!(dispatchers.aliases.len(), 1);
   assert_eq!(
-    dispatchers.aliases.get("faktor.actor.internal-dispatcher").map(String::as_str),
+    dispatchers.aliases.get("fraktor.actor.internal-dispatcher").map(String::as_str),
     Some(DEFAULT_DISPATCHER_ID)
   );
   assert!(!dispatchers.aliases.contains_key("default"), "legacy default must not be an alias");
@@ -383,7 +383,7 @@ fn canonical_id_returns_resolved_entry_id() {
   let mut dispatchers = Dispatchers::new();
   dispatchers.ensure_default(|| make_default_configurator(DEFAULT_DISPATCHER_ID));
 
-  let canonical = dispatchers.canonical_id("faktor.actor.internal-dispatcher").expect("canonical");
+  let canonical = dispatchers.canonical_id("fraktor.actor.internal-dispatcher").expect("canonical");
   assert_eq!(canonical, DEFAULT_DISPATCHER_ID);
 
   // canonical_id は resolve counter をインクリメントしない。

--- a/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/dispatcher/dispatchers/tests.rs
@@ -60,10 +60,10 @@ fn pekko_default_dispatcher_id_resolves_as_primary_entry_after_ensure_default() 
   // alias ではなく entry 直接 lookup になることを確認する。
   let mut dispatchers = Dispatchers::new();
   dispatchers.ensure_default(|| make_default_configurator(DEFAULT_DISPATCHER_ID));
-  let resolved = dispatchers.resolve("pekko.actor.default-dispatcher").expect("resolve primary entry");
+  let resolved = dispatchers.resolve("faktor.actor.default-dispatcher").expect("resolve primary entry");
   assert_eq!(resolved.id(), DEFAULT_DISPATCHER_ID);
   // canonical_id も同じ id を返す (alias chain を辿らず即時 entry 一致)。
-  assert_eq!(dispatchers.canonical_id("pekko.actor.default-dispatcher").expect("canonical"), DEFAULT_DISPATCHER_ID);
+  assert_eq!(dispatchers.canonical_id("faktor.actor.default-dispatcher").expect("canonical"), DEFAULT_DISPATCHER_ID);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn pekko_internal_dispatcher_id_resolves_via_alias_registered_by_ensure_default(
   // (Pekko `InternalDispatcherId` 互換のため)。
   let mut dispatchers = Dispatchers::new();
   dispatchers.ensure_default(|| make_default_configurator(DEFAULT_DISPATCHER_ID));
-  let resolved = dispatchers.resolve("pekko.actor.internal-dispatcher").expect("resolve internal");
+  let resolved = dispatchers.resolve("faktor.actor.internal-dispatcher").expect("resolve internal");
   assert_eq!(resolved.id(), DEFAULT_DISPATCHER_ID);
 }
 
@@ -101,7 +101,7 @@ fn ensure_default_inline_registers_only_internal_dispatcher_alias() {
   // aliases map には internal-dispatcher の 1 件のみ存在 (legacy "default" は登録されない)。
   assert_eq!(dispatchers.aliases.len(), 1);
   assert_eq!(
-    dispatchers.aliases.get("pekko.actor.internal-dispatcher").map(String::as_str),
+    dispatchers.aliases.get("faktor.actor.internal-dispatcher").map(String::as_str),
     Some(DEFAULT_DISPATCHER_ID)
   );
   assert!(!dispatchers.aliases.contains_key("default"), "legacy default must not be an alias");
@@ -383,7 +383,7 @@ fn canonical_id_returns_resolved_entry_id() {
   let mut dispatchers = Dispatchers::new();
   dispatchers.ensure_default(|| make_default_configurator(DEFAULT_DISPATCHER_ID));
 
-  let canonical = dispatchers.canonical_id("pekko.actor.internal-dispatcher").expect("canonical");
+  let canonical = dispatchers.canonical_id("faktor.actor.internal-dispatcher").expect("canonical");
   assert_eq!(canonical, DEFAULT_DISPATCHER_ID);
 
   // canonical_id は resolve counter をインクリメントしない。

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
@@ -34,7 +34,7 @@ mod tests;
 /// to match Pekko. `Mailboxes` does not currently support alias chain
 /// resolution (unlike `Dispatchers`), so the legacy `"default"` token is
 /// simply no longer registered.
-const DEFAULT_MAILBOX_ID: &str = "pekko.actor.default-mailbox";
+const DEFAULT_MAILBOX_ID: &str = "faktor.actor.default-mailbox";
 
 pub(crate) fn create_message_queue_from_policy(policy: MailboxPolicy) -> Box<dyn MessageQueue> {
   mailbox_type_from_policy(policy).create()

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
@@ -26,14 +26,14 @@ mod tests;
 
 /// Primary registry identifier for the default mailbox entry.
 ///
-/// Corresponds 1:1 to Pekko `Mailboxes.DefaultMailboxId` in
-/// `references/pekko/actor/src/main/scala/org/apache/pekko/dispatch/Mailboxes.scala:58`.
+/// The actual value is `"fraktor.actor.default-mailbox"`. This uses the
+/// Fraktor namespace and intentionally differs from Pekko
+/// `Mailboxes.DefaultMailboxId` (`"pekko.actor.default-mailbox"`).
 ///
-/// Historically fraktor-rs used `"default"` as the primary id, but change
-/// `pekko-dispatcher-primary-id-alignment` (2026-04-23) flipped the value
-/// to match Pekko. `Mailboxes` does not currently support alias chain
-/// resolution (unlike `Dispatchers`), so the legacy `"default"` token is
-/// simply no longer registered.
+/// Historically fraktor-rs used `"default"` as the primary id. `Mailboxes`
+/// does not currently support alias chain resolution (unlike `Dispatchers`),
+/// so the legacy `"default"` token is no longer registered after the Fraktor
+/// namespace split.
 const DEFAULT_MAILBOX_ID: &str = "fraktor.actor.default-mailbox";
 
 pub(crate) fn create_message_queue_from_policy(policy: MailboxPolicy) -> Box<dyn MessageQueue> {

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/mailboxes.rs
@@ -34,7 +34,7 @@ mod tests;
 /// to match Pekko. `Mailboxes` does not currently support alias chain
 /// resolution (unlike `Dispatchers`), so the legacy `"default"` token is
 /// simply no longer registered.
-const DEFAULT_MAILBOX_ID: &str = "faktor.actor.default-mailbox";
+const DEFAULT_MAILBOX_ID: &str = "fraktor.actor.default-mailbox";
 
 pub(crate) fn create_message_queue_from_policy(policy: MailboxPolicy) -> Box<dyn MessageQueue> {
   mailbox_type_from_policy(policy).create()

--- a/modules/actor-core/src/core/typed/dispatchers.rs
+++ b/modules/actor-core/src/core/typed/dispatchers.rs
@@ -25,7 +25,7 @@ use crate::core::{
 /// Matches [`DEFAULT_DISPATCHER_ID`] (the kernel primary entry id).
 const PEKKO_DEFAULT_DISPATCHER_ID: &str = DEFAULT_DISPATCHER_ID;
 /// Pekko-compatible public identifier for the internal dispatcher.
-const PEKKO_INTERNAL_DISPATCHER_ID: &str = "pekko.actor.internal-dispatcher";
+const PEKKO_INTERNAL_DISPATCHER_ID: &str = "fraktor.actor.internal-dispatcher";
 
 /// Typed facade for looking up dispatcher configurations by selector.
 ///

--- a/modules/actor-core/src/core/typed/dispatchers.rs
+++ b/modules/actor-core/src/core/typed/dispatchers.rs
@@ -13,19 +13,21 @@ use alloc::string::ToString;
 use crate::core::{
   kernel::{
     dispatch::dispatcher::{
-      DEFAULT_BLOCKING_DISPATCHER_ID, DEFAULT_DISPATCHER_ID, DispatchersError, MessageDispatcherShared,
+      DEFAULT_BLOCKING_DISPATCHER_ID as KERNEL_DEFAULT_BLOCKING_DISPATCHER_ID,
+      DEFAULT_DISPATCHER_ID as KERNEL_DEFAULT_DISPATCHER_ID, DispatchersError, MessageDispatcherShared,
     },
     system::state::SystemStateShared,
   },
   typed::DispatcherSelector,
 };
 
-/// Pekko-compatible public identifier for the default dispatcher.
+/// Fraktor public identifier for the default dispatcher.
 ///
-/// Matches [`DEFAULT_DISPATCHER_ID`] (the kernel primary entry id).
-const PEKKO_DEFAULT_DISPATCHER_ID: &str = DEFAULT_DISPATCHER_ID;
-/// Pekko-compatible public identifier for the internal dispatcher.
-const PEKKO_INTERNAL_DISPATCHER_ID: &str = "fraktor.actor.internal-dispatcher";
+/// Matches [`crate::core::kernel::dispatch::dispatcher::DEFAULT_DISPATCHER_ID`]
+/// (the kernel primary entry id).
+const FRAKTOR_DEFAULT_DISPATCHER_ID: &str = KERNEL_DEFAULT_DISPATCHER_ID;
+/// Fraktor public identifier for the internal dispatcher.
+const FRAKTOR_INTERNAL_DISPATCHER_ID: &str = "fraktor.actor.internal-dispatcher";
 
 /// Typed facade for looking up dispatcher configurations by selector.
 ///
@@ -42,12 +44,13 @@ pub struct Dispatchers {
 impl Dispatchers {
   /// Well-known identifier for the system default dispatcher.
   ///
-  /// Corresponds to Pekko's `Dispatchers.DefaultDispatcherId`.
-  pub const DEFAULT_DISPATCHER_ID: &str = PEKKO_DEFAULT_DISPATCHER_ID;
+  /// Corresponds to the kernel
+  /// [`DEFAULT_DISPATCHER_ID`](crate::core::kernel::dispatch::dispatcher::DEFAULT_DISPATCHER_ID).
+  pub const DEFAULT_DISPATCHER_ID: &str = FRAKTOR_DEFAULT_DISPATCHER_ID;
   /// Well-known identifier for the internal dispatcher.
   ///
-  /// Corresponds to Pekko's `Dispatchers.InternalDispatcherId`.
-  pub const INTERNAL_DISPATCHER_ID: &str = PEKKO_INTERNAL_DISPATCHER_ID;
+  /// Registered by the kernel as an alias of [`Self::DEFAULT_DISPATCHER_ID`].
+  pub const INTERNAL_DISPATCHER_ID: &str = FRAKTOR_INTERNAL_DISPATCHER_ID;
 
   /// Creates a new dispatcher lookup facade.
   #[must_use]
@@ -61,15 +64,15 @@ impl Dispatchers {
   ///
   /// | Selector | Passed to kernel `resolve` |
   /// |----------|----------------------------|
-  /// | `Default` / `SameAsParent` | `"pekko.actor.default-dispatcher"` (kernel `DEFAULT_DISPATCHER_ID`) |
+  /// | `Default` / `SameAsParent` | [`Self::DEFAULT_DISPATCHER_ID`] (`"fraktor.actor.default-dispatcher"`) |
   /// | `FromConfig(id)` | `id` verbatim (kernel follows its alias chain) |
-  /// | `Blocking` | `"pekko.actor.default-blocking-io-dispatcher"` |
+  /// | `Blocking` | kernel `DEFAULT_BLOCKING_DISPATCHER_ID` (`"fraktor.actor.default-blocking-io-dispatcher"`) |
   ///
   /// The `FromConfig` arm passes the identifier through unchanged so that
   /// kernel [`Dispatchers`](crate::core::kernel::dispatch::dispatcher::Dispatchers)
   /// alias chain resolution is authoritative. This preserves any
   /// user-provided entry override such as
-  /// `register_or_update("pekko.actor.default-dispatcher", custom)`, which
+  /// `register_or_update("fraktor.actor.default-dispatcher", custom)`, which
   /// a stale typed-level normalization step would otherwise shadow.
   ///
   /// # Errors
@@ -78,9 +81,9 @@ impl Dispatchers {
   /// has not been registered in the kernel dispatcher registry.
   pub fn lookup(&self, selector: &DispatcherSelector) -> Result<MessageDispatcherShared, DispatchersError> {
     let id: &str = match selector {
-      | DispatcherSelector::Default | DispatcherSelector::SameAsParent => DEFAULT_DISPATCHER_ID,
+      | DispatcherSelector::Default | DispatcherSelector::SameAsParent => Self::DEFAULT_DISPATCHER_ID,
       | DispatcherSelector::FromConfig(id) => id,
-      | DispatcherSelector::Blocking => DEFAULT_BLOCKING_DISPATCHER_ID,
+      | DispatcherSelector::Blocking => KERNEL_DEFAULT_BLOCKING_DISPATCHER_ID,
     };
     self.state.resolve_dispatcher(id).ok_or_else(|| DispatchersError::Unknown(id.to_string()))
   }

--- a/modules/actor-core/src/core/typed/dispatchers/tests.rs
+++ b/modules/actor-core/src/core/typed/dispatchers/tests.rs
@@ -139,13 +139,13 @@ fn lookup_blocking_selector_resolves_blocking_dispatcher() {
 #[test]
 fn default_dispatcher_id_matches_kernel_constant() {
   let id = Dispatchers::DEFAULT_DISPATCHER_ID;
-  assert_eq!(id, "faktor.actor.default-dispatcher");
+  assert_eq!(id, "fraktor.actor.default-dispatcher");
 }
 
 #[test]
 fn internal_dispatcher_id_matches_pekko_constant() {
   let id = Dispatchers::INTERNAL_DISPATCHER_ID;
-  assert_eq!(id, "faktor.actor.internal-dispatcher");
+  assert_eq!(id, "fraktor.actor.internal-dispatcher");
 }
 
 // --- shutdown --------------------------------------------------------------

--- a/modules/actor-core/src/core/typed/dispatchers/tests.rs
+++ b/modules/actor-core/src/core/typed/dispatchers/tests.rs
@@ -86,7 +86,7 @@ fn lookup_from_config_preserves_user_override_of_pekko_alias() {
     let executor = ExecutorShared::new(Box::new(NoopExecutor), TrampolineState::new());
     let custom: ArcShared<Box<dyn MessageDispatcherFactory>> =
       ArcShared::new(Box::new(DefaultDispatcherFactory::new(&custom_config, executor)));
-    config.with_dispatcher_factory("pekko.actor.default-dispatcher", custom)
+    config.with_dispatcher_factory("fraktor.actor.default-dispatcher", custom)
   });
 
   let dispatchers = Dispatchers::new(system.state());
@@ -139,13 +139,13 @@ fn lookup_blocking_selector_resolves_blocking_dispatcher() {
 #[test]
 fn default_dispatcher_id_matches_kernel_constant() {
   let id = Dispatchers::DEFAULT_DISPATCHER_ID;
-  assert_eq!(id, "pekko.actor.default-dispatcher");
+  assert_eq!(id, "faktor.actor.default-dispatcher");
 }
 
 #[test]
 fn internal_dispatcher_id_matches_pekko_constant() {
   let id = Dispatchers::INTERNAL_DISPATCHER_ID;
-  assert_eq!(id, "pekko.actor.internal-dispatcher");
+  assert_eq!(id, "faktor.actor.internal-dispatcher");
 }
 
 // --- shutdown --------------------------------------------------------------

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -83,14 +83,95 @@ DEFAULT_CARGO_CMD=("${CI_CHECK_CARGO_PREFIX[@]}")
 build_cargo_prefix_for "${FMT_TOOLCHAIN}" || exit 1
 FMT_CARGO_CMD=("${CI_CHECK_CARGO_PREFIX[@]}")
 
-resolve_rustfmt_bin_for() {
+resolve_tool_bin_for() {
   local toolchain="${1:-}"
+  local tool="${2:-}"
+  if [[ -z "${tool}" ]]; then
+    echo "エラー: 解決するツール名が指定されていません。" >&2
+    return 1
+  fi
+
   if [[ -n "${toolchain}" ]]; then
-    rustup which --toolchain "${toolchain}" rustfmt
+    rustup which --toolchain "${toolchain}" "${tool}"
     return
   fi
 
-  command -v rustfmt
+  command -v "${tool}"
+}
+
+DEFAULT_RUSTC_BIN="$(resolve_tool_bin_for "${DEFAULT_TOOLCHAIN}" rustc)" || {
+  echo "エラー: rustc バイナリを特定できませんでした。" >&2
+  exit 1
+}
+DEFAULT_RUSTDOC_BIN="$(resolve_tool_bin_for "${DEFAULT_TOOLCHAIN}" rustdoc)" || {
+  echo "エラー: rustdoc バイナリを特定できませんでした。" >&2
+  exit 1
+}
+DEFAULT_CARGO_BIN="$(resolve_tool_bin_for "${DEFAULT_TOOLCHAIN}" cargo)" || {
+  echo "エラー: cargo バイナリを特定できませんでした。" >&2
+  exit 1
+}
+DEFAULT_CARGO_CLIPPY_BIN="$(resolve_tool_bin_for "${DEFAULT_TOOLCHAIN}" cargo-clippy 2>/dev/null || true)"
+DEFAULT_CLIPPY_DRIVER_BIN="$(resolve_tool_bin_for "${DEFAULT_TOOLCHAIN}" clippy-driver 2>/dev/null || true)"
+DEFAULT_TOOLCHAIN_BIN="${DEFAULT_RUSTC_BIN%/*}"
+
+case "${PATH}" in
+  "${DEFAULT_TOOLCHAIN_BIN}"|"${DEFAULT_TOOLCHAIN_BIN}:"*) ;;
+  *)
+    export PATH="${DEFAULT_TOOLCHAIN_BIN}:${PATH}"
+    ;;
+esac
+
+if [[ -n "${RUSTC:-}" && "${RUSTC}" != "${DEFAULT_RUSTC_BIN}" ]]; then
+  echo "info: RUSTC=${RUSTC} を上書きして ${DEFAULT_RUSTC_BIN} を使用します" >&2
+fi
+if [[ -n "${RUSTDOC:-}" && "${RUSTDOC}" != "${DEFAULT_RUSTDOC_BIN}" ]]; then
+  echo "info: RUSTDOC=${RUSTDOC} を上書きして ${DEFAULT_RUSTDOC_BIN} を使用します" >&2
+fi
+if [[ -n "${CARGO_BUILD_RUSTC:-}" && "${CARGO_BUILD_RUSTC}" != "${DEFAULT_RUSTC_BIN}" ]]; then
+  echo "info: CARGO_BUILD_RUSTC=${CARGO_BUILD_RUSTC} を上書きして ${DEFAULT_RUSTC_BIN} を使用します" >&2
+fi
+if [[ -n "${CARGO_BUILD_RUSTDOC:-}" && "${CARGO_BUILD_RUSTDOC}" != "${DEFAULT_RUSTDOC_BIN}" ]]; then
+  echo "info: CARGO_BUILD_RUSTDOC=${CARGO_BUILD_RUSTDOC} を上書きして ${DEFAULT_RUSTDOC_BIN} を使用します" >&2
+fi
+if [[ -n "${RUSTC_WRAPPER:-}" ]]; then
+  echo "info: RUSTC_WRAPPER=${RUSTC_WRAPPER} を解除します" >&2
+fi
+if [[ -n "${RUSTC_WORKSPACE_WRAPPER:-}" ]]; then
+  echo "info: RUSTC_WORKSPACE_WRAPPER=${RUSTC_WORKSPACE_WRAPPER} を解除します" >&2
+fi
+if [[ -n "${CARGO_BUILD_RUSTC_WRAPPER:-}" ]]; then
+  echo "info: CARGO_BUILD_RUSTC_WRAPPER=${CARGO_BUILD_RUSTC_WRAPPER} を解除します" >&2
+fi
+if [[ -n "${CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER:-}" ]]; then
+  echo "info: CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER=${CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER} を解除します" >&2
+fi
+export RUSTC="${DEFAULT_RUSTC_BIN}"
+export RUSTDOC="${DEFAULT_RUSTDOC_BIN}"
+export CARGO="${DEFAULT_CARGO_BIN}"
+export CARGO_BUILD_RUSTC="${DEFAULT_RUSTC_BIN}"
+export CARGO_BUILD_RUSTDOC="${DEFAULT_RUSTDOC_BIN}"
+unset RUSTC_WRAPPER
+unset RUSTC_WORKSPACE_WRAPPER
+unset CARGO_BUILD_RUSTC_WRAPPER
+unset CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER
+
+build_toolchain_fingerprint() {
+  printf 'toolchain=%s\n' "${DEFAULT_TOOLCHAIN}"
+  printf 'rustc=%s\n' "${DEFAULT_RUSTC_BIN}"
+  "${DEFAULT_RUSTC_BIN}" -vV
+  printf 'rustdoc=%s\n' "${DEFAULT_RUSTDOC_BIN}"
+  printf 'cargo=%s\n' "${DEFAULT_CARGO_BIN}"
+  printf 'cargo-clippy=%s\n' "${DEFAULT_CARGO_CLIPPY_BIN}"
+  printf 'clippy-driver=%s\n' "${DEFAULT_CLIPPY_DRIVER_BIN}"
+}
+
+CI_CHECK_TOOLCHAIN_FINGERPRINT="$(build_toolchain_fingerprint)"
+CI_CHECK_TOOLCHAIN_STAMP=".ci-check-toolchain"
+
+resolve_rustfmt_bin_for() {
+  local toolchain="${1:-}"
+  resolve_tool_bin_for "${toolchain}" rustfmt
 }
 
 FMT_RUSTFMT_BIN="$(resolve_rustfmt_bin_for "${FMT_TOOLCHAIN}")" || {
@@ -178,6 +259,52 @@ render_command() {
     rendered+="$(printf '%q' "${arg}")"
   done
   printf '%s\n' "${rendered}"
+}
+
+render_cargo_command() {
+  local -a cmd=("${DEFAULT_CARGO_CMD[@]}" -v "$@")
+  render_command "${cmd[@]}"
+}
+
+is_managed_target_dir() {
+  local target_dir="${1:-}"
+  case "${target_dir}" in
+    "${REPO_ROOT}/target/ci-check"|"${REPO_ROOT}/target/ci-check/"*)
+      return 0
+      ;;
+    "${REPO_ROOT}/lints/"*"/target"|"${REPO_ROOT}/lints/"*"/target/"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+prepare_ci_target_dir() {
+  local target_dir="${1:-}"
+  if [[ -z "${target_dir}" ]]; then
+    echo "error: prepare_ci_target_dir に target_dir が指定されていません。" >&2
+    return 1
+  fi
+  if ! is_managed_target_dir "${target_dir}"; then
+    echo "error: 管理対象外の target ディレクトリは自動削除しません: ${target_dir}" >&2
+    return 1
+  fi
+
+  local stamp_file="${target_dir}/${CI_CHECK_TOOLCHAIN_STAMP}"
+  local current_fingerprint=""
+  if [[ -f "${stamp_file}" ]]; then
+    current_fingerprint="$(cat "${stamp_file}" 2>/dev/null || true)"
+  fi
+
+  if [[ -d "${target_dir}" && "${current_fingerprint}" != "${CI_CHECK_TOOLCHAIN_FINGERPRINT}" ]]; then
+    rm -rf -- "${target_dir}"
+    echo "info: ${target_dir#${REPO_ROOT}/} を削除しました (rustc/toolchain が変わったため)" >&2
+  fi
+
+  mkdir -p "${target_dir}"
+  printf '%s\n' "${CI_CHECK_TOOLCHAIN_FINGERPRINT}" > "${stamp_file}"
 }
 
 should_guard_cargo_command() {
@@ -409,7 +536,7 @@ start_parallel_cargo() {
   shift 2
 
   local target_dir="${REPO_ROOT}/target/ci-check/${shard}"
-  mkdir -p "${target_dir}"
+  prepare_ci_target_dir "${target_dir}" || return 1
 
   log_step "[parallel] ${label} (CARGO_TARGET_DIR=${target_dir#${REPO_ROOT}/})"
   (
@@ -426,7 +553,7 @@ start_parallel_phase() {
   local func="$3"
 
   local target_dir="${REPO_ROOT}/target/ci-check/${shard}"
-  mkdir -p "${target_dir}"
+  prepare_ci_target_dir "${target_dir}" || return 1
 
   log_step "[parallel] ${label} (CARGO_TARGET_DIR=${target_dir#${REPO_ROOT}/})"
   (
@@ -802,12 +929,12 @@ run_dylint() {
      local channel
      channel=$(awk -F'"' '/channel/ {print $2; exit}' "${REPO_ROOT}/rust-toolchain.toml")
      if [[ -n "${channel}" ]]; then
-       toolchain="${channel}-$(rustc -vV | awk '/^host:/{print $2}')"
+       toolchain="${channel}-$("${DEFAULT_RUSTC_BIN}" -vV | awk '/^host:/{print $2}')"
      else
-       toolchain="nightly-$(rustc -vV | awk '/^host:/{print $2}')"
+       toolchain="nightly-$("${DEFAULT_RUSTC_BIN}" -vV | awk '/^host:/{print $2}')"
      fi
   else
-     toolchain="nightly-$(rustc -vV | awk '/^host:/{print $2}')"
+     toolchain="nightly-$("${DEFAULT_RUSTC_BIN}" -vV | awk '/^host:/{print $2}')"
   fi
   local -a lib_dirs=()
   local -a dylint_args=()
@@ -817,6 +944,9 @@ run_dylint() {
     local crate="${entry%%:*}"
     local lint_path="${entry#*:}"
     local lib_name="${crate//-/_}"
+    local lint_target_dir="${REPO_ROOT}/${lint_path}/target"
+
+    prepare_ci_target_dir "${lint_target_dir}" || return 1
 
     local -a build_cmd=("${DEFAULT_CARGO_CMD[@]}" -v build --manifest-path "${lint_path}/Cargo.toml" --release)
     log_step "$(render_command "${build_cmd[@]}")"
@@ -863,7 +993,7 @@ run_dylint() {
 
   local -a common_dylint_args=("${dylint_args[@]}" "--no-metadata")
   local sysroot_lib=""
-  sysroot_lib="$(rustc --print sysroot)/lib"
+  sysroot_lib="$("${DEFAULT_RUSTC_BIN}" --print sysroot)/lib"
   local dynlib_path="${sysroot_lib}"
   if [[ "$(uname -s)" == "Darwin" ]]; then
     if [[ -n "${DYLD_FALLBACK_LIBRARY_PATH-}" ]]; then
@@ -969,12 +1099,11 @@ PY
   local -a main_invocation=()
   if [[ ${#main_package_args[@]} -gt 0 ]]; then
     main_invocation=("${main_package_args[@]}" "${common_dylint_args[@]}")
-    local log_main="${main_invocation[*]}"
-    local log_trailing=""
+    local -a log_main_cmd=(dylint "${main_invocation[@]}")
     if [[ ${#trailing_args[@]} -gt 0 ]]; then
-      log_trailing=" -- ${trailing_args[*]}"
+      log_main_cmd+=(-- "${trailing_args[@]}")
     fi
-    log_step "cargo +${DEFAULT_TOOLCHAIN} dylint ${log_main}${log_trailing} (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
+    log_step "$(render_cargo_command "${log_main_cmd[@]}") (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
     if [[ ${#trailing_args[@]} -gt 0 ]]; then
       RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${main_invocation[@]}" -- "${trailing_args[@]}" || return 1
     else
@@ -1002,7 +1131,7 @@ PY
     if [[ ${#trailing_args[@]} -gt 0 ]]; then
       fqcn_tests_cargo_args+=("${trailing_args[@]}")
     fi
-    log_step "cargo +${DEFAULT_TOOLCHAIN} dylint ${fqcn_tests_invocation[*]} -- ${fqcn_tests_cargo_args[*]} (redundant-fqcn-lint --tests pass, RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
+    log_step "$(render_cargo_command dylint "${fqcn_tests_invocation[@]}" -- "${fqcn_tests_cargo_args[@]}") (redundant-fqcn-lint --tests pass, RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
     RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${fqcn_tests_invocation[@]}" -- "${fqcn_tests_cargo_args[@]}" || return 1
   fi
 
@@ -1010,12 +1139,11 @@ PY
     local pkg
     for pkg in "${hardware_targets[@]}"; do
       local -a pkg_invocation=("-p" "${pkg}" "${common_dylint_args[@]}")
-      local log_pkg="${pkg_invocation[*]}"
-      local log_trailing=""
+      local -a log_pkg_cmd=(dylint "${pkg_invocation[@]}")
       if [[ ${#trailing_args[@]} -gt 0 ]]; then
-        log_trailing=" -- ${trailing_args[*]}"
+        log_pkg_cmd+=(-- "${trailing_args[@]}")
       fi
-      log_step "cargo +${DEFAULT_TOOLCHAIN} dylint ${log_pkg}${log_trailing} (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
+      log_step "$(render_cargo_command "${log_pkg_cmd[@]}") (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
       if [[ ${#trailing_args[@]} -gt 0 ]]; then
         RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${pkg_invocation[@]}" -- "${trailing_args[@]}" || return 1
       else
@@ -1050,12 +1178,12 @@ PY
 
       local -a feature_invocation=("-p" "${feature_pkg}" "${common_dylint_args[@]}")
       local -a feature_trailing=(--features "${feature_list}")
-      local log_feature="${feature_invocation[*]} -- --features ${feature_list}"
+      local -a log_feature_cmd=(dylint "${feature_invocation[@]}" -- --features "${feature_list}")
       if [[ ${#trailing_args[@]} -gt 0 ]]; then
-        log_feature+=" -- ${trailing_args[*]}"
+        log_feature_cmd+=("${trailing_args[@]}")
         feature_trailing+=("${trailing_args[@]}")
       fi
-      log_step "cargo +${DEFAULT_TOOLCHAIN} dylint ${log_feature} (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
+      log_step "$(render_cargo_command "${log_feature_cmd[@]}") (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
       RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${feature_invocation[@]}" -- "${feature_trailing[@]}" || return 1
     done
   fi
@@ -1065,7 +1193,7 @@ run_clippy() {
   # --all-targets は dev-dep 解決時に ahash/proptest のトランジティブ依存が
   # 壊れるため --lib --bins に限定する（テストコードは run_tests で検証される）。
   # postcard 1.1.3 が nightly と非互換のため fraktor-cluster-core-rs / fraktor-cluster-adaptor-std-rs を一時的に除外する。
-  log_step "cargo +${DEFAULT_TOOLCHAIN} clippy --workspace --exclude fraktor-cluster-core-rs --exclude fraktor-cluster-adaptor-std-rs --lib --bins -- -D warnings"
+  log_step "$(render_cargo_command clippy --workspace --exclude fraktor-cluster-core-rs --exclude fraktor-cluster-adaptor-std-rs --lib --bins -- -D warnings)"
   run_cargo clippy --workspace --exclude fraktor-cluster-core-rs --exclude fraktor-cluster-adaptor-std-rs --lib --bins -- -D warnings || return 1
 }
 
@@ -1073,11 +1201,11 @@ run_no_std() {
   PARALLEL_PIDS=()
   PARALLEL_LABELS=()
   start_parallel_cargo \
-    "cargo +${DEFAULT_TOOLCHAIN} check -p fraktor-utils-core-rs --no-default-features --features alloc" \
+    "$(render_cargo_command check -p fraktor-utils-core-rs --no-default-features --features alloc)" \
     "no-std-host-utils" \
     check -p fraktor-utils-core-rs --no-default-features --features alloc
   start_parallel_cargo \
-    "cargo +${DEFAULT_TOOLCHAIN} check -p fraktor-actor-core-rs -p fraktor-stream-core-rs -p fraktor-rs --no-default-features" \
+    "$(render_cargo_command check -p fraktor-actor-core-rs -p fraktor-stream-core-rs -p fraktor-rs --no-default-features)" \
     "no-std-host-core" \
     check -p fraktor-actor-core-rs -p fraktor-stream-core-rs -p fraktor-rs --no-default-features
   wait_parallel_cargo || return 1
@@ -1087,11 +1215,11 @@ run_no_std() {
     PARALLEL_PIDS=()
     PARALLEL_LABELS=()
     start_parallel_cargo \
-      "cargo +${DEFAULT_TOOLCHAIN} check -p fraktor-utils-core-rs --no-default-features --target ${thumb_target} -F fraktor-utils-core-rs/alloc" \
+      "$(render_cargo_command check -p fraktor-utils-core-rs --no-default-features --target "${thumb_target}" -F fraktor-utils-core-rs/alloc)" \
       "no-std-thumb-utils" \
       check -p fraktor-utils-core-rs --no-default-features --target "${thumb_target}" -F fraktor-utils-core-rs/alloc
     start_parallel_cargo \
-      "cargo +${DEFAULT_TOOLCHAIN} check -p fraktor-actor-core-rs -p fraktor-stream-core-rs --no-default-features --target ${thumb_target}" \
+      "$(render_cargo_command check -p fraktor-actor-core-rs -p fraktor-stream-core-rs --no-default-features --target "${thumb_target}")" \
       "no-std-thumb-core" \
       check -p fraktor-actor-core-rs -p fraktor-stream-core-rs --no-default-features --target "${thumb_target}"
     wait_parallel_cargo || return 1
@@ -1113,7 +1241,7 @@ run_std() {
 }
 
 run_doc_tests() {
-  log_step "cargo +${DEFAULT_TOOLCHAIN} check -p fraktor-actor-core-rs --no-default-features"
+  log_step "$(render_cargo_command check -p fraktor-actor-core-rs --no-default-features)"
   run_cargo check -p fraktor-actor-core-rs --no-default-features || return 1
 }
 
@@ -1268,7 +1396,16 @@ run_examples() {
   python_bin="$(resolve_python3_bin)" || return 1
 
   local target_dir="${CARGO_TARGET_DIR:-${REPO_ROOT}/target/ci-check/integration-test}"
-  mkdir -p "${target_dir}"
+  local absolute_target_dir="${target_dir}"
+  case "${absolute_target_dir}" in
+    /*) ;;
+    *) absolute_target_dir="${REPO_ROOT}/${absolute_target_dir}" ;;
+  esac
+  if is_managed_target_dir "${absolute_target_dir}"; then
+    prepare_ci_target_dir "${absolute_target_dir}" || return 1
+  else
+    mkdir -p "${target_dir}"
+  fi
 
   local rustflags_value
   if [[ -n "${RUSTFLAGS-}" ]]; then
@@ -1335,10 +1472,8 @@ PY
     local -a cargo_args=(run --package "${package_name}" --example "${example_name}")
     if [[ -n "${features}" ]]; then
       cargo_args+=(--features "${features}")
-      log_step "cargo +${DEFAULT_TOOLCHAIN} -v run --package ${package_name} --example ${example_name} --features ${features}"
-    else
-      log_step "cargo +${DEFAULT_TOOLCHAIN} -v run --package ${package_name} --example ${example_name}"
     fi
+    log_step "$(render_cargo_command "${cargo_args[@]}")"
     CARGO_TARGET_DIR="${target_dir}" RUSTFLAGS="${rustflags_value}" run_cargo "${cargo_args[@]}" \
       || {
         [[ -n "${example_file}" ]] && rm -f "${example_file}"

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -82,6 +82,22 @@ build_cargo_prefix_for "${DEFAULT_TOOLCHAIN}" || exit 1
 DEFAULT_CARGO_CMD=("${CI_CHECK_CARGO_PREFIX[@]}")
 build_cargo_prefix_for "${FMT_TOOLCHAIN}" || exit 1
 FMT_CARGO_CMD=("${CI_CHECK_CARGO_PREFIX[@]}")
+
+resolve_rustfmt_bin_for() {
+  local toolchain="${1:-}"
+  if [[ -n "${toolchain}" ]]; then
+    rustup which --toolchain "${toolchain}" rustfmt
+    return
+  fi
+
+  command -v rustfmt
+}
+
+FMT_RUSTFMT_BIN="$(resolve_rustfmt_bin_for "${FMT_TOOLCHAIN}")" || {
+  echo "エラー: rustfmt バイナリを特定できませんでした。" >&2
+  exit 1
+}
+
 CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-4}"
 export CARGO_BUILD_JOBS
 CI_CHECK_GUARD_TIMEOUT_SEC="${CI_CHECK_GUARD_TIMEOUT_SEC:-0}"
@@ -622,15 +638,15 @@ ensure_dylint_installed() {
 }
 
 run_fmt() {
-  local -a fmt_cmd=("${FMT_CARGO_CMD[@]}" -v fmt --all)
-  log_step "$(render_command "${fmt_cmd[@]}")"
-  "${fmt_cmd[@]}" || return 1
+  local -a fmt_cmd=("${FMT_CARGO_CMD[@]}" -v fmt --all -- --config-path "${REPO_ROOT}/rustfmt.toml")
+  log_step "RUSTFMT=${FMT_RUSTFMT_BIN} $(render_command "${fmt_cmd[@]}")"
+  RUSTFMT="${FMT_RUSTFMT_BIN}" "${fmt_cmd[@]}" || return 1
 }
 
 run_lint() {
-  local -a lint_cmd=("${FMT_CARGO_CMD[@]}" -v fmt --all --check)
-  log_step "$(render_command "${lint_cmd[@]}")"
-  "${lint_cmd[@]}" || return 1
+  local -a lint_cmd=("${FMT_CARGO_CMD[@]}" -v fmt --all --check -- --config-path "${REPO_ROOT}/rustfmt.toml")
+  log_step "RUSTFMT=${FMT_RUSTFMT_BIN} $(render_command "${lint_cmd[@]}")"
+  RUSTFMT="${FMT_RUSTFMT_BIN}" "${lint_cmd[@]}" || return 1
 }
 
 run_dylint() {

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT_REAL="$(cd "${REPO_ROOT}" && pwd -P)"
 
 cd "${REPO_ROOT}"
 
@@ -11,6 +12,7 @@ THUMB_TARGETS=("thumbv6m-none-eabi" "thumbv8m.main-none-eabi")
 declare -a HARDWARE_PACKAGES=()
 declare -a PARALLEL_PIDS=()
 declare -a PARALLEL_LABELS=()
+PREPARED_CI_TARGET_DIR=""
 
 resolve_pinned_toolchain() {
   if [[ -f "${REPO_ROOT}/rust-toolchain.toml" ]]; then
@@ -266,13 +268,30 @@ render_cargo_command() {
   render_command "${cmd[@]}"
 }
 
+normalize_path() {
+  local path="${1:-}"
+  if [[ -z "${path}" ]]; then
+    echo "error: normalize_path に path が指定されていません。" >&2
+    return 1
+  fi
+
+  local python_bin=""
+  python_bin="$(resolve_python3_bin)" || return 1
+  "${python_bin}" - "${path}" <<'PY'
+import os
+import sys
+
+print(os.path.realpath(sys.argv[1]))
+PY
+}
+
 is_managed_target_dir() {
   local target_dir="${1:-}"
   case "${target_dir}" in
-    "${REPO_ROOT}/target/ci-check"|"${REPO_ROOT}/target/ci-check/"*)
+    "${REPO_ROOT_REAL}/target/ci-check"|"${REPO_ROOT_REAL}/target/ci-check/"*)
       return 0
       ;;
-    "${REPO_ROOT}/lints/"*"/target"|"${REPO_ROOT}/lints/"*"/target/"*)
+    "${REPO_ROOT_REAL}/lints/"*"/target"|"${REPO_ROOT_REAL}/lints/"*"/target/"*)
       return 0
       ;;
     *)
@@ -282,13 +301,16 @@ is_managed_target_dir() {
 }
 
 prepare_ci_target_dir() {
+  PREPARED_CI_TARGET_DIR=""
   local target_dir="${1:-}"
   if [[ -z "${target_dir}" ]]; then
     echo "error: prepare_ci_target_dir に target_dir が指定されていません。" >&2
     return 1
   fi
+  local original_target_dir="${target_dir}"
+  target_dir="$(normalize_path "${target_dir}")" || return 1
   if ! is_managed_target_dir "${target_dir}"; then
-    echo "error: 管理対象外の target ディレクトリは自動削除しません: ${target_dir}" >&2
+    echo "error: 管理対象外の target ディレクトリは自動削除しません: ${original_target_dir} -> ${target_dir}" >&2
     return 1
   fi
 
@@ -299,12 +321,25 @@ prepare_ci_target_dir() {
   fi
 
   if [[ -d "${target_dir}" && "${current_fingerprint}" != "${CI_CHECK_TOOLCHAIN_FINGERPRINT}" ]]; then
-    rm -rf -- "${target_dir}"
-    echo "info: ${target_dir#${REPO_ROOT}/} を削除しました (rustc/toolchain が変わったため)" >&2
+    local deletion_target=""
+    deletion_target="$(normalize_path "${target_dir}")" || return 1
+    if [[ "${deletion_target}" != "${target_dir}" ]] || ! is_managed_target_dir "${deletion_target}"; then
+      echo "error: 管理対象 target ディレクトリの再検証に失敗しました: ${target_dir} -> ${deletion_target}" >&2
+      return 1
+    fi
+    rm -rf -- "${deletion_target}"
+    echo "info: ${deletion_target#${REPO_ROOT_REAL}/} を削除しました (rustc/toolchain が変わったため)" >&2
   fi
 
   mkdir -p "${target_dir}"
+  target_dir="$(normalize_path "${target_dir}")" || return 1
+  if ! is_managed_target_dir "${target_dir}"; then
+    echo "error: 作成後の target ディレクトリが管理対象外です: ${target_dir}" >&2
+    return 1
+  fi
+  stamp_file="${target_dir}/${CI_CHECK_TOOLCHAIN_STAMP}"
   printf '%s\n' "${CI_CHECK_TOOLCHAIN_FINGERPRINT}" > "${stamp_file}"
+  PREPARED_CI_TARGET_DIR="${target_dir}"
 }
 
 should_guard_cargo_command() {
@@ -432,6 +467,13 @@ clean_stale_lint_targets() {
     if [[ ! -d "${lint_path}" || ! -d "${lint_path}/target" ]]; then
       continue
     fi
+    local lint_target_dir="${lint_path}/target"
+    local normalized_lint_target_dir=""
+    normalized_lint_target_dir="$(normalize_path "${lint_target_dir}")" || return 1
+    if ! is_managed_target_dir "${normalized_lint_target_dir}"; then
+      echo "error: 管理対象外の lint target ディレクトリは読み取り・自動削除しません: ${lint_target_dir} -> ${normalized_lint_target_dir}" >&2
+      return 1
+    fi
 
     local stale=""
     while IFS= read -r output_file; do
@@ -440,11 +482,11 @@ clean_stale_lint_targets() {
         stale="yes"
         break
       fi
-    done < <(find "${lint_path}/target" -path "*/libssh2-sys-*/output" -type f 2>/dev/null)
+    done < <(find "${normalized_lint_target_dir}" -path "*/libssh2-sys-*/output" -type f 2>/dev/null)
 
     if [[ -n "${stale}" ]]; then
-      rm -rf "${lint_path}/target"
-      echo "info: ${lint_path#${REPO_ROOT}/}/target を削除しました (libssh2-sys キャッシュの再生成)" >&2
+      rm -rf -- "${normalized_lint_target_dir}"
+      echo "info: ${normalized_lint_target_dir#${REPO_ROOT_REAL}/} を削除しました (libssh2-sys キャッシュの再生成)" >&2
       removed=1
     fi
   done
@@ -537,8 +579,9 @@ start_parallel_cargo() {
 
   local target_dir="${REPO_ROOT}/target/ci-check/${shard}"
   prepare_ci_target_dir "${target_dir}" || return 1
+  target_dir="${PREPARED_CI_TARGET_DIR}"
 
-  log_step "[parallel] ${label} (CARGO_TARGET_DIR=${target_dir#${REPO_ROOT}/})"
+  log_step "[parallel] ${label} (CARGO_TARGET_DIR=${target_dir#${REPO_ROOT_REAL}/})"
   (
     CARGO_TARGET_DIR="${target_dir}" run_cargo "$@"
   ) &
@@ -554,8 +597,9 @@ start_parallel_phase() {
 
   local target_dir="${REPO_ROOT}/target/ci-check/${shard}"
   prepare_ci_target_dir "${target_dir}" || return 1
+  target_dir="${PREPARED_CI_TARGET_DIR}"
 
-  log_step "[parallel] ${label} (CARGO_TARGET_DIR=${target_dir#${REPO_ROOT}/})"
+  log_step "[parallel] ${label} (CARGO_TARGET_DIR=${target_dir#${REPO_ROOT_REAL}/})"
   (
     export CARGO_TARGET_DIR="${target_dir}"
     "${func}"
@@ -1401,8 +1445,11 @@ run_examples() {
     /*) ;;
     *) absolute_target_dir="${REPO_ROOT}/${absolute_target_dir}" ;;
   esac
-  if is_managed_target_dir "${absolute_target_dir}"; then
-    prepare_ci_target_dir "${absolute_target_dir}" || return 1
+  local normalized_target_dir=""
+  normalized_target_dir="$(normalize_path "${absolute_target_dir}")" || return 1
+  if is_managed_target_dir "${normalized_target_dir}"; then
+    prepare_ci_target_dir "${normalized_target_dir}" || return 1
+    target_dir="${PREPARED_CI_TARGET_DIR}"
   else
     mkdir -p "${target_dir}"
   fi

--- a/showcases/std/Cargo.toml
+++ b/showcases/std/Cargo.toml
@@ -128,6 +128,10 @@ name = "kernel_first_example"
 path = "kernel/first-example/main.rs"
 
 [[example]]
+name = "kernel_affinity_executor"
+path = "kernel/affinity-executor/main.rs"
+
+[[example]]
 name = "kernel_supervision"
 path = "kernel/supervision/main.rs"
 

--- a/showcases/std/kernel/affinity-executor/main.rs
+++ b/showcases/std/kernel/affinity-executor/main.rs
@@ -1,7 +1,7 @@
 #![cfg(not(target_os = "none"))]
 
 use core::time::Duration;
-use std::{string::String, thread, vec::Vec};
+use std::{string::String, thread, time::Instant, vec::Vec};
 
 use fraktor_actor_adaptor_std_rs::std::{
   StdBlocker, dispatch::dispatcher::AffinityExecutor, tick_driver::StdTickDriver,
@@ -23,6 +23,7 @@ use fraktor_actor_core_rs::core::kernel::{
 use fraktor_utils_core_rs::core::sync::{ArcShared, SharedLock, SpinSyncMutex};
 
 const POOL_NAME: &str = "kernel-affinity-executor";
+const WAIT_TIMEOUT: Duration = Duration::from_secs(3);
 
 struct Greet;
 
@@ -50,7 +51,7 @@ fn main() {
     move || GreeterActor { greetings: greetings.clone() }
   });
 
-  // `pekko.actor.default-dispatcher` のデフォルトは Inline executor を指している。
+  // `fraktor.actor.default-dispatcher` のデフォルトは Inline executor を指している。
   // ここでは AffinityExecutor (Pekko の `AffinityPool` 相当) を直接ぶら下げて
   // default-dispatcher を上書きする: 4 本のワーカースレッドと、各ワーカーが
   // 64 スロットの bounded queue を持つ。mailbox は `key % parallelism` で
@@ -67,7 +68,7 @@ fn main() {
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Greet));
-  wait_until(|| greetings.with_lock(|greetings| greetings.len() == 1));
+  wait_until_deadline(Instant::now() + WAIT_TIMEOUT, || greetings.with_lock(|greetings| greetings.len() == 1));
 
   // receive は AffinityExecutor のワーカースレッド上で走るため、記録された
   // スレッド名はプール接頭辞で始まっているはず。Inline 版との挙動差を
@@ -82,8 +83,8 @@ fn main() {
   termination.wait_blocking(&StdBlocker::new());
 }
 
-fn wait_until(mut condition: impl FnMut() -> bool) {
-  for _ in 0..1_000 {
+fn wait_until_deadline(deadline: Instant, mut condition: impl FnMut() -> bool) {
+  while Instant::now() < deadline {
     if condition() {
       return;
     }

--- a/showcases/std/kernel/affinity-executor/main.rs
+++ b/showcases/std/kernel/affinity-executor/main.rs
@@ -1,0 +1,93 @@
+#![cfg(not(target_os = "none"))]
+
+use core::time::Duration;
+use std::{string::String, thread, vec::Vec};
+
+use fraktor_actor_adaptor_std_rs::std::{
+  StdBlocker, dispatch::dispatcher::AffinityExecutor, tick_driver::StdTickDriver,
+};
+use fraktor_actor_core_rs::core::kernel::{
+  actor::{
+    Actor, ActorContext,
+    error::ActorError,
+    messaging::{AnyMessage, AnyMessageView},
+    props::Props,
+    setup::ActorSystemConfig,
+  },
+  dispatch::dispatcher::{
+    DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecutorShared, MessageDispatcherFactory,
+    TrampolineState,
+  },
+  system::ActorSystem,
+};
+use fraktor_utils_core_rs::core::sync::{ArcShared, SharedLock, SpinSyncMutex};
+
+const POOL_NAME: &str = "kernel-affinity-executor";
+
+struct Greet;
+
+struct GreeterActor {
+  greetings: SharedLock<Vec<String>>,
+}
+
+impl Actor for GreeterActor {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    if message.downcast_ref::<Greet>().is_some() {
+      // どのスレッド上で receive が走ったかを記録する。Inline executor 版では
+      // 起動スレッド (StdTickDriver の exec_thread) でしか走らないが、ここでは
+      // AffinityExecutor のワーカースレッド名 (`kernel-affinity-executor-N`) が観測される。
+      let thread_name = thread::current().name().unwrap_or("<unnamed>").into();
+      self.greetings.with_lock(|greetings| greetings.push(thread_name));
+    }
+    Ok(())
+  }
+}
+
+fn main() {
+  let greetings = SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new());
+  let props = Props::from_fn({
+    let greetings = greetings.clone();
+    move || GreeterActor { greetings: greetings.clone() }
+  });
+
+  // `pekko.actor.default-dispatcher` のデフォルトは Inline executor を指している。
+  // ここでは AffinityExecutor (Pekko の `AffinityPool` 相当) を直接ぶら下げて
+  // default-dispatcher を上書きする: 4 本のワーカースレッドと、各ワーカーが
+  // 64 スロットの bounded queue を持つ。mailbox は `key % parallelism` で
+  // 同じワーカーに固定されるため、同一アクターのメッセージは常に同じ OS
+  // スレッドで処理される。
+  let executor = ExecutorShared::new(Box::new(AffinityExecutor::new(POOL_NAME, 4, 64)), TrampolineState::new());
+  let dispatcher_config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
+  let dispatcher_factory: ArcShared<Box<dyn MessageDispatcherFactory>> =
+    ArcShared::new(Box::new(DefaultDispatcherFactory::new(&dispatcher_config, executor)));
+  let actor_system_config =
+    ActorSystemConfig::new(StdTickDriver::default()).with_dispatcher_factory(DEFAULT_DISPATCHER_ID, dispatcher_factory);
+
+  let system = ActorSystem::create_with_config(&props, actor_system_config).expect("system");
+  let termination = system.when_terminated();
+
+  system.user_guardian_ref().tell(AnyMessage::new(Greet));
+  wait_until(|| greetings.with_lock(|greetings| greetings.len() == 1));
+
+  // receive は AffinityExecutor のワーカースレッド上で走るため、記録された
+  // スレッド名はプール接頭辞で始まっているはず。Inline 版との挙動差を
+  // この assert で固定する。
+  let observed = greetings.with_lock(|greetings| greetings[0].clone());
+  assert!(
+    observed.starts_with(POOL_NAME),
+    "Greet should be processed on a {POOL_NAME}-* worker thread, observed: {observed}"
+  );
+
+  system.terminate().expect("terminate");
+  termination.wait_blocking(&StdBlocker::new());
+}
+
+fn wait_until(mut condition: impl FnMut() -> bool) {
+  for _ in 0..1_000 {
+    if condition() {
+      return;
+    }
+    thread::sleep(Duration::from_millis(1));
+  }
+  assert!(condition());
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes well-known dispatcher/mailbox identifier strings and their aliasing behavior, which can break external configuration expecting Pekko IDs. CI script refactor also touches build tooling and target-dir cleanup logic, so mis-detection could delete or reuse the wrong build artifacts.
> 
> **Overview**
> Updates kernel/typed dispatcher and mailbox default identifiers to use the **Fraktor namespace** (e.g. `fraktor.actor.default-dispatcher`, `fraktor.actor.default-mailbox`) and adjusts the internal-dispatcher alias/tests accordingly.
> 
> Extends CI tooling in `scripts/ci-check.sh` to **pin and export explicit rust tool binaries**, pass an explicit `rustfmt.toml` config path, and manage `target` directories via a toolchain fingerprint + safe realpath checks (including conditional cleanup when toolchains change).
> 
> Adds a new `showcases/std` example `kernel_affinity_executor` demonstrating overriding the default dispatcher with an `AffinityExecutor`, and bumps `codex` from `0.125.0` to `0.128.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6670db3d10f971e5cfbbe2b6a9331434d5f6ad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * 開発ツール (codex) をバージョン 0.125.0 から 0.128.0 に更新しました。

* **新機能**
  * カーネル アフィニティ エグゼキューターの新しいサンプルコードを追加しました。

* **改善**
  * フレームワーク内部のディスパッチャーおよびメールボックス識別子を更新しました。
  * CI ビルドシステムのツールチェーン管理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->