### PR TITLE
feat(actor-system): add `noop_with_config` API to streamline no-op gu…

### DIFF
--- a/docs/plan/actor-system-noop-with-config.md
+++ b/docs/plan/actor-system-noop-with-config.md
@@ -1,0 +1,51 @@
+# ActorSystem no-op guardian 生成 API 追加計画
+
+## 概要
+
+`GuardianActor` のような no-op user guardian を利用側で毎回定義しなくて済むように、`ActorSystem` に no-op guardian 付きで起動する public API を追加する。
+
+既存の `new_empty` / `new_empty_with` は「guardian なし」の test helper なので、意味の衝突を避けて `empty_with_config` は追加しない。追加 API 名は `noop_with_config` に寄せる。
+
+## 主要変更
+
+- `actor-core` に内部 no-op actor 型を追加する。
+  - 型名は `NoopGuardianActor`
+  - 配置は `modules/actor-core/src/core/kernel/system/guardian/`
+  - `receive` は常に `Ok(())`
+  - public に露出させず、`ActorSystem` の生成 API からのみ使う
+- `ActorSystem` に以下を追加する。
+  - `pub fn noop_with_config(config: ActorSystemConfig) -> Result<Self, SpawnError>`
+  - `pub fn noop_with_setup(setup: ActorSystemSetup) -> Result<Self, SpawnError>`
+  - 実装は `Props::from_fn(NoopGuardianActor::new)` を作って既存の `create_with_config` に委譲する
+- 既存テストの一部ボイラープレートを置き換える。
+  - `modules/actor-adaptor-std/src/std/tick_driver/tests.rs` の `GuardianActor` を削除し、`ActorSystem::noop_with_config(config)` を使う
+  - actor-core 側に no-op guardian 起動 API の契約テストを追加する
+
+## Public API
+
+```rust
+impl ActorSystem {
+  pub fn noop_with_config(config: ActorSystemConfig) -> Result<Self, SpawnError>;
+
+  pub fn noop_with_setup(setup: ActorSystemSetup) -> Result<Self, SpawnError>;
+}
+```
+
+`noop_with_config` は `/user` guardian を実際に起動する。したがって `actor_of`、`user_guardian_ref`、`terminate`、receptionist 初期化などは `create_with_config` と同じ契約で動く。
+
+## Test Plan
+
+- `ActorSystem::noop_with_config` が成功し、`state().has_root_started()` が true になること
+- `user_guardian_ref()` が取得でき、パスが `/user/...` 配下になること
+- `actor_of` で user guardian 配下に actor を spawn できること
+- `terminate()` が成功すること
+- `ActorSystemConfig::default()` のように tick driver がない設定では、既存どおり `SpawnError::SystemBuildError` になること
+- `rtk cargo test -p fraktor-actor-core-rs actor_system_noop_with_config`
+- `rtk cargo test -p fraktor-actor-adaptor-std-rs tick_driver`
+- ソース編集後の最終確認として `./scripts/ci-check.sh ai all`
+
+## 前提
+
+- `empty` は既存の「guardian なし」語彙として維持し、今回の用途には使わない。
+- no-op guardian 型は API として公開しない。利用者には `ActorSystem::noop_with_config` と `ActorSystem::noop_with_setup` だけを提供する。
+- 後方互換は不要だが、既存 API の削除は今回の目的外なので行わない。

--- a/modules/actor-adaptor-std/src/std/tick_driver/tests.rs
+++ b/modules/actor-adaptor-std/src/std/tick_driver/tests.rs
@@ -8,10 +8,6 @@ use std::{
 
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
-    Actor, ActorContext,
-    error::ActorError,
-    messaging::AnyMessageView,
-    props::Props,
     scheduler::{
       SchedulerConfig, SchedulerContext,
       tick_driver::{
@@ -27,19 +23,10 @@ use fraktor_actor_core_rs::core::kernel::{
 use super::{StdTickDriver, StdTickDriverStopper};
 use crate::std::StdBlocker;
 
-struct GuardianActor;
-
-impl Actor for GuardianActor {
-  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
-    Ok(())
-  }
-}
-
 fn build_system_with_driver(driver: StdTickDriver) -> ActorSystem {
-  let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(driver).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::noop_with_config(config).expect("system should build")
 }
 
 fn provision_inputs() -> (TickFeedHandle, SchedulerTickExecutor) {
@@ -143,20 +130,18 @@ mod tokio_tests {
   use core::time::Duration;
 
   use fraktor_actor_core_rs::core::kernel::{
-    actor::{props::Props, scheduler::SchedulerConfig, setup::ActorSystemConfig},
+    actor::{scheduler::SchedulerConfig, setup::ActorSystemConfig},
     system::ActorSystem,
   };
 
-  use super::GuardianActor;
   use crate::std::tick_driver::TokioTickDriver;
 
   #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
   async fn tokio_tick_driver_boots_actor_system() {
-    let props = Props::from_fn(|| GuardianActor);
     let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
     let driver = TokioTickDriver::new(Duration::from_millis(10));
     let config = ActorSystemConfig::new(driver).with_scheduler_config(scheduler);
-    let system = ActorSystem::create_with_config(&props, config).expect("system should build");
+    let system = ActorSystem::noop_with_config(config).expect("system should build");
     system.terminate().expect("terminate");
   }
 }

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -639,7 +639,8 @@ impl ActorSystem {
     let root_pid = root_cell.pid();
     self.state.set_root_guardian(&root_cell);
 
-    let user_guardian = self.spawn_child(root_pid, user_guardian_props)?;
+    let user_guardian_props = user_guardian_props.clone().with_name("user");
+    let user_guardian = self.spawn_child(root_pid, &user_guardian_props)?;
     if let Some(cell) = self.state.cell(&user_guardian.pid()) {
       self.state.set_user_guardian(&cell);
     } else {

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -18,7 +18,7 @@ use fraktor_utils_core_rs::core::{
 
 use super::{
   ActorSystemWeak, Blocker, ExtendedActorSystem, TerminationSignal,
-  guardian::{RootGuardianActor, SystemGuardianActor, SystemGuardianProtocol},
+  guardian::{NoopGuardianActor, RootGuardianActor, SystemGuardianActor, SystemGuardianProtocol},
   remote::RemotingConfig,
 };
 use crate::core::{
@@ -99,6 +99,19 @@ impl ActorSystem {
     Self::create_with_config_and(user_guardian_props, config, |_| Ok(()))
   }
 
+  /// Creates an actor system with a no-op user guardian and the provided configuration.
+  ///
+  /// This is intended for callers that need a fully bootstrapped actor system
+  /// but do not need custom user guardian behavior.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`SpawnError`] when guardian initialization fails.
+  pub fn noop_with_config(config: ActorSystemConfig) -> Result<Self, SpawnError> {
+    let user_guardian_props = Props::from_fn(NoopGuardianActor::new);
+    Self::create_with_config(&user_guardian_props, config)
+  }
+
   /// Creates a new actor system from a Pekko-style setup facade.
   ///
   /// # Errors
@@ -106,6 +119,15 @@ impl ActorSystem {
   /// Returns [`SpawnError`] when guardian initialization or bootstrap fails.
   pub fn create_with_setup(user_guardian_props: &Props, setup: ActorSystemSetup) -> Result<Self, SpawnError> {
     Self::create_with_config(user_guardian_props, setup.into_actor_system_config())
+  }
+
+  /// Creates an actor system with a no-op user guardian from a Pekko-style setup facade.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`SpawnError`] when guardian initialization or bootstrap fails.
+  pub fn noop_with_setup(setup: ActorSystemSetup) -> Result<Self, SpawnError> {
+    Self::noop_with_config(setup.into_actor_system_config())
   }
 
   /// Creates an actor system with configuration and a bootstrap callback.

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -33,7 +33,7 @@ use crate::core::{
           tests::TestTickDriver,
         },
       },
-      setup::ActorSystemConfig,
+      setup::{ActorSystemConfig, ActorSystemSetup, BootstrapSetup},
       spawn::SpawnError,
     },
     dispatch::dispatcher::{
@@ -376,6 +376,52 @@ fn actor_system_create_with_config_and_fails_without_tick_driver() {
     | Err(SpawnError::SystemBuildError(message)) => assert!(message.contains("tick driver is required")),
     | Err(other) => panic!("unexpected error: {other:?}"),
   };
+}
+
+#[test]
+fn actor_system_noop_with_config_bootstraps_user_guardian() {
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("noop-system");
+
+  let system = ActorSystem::noop_with_config(config).expect("system should build");
+
+  assert!(system.state().has_root_started());
+  assert!(system.state().extra_top_level(SYSTEM_RECEPTIONIST_TOP_LEVEL).is_some());
+  let user_guardian = system.user_guardian_ref();
+  let path = user_guardian.path().expect("user guardian path");
+  assert!(path.to_relative_string().starts_with("/user/"));
+}
+
+#[test]
+fn actor_system_noop_with_config_spawns_user_child() {
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("noop-child-system");
+  let system = ActorSystem::noop_with_config(config).expect("system should build");
+
+  let child = system.actor_of(&Props::from_fn(|| TestActor)).expect("spawn child");
+  let path = child.actor_ref().path().expect("child path");
+
+  assert!(path.to_relative_string().starts_with("/user/"));
+}
+
+#[test]
+fn actor_system_noop_with_config_fails_without_tick_driver() {
+  let result = ActorSystem::noop_with_config(ActorSystemConfig::default());
+
+  match result {
+    | Err(SpawnError::SystemBuildError(message)) => assert!(message.contains("tick driver is required")),
+    | Ok(_) => panic!("system should not build without tick driver"),
+    | Err(other) => panic!("unexpected error: {other:?}"),
+  }
+}
+
+#[test]
+fn actor_system_noop_with_setup_uses_setup_config() {
+  let setup = ActorSystemSetup::new(BootstrapSetup::default().with_system_name("noop-setup-system"))
+    .with_tick_driver(TestTickDriver::default());
+
+  let system = ActorSystem::noop_with_setup(setup).expect("system should build");
+
+  assert_eq!(system.name(), "noop-setup-system");
+  assert!(system.state().has_root_started());
 }
 
 #[test]

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -388,7 +388,7 @@ fn actor_system_noop_with_config_bootstraps_user_guardian() {
   assert!(system.state().extra_top_level(SYSTEM_RECEPTIONIST_TOP_LEVEL).is_some());
   let user_guardian = system.user_guardian_ref();
   let path = user_guardian.path().expect("user guardian path");
-  assert!(path.to_relative_string().starts_with("/user/"));
+  assert_eq!(path.to_relative_string(), "/user");
 }
 
 #[test]

--- a/modules/actor-core/src/core/kernel/system/guardian.rs
+++ b/modules/actor-core/src/core/kernel/system/guardian.rs
@@ -2,12 +2,14 @@
 
 mod guardian_kind;
 mod guardians_state;
+mod noop_guardian_actor;
 mod root_guardian_actor;
 mod system_guardian_actor;
 mod system_guardian_protocol;
 
 pub use guardian_kind::GuardianKind;
 pub(crate) use guardians_state::GuardiansState;
+pub(crate) use noop_guardian_actor::NoopGuardianActor;
 pub(crate) use root_guardian_actor::RootGuardianActor;
 pub(crate) use system_guardian_actor::SystemGuardianActor;
 pub use system_guardian_protocol::SystemGuardianProtocol;

--- a/modules/actor-core/src/core/kernel/system/guardian/noop_guardian_actor.rs
+++ b/modules/actor-core/src/core/kernel/system/guardian/noop_guardian_actor.rs
@@ -1,0 +1,20 @@
+//! No-op user guardian actor used by convenience actor-system factories.
+
+use crate::core::kernel::actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView};
+
+/// User guardian actor that accepts every message without side effects.
+pub(crate) struct NoopGuardianActor;
+
+impl NoopGuardianActor {
+  /// Creates a no-op user guardian actor.
+  #[must_use]
+  pub(crate) const fn new() -> Self {
+    Self
+  }
+}
+
+impl Actor for NoopGuardianActor {
+  fn receive(&mut self, _context: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}

--- a/modules/actor-core/src/core/kernel/system/guardian/noop_guardian_actor.rs
+++ b/modules/actor-core/src/core/kernel/system/guardian/noop_guardian_actor.rs
@@ -1,5 +1,8 @@
 //! No-op user guardian actor used by convenience actor-system factories.
 
+#[cfg(test)]
+mod tests;
+
 use crate::core::kernel::actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView};
 
 /// User guardian actor that accepts every message without side effects.

--- a/modules/actor-core/src/core/kernel/system/guardian/noop_guardian_actor/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/guardian/noop_guardian_actor/tests.rs
@@ -1,0 +1,16 @@
+use super::NoopGuardianActor;
+use crate::core::kernel::{
+  actor::{Actor, ActorContext, messaging::AnyMessage},
+  system::ActorSystem,
+};
+
+#[test]
+fn noop_guardian_actor_receive_accepts_messages() {
+  let system = ActorSystem::new_empty();
+  let mut context = ActorContext::new(&system, system.allocate_pid());
+  let mut actor = NoopGuardianActor::new();
+  let message = AnyMessage::new(());
+  let view = message.as_view();
+
+  assert!(actor.receive(&mut context, view).is_ok());
+}

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -190,6 +190,7 @@ CI_CHECK_GUARD_KILL_AFTER_SEC="${CI_CHECK_GUARD_KILL_AFTER_SEC:-15}"
 CI_CHECK_HANG_COOLDOWN_SEC="${CI_CHECK_HANG_COOLDOWN_SEC:-1800}"
 CI_CHECK_HANG_RECORD_FILE="${CI_CHECK_HANG_RECORD_FILE:-${REPO_ROOT}/target/.ci-check.last-hang}"
 CI_CHECK_ALLOW_RERUN_AFTER_HANG="${CI_CHECK_ALLOW_RERUN_AFTER_HANG:-0}"
+CI_CHECK_HEARTBEAT="${CI_CHECK_HEARTBEAT:-0}"
 export CI_CHECK_GUARD_TIMEOUT_SEC
 export CI_CHECK_GUARD_TIMEOUT_UNIT_SEC
 export CI_CHECK_GUARD_TIMEOUT_INTEGRATION_SEC
@@ -197,6 +198,7 @@ export CI_CHECK_GUARD_KILL_AFTER_SEC
 export CI_CHECK_HANG_COOLDOWN_SEC
 export CI_CHECK_HANG_RECORD_FILE
 export CI_CHECK_ALLOW_RERUN_AFTER_HANG
+export CI_CHECK_HEARTBEAT
 
 usage() {
   cat <<'EOF'
@@ -230,6 +232,8 @@ usage() {
   CI_CHECK_GUARD_KILL_AFTER_SEC : タイムアウト後に強制終了へ移るまでの猶予秒数（既定 15）
   CI_CHECK_HANG_COOLDOWN_SEC  : HANG_SUSPECT 後に同一コマンドの再実行を拒否する秒数（既定 1800）
   CI_CHECK_ALLOW_RERUN_AFTER_HANG : 1 のとき HANG_SUSPECT 後の同一コマンド再実行を許可
+  CI_CHECK_HEARTBEAT          : 1 のとき長時間実行中の heartbeat ログを表示（既定 0）
+  CI_CHECK_HEARTBEAT_INTERVAL_SEC : heartbeat ログの表示間隔秒数（既定 30）
 EOF
 }
 
@@ -419,7 +423,12 @@ enable_ai_mode() {
   export CI_CHECK_GUARD_KILL_AFTER_SEC="${CI_CHECK_GUARD_KILL_AFTER_SEC:-15}"
   export CI_CHECK_HANG_COOLDOWN_SEC="${CI_CHECK_HANG_COOLDOWN_SEC:-1800}"
 
-  echo "info: AI モードを有効化しました (default-timeout=${CI_CHECK_GUARD_TIMEOUT_SEC}s, unit-timeout=${CI_CHECK_GUARD_TIMEOUT_UNIT_SEC}s, integration-timeout=${CI_CHECK_GUARD_TIMEOUT_INTEGRATION_SEC}s, cooldown=${CI_CHECK_HANG_COOLDOWN_SEC}s, heartbeat=${CI_CHECK_HEARTBEAT_INTERVAL_SEC}s)" >&2
+  local heartbeat_status="off"
+  if [[ "${CI_CHECK_HEARTBEAT}" != "0" ]]; then
+    heartbeat_status="${CI_CHECK_HEARTBEAT_INTERVAL_SEC}s"
+  fi
+
+  echo "info: AI モードを有効化しました (default-timeout=${CI_CHECK_GUARD_TIMEOUT_SEC}s, unit-timeout=${CI_CHECK_GUARD_TIMEOUT_UNIT_SEC}s, integration-timeout=${CI_CHECK_GUARD_TIMEOUT_INTEGRATION_SEC}s, cooldown=${CI_CHECK_HANG_COOLDOWN_SEC}s, heartbeat=${heartbeat_status})" >&2
 }
 
 run_with_heartbeat() {
@@ -427,7 +436,7 @@ run_with_heartbeat() {
   shift
 
   local interval="${CI_CHECK_HEARTBEAT_INTERVAL_SEC:-60}"
-  local enabled="${CI_CHECK_HEARTBEAT:-1}"
+  local enabled="${CI_CHECK_HEARTBEAT:-0}"
   local heartbeat_pid=""
 
   if [[ ! "${interval}" =~ ^[0-9]+$ ]] || [[ "${interval}" -lt 1 ]]; then

--- a/showcases/std/stream/basics/main.rs
+++ b/showcases/std/stream/basics/main.rs
@@ -3,27 +3,15 @@
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
-use fraktor_actor_core_rs::core::kernel::{
-  actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, setup::ActorSystemConfig},
-  system::ActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::setup::ActorSystemConfig, system::ActorSystem};
 use fraktor_stream_core_rs::core::{
   dsl::{Sink, Source},
   materialization::{ActorMaterializer, ActorMaterializerConfig, KeepRight},
 };
 
-struct GuardianActor;
-
-impl Actor for GuardianActor {
-  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
-    Ok(())
-  }
-}
-
 fn main() {
-  let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::noop_with_config(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/composition/main.rs
+++ b/showcases/std/stream/composition/main.rs
@@ -3,27 +3,15 @@
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
-use fraktor_actor_core_rs::core::kernel::{
-  actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, setup::ActorSystemConfig},
-  system::ActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::setup::ActorSystemConfig, system::ActorSystem};
 use fraktor_stream_core_rs::core::{
   dsl::{Flow, Sink, Source},
   materialization::{ActorMaterializer, ActorMaterializerConfig, KeepRight},
 };
 
-struct GuardianActor;
-
-impl Actor for GuardianActor {
-  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
-    Ok(())
-  }
-}
-
 fn main() {
-  let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::noop_with_config(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/first-example/main.rs
+++ b/showcases/std/stream/first-example/main.rs
@@ -3,27 +3,15 @@
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
-use fraktor_actor_core_rs::core::kernel::{
-  actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, setup::ActorSystemConfig},
-  system::ActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::setup::ActorSystemConfig, system::ActorSystem};
 use fraktor_stream_core_rs::core::{
   dsl::{Sink, Source},
   materialization::{ActorMaterializer, ActorMaterializerConfig, KeepRight},
 };
 
-struct GuardianActor;
-
-impl Actor for GuardianActor {
-  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
-    Ok(())
-  }
-}
-
 fn main() {
-  let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::noop_with_config(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/graphs/main.rs
+++ b/showcases/std/stream/graphs/main.rs
@@ -3,27 +3,15 @@
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
-use fraktor_actor_core_rs::core::kernel::{
-  actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, setup::ActorSystemConfig},
-  system::ActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::setup::ActorSystemConfig, system::ActorSystem};
 use fraktor_stream_core_rs::core::{
   dsl::{Flow, GraphDsl, GraphDslBuilder, Sink, Source},
   materialization::{ActorMaterializer, ActorMaterializerConfig, KeepRight, StreamNotUsed},
 };
 
-struct GuardianActor;
-
-impl Actor for GuardianActor {
-  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
-    Ok(())
-  }
-}
-
 fn main() {
-  let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::noop_with_config(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/rate/main.rs
+++ b/showcases/std/stream/rate/main.rs
@@ -3,28 +3,16 @@
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
-use fraktor_actor_core_rs::core::kernel::{
-  actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, setup::ActorSystemConfig},
-  system::ActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::setup::ActorSystemConfig, system::ActorSystem};
 use fraktor_stream_core_rs::core::{
   OverflowStrategy, ThrottleMode,
   dsl::{Flow, Sink, Source},
   materialization::{ActorMaterializer, ActorMaterializerConfig, KeepRight},
 };
 
-struct GuardianActor;
-
-impl Actor for GuardianActor {
-  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
-    Ok(())
-  }
-}
-
 fn main() {
-  let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::noop_with_config(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");


### PR DESCRIPTION
…ardian initialization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new public ActorSystem constructors and changes bootstrap to force the user guardian to be spawned with the fixed name `user`, which could affect callers relying on custom guardian naming/path behavior.
> 
> **Overview**
> Adds convenience constructors `ActorSystem::noop_with_config` and `ActorSystem::noop_with_setup` that bootstrap a fully functional system using an internal `NoopGuardianActor` (non-public) as the `/user` guardian.
> 
> During bootstrap, the user guardian props are now cloned and renamed to `user` before spawning, ensuring the user guardian path is consistently `/user`; new contract tests cover bootstrapping, spawning children under `/user`, setup-based config, and the existing “tick driver required” failure.
> 
> Updates std tick-driver tests and stream showcase examples to use the new no-op constructors instead of defining ad-hoc guardian actors, and extends `scripts/ci-check.sh` with an opt-in heartbeat log (`CI_CHECK_HEARTBEAT`) with clearer AI-mode status output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23b1838c898434648f0ddd297ef41ca74a265af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ActorSystem初期化の簡素化：`noop_with_config`と`noop_with_setup`メソッドを追加し、定型的なガーディアンアクターの実装が不要に

* **改善**
  * サンプルコードのボイラープレートを削除し、より簡潔な実装例に更新
  * アクターシステム起動時の開発者体験を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->