### PR TITLE
[codex] Add std ask and logging outputs

### DIFF
--- a/showcases/std/Cargo.toml
+++ b/showcases/std/Cargo.toml
@@ -16,6 +16,7 @@ fraktor-stream-core-rs = { workspace = true }
 serde_json = { workspace = true }
 bincode = { workspace = true, features = ["alloc", "serde"] }
 serde = { workspace = true, features = ["derive"] }
+tracing = { workspace = true, features = ["std"] }
 
 # advanced 依存（cross-module examples 用）
 fraktor-persistence-core-rs = { workspace = true, optional = true }
@@ -156,6 +157,10 @@ name = "kernel_fsm"
 path = "kernel/fsm/main.rs"
 
 [[example]]
+name = "kernel_interaction_patterns"
+path = "kernel/ask_from_non_actor/main.rs"
+
+[[example]]
 name = "kernel_persistence"
 path = "kernel/persistence/main.rs"
 required-features = ["advanced"]
@@ -233,5 +238,11 @@ path = "stream/composition/main.rs"
 name = "stream_rate"
 path = "stream/rate/main.rs"
 
-[lints]
-workspace = true
+[lints.rust]
+unused_must_use = "deny"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fraktor_disable_tell)'] }
+
+[lints.clippy]
+let_underscore_must_use = "deny"
+let_underscore_future = "deny"
+print_stdout = "allow"

--- a/showcases/std/kernel/affinity-executor/main.rs
+++ b/showcases/std/kernel/affinity-executor/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{string::String, thread, time::Instant, vec::Vec};
 
@@ -78,6 +76,7 @@ fn main() {
     observed.starts_with(POOL_NAME),
     "Greet should be processed on a {POOL_NAME}-* worker thread, observed: {observed}"
   );
+  println!("kernel_affinity_executor processed Greet on {observed}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/ask_from_non_actor/main.rs
+++ b/showcases/std/kernel/ask_from_non_actor/main.rs
@@ -1,0 +1,57 @@
+use core::time::Duration;
+use std::{thread, time::Instant};
+
+use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
+use fraktor_actor_core_rs::core::kernel::{
+  actor::{
+    Actor, ActorContext,
+    error::ActorError,
+    messaging::{AnyMessage, AnyMessageView},
+    props::Props,
+    setup::ActorSystemConfig,
+  },
+  system::ActorSystem,
+};
+use fraktor_utils_core_rs::core::sync::SharedAccess;
+
+struct Question;
+struct Answer(u32);
+
+struct Responder;
+
+impl Actor for Responder {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    if message.downcast_ref::<Question>().is_some() {
+      let Some(sender) = message.sender() else {
+        return Err(ActorError::recoverable("ask sender missing"));
+      };
+      let mut reply_to = sender.clone();
+      reply_to
+        .try_tell(AnyMessage::new(Answer(42)))
+        .map_err(|error| ActorError::recoverable(format!("ask reply delivery failed: {error:?}")))?;
+    }
+    Ok(())
+  }
+}
+
+fn main() {
+  let props = Props::from_fn(|| Responder);
+  let system =
+    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let termination = system.when_terminated();
+  let mut responder = system.user_guardian_ref();
+
+  let response = responder.ask(AnyMessage::new(Question));
+  let deadline = Instant::now() + Duration::from_secs(1);
+  while !response.future().with_read(|future| future.is_ready()) {
+    assert!(Instant::now() < deadline, "kernel ask should complete within 1 second");
+    thread::sleep(Duration::from_millis(1));
+  }
+  let reply = response.future().with_write(|future| future.try_take()).expect("ready").expect("ok");
+  let answer = reply.downcast_ref::<Answer>().expect("answer payload");
+  println!("received response: {}", answer.0);
+  assert_eq!(answer.0, 42);
+
+  system.terminate().expect("terminate");
+  termination.wait_blocking(&StdBlocker::new());
+}

--- a/showcases/std/kernel/dispatchers/main.rs
+++ b/showcases/std/kernel/dispatchers/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -45,6 +43,7 @@ fn main() {
 
   system.user_guardian_ref().tell(AnyMessage::new(RunBlockingWork));
   wait_until(|| events.with_lock(|events| events.as_slice() == ["blocking-dispatcher-work"]));
+  println!("kernel_dispatchers recorded blocking dispatcher work");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/fault-tolerance/main.rs
+++ b/showcases/std/kernel/fault-tolerance/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -89,6 +87,7 @@ fn main() {
   let snapshot = events.with_lock(|events| events.clone());
   assert!(snapshot.contains(&"pre-restart"));
   assert!(snapshot.contains(&"post-restart"));
+  println!("kernel_fault_tolerance observed events: {snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/first-example/main.rs
+++ b/showcases/std/kernel/first-example/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -43,6 +41,8 @@ fn main() {
 
   system.user_guardian_ref().tell(AnyMessage::new(Greet));
   wait_until(|| greetings.with_lock(|greetings| greetings.as_slice() == ["hello"]));
+  let snapshot = greetings.with_lock(|greetings| greetings.clone());
+  println!("kernel_first_example recorded greetings: {snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/fsm/main.rs
+++ b/showcases/std/kernel/fsm/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -88,7 +86,9 @@ fn main() {
   guardian.tell(AnyMessage::new(Coin));
   guardian.tell(AnyMessage::new(Pass));
   wait_until(|| pass_count.with_lock(|count| *count == 1));
-  assert_eq!(transitions.with_lock(|transitions| transitions.clone()), vec!["locked-to-open", "open-to-locked"]);
+  let transitions_snapshot = transitions.with_lock(|transitions| transitions.clone());
+  assert_eq!(transitions_snapshot, vec!["locked-to-open", "open-to-locked"]);
+  println!("kernel_fsm completed transitions: {transitions_snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/mailboxes/main.rs
+++ b/showcases/std/kernel/mailboxes/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::{num::NonZeroUsize, time::Duration};
 use std::thread;
 
@@ -51,7 +49,9 @@ fn main() {
     system.user_guardian_ref().tell(AnyMessage::new(Record(value)));
   }
   wait_until(|| records.with_lock(|records| records.len() == 3));
-  assert_eq!(records.with_lock(|records| records.clone()), vec![1, 2, 3]);
+  let snapshot = records.with_lock(|records| records.clone());
+  assert_eq!(snapshot, vec![1, 2, 3]);
+  println!("kernel_mailboxes delivered records: {snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/persistence-fsm/main.rs
+++ b/showcases/std/kernel/persistence-fsm/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -188,6 +186,8 @@ fn main() {
   wait_until(|| observed.with_lock(|observed| observed.0 == DoorState::Open));
   guardian.tell(AnyMessage::new(GuardianCommand::Pass));
   wait_until(|| observed.with_lock(|observed| *observed == (DoorState::Closed, 1)));
+  let observed_state = observed.with_lock(|observed| *observed);
+  println!("kernel_persistence_fsm observed door state: {observed_state:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/persistence/main.rs
+++ b/showcases/std/kernel/persistence/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -118,6 +116,8 @@ fn main() {
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
   wait_until(|| observed.with_lock(|value| *value == 9));
+  let observed_value = observed.with_lock(|value| *value);
+  println!("kernel_persistence replayed counter value: {observed_value}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/routing/main.rs
+++ b/showcases/std/kernel/routing/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -81,6 +79,7 @@ fn main() {
   let snapshot = records.with_lock(|records| records.clone());
   assert_eq!(snapshot.iter().filter(|(index, _)| *index == 0).count(), 2);
   assert_eq!(snapshot.iter().filter(|(index, _)| *index == 1).count(), 2);
+  println!("kernel_routing routed {} work items: {snapshot:?}", snapshot.len());
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/kernel/supervision/main.rs
+++ b/showcases/std/kernel/supervision/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -93,7 +91,9 @@ fn main() {
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
   wait_until(|| events.with_lock(|events| events.contains(&"work-accepted")));
-  assert!(events.with_lock(|events| events.iter().filter(|event| **event == "worker-started").count() >= 2));
+  let snapshot = events.with_lock(|events| events.clone());
+  assert!(snapshot.iter().filter(|event| **event == "worker-started").count() >= 2);
+  println!("kernel_supervision observed events: {snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/legacy/child_lifecycle/main.rs
+++ b/showcases/std/legacy/child_lifecycle/main.rs
@@ -14,13 +14,17 @@ use std::sync::Arc;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
-  kernel::actor::{
-    error::ActorError,
-    setup::ActorSystemConfig,
-    supervision::{RestartLimit, SupervisorDirective, SupervisorStrategy, SupervisorStrategyKind},
+  kernel::{
+    actor::{
+      error::ActorError,
+      setup::ActorSystemConfig,
+      supervision::{RestartLimit, SupervisorDirective, SupervisorStrategy, SupervisorStrategyKind},
+    },
+    event::logging::LogLevel,
   },
   typed::{Behavior, TypedActorSystem, TypedProps, dsl::Behaviors, message_and_signals::BehaviorSignal},
 };
+use fraktor_showcases_std::subscribe_typed_tracing_logger;
 
 // --- メッセージ定義 ---
 
@@ -39,19 +43,24 @@ enum ChildCommand {
 // crashes_remaining を Arc<AtomicU32> で共有し、リスタートを跨いでカウントを維持する
 
 fn fussy_worker(crashes_remaining: Arc<AtomicU32>) -> Behavior<ChildCommand> {
-  Behaviors::receive_message(move |_ctx, message: &ChildCommand| match message {
+  Behaviors::receive_message(move |ctx, message: &ChildCommand| match message {
     | ChildCommand::Work => {
-      println!("  [child] 正常に処理しました");
+      ctx.system().emit_log(LogLevel::Info, "[child] processed work", Some(ctx.pid()), None);
       Ok(Behaviors::same())
     },
     | ChildCommand::Crash => {
       let remaining = crashes_remaining.load(Ordering::Acquire);
       if remaining > 0 {
         crashes_remaining.fetch_sub(1, Ordering::Release);
-        println!("  [child] クラッシュします (残り {} 回)", remaining - 1);
+        ctx.system().emit_log(
+          LogLevel::Warn,
+          format!("[child] crashing, remaining restarts: {}", remaining - 1),
+          Some(ctx.pid()),
+          None,
+        );
         Err(ActorError::recoverable("simulated crash"))
       } else {
-        println!("  [child] クラッシュ回数を超過、正常処理に切り替え");
+        ctx.system().emit_log(LogLevel::Info, "[child] switching back to normal work", Some(ctx.pid()), None);
         Ok(Behaviors::same())
       }
     },
@@ -81,9 +90,9 @@ fn parent() -> Behavior<ParentCommand> {
       .expect("spawn child");
     let child_ref = child.actor_ref();
 
-    Behaviors::receive_message(move |_ctx, message: &ParentCommand| match message {
+    Behaviors::receive_message(move |ctx, message: &ParentCommand| match message {
       | ParentCommand::Start => {
-        println!("[parent] 子アクターにクラッシュを指示します");
+        ctx.system().emit_log(LogLevel::Info, "[parent] sending crash commands to child", Some(ctx.pid()), None);
         let mut child = child_ref.clone();
         child.tell(ChildCommand::Crash);
         child.tell(ChildCommand::Crash);
@@ -91,16 +100,26 @@ fn parent() -> Behavior<ParentCommand> {
         Ok(Behaviors::same())
       },
     })
-    .receive_signal(|_ctx, signal| {
+    .receive_signal(|ctx, signal| {
       match signal {
         | BehaviorSignal::Terminated(terminated) => {
-          println!("[parent] 子アクター {:?} の停止を検知 (Terminated)", terminated.pid());
+          ctx.system().emit_log(
+            LogLevel::Info,
+            format!("[parent] observed child termination: {:?}", terminated.pid()),
+            Some(ctx.pid()),
+            None,
+          );
         },
         | BehaviorSignal::ChildFailed(child_failed) => {
-          println!("[parent] 子アクター {:?} が失敗: {:?}", child_failed.pid(), child_failed.error());
+          ctx.system().emit_log(
+            LogLevel::Warn,
+            format!("[parent] child failed: {:?}: {:?}", child_failed.pid(), child_failed.error()),
+            Some(ctx.pid()),
+            None,
+          );
         },
         | BehaviorSignal::PreRestart => {
-          println!("[parent] PreRestart シグナル受信");
+          ctx.system().emit_log(LogLevel::Info, "[parent] received PreRestart", Some(ctx.pid()), None);
         },
         | _ => {},
       }
@@ -113,13 +132,13 @@ fn parent() -> Behavior<ParentCommand> {
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   use std::thread;
 
   let props = TypedProps::from_behavior_factory(parent);
   let system =
     TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 
   // 親アクターにメッセージを送信して子ライフサイクルのデモを開始
@@ -127,6 +146,7 @@ fn main() {
 
   // supervision と再起動が行われる時間を待つ
   thread::sleep(std::time::Duration::from_millis(300));
+  println!("child_lifecycle completed supervised child restart flow");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/legacy/classic_logging/main.rs
+++ b/showcases/std/legacy/classic_logging/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use std::{boxed::Box, string::String, thread, time::Duration, vec::Vec};
 
 use fraktor_actor_adaptor_std_rs::std::tick_driver::StdTickDriver;
@@ -17,6 +15,7 @@ use fraktor_actor_core_rs::core::kernel::{
   },
   system::ActorSystem,
 };
+use fraktor_showcases_std::subscribe_kernel_tracing_logger;
 use fraktor_utils_core_rs::core::sync::{SharedLock, SpinSyncMutex};
 
 struct Start;
@@ -70,6 +69,7 @@ fn main() {
   let props = Props::from_fn(|| LoggingActor);
   let system =
     ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let _log_subscription = subscribe_kernel_tracing_logger(&system);
   let _subscription = system.event_stream().subscribe(&subscriber);
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
@@ -98,6 +98,7 @@ fn main() {
       has_info && has_warning && has_debug && has_receive
     })
   });
+  println!("classic_logging captured {} log event(s)", events.with_lock(|events| events.len()));
 
   system.terminate().expect("terminate");
 }

--- a/showcases/std/legacy/classic_timers/main.rs
+++ b/showcases/std/legacy/classic_timers/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, vec::Vec};
 
@@ -58,6 +56,7 @@ fn main() {
 
   wait_until(|| events.with_lock(|events| !events.is_empty()));
   assert_eq!(events.with_lock(|events| events.clone()), vec!["tick"]);
+  println!("classic_timers fired events: {:?}", events.with_lock(|events| events.clone()));
 
   system.terminate().expect("terminate");
 }

--- a/showcases/std/legacy/getting_started/main.rs
+++ b/showcases/std/legacy/getting_started/main.rs
@@ -7,9 +7,10 @@
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
-  kernel::actor::setup::ActorSystemConfig,
+  kernel::{actor::setup::ActorSystemConfig, event::logging::LogLevel},
   typed::{Behavior, TypedActorSystem, TypedProps, dsl::Behaviors},
 };
+use fraktor_showcases_std::subscribe_typed_tracing_logger;
 
 // --- メッセージ定義 ---
 
@@ -21,9 +22,9 @@ enum Command {
 // --- Behavior 定義 ---
 
 fn greeter() -> Behavior<Command> {
-  Behaviors::receive_message(|_ctx, message: &Command| match message {
+  Behaviors::receive_message(|ctx, message: &Command| match message {
     | Command::Greet => {
-      println!("Hello from fraktor-rs!");
+      ctx.system().emit_log(LogLevel::Info, "Hello from fraktor-rs!", Some(ctx.pid()), None);
       Ok(Behaviors::same())
     },
   })
@@ -31,16 +32,17 @@ fn greeter() -> Behavior<Command> {
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   // アクターシステムを起動
   let props = TypedProps::from_behavior_factory(greeter);
   let system =
     TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 
   // guardian にメッセージを送信
   system.user_guardian_ref().tell(Command::Greet);
+  println!("getting_started sent Greet to the guardian actor");
 
   // システムを終了し、TerminationSignal で安全に待機
   system.terminate().expect("terminate");

--- a/showcases/std/legacy/persistent_actor/main.rs
+++ b/showcases/std/legacy/persistent_actor/main.rs
@@ -16,12 +16,14 @@ use fraktor_actor_core_rs::core::kernel::{
     props::Props,
     setup::ActorSystemConfig,
   },
+  event::logging::LogLevel,
   system::ActorSystem,
 };
 use fraktor_persistence_core_rs::core::{
   Eventsourced, InMemoryJournal, InMemorySnapshotStore, PersistenceContext, PersistenceExtensionInstaller,
   PersistentActor, PersistentRepr, Snapshot, persistent_props, spawn_persistent,
 };
+use fraktor_showcases_std::subscribe_kernel_tracing_logger;
 // --- メッセージ定義 ---
 
 struct Start;
@@ -73,10 +75,10 @@ impl Eventsourced for CounterActor {
 
   fn receive_command(&mut self, ctx: &mut ActorContext<'_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
     if let Some(Command::Add(delta)) = message.downcast_ref::<Command>() {
-      println!("command: Add({delta}), current value: {}", self.value);
+      ctx.log(LogLevel::Info, format!("command: Add({delta}), current value: {}", self.value));
       self.persist(ctx, Event::Incremented(*delta), |actor, event| actor.apply_event(event));
       self.flush_batch(ctx)?;
-      println!("after persist: value = {}", self.value);
+      ctx.log(LogLevel::Info, format!("after persist: value = {}", self.value));
     }
     Ok(())
   }
@@ -115,7 +117,6 @@ impl Actor for GuardianActor {
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   use std::thread;
 
@@ -128,6 +129,7 @@ fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default()).with_extension_installers(installers);
 
   let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let _log_subscription = subscribe_kernel_tracing_logger(&system);
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));

--- a/showcases/std/legacy/remote_lifecycle/main.rs
+++ b/showcases/std/legacy/remote_lifecycle/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use fraktor_actor_adaptor_std_rs::std::tick_driver::StdTickDriver;
 use fraktor_actor_core_rs::core::kernel::{
   actor::{
@@ -32,6 +30,7 @@ async fn main() {
   let installers = ExtensionInstallers::default().with_shared_extension_installer(installer);
   let config = ActorSystemConfig::new(StdTickDriver::default()).with_extension_installers(installers);
   let system = ActorSystem::create_with_config(&props, config).expect("system");
+  println!("remote_lifecycle initialized remoting extension for 127.0.0.1");
 
   system.terminate().expect("terminate");
 }

--- a/showcases/std/legacy/request_reply/main.rs
+++ b/showcases/std/legacy/request_reply/main.rs
@@ -14,9 +14,13 @@ use std::sync::Arc;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
-  kernel::actor::{error::ActorError, setup::ActorSystemConfig},
+  kernel::{
+    actor::{error::ActorError, setup::ActorSystemConfig},
+    event::logging::LogLevel,
+  },
   typed::{Behavior, TypedActorRef, TypedActorSystem, TypedProps, dsl::Behaviors},
 };
+use fraktor_showcases_std::subscribe_typed_tracing_logger;
 
 // --- メッセージ定義 ---
 
@@ -67,12 +71,12 @@ fn requester(done: Arc<AtomicBool>) -> Behavior<RequesterMsg> {
         Ok(Behaviors::same())
       },
       | RequesterMsg::GotResponse(value) => {
-        println!("received response: {value}");
+        ctx.system().emit_log(LogLevel::Info, format!("received response: {value}"), Some(ctx.pid()), None);
         done.store(true, Ordering::Release);
         Ok(Behaviors::same())
       },
       | RequesterMsg::GotFailure => {
-        println!("ask failed (timeout or error)");
+        ctx.system().emit_log(LogLevel::Warn, "ask failed (timeout or error)", Some(ctx.pid()), None);
         done.store(true, Ordering::Release);
         Ok(Behaviors::same())
       },
@@ -82,7 +86,6 @@ fn requester(done: Arc<AtomicBool>) -> Behavior<RequesterMsg> {
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   use std::{thread, time::Instant};
 
@@ -91,6 +94,7 @@ fn main() {
   let props = TypedProps::from_behavior_factory(move || requester(done_clone.clone()));
   let system =
     TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 
   // ask リクエストを開始
@@ -105,6 +109,7 @@ fn main() {
     }
     thread::sleep(Duration::from_millis(1));
   }
+  println!("request_reply completed ask-style request");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/legacy/routing/main.rs
+++ b/showcases/std/legacy/routing/main.rs
@@ -93,6 +93,7 @@ fn main() {
     let records = future.try_take().expect("ready").expect("ok");
     let observed_count = records.len();
     if observed_count == 4 {
+      println!("routing distributed records: {records:?}");
       break;
     }
     assert!(Instant::now() < deadline, "all work items should be routed within 3 seconds, observed {}", observed_count);

--- a/showcases/std/legacy/serialization/main.rs
+++ b/showcases/std/legacy/serialization/main.rs
@@ -231,7 +231,6 @@ fn serialize_and_restore(serialization: &SerializationExtensionShared, payload: 
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   let json_id = SerializerId::try_from(201).expect("valid json serializer id");
   let bincode_id = SerializerId::try_from(202).expect("valid bincode serializer id");

--- a/showcases/std/legacy/stash/main.rs
+++ b/showcases/std/legacy/stash/main.rs
@@ -73,7 +73,6 @@ fn open(total: i32) -> Behavior<Command> {
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   use std::{
     thread,

--- a/showcases/std/legacy/state_management/main.rs
+++ b/showcases/std/legacy/state_management/main.rs
@@ -13,9 +13,10 @@ use core::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
-  kernel::actor::setup::ActorSystemConfig,
+  kernel::{actor::setup::ActorSystemConfig, event::logging::LogLevel},
   typed::{Behavior, TypedActorRef, TypedActorSystem, TypedProps, dsl::Behaviors},
 };
+use fraktor_showcases_std::subscribe_typed_tracing_logger;
 
 // =============================================================================
 // パート 1: カウンターアクター（イミュータブルな状態遷移）
@@ -54,13 +55,13 @@ enum GateCommand {
 }
 
 fn locked(pass_count: u32) -> Behavior<GateCommand> {
-  Behaviors::receive_message(move |_ctx, message| match message {
+  Behaviors::receive_message(move |ctx, message| match message {
     | GateCommand::InsertCoin => {
-      println!("locked -> unlocked");
+      ctx.system().emit_log(LogLevel::Info, "locked -> unlocked", Some(ctx.pid()), None);
       Ok(unlocked(pass_count))
     },
     | GateCommand::PassThrough => {
-      println!("locked: PassThrough ignored");
+      ctx.system().emit_log(LogLevel::Info, "locked: PassThrough ignored", Some(ctx.pid()), None);
       Ok(Behaviors::ignore())
     },
     | GateCommand::ReadPassCount { reply_to } => {
@@ -73,14 +74,14 @@ fn locked(pass_count: u32) -> Behavior<GateCommand> {
 }
 
 fn unlocked(pass_count: u32) -> Behavior<GateCommand> {
-  Behaviors::receive_message(move |_ctx, message| match message {
+  Behaviors::receive_message(move |ctx, message| match message {
     | GateCommand::PassThrough => {
       let next_total = pass_count + 1;
-      println!("unlocked -> locked (total {next_total})");
+      ctx.system().emit_log(LogLevel::Info, format!("unlocked -> locked (total {next_total})"), Some(ctx.pid()), None);
       Ok(locked(next_total))
     },
     | GateCommand::InsertCoin => {
-      println!("unlocked: extra InsertCoin ignored");
+      ctx.system().emit_log(LogLevel::Info, "unlocked: extra InsertCoin ignored", Some(ctx.pid()), None);
       Ok(Behaviors::ignore())
     },
     | GateCommand::ReadPassCount { reply_to } => {
@@ -94,7 +95,6 @@ fn unlocked(pass_count: u32) -> Behavior<GateCommand> {
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   println!("=== Part 1: Counter ===");
   run_counter();
@@ -143,6 +143,7 @@ fn run_gate() {
   let props = TypedProps::from_behavior_factory(|| locked(0));
   let system =
     TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let _log_subscription = subscribe_typed_tracing_logger(&system);
   let mut gate = system.user_guardian_ref();
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/stream_authoring_apis/main.rs
+++ b/showcases/std/legacy/stream_authoring_apis/main.rs
@@ -102,7 +102,6 @@ impl SubSourceOutletHandler<u32> for ExampleSubSourceHandler {
   }
 }
 
-#[allow(clippy::print_stdout)]
 fn main() {
   let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default());

--- a/showcases/std/legacy/stream_pipeline/main.rs
+++ b/showcases/std/legacy/stream_pipeline/main.rs
@@ -10,16 +10,12 @@
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
-use fraktor_actor_core_rs::core::kernel::{
-  actor::{Actor, ActorContext, error::ActorError, messaging::AnyMessageView, props::Props, setup::ActorSystemConfig},
-  system::ActorSystem,
-};
+use fraktor_actor_core_rs::core::kernel::{actor::setup::ActorSystemConfig, system::ActorSystem};
 use fraktor_stream_core_rs::core::{
   dsl::{Sink, Source},
   materialization::{ActorMaterializer, ActorMaterializerConfig, KeepRight},
 };
 
-#[allow(clippy::print_stdout)]
 fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default());
   let system = ActorSystem::noop_with_config(config).expect("actor system");

--- a/showcases/std/legacy/timers/main.rs
+++ b/showcases/std/legacy/timers/main.rs
@@ -16,12 +16,13 @@ use std::sync::Arc;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
-  kernel::actor::setup::ActorSystemConfig,
+  kernel::{actor::setup::ActorSystemConfig, event::logging::LogLevel},
   typed::{
     Behavior, TypedActorSystem, TypedProps,
     dsl::{Behaviors, TimerKey},
   },
 };
+use fraktor_showcases_std::subscribe_typed_tracing_logger;
 
 // --- メッセージ定義 ---
 
@@ -42,17 +43,17 @@ enum Command {
 fn timer_demo() -> Behavior<Command> {
   Behaviors::with_timers(|timers| {
     let tick_count = Arc::new(AtomicU32::new(0));
-    Behaviors::receive_message(move |_ctx, message: &Command| match message {
+    Behaviors::receive_message(move |ctx, message: &Command| match message {
       | Command::Start => {
         // Part 1: 遅延実行（one-shot）
-        println!("=== Part 1: One-shot timer ===");
+        ctx.system().emit_log(LogLevel::Info, "starting one-shot timer", Some(ctx.pid()), None);
         let once_key = TimerKey::new("delayed-hello");
         timers
           .with_lock(|timers| timers.start_single_timer(once_key, Command::DelayedHello, Duration::from_millis(50)))
           .expect("schedule once");
 
         // Part 2: 定期実行
-        println!("=== Part 2: Periodic timer ===");
+        ctx.system().emit_log(LogLevel::Info, "starting periodic timer", Some(ctx.pid()), None);
         let periodic_key = TimerKey::new("periodic-tick");
         timers
           .with_lock(|timers| {
@@ -61,7 +62,7 @@ fn timer_demo() -> Behavior<Command> {
           .expect("schedule periodic");
 
         // Part 3: キャンセル
-        println!("=== Part 3: Cancellation ===");
+        ctx.system().emit_log(LogLevel::Info, "starting cancellable timer", Some(ctx.pid()), None);
         let cancel_key = TimerKey::new("cancel-me");
         timers
           .with_lock(|timers| {
@@ -69,22 +70,22 @@ fn timer_demo() -> Behavior<Command> {
           })
           .expect("schedule to cancel");
         timers.with_lock(|timers| timers.cancel(&cancel_key));
-        println!("  timer 'cancel-me' をキャンセルしました");
+        ctx.system().emit_log(LogLevel::Info, "cancelled timer 'cancel-me'", Some(ctx.pid()), None);
 
         Ok(Behaviors::same())
       },
       | Command::DelayedHello => {
-        println!("  [one-shot] DelayedHello を受信しました");
+        ctx.system().emit_log(LogLevel::Info, "received DelayedHello from one-shot timer", Some(ctx.pid()), None);
         Ok(Behaviors::same())
       },
       | Command::PeriodicTick => {
         let seq = tick_count.fetch_add(1, Ordering::Relaxed);
-        println!("  [periodic] tick #{seq}");
+        ctx.system().emit_log(LogLevel::Info, format!("received periodic tick #{seq}"), Some(ctx.pid()), None);
         Ok(Behaviors::same())
       },
       | Command::ShouldNotArrive => {
         // キャンセルは best-effort のため、タイミングによっては到着しうる
-        println!("  [cancel] キャンセル済みメッセージが到着しました（best-effort のため許容）");
+        ctx.system().emit_log(LogLevel::Warn, "received cancelled timer message", Some(ctx.pid()), None);
         Ok(Behaviors::same())
       },
     })
@@ -93,19 +94,20 @@ fn timer_demo() -> Behavior<Command> {
 
 // --- エントリーポイント ---
 
-#[allow(clippy::print_stdout)]
 fn main() {
   use std::thread;
 
   let props = TypedProps::from_behavior_factory(timer_demo);
   let system =
     TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(Command::Start);
 
   // タイマーが動作する時間を待つ
   thread::sleep(std::time::Duration::from_millis(300));
+  println!("timers completed one-shot, periodic, and cancellation flow");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/legacy/typed_event_stream/main.rs
+++ b/showcases/std/legacy/typed_event_stream/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::vec::Vec;
 
@@ -112,6 +110,7 @@ fn main() {
     .expect("system actor");
   assert_eq!(system_actor.path().expect("system actor path").to_string(), "/system/typed-event-stream-example");
   assert!(system.print_tree().contains("typed-event-stream-example"));
+  println!("typed_event_stream collected {} event(s)", events.with_lock(|events| events.len()));
 
   system.terminate().expect("terminate");
 }

--- a/showcases/std/legacy/typed_receptionist_router/main.rs
+++ b/showcases/std/legacy/typed_receptionist_router/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use std::{thread, time::Duration, vec::Vec};
 
 use fraktor_actor_adaptor_std_rs::std::tick_driver::StdTickDriver;
@@ -58,6 +56,7 @@ fn main() {
 
   router_ref.tell(42);
   wait_until(|| records.with_lock(|records| records.as_slice() == [42]));
+  println!("typed_receptionist_router delivered records: {:?}", records.with_lock(|records| records.clone()));
 
   system.terminate().expect("terminate");
 }

--- a/showcases/std/src/lib.rs
+++ b/showcases/std/src/lib.rs
@@ -1,1 +1,106 @@
+use core::{
+  fmt::{Debug, Write},
+  sync::atomic::{AtomicU64, Ordering},
+};
+use std::{println, string::String, vec::Vec};
 
+use fraktor_actor_adaptor_std_rs::std::event::logging::TracingLoggerSubscriber;
+use fraktor_actor_core_rs::core::{
+  kernel::{
+    event::{
+      logging::LogLevel,
+      stream::{EventStreamSubscriberShared, EventStreamSubscription},
+    },
+    system::ActorSystem,
+  },
+  typed::TypedActorSystem,
+};
+use tracing::{
+  Event, Id, Metadata, Subscriber,
+  field::{Field, Visit},
+  span::{Attributes, Record},
+  subscriber::set_global_default,
+};
+
+/// Subscribes a `tracing` logger to a kernel actor system.
+#[must_use]
+pub fn subscribe_kernel_tracing_logger(system: &ActorSystem) -> EventStreamSubscription {
+  init_stdout_tracing();
+  system.subscribe_event_stream(&tracing_logger_subscriber())
+}
+
+/// Subscribes a `tracing` logger to a typed actor system.
+#[must_use]
+pub fn subscribe_typed_tracing_logger<M>(system: &TypedActorSystem<M>) -> EventStreamSubscription
+where
+  M: Send + Sync + 'static, {
+  init_stdout_tracing();
+  system.subscribe_event_stream(&tracing_logger_subscriber())
+}
+
+fn tracing_logger_subscriber() -> EventStreamSubscriberShared {
+  EventStreamSubscriberShared::new(Box::new(TracingLoggerSubscriber::new(LogLevel::Trace)))
+}
+
+fn init_stdout_tracing() -> bool {
+  set_global_default(StdoutTracingSubscriber::default()).is_ok()
+}
+
+#[derive(Default)]
+struct StdoutTracingSubscriber {
+  next_span_id: AtomicU64,
+}
+
+impl Subscriber for StdoutTracingSubscriber {
+  fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+    true
+  }
+
+  fn new_span(&self, _span: &Attributes<'_>) -> Id {
+    Id::from_u64(self.next_span_id.fetch_add(1, Ordering::Relaxed) + 1)
+  }
+
+  fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+  fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+  fn event(&self, event: &Event<'_>) {
+    let mut visitor = TracingEventVisitor::default();
+    event.record(&mut visitor);
+
+    let metadata = event.metadata();
+    match visitor.message {
+      | Some(message) if visitor.fields.is_empty() => {
+        println!("[actor-log {} {}] {message}", metadata.level(), metadata.target());
+      },
+      | Some(message) => {
+        println!("[actor-log {} {}] {message} {}", metadata.level(), metadata.target(), visitor.fields.join(" "));
+      },
+      | None => {
+        println!("[actor-log {} {}] {}", metadata.level(), metadata.target(), visitor.fields.join(" "));
+      },
+    }
+  }
+
+  fn enter(&self, _span: &Id) {}
+
+  fn exit(&self, _span: &Id) {}
+}
+
+#[derive(Default)]
+struct TracingEventVisitor {
+  message: Option<String>,
+  fields:  Vec<String>,
+}
+
+impl Visit for TracingEventVisitor {
+  fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+    let mut rendered = String::new();
+    write!(&mut rendered, "{value:?}").expect("format tracing field");
+    if field.name() == "message" {
+      self.message = Some(rendered);
+    } else {
+      self.fields.push(format!("{}={rendered}", field.name()));
+    }
+  }
+}

--- a/showcases/std/stream/basics/main.rs
+++ b/showcases/std/stream/basics/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
@@ -22,5 +20,6 @@ fn main() {
   let materialized = graph.run(&mut materializer).expect("run");
   let values = materialized.materialized().wait_blocking(&StdBlocker::new()).expect("stream should succeed");
   assert_eq!(values, vec![3, 5, 7]);
+  println!("stream_basics collected values: {values:?}");
   materializer.shutdown().expect("materializer shutdown");
 }

--- a/showcases/std/stream/composition/main.rs
+++ b/showcases/std/stream/composition/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
@@ -21,5 +19,6 @@ fn main() {
   let materialized = graph.run(&mut materializer).expect("run");
   let values = materialized.materialized().wait_blocking(&StdBlocker::new()).expect("stream should succeed");
   assert_eq!(values, vec![1, 2, 3, 4]);
+  println!("stream_composition collected values: {values:?}");
   materializer.shutdown().expect("materializer shutdown");
 }

--- a/showcases/std/stream/first-example/main.rs
+++ b/showcases/std/stream/first-example/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
@@ -19,5 +17,6 @@ fn main() {
   let materialized = graph.run(&mut materializer).expect("run");
   let result = materialized.materialized().wait_blocking(&StdBlocker::new()).expect("stream should succeed");
   assert_eq!(result, 42);
+  println!("stream_first_example result: {result}");
   materializer.shutdown().expect("materializer shutdown");
 }

--- a/showcases/std/stream/graphs/main.rs
+++ b/showcases/std/stream/graphs/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
@@ -22,5 +20,6 @@ fn main() {
   let materialized = graph.run(&mut materializer).expect("run");
   let values = materialized.materialized().wait_blocking(&StdBlocker::new()).expect("stream should succeed");
   assert_eq!(values, vec![11, 12, 13]);
+  println!("stream_graphs collected values: {values:?}");
   materializer.shutdown().expect("materializer shutdown");
 }

--- a/showcases/std/stream/rate/main.rs
+++ b/showcases/std/stream/rate/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use std::time::Duration;
 
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
@@ -23,5 +21,6 @@ fn main() {
   let materialized = graph.run(&mut materializer).expect("run");
   let values = materialized.materialized().wait_blocking(&StdBlocker::new()).expect("stream should succeed");
   assert_eq!(values, vec![1, 2, 3]);
+  println!("stream_rate collected values with throttle/backpressure: {values:?}");
   materializer.shutdown().expect("materializer shutdown");
 }

--- a/showcases/std/typed/actor-discovery/main.rs
+++ b/showcases/std/typed/actor-discovery/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, time::Instant};
 
@@ -29,6 +27,7 @@ fn main() {
   let listing = wait_for_listing(&mut receptionist_ref, &key);
   let instances = listing.service_instances(&key).expect("matching key");
   assert!(instances.contains(&service_ref));
+  println!("typed_actor_discovery found {} service instance(s)", instances.len());
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/actor-lifecycle/main.rs
+++ b/showcases/std/typed/actor-lifecycle/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, time::Instant};
 
@@ -73,6 +71,7 @@ fn main() {
   let snapshot = events.with_lock(|events| events.clone());
   assert!(snapshot.contains(&"parent-setup"));
   assert!(snapshot.contains(&"child-post-stop"));
+  println!("typed_actor_lifecycle observed events: {snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/coordinated-shutdown/main.rs
+++ b/showcases/std/typed/coordinated-shutdown/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::{
   future::Future,
   pin::pin,
@@ -31,6 +29,7 @@ fn main() {
 
   assert_eq!(events.with_lock(|events| events.clone()), vec!["flushed"]);
   assert_eq!(shutdown.shutdown_reason(), Some(CoordinatedShutdownReason::Custom("typed-coordinated-shutdown".into())));
+  println!("typed_coordinated_shutdown ran tasks: {:?}", events.with_lock(|events| events.clone()));
 }
 
 fn block_on_ready<F: Future>(future: F, timeout: Duration) -> Option<F::Output> {

--- a/showcases/std/typed/dispatchers/main.rs
+++ b/showcases/std/typed/dispatchers/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -38,6 +36,7 @@ fn main() {
 
   actor.tell(Command::Run);
   wait_until(|| events.with_lock(|events| events.as_slice() == ["typed-blocking-dispatcher-work"]));
+  println!("typed_dispatchers recorded events: {:?}", events.with_lock(|events| events.clone()));
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/fault-tolerance/main.rs
+++ b/showcases/std/typed/fault-tolerance/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::thread;
 
@@ -71,7 +69,9 @@ fn main() {
 
   guardian.tell(ParentCommand::Start);
   wait_until(|| events.with_lock(|events| events.contains(&"work-after-restart")));
-  assert!(events.with_lock(|events| events.iter().filter(|event| **event == "child-started").count() >= 2));
+  let snapshot = events.with_lock(|events| events.clone());
+  assert!(snapshot.iter().filter(|event| **event == "child-started").count() >= 2);
+  println!("typed_fault_tolerance observed events: {snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/first-example/main.rs
+++ b/showcases/std/typed/first-example/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, time::Instant};
 
@@ -37,6 +35,7 @@ fn main() {
 
   guardian.tell(Command::Greet);
   wait_until(|| greetings.with_lock(|greetings| greetings.as_slice() == ["hello"]), Duration::from_secs(10));
+  println!("typed_first_example recorded greetings: {:?}", greetings.with_lock(|greetings| greetings.clone()));
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/fsm/main.rs
+++ b/showcases/std/typed/fsm/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, time::Instant};
 
@@ -50,7 +48,9 @@ fn main() {
   gate.tell(Command::Pass);
   gate.tell(Command::Coin);
   gate.tell(Command::Pass);
-  assert_eq!(read_pass_count(&mut gate), 1);
+  let pass_count = read_pass_count(&mut gate);
+  assert_eq!(pass_count, 1);
+  println!("typed_fsm recorded pass count: {pass_count}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/interaction-patterns/main.rs
+++ b/showcases/std/typed/interaction-patterns/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, time::Instant};
 
@@ -37,7 +35,9 @@ fn main() {
     assert!(Instant::now() < deadline, "ask should complete within 1 second");
     thread::sleep(Duration::from_millis(1));
   }
-  assert_eq!(future.try_take().expect("ready").expect("ok"), 42);
+  let value = future.try_take().expect("ready").expect("ok");
+  assert_eq!(value, 42);
+  println!("typed_interaction_patterns received response: {value}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/mailboxes/main.rs
+++ b/showcases/std/typed/mailboxes/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::{num::NonZeroUsize, time::Duration};
 use std::thread;
 
@@ -40,7 +38,9 @@ fn main() {
     actor.tell(Command::Record(value));
   }
   wait_until(|| records.with_lock(|records| records.len() == 3));
-  assert_eq!(records.with_lock(|records| records.clone()), vec![1, 2, 3]);
+  let snapshot = records.with_lock(|records| records.clone());
+  assert_eq!(snapshot, vec![1, 2, 3]);
+  println!("typed_mailboxes delivered records: {snapshot:?}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/routers/main.rs
+++ b/showcases/std/typed/routers/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, time::Instant};
 
@@ -63,6 +61,7 @@ fn main() {
   let snapshot = wait_for_records(&mut router);
   assert_eq!(snapshot.iter().filter(|(index, _)| *index == 0).count(), 2);
   assert_eq!(snapshot.iter().filter(|(index, _)| *index == 1).count(), 2);
+  println!("typed_routers routed {} work items: {snapshot:?}", snapshot.len());
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());

--- a/showcases/std/typed/stash/main.rs
+++ b/showcases/std/typed/stash/main.rs
@@ -1,5 +1,3 @@
-#![cfg(not(target_os = "none"))]
-
 use core::time::Duration;
 use std::{thread, time::Instant};
 
@@ -67,7 +65,9 @@ fn main() {
   actor.tell(Command::Buffer(5));
   actor.tell(Command::Buffer(3));
   actor.tell(Command::Open);
-  assert_eq!(read_total(&mut actor), 208);
+  let total = read_total(&mut actor);
+  assert_eq!(total, 208);
+  println!("typed_stash unstashed total: {total}");
 
   system.terminate().expect("terminate");
   termination.wait_blocking(&StdBlocker::new());


### PR DESCRIPTION
## Summary

- add a kernel ask-from-non-actor showcase under `showcases/std/kernel`
- remove per-example `target_os = "none"` gating from std showcase mains
- allow stdout prints for `showcases/std` and add outside-actor `println!` output across examples
- route actor-internal output through logging APIs and subscribe std examples through the existing `TracingLoggerSubscriber`

## Validation

- `cargo fmt --check --package fraktor-showcases-std`
- `cargo clippy -p fraktor-showcases-std --all-targets -- -D warnings`
- `cargo clippy -p fraktor-showcases-std --features advanced --examples --no-deps -- -D warnings`
- ran `getting_started`, `request_reply`, `child_lifecycle`, `timers`, `classic_logging`, `state_management`, `persistent_actor`, and `kernel_interaction_patterns` to confirm outputs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added kernel "ask" pattern example demonstrating actor-to-system communication.
  * Introduced structured logging integration for actor system diagnostics.

* **Refactor**
  * Updated legacy examples to use structured logging instead of standard output.
  * Improved platform compatibility by enabling showcase examples on additional target systems.

* **Improvements**
  * Enhanced example visibility with diagnostic output snapshots.
  * Refined example modularity through streamlined import statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->