### PR TITLE
refactor(actor-core)!: rename create_with_config to create_from_props

### DIFF
--- a/.codex-corporate/config.toml
+++ b/.codex-corporate/config.toml
@@ -7,7 +7,7 @@ personality = "pragmatic"
 approvals_reviewer = "user"
 
 [features]
-codex_hooks = true
+hooks = true
 rmcp_client = true
 skills = true
 unified_exec = true
@@ -55,3 +55,8 @@ enabled = true
 
 [plugins."github@openai-curated"]
 enabled = true
+
+[hooks.state]
+
+[hooks.state."/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs/.codex/config.toml:post_tool_use:0:0"]
+trusted_hash = "sha256:50c9cb42ba05dfde72d7213af8d0d026faab8dc52faebe2afdced32c7d0b3bce"

--- a/.codex-personal/config.toml
+++ b/.codex-personal/config.toml
@@ -6,7 +6,7 @@ web_search = "live"
 personality = "pragmatic"
 
 [features]
-codex_hooks = true
+hooks = true
 rmcp_client = true
 skills = true
 unified_exec = true
@@ -47,3 +47,8 @@ hide_rate_limit_model_nudge = true
 
 [plugins."github@openai-curated"]
 enabled = true
+
+[hooks.state]
+
+[hooks.state."/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs/.codex/config.toml:post_tool_use:0:0"]
+trusted_hash = "sha256:50c9cb42ba05dfde72d7213af8d0d026faab8dc52faebe2afdced32c7d0b3bce"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -30,7 +30,7 @@ config_file = "agents/worker.toml"
 description = "Implementation-focused agent for small targeted fixes."
 
 [features]
-codex_hooks = true
+hooks = true
 js_repl = false
 multi_agent = true
 prevent_idle_sleep = true

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 node = "20"
 python = "3"
 "npm:@fission-ai/openspec" = "1.3.1"
-codex = "0.128.0"
+codex = "0.129.0"

--- a/modules/actor-adaptor-std/benches/actor_baseline.rs
+++ b/modules/actor-adaptor-std/benches/actor_baseline.rs
@@ -142,7 +142,7 @@ impl TokioBenchSystem {
       let configurator: Box<dyn MessageDispatcherFactory> =
         Box::new(DefaultDispatcherFactory::new(&settings, executor));
       let config = config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(configurator));
-      ActorSystem::create_with_config(props, config).expect("actor system")
+      ActorSystem::create_from_props(props, config).expect("actor system")
     });
     Self { runtime, system }
   }

--- a/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
+++ b/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
@@ -138,7 +138,7 @@ impl DispatcherBenchSystem {
         .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
         .with_dispatcher_factory(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
       let props = Props::from_fn(|| TeamGuardian);
-      ActorSystem::create_with_config(&props, config).expect("actor system")
+      ActorSystem::create_from_props(&props, config).expect("actor system")
     });
     Self { runtime, system }
   }

--- a/modules/actor-adaptor-std/src/std/dispatch/dispatcher/tests.rs
+++ b/modules/actor-adaptor-std/src/std/dispatch/dispatcher/tests.rs
@@ -125,7 +125,7 @@ fn build_system() -> ActorSystem {
     .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))
     .with_dispatcher_factory(BALANCING_DISPATCHER_ID, ArcShared::new(balancing_configurator));
   let props = Props::from_fn(|| TeamGuardian);
-  ActorSystem::create_with_config(&props, config).expect("actor system")
+  ActorSystem::create_from_props(&props, config).expect("actor system")
 }
 
 fn spawn_team(

--- a/modules/actor-adaptor-std/src/std/system/empty_system.rs
+++ b/modules/actor-adaptor-std/src/std/system/empty_system.rs
@@ -20,7 +20,7 @@ pub fn new_empty_actor_system() -> ActorSystem {
 /// [`ActorSystemConfig`] before the system state is built.
 ///
 /// The system is backed by [`TestTickDriver`] (std-thread driven, suitable for deterministic
-/// integration tests). Internally calls [`ActorSystem::new_started_from_config`] which marks
+/// integration tests). Internally calls [`ActorSystem::create_started_from_config`] which marks
 /// the root as started.
 ///
 /// # Panics
@@ -34,10 +34,10 @@ where
   // system 配下で `ActorCell::create` が構築するすべての mailbox が
   // throughput deadline 判定時に実経過時間を観測する (Pekko `Mailbox.scala:263-275`)。
   // config 経路に寄せることで、このテスト用 factory に限らず
-  // `ActorSystem::create_*` / `new_started_from_config` 全般で同じ clock が届く。
+  // `ActorSystem::create_*` / `create_started_from_config` 全般で同じ clock が届く。
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_mailbox_clock(std_monotonic_mailbox_clock());
   let config = configure(config);
-  match ActorSystem::new_started_from_config(config) {
+  match ActorSystem::create_started_from_config(config) {
     | Ok(system) => system,
     | Err(error) => panic!("test-support config failed to build in new_empty_actor_system_with: {error:?}"),
   }

--- a/modules/actor-adaptor-std/src/std/tick_driver/tests.rs
+++ b/modules/actor-adaptor-std/src/std/tick_driver/tests.rs
@@ -26,7 +26,7 @@ use crate::std::StdBlocker;
 fn build_system_with_driver(driver: StdTickDriver) -> ActorSystem {
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(driver).with_scheduler_config(scheduler);
-  ActorSystem::noop_with_config(config).expect("system should build")
+  ActorSystem::create_with_noop_guardian(config).expect("system should build")
 }
 
 fn provision_inputs() -> (TickFeedHandle, SchedulerTickExecutor) {
@@ -141,7 +141,7 @@ mod tokio_tests {
     let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
     let driver = TokioTickDriver::new(Duration::from_millis(10));
     let config = ActorSystemConfig::new(driver).with_scheduler_config(scheduler);
-    let system = ActorSystem::noop_with_config(config).expect("system should build");
+    let system = ActorSystem::create_with_noop_guardian(config).expect("system should build");
     system.terminate().expect("terminate");
   }
 }

--- a/modules/actor-adaptor-std/tests/sp_h1_5_system_escalation.rs
+++ b/modules/actor-adaptor-std/tests/sp_h1_5_system_escalation.rs
@@ -102,7 +102,7 @@ fn panic_guard_escalates_receive_panic_through_supervisor_path() {
   });
 
   let config = install_panic_invoke_guard(ActorSystemConfig::new(TestTickDriver::default()));
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
   let mut child = child_slot.lock().clone().expect("child");

--- a/modules/actor-adaptor-std/tests/std_adaptor_boot_e2e.rs
+++ b/modules/actor-adaptor-std/tests/std_adaptor_boot_e2e.rs
@@ -76,7 +76,7 @@ fn std_adaptor_boot_flow_wires_config_dispatcher_mailbox_scheduler_logging_and_t
     let message_log = message_log.clone();
     move || BootActor::new(message_log.clone())
   });
-  let system = ActorSystem::create_with_config(&props, config).expect("std actor system");
+  let system = ActorSystem::create_from_props(&props, config).expect("std actor system");
   let subscriber = subscriber_handle(LogRecorder::new(log_messages.clone()));
   let _subscription = system.subscribe_event_stream(&subscriber);
 

--- a/modules/actor-core/src/core/kernel/actor/actor_ref_provider/local_actor_ref_provider/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_ref_provider/local_actor_ref_provider/tests.rs
@@ -40,7 +40,7 @@ impl ActorRefSender for TempProbeSender {
 fn local_actor_ref_provider_exposes_guardians_dead_letters_and_temp_path() {
   let props = Props::from_fn(|| ProbeActor);
   let config = ActorSystemConfig::new(TestTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let provider = LocalActorRefProvider::new_with_state(&system.state());
 
   assert!(provider.root_guardian().is_some());
@@ -88,7 +88,7 @@ fn local_actor_ref_provider_unbound_dead_letters_debug_asserts() {
 fn local_actor_ref_provider_exposes_root_path_and_resolves_actor_ref_str() {
   let props = Props::from_fn(|| ProbeActor).with_name("user-root");
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-compat");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let child = system.actor_of_named(&Props::from_fn(|| ProbeActor), "provider-child").expect("child");
   let canonical = child.actor_ref().canonical_path().expect("canonical path").to_canonical_uri();
 
@@ -103,7 +103,7 @@ fn local_actor_ref_provider_exposes_root_path_and_resolves_actor_ref_str() {
 fn local_actor_ref_provider_resolves_guardians_and_reports_missing_local_path() {
   let props = Props::from_fn(|| ProbeActor).with_name("user-root");
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-guards");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let mut provider = LocalActorRefProvider::new_with_state(&system.state());
 
   let user_path = ActorPathParser::parse("fraktor://provider-guards/user").expect("user path");
@@ -126,7 +126,7 @@ fn local_actor_ref_provider_resolves_guardians_and_reports_missing_local_path() 
 fn local_actor_ref_provider_temp_helpers_handle_empty_prefix_and_invalid_path() {
   let props = Props::from_fn(|| ProbeActor);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-temp");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let provider = LocalActorRefProvider::new_with_state(&system.state());
 
   // 空 prefix は LocalActorRefProvider 側で "tmp" prefix にフォールバックする契約。
@@ -142,7 +142,7 @@ fn local_actor_ref_provider_temp_helpers_handle_empty_prefix_and_invalid_path() 
 fn local_actor_ref_provider_external_address_rejects_unrelated_local_system() {
   let props = Props::from_fn(|| ProbeActor);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-address");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let provider = LocalActorRefProvider::new_with_state(&system.state());
 
   assert!(provider.root_guardian_at(&Address::local("other-system")).is_none());
@@ -153,7 +153,7 @@ fn local_actor_ref_provider_external_address_rejects_unrelated_local_system() {
 fn local_actor_ref_provider_supports_temp_actor_round_trip() {
   let props = Props::from_fn(|| ProbeActor);
   let config = ActorSystemConfig::new(TestTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let provider = LocalActorRefProvider::new_with_state(&system.state());
   let temp_ref = ActorRef::new_with_builtin_lock(Pid::new(4242, 0), TempProbeSender);
 
@@ -174,7 +174,7 @@ fn local_actor_ref_provider_supports_temp_actor_round_trip() {
 fn local_actor_ref_provider_exposes_classic_contract_helpers() {
   let props = Props::from_fn(|| ProbeActor);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-helpers");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let provider = LocalActorRefProvider::new_with_state(&system.state());
 
   let root_at = provider.root_guardian_at(&Address::local("provider-helpers")).expect("root guardian at local");
@@ -233,7 +233,7 @@ fn local_actor_ref_provider_does_not_keep_system_state_alive_after_registration(
 fn actor_ref_provider_shared_resolves_actor_refs_via_shared_borrow() {
   let props = Props::from_fn(|| ProbeActor).with_name("user-root");
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-shared");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let child = system.actor_of_named(&Props::from_fn(|| ProbeActor), "provider-child").expect("child");
   let canonical = child.actor_ref().canonical_path().expect("canonical path").to_canonical_uri();
 
@@ -248,7 +248,7 @@ fn actor_ref_provider_shared_resolves_actor_refs_via_shared_borrow() {
 fn actor_ref_provider_shared_delegates_shared_access() {
   let props = Props::from_fn(|| ProbeActor).with_name("user-root");
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-shared-full");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let child = system.actor_of_named(&Props::from_fn(|| ProbeActor), "provider-child").expect("child");
   let canonical = child.actor_ref().canonical_path().expect("canonical path").to_canonical_uri();
   let shared = ActorRefProviderHandleShared::new(LocalActorRefProvider::new_with_state(&system.state()));
@@ -265,7 +265,7 @@ fn actor_ref_provider_shared_delegates_shared_access() {
 fn local_actor_ref_provider_accessors_and_resolve_cover_public_contract() {
   let props = Props::from_fn(|| ProbeActor).with_name("user-root");
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-accessors");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let child = system.actor_of_named(&Props::from_fn(|| ProbeActor), "provider-child").expect("child");
   let canonical = child.actor_ref().canonical_path().expect("canonical path").to_canonical_uri();
   let child_path = ActorPathParser::parse(&canonical).expect("canonical child path");
@@ -281,7 +281,7 @@ fn local_actor_ref_provider_accessors_and_resolve_cover_public_contract() {
 fn local_actor_ref_provider_temp_actor_path_round_trip() {
   let props = Props::from_fn(|| ProbeActor);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-temp-path");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let provider = LocalActorRefProvider::new_with_state(&system.state());
   let prefixed = provider.temp_path_with_prefix("reply").expect("prefixed temp path");
   assert!(prefixed.to_relative_string().starts_with("/user/temp/reply-"));
@@ -300,7 +300,7 @@ fn local_actor_ref_provider_temp_actor_path_round_trip() {
 fn local_actor_ref_provider_temp_actor_name_round_trip() {
   let props = Props::from_fn(|| ProbeActor);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("provider-temp-name");
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let provider = LocalActorRefProvider::new_with_state(&system.state());
   let temp_ref = ActorRef::new_with_builtin_lock(Pid::new(6363, 0), TempProbeSender);
   let name = provider.register_temp_actor(temp_ref).expect("temp actor");

--- a/modules/actor-core/src/core/kernel/actor/actor_selection/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/actor_selection/tests.rs
@@ -55,7 +55,7 @@ impl Actor for SelectionProbeActor {
 fn build_selection_system() -> ActorSystem {
   let props = Props::from_fn(|| NoopActor).with_name("selection-root");
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("selection-spec");
-  ActorSystem::create_with_config(&props, config).expect("system")
+  ActorSystem::create_from_props(&props, config).expect("system")
 }
 
 fn spawn_selection_probe(

--- a/modules/actor-core/src/core/kernel/actor/extension/tests.rs
+++ b/modules/actor-core/src/core/kernel/actor/extension/tests.rs
@@ -62,7 +62,7 @@ fn shared_extension_installer_keeps_caller_handle_usable() {
   let installers = ExtensionInstallers::default().with_shared_extension_installer(installer.clone());
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_extension_installers(installers);
 
-  let system = ActorSystem::noop_with_config(config).expect("system should build");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("system should build");
 
   assert_eq!(calls.load(Ordering::Relaxed), 1);
   assert_eq!(installer.calls.load(Ordering::Relaxed), 1);

--- a/modules/actor-core/src/core/kernel/dispatch/mailbox/tests.rs
+++ b/modules/actor-core/src/core/kernel/dispatch/mailbox/tests.rs
@@ -48,7 +48,7 @@ fn mailbox_metrics_and_warnings_are_emitted() {
     .with_warn_threshold(Some(warn_threshold));
   let props = Props::from_fn(|| PassiveActor).with_mailbox_config(mailbox_config);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let subscriber = subscriber_handle(RecordingSubscriber { events: events.clone() });

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -36,7 +36,7 @@ use crate::core::{
       messaging::{AnyMessage, AskResult, system_message::SystemMessage},
       props::{MailboxRequirement, Props},
       scheduler::{SchedulerBackedDelayProvider, SchedulerShared, tick_driver::TickDriverBundle},
-      setup::{ActorSystemConfig, ActorSystemSetup, CircuitBreakerConfig},
+      setup::{ActorSystemConfig, CircuitBreakerConfig},
       spawn::SpawnError,
     },
     event::{
@@ -65,25 +65,35 @@ pub struct ActorSystem {
 }
 
 impl ActorSystem {
-  /// Creates an actor system from an existing system state.
+  /// Wraps an existing [`SystemStateShared`] into an [`ActorSystem`] handle.
+  ///
+  /// Internal seam used by the runtime to convert shared state references back to a typed
+  /// [`ActorSystem`] (e.g. weak upgrades, actor selection, actor cell back-refs) and by
+  /// cross-crate test helpers that build synthetic states. Application code should use
+  /// [`ActorSystem::create_from_props`] or [`ActorSystem::create_with_noop_guardian`] instead.
+  #[doc(hidden)]
   #[must_use]
   pub fn from_state(state: SystemStateShared) -> Self {
     let settings = TypedActorSystemConfig::new(state.system_name(), state.start_time());
     Self { state, settings }
   }
 
-  /// Builds and starts an actor system from a fully constructed configuration.
+  /// Builds and starts an actor system without a user guardian.
   ///
   /// Creates the system state from the provided [`ActorSystemConfig`], wraps it in a
-  /// [`SystemStateShared`], and marks the root as started before returning. Designed as the
-  /// public seam used by adaptor-level test helpers (e.g. `new_empty_actor_system_with` in
-  /// `fraktor-actor-adaptor-std-rs`) that previously relied on private constructors.
+  /// [`SystemStateShared`], and marks the root as started before returning. No user
+  /// guardian, bootstrap callback, or extension installation is performed; the resulting
+  /// system is essentially an empty shell. Intended only as a seam for adaptor-level test
+  /// helpers (e.g. `new_empty_actor_system_with` in `fraktor-actor-adaptor-std-rs`) and
+  /// cross-crate tests. Application code should use [`ActorSystem::create_from_props`] or
+  /// [`ActorSystem::create_with_noop_guardian`].
   ///
   /// # Errors
   ///
   /// Returns [`SpawnError`] when the underlying [`SystemState`] cannot be built from the
   /// supplied configuration.
-  pub fn new_started_from_config(config: ActorSystemConfig) -> Result<Self, SpawnError> {
+  #[doc(hidden)]
+  pub fn create_started_from_config(config: ActorSystemConfig) -> Result<Self, SpawnError> {
     let state = SystemState::build_from_owned_config(config)?;
     let system = Self::from_state(SystemStateShared::new(state));
     system.state.mark_root_started();
@@ -107,27 +117,9 @@ impl ActorSystem {
   /// # Errors
   ///
   /// Returns [`SpawnError`] when guardian initialization fails.
-  pub fn noop_with_config(config: ActorSystemConfig) -> Result<Self, SpawnError> {
+  pub fn create_with_noop_guardian(config: ActorSystemConfig) -> Result<Self, SpawnError> {
     let user_guardian_props = Props::from_fn(NoopGuardianActor::new);
     Self::create_from_props(&user_guardian_props, config)
-  }
-
-  /// Creates a new actor system from a Pekko-style setup facade.
-  ///
-  /// # Errors
-  ///
-  /// Returns [`SpawnError`] when guardian initialization or bootstrap fails.
-  pub fn create_with_setup(user_guardian_props: &Props, setup: ActorSystemSetup) -> Result<Self, SpawnError> {
-    Self::create_from_props(user_guardian_props, setup.into_actor_system_config())
-  }
-
-  /// Creates an actor system with a no-op user guardian from a Pekko-style setup facade.
-  ///
-  /// # Errors
-  ///
-  /// Returns [`SpawnError`] when guardian initialization or bootstrap fails.
-  pub fn noop_with_setup(setup: ActorSystemSetup) -> Result<Self, SpawnError> {
-    Self::noop_with_config(setup.into_actor_system_config())
   }
 
   /// Creates an actor system with configuration and a bootstrap callback.

--- a/modules/actor-core/src/core/kernel/system/base.rs
+++ b/modules/actor-core/src/core/kernel/system/base.rs
@@ -95,8 +95,8 @@ impl ActorSystem {
   /// # Errors
   ///
   /// Returns [`SpawnError`] when guardian initialization fails.
-  pub fn create_with_config(user_guardian_props: &Props, config: ActorSystemConfig) -> Result<Self, SpawnError> {
-    Self::create_with_config_and(user_guardian_props, config, |_| Ok(()))
+  pub fn create_from_props(user_guardian_props: &Props, config: ActorSystemConfig) -> Result<Self, SpawnError> {
+    Self::create_from_props_with_init(user_guardian_props, config, |_| Ok(()))
   }
 
   /// Creates an actor system with a no-op user guardian and the provided configuration.
@@ -109,7 +109,7 @@ impl ActorSystem {
   /// Returns [`SpawnError`] when guardian initialization fails.
   pub fn noop_with_config(config: ActorSystemConfig) -> Result<Self, SpawnError> {
     let user_guardian_props = Props::from_fn(NoopGuardianActor::new);
-    Self::create_with_config(&user_guardian_props, config)
+    Self::create_from_props(&user_guardian_props, config)
   }
 
   /// Creates a new actor system from a Pekko-style setup facade.
@@ -118,7 +118,7 @@ impl ActorSystem {
   ///
   /// Returns [`SpawnError`] when guardian initialization or bootstrap fails.
   pub fn create_with_setup(user_guardian_props: &Props, setup: ActorSystemSetup) -> Result<Self, SpawnError> {
-    Self::create_with_config(user_guardian_props, setup.into_actor_system_config())
+    Self::create_from_props(user_guardian_props, setup.into_actor_system_config())
   }
 
   /// Creates an actor system with a no-op user guardian from a Pekko-style setup facade.
@@ -135,7 +135,7 @@ impl ActorSystem {
   /// # Errors
   ///
   /// Returns [`SpawnError`] when guardian initialization or configuration fails.
-  pub fn create_with_config_and<F>(
+  pub fn create_from_props_with_init<F>(
     user_guardian_props: &Props,
     mut config: ActorSystemConfig,
     configure: F,

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -33,7 +33,7 @@ use crate::core::{
           tests::TestTickDriver,
         },
       },
-      setup::{ActorSystemConfig, ActorSystemSetup, BootstrapSetup},
+      setup::ActorSystemConfig,
       spawn::SpawnError,
     },
     dispatch::dispatcher::{
@@ -84,7 +84,7 @@ impl ActorSystem {
     use crate::core::kernel::actor::scheduler::tick_driver::tests::TestTickDriver;
 
     let config = configure(ActorSystemConfig::new(TestTickDriver::default()));
-    match Self::new_started_from_config(config) {
+    match Self::create_started_from_config(config) {
       | Ok(system) => system,
       | Err(error) => panic!("test-support config failed to build in new_empty_with: {error:?}"),
     }
@@ -379,10 +379,10 @@ fn actor_system_create_from_props_with_init_fails_without_tick_driver() {
 }
 
 #[test]
-fn actor_system_noop_with_config_bootstraps_user_guardian() {
+fn actor_system_create_with_noop_guardian_bootstraps_user_guardian() {
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("noop-system");
 
-  let system = ActorSystem::noop_with_config(config).expect("system should build");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("system should build");
 
   assert!(system.state().has_root_started());
   assert!(system.state().extra_top_level(SYSTEM_RECEPTIONIST_TOP_LEVEL).is_some());
@@ -392,9 +392,9 @@ fn actor_system_noop_with_config_bootstraps_user_guardian() {
 }
 
 #[test]
-fn actor_system_noop_with_config_spawns_user_child() {
+fn actor_system_create_with_noop_guardian_spawns_user_child() {
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("noop-child-system");
-  let system = ActorSystem::noop_with_config(config).expect("system should build");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("system should build");
 
   let child = system.actor_of(&Props::from_fn(|| TestActor)).expect("spawn child");
   let path = child.actor_ref().path().expect("child path");
@@ -403,25 +403,14 @@ fn actor_system_noop_with_config_spawns_user_child() {
 }
 
 #[test]
-fn actor_system_noop_with_config_fails_without_tick_driver() {
-  let result = ActorSystem::noop_with_config(ActorSystemConfig::default());
+fn actor_system_create_with_noop_guardian_fails_without_tick_driver() {
+  let result = ActorSystem::create_with_noop_guardian(ActorSystemConfig::default());
 
   match result {
     | Err(SpawnError::SystemBuildError(message)) => assert!(message.contains("tick driver is required")),
     | Ok(_) => panic!("system should not build without tick driver"),
     | Err(other) => panic!("unexpected error: {other:?}"),
   }
-}
-
-#[test]
-fn actor_system_noop_with_setup_uses_setup_config() {
-  let setup = ActorSystemSetup::new(BootstrapSetup::default().with_system_name("noop-setup-system"))
-    .with_tick_driver(TestTickDriver::default());
-
-  let system = ActorSystem::noop_with_setup(setup).expect("system should build");
-
-  assert_eq!(system.name(), "noop-setup-system");
-  assert!(system.state().has_root_started());
 }
 
 #[test]

--- a/modules/actor-core/src/core/kernel/system/base/tests.rs
+++ b/modules/actor-core/src/core/kernel/system/base/tests.rs
@@ -314,7 +314,7 @@ fn actor_system_new_with_config_and_allows_extra_top_level_registration_in_confi
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
 
-  let system = ActorSystem::create_with_config_and(&props, config, |system| {
+  let system = ActorSystem::create_from_props_with_init(&props, config, |system| {
     assert!(!system.state().has_root_started());
     let actor = ActorRef::null();
     system
@@ -338,7 +338,7 @@ fn actor_system_registers_system_receptionist_during_bootstrap() {
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
 
-  let system = ActorSystem::create_with_config_and(&props, config, |_| Ok(())).expect("system should build");
+  let system = ActorSystem::create_from_props_with_init(&props, config, |_| Ok(())).expect("system should build");
 
   assert!(system.state().extra_top_level(SYSTEM_RECEPTIONIST_TOP_LEVEL).is_some());
 }
@@ -368,10 +368,10 @@ fn bootstrap_rolls_back_receptionist_when_extra_top_level_registration_fails() {
 }
 
 #[test]
-fn actor_system_create_with_config_and_fails_without_tick_driver() {
+fn actor_system_create_from_props_with_init_fails_without_tick_driver() {
   let props = Props::from_fn(|| TestActor);
   let config = ActorSystemConfig::default();
-  match ActorSystem::create_with_config_and(&props, config, |_| Ok(())) {
+  match ActorSystem::create_from_props_with_init(&props, config, |_| Ok(())) {
     | Ok(_) => panic!("system should not build without tick driver"),
     | Err(SpawnError::SystemBuildError(message)) => assert!(message.contains("tick driver is required")),
     | Err(other) => panic!("unexpected error: {other:?}"),
@@ -612,7 +612,7 @@ fn make_test_system() -> ActorSystem {
 fn make_test_system_with_name(name: &str) -> ActorSystem {
   let props = Props::from_fn(|| TestActor);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name(name);
-  ActorSystem::create_with_config(&props, config).expect("system")
+  ActorSystem::create_from_props(&props, config).expect("system")
 }
 
 #[test]
@@ -810,7 +810,7 @@ fn poll_delay(future: &mut DelayFuture) -> Poll<()> {
 fn actor_system_scheduler_handles_delays() {
   let props = Props::from_fn(|| TestActor);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   let mut provider = system.delay_provider();
   let mut future = provider.delay(Duration::from_millis(1));
   assert!(matches!(poll_delay(&mut future), Poll::Pending));
@@ -825,7 +825,7 @@ fn actor_system_scheduler_handles_delays() {
 fn actor_system_terminate_runs_scheduler_tasks() {
   let props = Props::from_fn(|| TestActor);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   let log = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   {
     let scheduler = system.scheduler();
@@ -871,7 +871,7 @@ fn poll_delay_future(future: &mut DelayFuture) -> Poll<()> {
 fn actor_system_installs_scheduler() {
   let props = Props::from_fn(|| TestActor);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("actor system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("actor system");
   let mut provider = system.delay_provider();
   let mut future = provider.delay(Duration::from_millis(1));
   assert!(matches!(poll_delay_future(&mut future), Poll::Pending));
@@ -989,7 +989,7 @@ fn guardian_refs_preserve_canonical_authority() {
     .with_system_name("guardian-compat")
     .with_remoting_config(remoting);
 
-  let system = ActorSystem::create_with_config(&user_props, config).expect("actor system bootstrap");
+  let system = ActorSystem::create_from_props(&user_props, config).expect("actor system bootstrap");
 
   let user_pid = system.state().user_guardian_pid().expect("user guardian pid");
   let user_ref = system.user_guardian_ref();

--- a/modules/actor-core/src/core/typed/actor/actor_context/tests.rs
+++ b/modules/actor-core/src/core/typed/actor/actor_context/tests.rs
@@ -61,7 +61,7 @@ impl EventStreamSubscriber for RecordingLogSubscriber {
 fn delegate_returns_delegatee_when_behavior_reports_same() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let outer_count = ArcShared::new(SpinSyncMutex::new(0_usize));
@@ -165,7 +165,7 @@ impl AbstractBehavior<AnonymousRestartChildMsg> for AnonymousRestartCrashBehavio
 #[test]
 fn ask_sends_request_and_delivers_adapted_response() {
   let guardian_props = TypedProps::<RequesterMsg>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::<RequesterMsg>::create_with_config(
+  let system = TypedActorSystem::<RequesterMsg>::create_from_props(
     &guardian_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -246,7 +246,7 @@ fn ask_sends_request_and_delivers_adapted_response() {
 #[test]
 fn ask_with_status_sends_request_and_delivers_adapted_success() {
   let guardian_props = TypedProps::<RequesterMsg>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::<RequesterMsg>::create_with_config(
+  let system = TypedActorSystem::<RequesterMsg>::create_from_props(
     &guardian_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -322,7 +322,7 @@ fn ask_with_status_sends_request_and_delivers_adapted_success() {
 #[test]
 fn ask_timeout_delivers_error_to_actor() {
   let guardian_props = TypedProps::<RequesterMsg>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::<RequesterMsg>::create_with_config(
+  let system = TypedActorSystem::<RequesterMsg>::create_from_props(
     &guardian_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -391,7 +391,7 @@ fn ask_timeout_delivers_error_to_actor() {
 #[test]
 fn ask_concurrent_same_response_type_delivers_both() {
   let guardian_props = TypedProps::<RequesterMsg>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::<RequesterMsg>::create_with_config(
+  let system = TypedActorSystem::<RequesterMsg>::create_from_props(
     &guardian_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -532,7 +532,7 @@ fn schedule_once_registers_command_in_scheduler() {
 
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   // Access the scheduler via the system to verify schedule_once registers a command.
@@ -558,7 +558,7 @@ fn schedule_once_registers_command_in_scheduler() {
 #[test]
 fn ask_with_status_error_preserves_failure_reason() {
   let guardian_props = TypedProps::<RequesterMsg>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::<RequesterMsg>::create_with_config(
+  let system = TypedActorSystem::<RequesterMsg>::create_from_props(
     &guardian_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -810,7 +810,7 @@ fn typed_context_system_reuses_shared_event_stream_endpoint() {
 fn spawn_anonymous_creates_child_actor_that_receives_messages() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let received = ArcShared::new(SpinSyncMutex::new(0_u32));
@@ -850,7 +850,7 @@ fn spawn_anonymous_creates_child_actor_that_receives_messages() {
 fn spawn_anonymous_child_has_no_explicit_name() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let child_pid_slot: ArcShared<SpinSyncMutex<Option<Pid>>> = ArcShared::new(SpinSyncMutex::new(None));
@@ -888,7 +888,7 @@ fn spawn_anonymous_child_has_no_explicit_name() {
 fn spawn_anonymous_multiple_children_are_independent() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let count = ArcShared::new(SpinSyncMutex::new(0_u32));
@@ -939,7 +939,7 @@ fn spawn_anonymous_multiple_children_are_independent() {
 fn spawn_anonymous_can_spawn_same_from_abstract_behavior_twice() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let count = ArcShared::new(SpinSyncMutex::new(0_u32));
@@ -977,7 +977,7 @@ fn spawn_anonymous_can_spawn_same_from_abstract_behavior_twice() {
 #[test]
 fn spawn_anonymous_child_restarts_under_supervision() {
   let guardian_props = TypedProps::<AnonymousRestartParentMsg>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::<AnonymousRestartParentMsg>::create_with_config(
+  let system = TypedActorSystem::<AnonymousRestartParentMsg>::create_from_props(
     &guardian_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -1034,7 +1034,7 @@ fn spawn_anonymous_child_restarts_under_supervision() {
 #[test]
 fn spawn_anonymous_narrowed_child_restarts_under_supervision() {
   let guardian_props = TypedProps::<AnonymousRestartParentMsg>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::<AnonymousRestartParentMsg>::create_with_config(
+  let system = TypedActorSystem::<AnonymousRestartParentMsg>::create_from_props(
     &guardian_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -1103,7 +1103,7 @@ fn typed_context_set_logger_name_delegates_to_untyped() {
 
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let actor_props = TypedProps::<u32>::from_behavior_factory({
@@ -1139,7 +1139,7 @@ fn typed_context_logger_name_initially_none() {
 
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let actor_props = TypedProps::<u32>::from_behavior_factory({
@@ -1174,7 +1174,7 @@ fn typed_pipe_to_delivers_ok_result_to_external_target() {
   // Given: a system with a sender actor and a receiver actor
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let received = ArcShared::new(SpinSyncMutex::new(Vec::<u32>::new()));
@@ -1226,7 +1226,7 @@ fn typed_pipe_to_delivers_err_result_to_external_target() {
   // Given: a system with a sender actor and a receiver actor
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let received = ArcShared::new(SpinSyncMutex::new(Vec::<u32>::new()));
@@ -1273,7 +1273,7 @@ fn typed_pipe_to_delivers_err_result_to_external_target() {
 fn typed_pipe_to_drops_message_and_logs_when_map_ok_returns_adapter_error() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let received = ArcShared::new(SpinSyncMutex::new(Vec::<u32>::new()));
@@ -1335,7 +1335,7 @@ fn typed_pipe_to_drops_message_and_logs_when_map_ok_returns_adapter_error() {
 fn typed_pipe_to_drops_message_and_logs_when_map_err_returns_adapter_error() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let received = ArcShared::new(SpinSyncMutex::new(Vec::<u32>::new()));

--- a/modules/actor-core/src/core/typed/actor_ref_resolver/tests.rs
+++ b/modules/actor-core/src/core/typed/actor_ref_resolver/tests.rs
@@ -63,7 +63,7 @@ fn actor_ref_resolver_setup_overrides_default_extension_factory() {
   let config = ActorSystemConfig::new(TestTickDriver::default())
     .with_extension_installers(ExtensionInstallers::default().with_extension_installer(setup));
 
-  let system = TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system");
+  let system = TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system");
   assert!(ActorRefResolver::get(&system).is_some());
   assert!(*invoked.lock(), "custom resolver factory should be invoked");
   system.terminate().expect("terminate");

--- a/modules/actor-core/src/core/typed/delivery/tests.rs
+++ b/modules/actor-core/src/core/typed/delivery/tests.rs
@@ -34,7 +34,7 @@ fn wait_until(mut condition: impl FnMut() -> bool) {
 /// Helper to create a test actor system.
 fn test_system() -> TypedActorSystem<u32> {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
-  TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+  TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system")
 }
 

--- a/modules/actor-core/src/core/typed/dsl/ask_pattern/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/ask_pattern/tests.rs
@@ -45,11 +45,9 @@ fn ask_pattern_behavior() -> Behavior<AskPatternCommand> {
 #[test]
 fn ask_pattern_exposes_timeout_aware_standalone_ask() {
   let props = TypedProps::<AskPatternCommand>::from_behavior_factory(ask_pattern_behavior);
-  let system = TypedActorSystem::<AskPatternCommand>::create_with_config(
-    &props,
-    ActorSystemConfig::new(TestTickDriver::default()),
-  )
-  .expect("system");
+  let system =
+    TypedActorSystem::<AskPatternCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
+      .expect("system");
   let mut actor = system.user_guardian_ref();
 
   let response =
@@ -65,11 +63,9 @@ fn ask_pattern_exposes_timeout_aware_standalone_ask() {
 #[test]
 fn ask_pattern_exposes_timeout_aware_status_ask() {
   let props = TypedProps::<AskPatternCommand>::from_behavior_factory(ask_pattern_behavior);
-  let system = TypedActorSystem::<AskPatternCommand>::create_with_config(
-    &props,
-    ActorSystemConfig::new(TestTickDriver::default()),
-  )
-  .expect("system");
+  let system =
+    TypedActorSystem::<AskPatternCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
+      .expect("system");
   let mut actor = system.user_guardian_ref();
 
   let response = AskPattern::ask_with_status(
@@ -89,11 +85,9 @@ fn ask_pattern_exposes_timeout_aware_status_ask() {
 #[test]
 fn ask_pattern_times_out_when_target_does_not_reply() {
   let props = TypedProps::<AskPatternCommand>::from_behavior_factory(ask_pattern_behavior);
-  let system = TypedActorSystem::<AskPatternCommand>::create_with_config(
-    &props,
-    ActorSystemConfig::new(TestTickDriver::default()),
-  )
-  .expect("system");
+  let system =
+    TypedActorSystem::<AskPatternCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
+      .expect("system");
   let mut actor = system.user_guardian_ref();
 
   let response =

--- a/modules/actor-core/src/core/typed/dsl/routing/balancing_pool_router_builder/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/balancing_pool_router_builder/tests.rs
@@ -79,7 +79,7 @@ fn balancing_pool_distributes_to_idle_workers() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<WorkItem>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<WorkItem>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<WorkItem>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 
@@ -158,7 +158,7 @@ fn balancing_pool_stopped_routee_does_not_receive_pending_work() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<WorkItem>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<WorkItem>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<WorkItem>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 
@@ -222,7 +222,7 @@ fn balancing_pool_stops_when_all_routees_terminate() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<WorkItem>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<WorkItem>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<WorkItem>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 
@@ -276,7 +276,7 @@ fn balancing_pool_routee_stopped_on_start_does_not_receive_work() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<WorkItem>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<WorkItem>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<WorkItem>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 

--- a/modules/actor-core/src/core/typed/dsl/routing/group_router/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/group_router/tests.rs
@@ -59,7 +59,7 @@ fn group_router_should_route_via_system_receptionist() {
     move || Routers::group(key.clone())
   });
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let router = system.as_untyped().spawn(router_props.to_untyped()).expect("spawn group router");
   let mut router = TypedActorRef::<u32>::from_untyped(router.into_actor_ref());
@@ -98,7 +98,7 @@ fn group_router_public_type_routes_via_system_receptionist() {
     }
   });
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let router = system.as_untyped().spawn(router_props.to_untyped()).expect("spawn group router");
   let mut router = TypedActorRef::<u32>::from_untyped(router.into_actor_ref());
@@ -148,7 +148,7 @@ fn group_router_with_consistent_hash_routes_same_message_to_same_routee() {
   let key = ServiceKey::<u32>::new("test-group-consistent-hash");
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let router_props = TypedProps::<u32>::from_behavior_factory({
@@ -221,7 +221,7 @@ fn group_router_with_round_robin_routes_across_routees_in_order() {
   let key = ServiceKey::<u32>::new("test-group-round-robin-routing");
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let router_props = TypedProps::<u32>::from_behavior_factory({
@@ -276,7 +276,7 @@ fn group_router_with_random_routing_uses_random_selector_branch() {
   let key = ServiceKey::<u32>::new("test-group-random-routing");
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let router_props = TypedProps::<u32>::from_behavior_factory({
@@ -333,7 +333,7 @@ fn group_router_uses_random_routing_by_default() {
   let key = ServiceKey::<u32>::new("test-group-default-random-routing");
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let router_props = TypedProps::<u32>::from_behavior_factory({
@@ -391,7 +391,7 @@ fn group_router_should_route_via_explicit_receptionist() {
   let key = ServiceKey::<u32>::new("test-group-explicit");
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let receptionist_props = TypedProps::<ReceptionistCommand>::from_behavior_factory(Receptionist::behavior);
   let receptionist = system.as_untyped().spawn(receptionist_props.to_untyped()).expect("spawn explicit receptionist");
@@ -434,7 +434,7 @@ fn group_router_should_ignore_mismatched_listing_update() {
   let key = ServiceKey::<u32>::new("test-group-mismatch");
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let records = ArcShared::new(SpinSyncMutex::new(Vec::new()));
@@ -544,7 +544,7 @@ fn group_router_should_unsubscribe_when_stopped() {
   let key = ServiceKey::<u32>::new("test-group-unsubscribe");
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));

--- a/modules/actor-core/src/core/typed/dsl/routing/pool_router/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/pool_router/tests.rs
@@ -97,7 +97,7 @@ fn spawn_router_system(pool_size: usize, strategy: PoolTestStrategy) -> RouterSy
     }
   });
 
-  let system = TypedActorSystem::<u32>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+  let system = TypedActorSystem::<u32>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system");
   let router = system.user_guardian_ref();
   (system, router, records)
@@ -195,7 +195,7 @@ fn pool_router_public_type_with_broadcast_delivers_to_all_routees() {
     }
   });
 
-  let system = TypedActorSystem::<u32>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+  let system = TypedActorSystem::<u32>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system");
   let mut router = system.user_guardian_ref();
 
@@ -237,7 +237,7 @@ fn pool_router_with_broadcast_predicate_only_broadcasts_matching_messages() {
     }
   });
 
-  let system = TypedActorSystem::<u32>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+  let system = TypedActorSystem::<u32>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system");
   let mut router = system.user_guardian_ref();
 
@@ -401,7 +401,7 @@ fn pool_router_with_resizer_scales_up_to_lower_bound() {
     }
   });
 
-  let system = TypedActorSystem::<u32>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+  let system = TypedActorSystem::<u32>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system");
   let mut router = system.user_guardian_ref();
 
@@ -453,7 +453,7 @@ fn pool_router_with_resizer_scales_down_to_upper_bound() {
     }
   });
 
-  let system = TypedActorSystem::<u32>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+  let system = TypedActorSystem::<u32>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system");
   let mut router = system.user_guardian_ref();
 
@@ -528,7 +528,7 @@ fn pool_router_with_routee_props_applies_tags_to_routees() {
     }
   });
 
-  let system = TypedActorSystem::<u32>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+  let system = TypedActorSystem::<u32>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system");
   let mut router = system.user_guardian_ref();
 
@@ -679,7 +679,7 @@ mod optimal_size_exploring_resizer_smoke {
       }
     });
 
-    let system = TypedActorSystem::<u32>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    let system = TypedActorSystem::<u32>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
     let mut router = system.user_guardian_ref();
 

--- a/modules/actor-core/src/core/typed/dsl/routing/scatter_gather_first_completed_router_builder/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/scatter_gather_first_completed_router_builder/tests.rs
@@ -185,7 +185,7 @@ fn scatter_gather_returns_first_reply() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 
@@ -270,7 +270,7 @@ fn scatter_gather_returns_timeout_reply_when_no_routee_responds() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 
@@ -338,7 +338,7 @@ fn scatter_gather_stops_when_all_routees_terminate() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   // routee が即座に停止するため、Terminated シグナルでルーターも停止する
@@ -399,7 +399,7 @@ fn scatter_gather_stops_when_all_routee_spawns_fail() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   // spawn 失敗により routee_vec が空 → build 直後に Behaviors::stopped() → ルーター終了
@@ -474,7 +474,7 @@ fn scatter_gather_returns_timeout_reply_on_coordinator_spawn_failure() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 

--- a/modules/actor-core/src/core/typed/dsl/routing/tail_chopping_router_builder/tests.rs
+++ b/modules/actor-core/src/core/typed/dsl/routing/tail_chopping_router_builder/tests.rs
@@ -164,7 +164,7 @@ fn tail_chopping_returns_first_reply() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 
@@ -269,7 +269,7 @@ fn tail_chopping_retries_to_next_routee_after_interval() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 
@@ -352,7 +352,7 @@ fn tail_chopping_returns_timeout_reply_when_no_routee_responds() {
   let ob = outer_behavior.clone();
   let props = TypedProps::<TestReq>::from_behavior_factory(move || ob());
   let system =
-    TypedActorSystem::<TestReq>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<TestReq>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut guardian = system.user_guardian_ref();
 

--- a/modules/actor-core/src/core/typed/extension_setup/tests.rs
+++ b/modules/actor-core/src/core/typed/extension_setup/tests.rs
@@ -42,7 +42,7 @@ fn extension_setup_registers_custom_factory_during_bootstrap() {
     .with_extension_installer(ExtensionSetup::new(ProbeExtensionId, |_system| ProbeExtension::new("custom")));
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_extension_installers(installers);
 
-  let system = TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system");
+  let system = TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system");
   let extension = system
     .as_untyped()
     .extended()

--- a/modules/actor-core/src/core/typed/pubsub/topic/tests.rs
+++ b/modules/actor-core/src/core/typed/pubsub/topic/tests.rs
@@ -26,7 +26,7 @@ fn wait_until(mut condition: impl FnMut() -> bool) {
 fn topic_should_publish_to_subscribers_and_report_stats() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   let topic_props = TypedProps::<TopicCommand<u32>>::from_behavior_factory(|| Topic::behavior("numbers"));

--- a/modules/actor-core/src/core/typed/receptionist/tests.rs
+++ b/modules/actor-core/src/core/typed/receptionist/tests.rs
@@ -77,7 +77,7 @@ fn wait_until(mut condition: impl FnMut() -> bool) {
 
 fn new_test_system() -> TypedActorSystem<u32> {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
-  TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
+  TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()))
     .expect("system")
 }
 

--- a/modules/actor-core/src/core/typed/spawn_protocol/tests.rs
+++ b/modules/actor-core/src/core/typed/spawn_protocol/tests.rs
@@ -58,7 +58,7 @@ fn spawn_protocol_spawns_named_children() {
   let start_count = Arc::new(AtomicUsize::new(0));
   let props = TypedProps::<SpawnProtocol>::from_behavior_factory(SpawnProtocol::behavior);
   let system =
-    TypedActorSystem::<SpawnProtocol>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<SpawnProtocol>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut parent = system.user_guardian_ref();
 
@@ -80,7 +80,7 @@ fn spawn_protocol_spawns_anonymous_children() {
   let start_count = Arc::new(AtomicUsize::new(0));
   let props = TypedProps::<SpawnProtocol>::from_behavior_factory(SpawnProtocol::behavior);
   let system =
-    TypedActorSystem::<SpawnProtocol>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<SpawnProtocol>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut parent = system.user_guardian_ref();
 
@@ -103,7 +103,7 @@ fn spawn_protocol_spawns_children_with_different_message_types() {
   let second_start_count = Arc::new(AtomicUsize::new(0));
   let props = TypedProps::<SpawnProtocol>::from_behavior_factory(SpawnProtocol::behavior);
   let system =
-    TypedActorSystem::<SpawnProtocol>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<SpawnProtocol>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut parent = system.user_guardian_ref();
 
@@ -132,7 +132,7 @@ fn spawn_protocol_survives_duplicate_named_spawn_failure() {
   let start_count = Arc::new(AtomicUsize::new(0));
   let props = TypedProps::<SpawnProtocol>::from_behavior_factory(SpawnProtocol::behavior);
   let system =
-    TypedActorSystem::<SpawnProtocol>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<SpawnProtocol>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut parent = system.user_guardian_ref();
 

--- a/modules/actor-core/src/core/typed/system.rs
+++ b/modules/actor-core/src/core/typed/system.rs
@@ -35,6 +35,7 @@ use crate::core::{
   },
   typed::{
     TypedActorRef, TypedActorSystemConfig, TypedActorSystemLog,
+    behavior::Behavior,
     dispatchers::Dispatchers,
     eventstream::EventStreamCommand,
     internal::TypedSchedulerShared,
@@ -186,11 +187,32 @@ where
   /// # Errors
   ///
   /// Returns [`SpawnError`] if guardian initialization fails.
-  pub fn create_with_config(guardian: &TypedProps<M>, config: ActorSystemConfig) -> Result<Self, SpawnError> {
-    let inner = ActorSystem::create_with_config(guardian.to_untyped(), config)?;
+  pub fn create_from_props(guardian: &TypedProps<M>, config: ActorSystemConfig) -> Result<Self, SpawnError> {
+    let inner = ActorSystem::create_from_props(guardian.to_untyped(), config)?;
     let cached_address = Address::local(inner.name());
     let event_stream_ref = build_event_stream_ref(&inner);
     Ok(Self { inner, cached_address, event_stream_ref, marker: PhantomData })
+  }
+}
+
+impl<M> TypedActorSystem<M>
+where
+  M: Send + Sync + 'static,
+{
+  /// Creates a typed actor system from a guardian behavior factory.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`SpawnError`] if guardian initialization fails.
+  pub fn create_from_behavior_factory<F, B>(
+    guardian_factory: F,
+    config: ActorSystemConfig,
+  ) -> Result<Self, SpawnError>
+  where
+    F: Fn() -> B + Send + Sync + 'static,
+    B: Into<Behavior<M>>, {
+    let props = TypedProps::from_behavior_factory(guardian_factory);
+    Self::create_from_props(&props, config)
   }
 }
 

--- a/modules/actor-core/src/core/typed/system/tests.rs
+++ b/modules/actor-core/src/core/typed/system/tests.rs
@@ -104,7 +104,7 @@ impl ActorRefSender for CollectorSender {
 fn new_test_system() -> TypedActorSystem<u32> {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_start_time(Duration::from_secs(1));
-  TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system")
+  TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system")
 }
 
 // --- T5: Extension facade tests ---
@@ -202,7 +202,7 @@ fn name_returns_configured_system_name() {
   // Given: a typed actor system with a custom name
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("my-actor-system");
-  let system = TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system");
+  let system = TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system");
 
   // When: name() is called
   let name = system.name();
@@ -247,7 +247,7 @@ fn start_time_returns_configured_value() {
   let expected_start = Duration::from_secs(1_700_000_000);
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_start_time(expected_start);
-  let system = TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system");
+  let system = TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system");
 
   // When: start_time() is called
   let start_time = system.start_time();
@@ -264,7 +264,7 @@ fn uptime_returns_elapsed_since_start() {
   let start = Duration::from_secs(1_000);
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_start_time(start);
-  let system = TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system");
+  let system = TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system");
 
   // When: uptime is calculated with a known "now"
   let now = Duration::from_secs(1_042);
@@ -282,7 +282,7 @@ fn uptime_saturates_when_now_is_before_start() {
   let start = Duration::from_secs(1_000);
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_start_time(start);
-  let system = TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system");
+  let system = TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system");
 
   // When: now is before start_time (edge case)
   let now = Duration::from_secs(500);
@@ -415,7 +415,7 @@ fn address_returns_local_address_with_custom_name() {
   // Given: a typed actor system with a custom name
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_system_name("custom-system");
-  let system = TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system");
+  let system = TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system");
 
   // When: address() is called
   let address = system.address();
@@ -855,7 +855,7 @@ fn typed_actor_system_new_rejects_empty_guardian_props() {
 
   // 実行: typed actor system を bootstrap する
   let result =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()));
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(TestTickDriver::default()));
 
   // 検証: invalid props として明示的に失敗する
   assert!(matches!(result, Err(crate::core::kernel::actor::spawn::SpawnError::InvalidProps(_))));

--- a/modules/actor-core/src/core/typed/system/tests.rs
+++ b/modules/actor-core/src/core/typed/system/tests.rs
@@ -891,3 +891,27 @@ fn print_tree_contains_spawned_system_actor_name() {
 
   system.terminate().expect("terminate");
 }
+
+#[test]
+fn create_from_behavior_factory_builds_running_system_and_invokes_factory() {
+  // 前提: 呼び出し回数を観測するカウンタ付きの guardian factory を用意する
+  let invocations = ArcShared::new(SpinSyncMutex::new(0_u32));
+  let invocations_factory = invocations.clone();
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_start_time(Duration::from_secs(1));
+
+  // 実行: convenience method 経由で typed actor system を生成する
+  let system = TypedActorSystem::<u32>::create_from_behavior_factory(
+    move || {
+      *invocations_factory.lock() += 1;
+      Behaviors::ignore::<u32>()
+    },
+    config,
+  )
+  .expect("system");
+
+  // 検証: system が起動済みで、guardian factory が少なくとも 1 回呼び出されている
+  assert!(system.state().has_root_started());
+  assert!(*invocations.lock() >= 1, "guardian factory should have been invoked at least once");
+
+  system.terminate().expect("terminate");
+}

--- a/modules/actor-core/src/core/typed/tests.rs
+++ b/modules/actor-core/src/core/typed/tests.rs
@@ -123,7 +123,7 @@ impl TypedActor<CounterMessage> for CounterActor {
 fn typed_actor_system_handles_basic_flow() {
   let props = TypedProps::<CounterMessage>::new(CounterActor::new);
   let system =
-    TypedActorSystem::<CounterMessage>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<CounterMessage>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut counter = system.user_guardian_ref();
 
@@ -145,7 +145,7 @@ fn typed_props_with_blocking_dispatcher_selector_should_spawn() {
   let props = TypedProps::<CounterMessage>::from_behavior_factory(|| behavior_counter(0))
     .with_dispatcher_selector(DispatcherSelector::Blocking);
   let system =
-    TypedActorSystem::<CounterMessage>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<CounterMessage>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
 
   system.terminate().expect("terminate");
@@ -204,7 +204,7 @@ fn typed_props_with_mailbox_unbounded_overrides_bounded_selector() {
 fn typed_behaviors_handle_recursive_state() {
   let props = TypedProps::<CounterMessage>::from_behavior_factory(|| behavior_counter(0));
   let system =
-    TypedActorSystem::<CounterMessage>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<CounterMessage>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut counter = system.user_guardian_ref();
 
@@ -225,7 +225,7 @@ fn typed_behaviors_handle_recursive_state() {
 fn typed_behaviors_ignore_keeps_current_state() {
   let props = TypedProps::<IgnoreCommand>::from_behavior_factory(|| ignore_gate(0));
   let system =
-    TypedActorSystem::<IgnoreCommand>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<IgnoreCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut gate = system.user_guardian_ref();
 
@@ -247,7 +247,7 @@ fn typed_behaviors_ignore_keeps_current_state() {
 fn typed_behaviors_stash_buffered_messages_across_transition() {
   let props = TypedProps::<StashCommand>::from_behavior_factory(|| stash_behavior(0)).with_stash_mailbox();
   let system =
-    TypedActorSystem::<StashCommand>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<StashCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut actor = system.user_guardian_ref();
 
@@ -270,7 +270,7 @@ fn typed_behaviors_with_stash_limits_capacity() {
   })
   .with_stash_mailbox();
   let system =
-    TypedActorSystem::<StashCommand>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<StashCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut actor = system.user_guardian_ref();
 
@@ -294,7 +294,7 @@ fn typed_behaviors_with_stash_keeps_adapter_payload_after_unstash() {
   })
   .with_stash_mailbox();
   let system =
-    TypedActorSystem::<StashCommand>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<StashCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut actor = system.user_guardian_ref();
 
@@ -315,11 +315,9 @@ fn typed_behaviors_with_stash_keeps_adapter_payload_after_unstash() {
 fn typed_behaviors_unstash_replays_before_already_queued_messages() {
   let props =
     TypedProps::<StashOrderCommand>::from_behavior_factory(|| stash_order_behavior(Vec::new())).with_stash_mailbox();
-  let system = TypedActorSystem::<StashOrderCommand>::create_with_config(
-    &props,
-    ActorSystemConfig::new(TestTickDriver::default()),
-  )
-  .expect("system");
+  let system =
+    TypedActorSystem::<StashOrderCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
+      .expect("system");
   let mut actor = system.user_guardian_ref();
 
   actor.tell(StashOrderCommand::Buffer(String::from("stashed")));
@@ -346,7 +344,7 @@ fn typed_behaviors_receive_signal_notifications() {
     signal_probe_behavior(&start_probe, &post_stop_probe)
   });
   let system =
-    TypedActorSystem::<LifecycleCommand>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<LifecycleCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   system.terminate().expect("terminate");
   system.as_untyped().run_until_terminated(&SpinBlocker);
@@ -415,7 +413,7 @@ impl TypedActor<SchedulerProbeCommand> for SchedulerProbeActor {
 fn typed_ask_reports_type_mismatch() {
   let props = TypedProps::<MismatchCommand>::new(|| MismatchActor);
   let system =
-    TypedActorSystem::<MismatchCommand>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<MismatchCommand>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("system");
   let mut actor = system.user_guardian_ref();
 
@@ -432,7 +430,7 @@ fn typed_ask_reports_type_mismatch() {
 #[test]
 fn typed_context_exposes_scheduler() {
   let props = TypedProps::<SchedulerProbeCommand>::new(|| SchedulerProbeActor);
-  let system = TypedActorSystem::<SchedulerProbeCommand>::create_with_config(
+  let system = TypedActorSystem::<SchedulerProbeCommand>::create_from_props(
     &props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -722,7 +720,7 @@ fn behaviors_supervise_restarts_children() {
     |_| SupervisorDirective::Restart,
   );
   let parent_props = supervised_parent_props(restart_strategy, child);
-  let system = TypedActorSystem::<SupervisorCommand>::create_with_config(
+  let system = TypedActorSystem::<SupervisorCommand>::create_from_props(
     &parent_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -750,7 +748,7 @@ fn intercepted_behavior_survives_supervised_restart() {
     |_| SupervisorDirective::Restart,
   );
   let parent_props = supervised_parent_props(restart_strategy, child);
-  let system = TypedActorSystem::<SupervisorCommand>::create_with_config(
+  let system = TypedActorSystem::<SupervisorCommand>::create_from_props(
     &parent_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -782,7 +780,7 @@ fn behaviors_supervise_stops_children() {
     |_| SupervisorDirective::Stop,
   );
   let parent_props = supervised_parent_props(stop_strategy, child);
-  let system = TypedActorSystem::<SupervisorCommand>::create_with_config(
+  let system = TypedActorSystem::<SupervisorCommand>::create_from_props(
     &parent_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -811,7 +809,7 @@ fn backoff_strategy_via_supervise_on_failure() {
     let behavior = supervised_parent_behavior(child.clone());
     Behaviors::supervise(behavior).on_failure(backoff.clone())
   });
-  let system = TypedActorSystem::<SupervisorCommand>::create_with_config(
+  let system = TypedActorSystem::<SupervisorCommand>::create_from_props(
     &parent_props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -872,7 +870,7 @@ fn message_adapter_converts_external_messages() {
     let slot = adapter_slot.clone();
     move || adapter_counter_behavior(&slot)
   });
-  let system = TypedActorSystem::<AdapterCounterCommand>::create_with_config(
+  let system = TypedActorSystem::<AdapterCounterCommand>::create_from_props(
     &props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -904,7 +902,7 @@ fn adapter_not_found_routes_to_dead_letter() {
       counter_behavior(0)
     })
   });
-  let system = TypedActorSystem::<AdapterCounterCommand>::create_with_config(
+  let system = TypedActorSystem::<AdapterCounterCommand>::create_from_props(
     &props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )
@@ -939,7 +937,7 @@ fn pipe_to_self_converts_messages_via_adapter() {
       counter_behavior(0)
     })
   });
-  let system = TypedActorSystem::<AdapterCounterCommand>::create_with_config(
+  let system = TypedActorSystem::<AdapterCounterCommand>::create_from_props(
     &props,
     ActorSystemConfig::new(TestTickDriver::default()),
   )

--- a/modules/actor-core/tests/actor_selection_e2e.rs
+++ b/modules/actor-core/tests/actor_selection_e2e.rs
@@ -90,7 +90,7 @@ fn actor_selection_resolves_string_and_direct_path_targets() {
   let deliveries = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let worker_slot = ArcShared::new(SpinSyncMutex::new(None));
   let path_slot = ArcShared::new(SpinSyncMutex::new(None));
-  let system = ActorSystem::create_with_config(
+  let system = ActorSystem::create_from_props(
     &Props::from_fn(|| NoopGuardian),
     ActorSystemConfig::new(TestTickDriver::default())
       .with_system_name("selection-e2e")

--- a/modules/actor-core/tests/classic_user_flow_e2e.rs
+++ b/modules/actor-core/tests/classic_user_flow_e2e.rs
@@ -112,7 +112,7 @@ fn classic_user_flow_observes_spawn_tell_ask_watch_stop_and_dead_letter() {
     move || Guardian::new(tell_log.clone(), child_slot.clone(), ask_future.clone(), terminated_log.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 

--- a/modules/actor-core/tests/death_watch.rs
+++ b/modules/actor-core/tests/death_watch.rs
@@ -254,7 +254,7 @@ fn death_watch_notifies_parent_on_child_stop() {
     move || HarnessWatcher::new(terminated.clone(), order.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   system.user_guardian_ref().tell(AnyMessage::new(StopChild));
@@ -279,7 +279,7 @@ fn death_watch_unwatch_suppresses_notifications() {
     move || HarnessWatcher::new(terminated.clone(), order.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   system.user_guardian_ref().tell(AnyMessage::new(UnwatchChild));
@@ -305,7 +305,7 @@ fn death_watch_handles_multiple_watchers() {
     move || HarnessWatcher::new(primary_log.clone(), order.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   system.user_guardian_ref().tell(AnyMessage::new(SpawnSecondaryWatcherMessage { log: secondary_log.clone() }));
@@ -332,7 +332,7 @@ fn watch_after_stop_triggers_immediate_notification() {
     move || HarnessWatcher::new(terminated.clone(), order.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   system.user_guardian_ref().tell(AnyMessage::new(StopChild));
@@ -354,7 +354,7 @@ fn spawn_child_watched_notifies_on_stop() {
     move || SpawnWatchedGuardian::new(terminated.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   let observed = wait_until(200, || !terminated.lock().is_empty());
@@ -380,7 +380,7 @@ fn terminated_and_user_messages_are_both_processed() {
     move || HarnessWatcher::new(terminated.clone(), order.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   system.user_guardian_ref().tell(AnyMessage::new(QueueUserEvent));
@@ -403,7 +403,7 @@ fn cyclic_watchers_do_not_deadlock() {
     move || CycleGuardian::new(log_a.clone(), log_b.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(StartCycle));
 
@@ -485,7 +485,7 @@ fn watch_with_delivers_custom_message_instead_of_on_terminated() {
     move || WatchWithHarness::new(custom_log.clone(), terminated_log.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   system.user_guardian_ref().tell(AnyMessage::new(StopChild));
@@ -510,7 +510,7 @@ fn watch_with_unwatch_clears_custom_message_registration() {
     move || WatchWithHarness::new(custom_log.clone(), terminated_log.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(SpawnChild));
   system.user_guardian_ref().tell(AnyMessage::new(UnwatchChild));

--- a/modules/actor-core/tests/event_stream.rs
+++ b/modules/actor-core/tests/event_stream.rs
@@ -82,7 +82,7 @@ fn dead_letter_event_is_published_when_send_fails() {
     move || TestGuardian::new(child_slot.clone(), child_props.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let subscriber = subscriber_handle(RecordingSubscriber::new(events.clone()));

--- a/modules/actor-core/tests/ping_pong.rs
+++ b/modules/actor-core/tests/ping_pong.rs
@@ -118,7 +118,7 @@ fn spawn_and_tell_delivers_message() {
     move || RecordingGuardian::new(log.clone(), child_slot.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 
@@ -166,7 +166,7 @@ fn auto_naming_and_duplicate_detection() {
   });
 
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 
   let dead_line = Instant::now() + Duration::from_millis(20);

--- a/modules/actor-core/tests/supervisor.rs
+++ b/modules/actor-core/tests/supervisor.rs
@@ -53,7 +53,7 @@ fn recoverable_failure_restarts_child() {
   });
 
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 
   let mut child = child_slot.lock().clone().expect("child");
@@ -74,7 +74,7 @@ fn fatal_failure_stops_child() {
   });
 
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let subscriber = subscriber_handle(RecordingSubscriber { events: events.clone() });
@@ -113,7 +113,7 @@ fn escalate_failure_restarts_supervisor() {
   });
 
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 
   wait_until(|| child_slot.lock().is_some(), Duration::from_millis(20));
@@ -149,7 +149,7 @@ fn panic_propagates_without_intervention() {
   });
 
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   system.user_guardian_ref().tell(AnyMessage::new(Start));
   wait_until(|| child_slot.lock().is_some(), Duration::from_millis(20));
   let mut child = child_slot.lock().clone().expect("child");
@@ -173,7 +173,7 @@ fn resume_directive_continues_child_without_restart() {
   });
 
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 
   wait_until(|| child_slot.lock().is_some(), Duration::from_millis(100));

--- a/modules/actor-core/tests/system_events.rs
+++ b/modules/actor-core/tests/system_events.rs
@@ -56,7 +56,7 @@ impl Actor for Guardian {
 fn lifecycle_and_log_events_are_published() {
   let props = Props::from_fn(|| Guardian);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
 
   let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
   let subscriber = subscriber_handle(RecordingSubscriber { events: events.clone() });

--- a/modules/actor-core/tests/system_lifecycle.rs
+++ b/modules/actor-core/tests/system_lifecycle.rs
@@ -27,7 +27,7 @@ struct Start;
 fn terminate_signals_future() {
   let props = Props::from_fn(|| IdleGuardian);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   system.terminate().expect("terminate");
   system.run_until_terminated(&SpinBlocker);
@@ -43,7 +43,7 @@ fn stop_self_propagates_to_children() {
   });
 
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default())).expect("system");
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 
   let dead_line = Instant::now() + Duration::from_millis(20);

--- a/modules/actor-core/tests/typed_scheduler.rs
+++ b/modules/actor-core/tests/typed_scheduler.rs
@@ -14,7 +14,7 @@ use fraktor_utils_core_rs::core::sync::ArcShared;
 fn new_test_system() -> TypedActorSystem<u32> {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_start_time(Duration::from_secs(1));
-  TypedActorSystem::<u32>::create_with_config(&guardian_props, config).expect("system")
+  TypedActorSystem::<u32>::create_from_props(&guardian_props, config).expect("system")
 }
 
 fn null_receiver() -> TypedActorRef<u32> {

--- a/modules/actor-core/tests/typed_user_flow_e2e.rs
+++ b/modules/actor-core/tests/typed_user_flow_e2e.rs
@@ -146,7 +146,7 @@ fn typed_user_flow_observes_spawn_adapter_ask_pipe_stop_and_signal() {
     move || Root::new(adapted_log.clone(), pipe_log.clone(), ask_log.clone(), terminated_log.clone())
   });
   let system =
-    TypedActorSystem::<RootMsg>::create_with_config(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    TypedActorSystem::<RootMsg>::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
       .expect("typed system");
   let mut guardian = system.user_guardian_ref();
 

--- a/modules/cluster-adaptor-std/tests/remote_delivery_via_cluster_api.rs
+++ b/modules/cluster-adaptor-std/tests/remote_delivery_via_cluster_api.rs
@@ -155,7 +155,7 @@ fn build_cluster_node(port: u16, uid: u64, remote_authority: String) -> (RemoteN
     .with_system_name(SYSTEM_NAME)
     .with_extension_installers(extension_installers)
     .with_actor_ref_provider_installer(provider_installer);
-  let system = ActorSystem::noop_with_config(config).expect("cluster actor system should build");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("cluster actor system should build");
   let extension = system.extended().extension_by_type::<ClusterExtension>().expect("cluster extension");
   (RemoteNode { system, address }, extension)
 }
@@ -167,7 +167,7 @@ fn build_remote_node(port: u16, uid: u64) -> RemoteNode {
     .with_system_name(SYSTEM_NAME)
     .with_extension_installers(extension_installers)
     .with_actor_ref_provider_installer(provider_installer);
-  let system = ActorSystem::noop_with_config(config).expect("remote actor system should build");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("remote actor system should build");
   RemoteNode { system, address }
 }
 

--- a/modules/cluster-core/src/core/cluster_api/tests.rs
+++ b/modules/cluster-core/src/core/cluster_api/tests.rs
@@ -223,7 +223,7 @@ fn down_delegates_to_cluster_provider() {
       system.extended().register_actor_ref_provider(&actor_ref_provider_handle_shared)
     });
   let props = Props::from_fn(|| TestGuardian);
-  let system = ActorSystem::create_with_config(&props, config).expect("build system");
+  let system = ActorSystem::create_from_props(&props, config).expect("build system");
   let extension = system.extended().extension_by_type::<ClusterExtension>().expect("cluster extension");
   extension.start_member().expect("start member");
 
@@ -258,7 +258,7 @@ fn join_and_leave_delegate_to_cluster_provider() {
       system.extended().register_actor_ref_provider(&actor_ref_provider_handle_shared)
     });
   let props = Props::from_fn(|| TestGuardian);
-  let system = ActorSystem::create_with_config(&props, config).expect("build system");
+  let system = ActorSystem::create_from_props(&props, config).expect("build system");
   let extension = system.extended().extension_by_type::<ClusterExtension>().expect("cluster extension");
   extension.start_member().expect("start member");
 
@@ -462,7 +462,7 @@ where
       system.extended().register_actor_ref_provider(&actor_ref_provider_handle_shared)
     });
   let props = Props::from_fn(|| TestGuardian);
-  let system = ActorSystem::create_with_config(&props, config).expect("build system");
+  let system = ActorSystem::create_from_props(&props, config).expect("build system");
   let extension = system.extended().extension_by_type::<ClusterExtension>().expect("cluster extension");
   (system, extension)
 }

--- a/modules/cluster-core/src/core/grain/grain_context_generic/tests.rs
+++ b/modules/cluster-core/src/core/grain/grain_context_generic/tests.rs
@@ -62,7 +62,7 @@ where
       system.extended().register_actor_ref_provider(&actor_ref_provider_handle_shared)
     });
   let props = Props::from_fn(|| TestGuardian);
-  let system = ActorSystem::create_with_config(&props, config).expect("build system");
+  let system = ActorSystem::create_from_props(&props, config).expect("build system");
   let extension = system.extended().extension_by_type::<ClusterExtension>().expect("cluster extension");
   (system, extension)
 }

--- a/modules/cluster-core/src/core/grain/grain_context_scope/tests.rs
+++ b/modules/cluster-core/src/core/grain/grain_context_scope/tests.rs
@@ -64,7 +64,7 @@ where
       system.extended().register_actor_ref_provider(&actor_ref_provider_handle_shared)
     });
   let props = Props::from_fn(|| TestGuardian);
-  let system = ActorSystem::create_with_config(&props, config).expect("build system");
+  let system = ActorSystem::create_from_props(&props, config).expect("build system");
   let extension = system.extended().extension_by_type::<ClusterExtension>().expect("cluster extension");
   (system, extension)
 }

--- a/modules/cluster-core/src/core/grain/grain_ref/tests.rs
+++ b/modules/cluster-core/src/core/grain/grain_ref/tests.rs
@@ -175,7 +175,7 @@ where
       system.extended().register_actor_ref_provider(&actor_ref_provider_handle_shared)
     });
   let props = Props::from_fn(|| TestGuardian);
-  let system = ActorSystem::create_with_config(&props, config).expect("build system");
+  let system = ActorSystem::create_from_props(&props, config).expect("build system");
   let extension = system.extended().extension_by_type::<ClusterExtension>().expect("cluster extension");
   (system, extension)
 }

--- a/modules/persistence-core/src/core/persistence_extension/tests.rs
+++ b/modules/persistence-core/src/core/persistence_extension/tests.rs
@@ -25,7 +25,7 @@ fn persistence_extension_creates_actor_refs() {
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let journal = InMemoryJournal::new();
   let snapshot = InMemorySnapshotStore::new();
 

--- a/modules/persistence-core/src/core/persistence_extension_installer/tests.rs
+++ b/modules/persistence-core/src/core/persistence_extension_installer/tests.rs
@@ -32,7 +32,7 @@ fn installer_registers_persistence_extension() {
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   let extension = system.extended().extension_by_type::<PersistenceExtensionShared>();
 

--- a/modules/persistence-core/src/core/persistent_actor_adapter/tests.rs
+++ b/modules/persistence-core/src/core/persistent_actor_adapter/tests.rs
@@ -224,7 +224,7 @@ fn adapter_pre_start_binds_context() {
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   let mut ctx = build_context(&system);
   let actor = DummyPersistentActor::new();
@@ -247,7 +247,7 @@ fn adapter_pre_start_schedules_recovery_timeout() {
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   let mut ctx = build_context(&system);
   let actor = DummyPersistentActor::new();
@@ -269,7 +269,7 @@ fn adapter_pre_start_rejects_persistence_id_mismatch() {
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   let mut ctx = build_context(&system);
   let actor = MismatchPersistentActor::new();
@@ -290,7 +290,7 @@ fn adapter_rearms_recovery_timeout_on_snapshot_and_replayed_message() {
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   let mut ctx = build_context(&system);
   let actor = DummyPersistentActor::new();
@@ -378,7 +378,7 @@ fn adapter_ignores_stale_recovery_tick_epoch() {
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   let mut ctx = build_context(&system);
   let actor = DummyPersistentActor::new();

--- a/modules/persistence-core/tests/persistence_flow.rs
+++ b/modules/persistence-core/tests/persistence_flow.rs
@@ -192,7 +192,7 @@ fn recovery_flow_snapshot_then_replay() {
     let refs = refs.clone();
     move || Guardian::new(setups.clone(), refs.clone())
   });
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 
@@ -240,7 +240,7 @@ fn persist_flow_keeps_values_independent() {
     let refs = refs.clone();
     move || Guardian::new(setups.clone(), refs.clone())
   });
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 

--- a/modules/persistence-core/tests/persistent_actor_example.rs
+++ b/modules/persistence-core/tests/persistent_actor_example.rs
@@ -136,7 +136,7 @@ fn batch_flow_applies_all_events() {
     let child_refs = child_refs.clone();
     move || Guardian::new(value.clone(), child_refs.clone())
   });
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 

--- a/modules/remote-adaptor-std/src/std/extension_installer/tests.rs
+++ b/modules/remote-adaptor-std/src/std/extension_installer/tests.rs
@@ -240,7 +240,7 @@ async fn extension_installer_config_install_starts_listener() {
   ));
   let installers = ExtensionInstallers::default().with_shared_extension_installer(installer.clone());
   let config = std_actor_system_config(TestTickDriver::default()).with_extension_installers(installers);
-  let system = ActorSystem::noop_with_config(config).expect("system should install remoting extension");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("system should install remoting extension");
   let port = first_listen_started_port(&system);
 
   assert_listener_accepts(port).await;
@@ -256,7 +256,7 @@ async fn extension_installer_system_termination_shuts_down_remote() {
   ));
   let installers = ExtensionInstallers::default().with_shared_extension_installer(installer.clone());
   let config = std_actor_system_config(TestTickDriver::default()).with_extension_installers(installers);
-  let system = ActorSystem::noop_with_config(config).expect("system should install remoting extension");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("system should install remoting extension");
   let port = first_listen_started_port(&system);
 
   assert_listener_accepts(port).await;
@@ -281,7 +281,7 @@ async fn extension_installer_double_install_returns_configuration_error() {
 fn inbound_delivery_bridge_sends_bytes_payload_to_local_actor() {
   let config = std_actor_system_config(TestTickDriver::default())
     .with_actor_ref_provider_installer(LocalActorRefProviderInstaller::default());
-  let system = ActorSystem::noop_with_config(config).expect("noop actor system should build");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("noop actor system should build");
   let (tx, rx) = mpsc::channel();
   let props = Props::from_fn({
     let tx = tx.clone();

--- a/modules/remote-adaptor-std/src/std/provider/tests.rs
+++ b/modules/remote-adaptor-std/src/std/provider/tests.rs
@@ -331,7 +331,7 @@ async fn actor_system_config_registered_std_remote_actor_ref_provider_resolves_r
   let config = std_actor_system_config(TestTickDriver::default())
     .with_extension_installers(extension_installers)
     .with_actor_ref_provider_installer(installer);
-  let system = ActorSystem::noop_with_config(config).expect("system");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("system");
   let remote_path = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.1:2552/user/worker").expect("parse");
   let mut actor_ref = system.resolve_actor_ref(remote_path.clone()).expect("remote actor ref should resolve");
   let canonical_path = actor_ref.canonical_path().expect("remote actor ref canonical path");

--- a/modules/remote-adaptor-std/tests/remote_lifecycle.rs
+++ b/modules/remote-adaptor-std/tests/remote_lifecycle.rs
@@ -61,7 +61,7 @@ async fn remote_lifecycle_via_extension_installer() {
   let installers = ExtensionInstallers::default().with_shared_extension_installer(installer);
   let config = fraktor_actor_adaptor_std_rs::std::system::std_actor_system_config(TestTickDriver::default())
     .with_extension_installers(installers);
-  let system = ActorSystem::noop_with_config(config).expect("system should install and start remoting");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("system should install and start remoting");
 
   timeout(Duration::from_secs(5), TcpStream::connect(("127.0.0.1", port)))
     .await

--- a/modules/remote-adaptor-std/tests/two_node_actor_system_delivery.rs
+++ b/modules/remote-adaptor-std/tests/two_node_actor_system_delivery.rs
@@ -103,7 +103,7 @@ fn build_node(port: u16, uid: u64) -> RemoteNode {
     .with_system_name(SYSTEM_NAME)
     .with_extension_installers(extension_installers)
     .with_actor_ref_provider_installer(provider_installer);
-  let system = ActorSystem::noop_with_config(config).expect("actor system should build");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("actor system should build");
   RemoteNode { system, address }
 }
 

--- a/modules/stream-adaptor-std/src/std/io/stream_converters/tests.rs
+++ b/modules/stream-adaptor-std/src/std/io/stream_converters/tests.rs
@@ -44,7 +44,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn build_materializer(system: ActorSystem) -> ActorMaterializer {

--- a/modules/stream-adaptor-std/src/std/materializer/system_materializer/tests.rs
+++ b/modules/stream-adaptor-std/src/std/materializer/system_materializer/tests.rs
@@ -29,7 +29,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn build_running_system_materializer() -> SystemMaterializer {

--- a/modules/stream-core/src/core/dsl/topic_pub_sub/tests.rs
+++ b/modules/stream-core/src/core/dsl/topic_pub_sub/tests.rs
@@ -43,7 +43,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn spawn_topic<T>(system: &ActorSystem, name: &str) -> TypedActorRef<TopicCommand<T>>

--- a/modules/stream-core/src/core/materialization/actor_materializer/tests.rs
+++ b/modules/stream-core/src/core/materialization/actor_materializer/tests.rs
@@ -340,7 +340,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 struct InlineExec;
@@ -375,7 +375,7 @@ fn build_system_with_dispatcher(dispatcher_id: &'static str) -> (ActorSystem, Me
   let config = ActorSystemConfig::new(TestTickDriver::default())
     .with_scheduler_config(scheduler)
     .with_dispatcher_factory(dispatcher_id, configurator_handle);
-  (ActorSystem::create_with_config(&props, config).expect("system should build"), dispatcher)
+  (ActorSystem::create_from_props(&props, config).expect("system should build"), dispatcher)
 }
 
 fn system_child_names(system: &ActorSystem) -> Vec<String> {
@@ -622,7 +622,7 @@ fn start_with_remoting_config() {
   let remoting = RemotingConfig::default().with_canonical_host("127.0.0.1").with_canonical_port(2552);
   let config =
     ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler).with_remoting_config(remoting);
-  let system = ActorSystem::create_with_config(&props, config).expect("system should build");
+  let system = ActorSystem::create_from_props(&props, config).expect("system should build");
   let mut materializer = ActorMaterializer::new(system, ActorMaterializerConfig::default());
   materializer.start().expect("start");
 }

--- a/modules/stream-core/src/core/materialization/downstream_cancellation_control_plane/tests.rs
+++ b/modules/stream-core/src/core/materialization/downstream_cancellation_control_plane/tests.rs
@@ -61,7 +61,7 @@ impl SourceLogic for PendingSourceLogic {
 fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(TestTickDriver::default());
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn spawn_child_ref(system: &ActorSystem) -> ChildRef {

--- a/modules/stream-core/src/core/materialization/downstream_cancellation_route/tests.rs
+++ b/modules/stream-core/src/core/materialization/downstream_cancellation_route/tests.rs
@@ -41,7 +41,7 @@ impl SourceLogic for PendingSourceLogic {
 fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(TestTickDriver::default());
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn spawn_child_ref(system: &ActorSystem) -> ChildRef {

--- a/modules/stream-core/src/core/snapshot/materializer_state/tests.rs
+++ b/modules/stream-core/src/core/snapshot/materializer_state/tests.rs
@@ -31,7 +31,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn build_running_materializer() -> ActorMaterializer {

--- a/modules/stream-core/src/core/stage/stage_actor/tests.rs
+++ b/modules/stream-core/src/core/stage/stage_actor/tests.rs
@@ -23,7 +23,7 @@ use crate::core::{
 fn build_system() -> ActorSystem {
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::new_started_from_config(config).expect("system")
+  ActorSystem::create_started_from_config(config).expect("system")
 }
 
 struct NoopReceive;

--- a/modules/stream-core/tests/coupled_termination_flow.rs
+++ b/modules/stream-core/tests/coupled_termination_flow.rs
@@ -36,7 +36,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn wait_until_ready<T>(completion: &StreamFuture<T>)

--- a/modules/stream-core/tests/requirement_traceability.rs
+++ b/modules/stream-core/tests/requirement_traceability.rs
@@ -49,7 +49,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| TraceabilityGuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 const ALL_REQUIREMENT_IDS: &[&str] = &[

--- a/modules/stream-core/tests/stage_actor_public.rs
+++ b/modules/stream-core/tests/stage_actor_public.rs
@@ -35,7 +35,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn poll_completion<T>(completion: &StreamFuture<T>) -> Result<T, StreamError>

--- a/modules/stream-core/tests/stream_ref_public.rs
+++ b/modules/stream-core/tests/stream_ref_public.rs
@@ -30,7 +30,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn build_materializer() -> ActorMaterializer {

--- a/modules/stream-core/tests/support/mod.rs
+++ b/modules/stream-core/tests/support/mod.rs
@@ -27,7 +27,7 @@ fn build_system() -> ActorSystem {
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
-  ActorSystem::create_with_config(&props, config).expect("system should build")
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn build_materializer() -> ActorMaterializer {

--- a/showcases/std/kernel/affinity-executor/main.rs
+++ b/showcases/std/kernel/affinity-executor/main.rs
@@ -62,7 +62,7 @@ fn main() {
   let actor_system_config =
     ActorSystemConfig::new(StdTickDriver::default()).with_dispatcher_factory(DEFAULT_DISPATCHER_ID, dispatcher_factory);
 
-  let system = ActorSystem::create_with_config(&props, actor_system_config).expect("system");
+  let system = ActorSystem::create_from_props(&props, actor_system_config).expect("system");
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Greet));

--- a/showcases/std/kernel/ask_from_non_actor/main.rs
+++ b/showcases/std/kernel/ask_from_non_actor/main.rs
@@ -37,7 +37,7 @@ impl Actor for Responder {
 fn main() {
   let props = Props::from_fn(|| Responder);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut responder = system.user_guardian_ref();
 

--- a/showcases/std/kernel/dispatchers/main.rs
+++ b/showcases/std/kernel/dispatchers/main.rs
@@ -38,7 +38,7 @@ fn main() {
   })
   .with_dispatcher_id(DEFAULT_BLOCKING_DISPATCHER_ID);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(RunBlockingWork));

--- a/showcases/std/kernel/fault-tolerance/main.rs
+++ b/showcases/std/kernel/fault-tolerance/main.rs
@@ -79,7 +79,7 @@ fn main() {
     move || GuardianActor { events: events.clone() }
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));

--- a/showcases/std/kernel/first-example/main.rs
+++ b/showcases/std/kernel/first-example/main.rs
@@ -36,7 +36,7 @@ fn main() {
     move || GreeterActor { greetings: greetings.clone() }
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Greet));

--- a/showcases/std/kernel/fsm/main.rs
+++ b/showcases/std/kernel/fsm/main.rs
@@ -79,7 +79,7 @@ fn main() {
     move || GateActor::new(transitions.clone(), pass_count.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
 
   let mut guardian = system.user_guardian_ref();

--- a/showcases/std/kernel/mailboxes/main.rs
+++ b/showcases/std/kernel/mailboxes/main.rs
@@ -42,7 +42,7 @@ fn main() {
   })
   .with_mailbox_config(mailbox);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
 
   for value in [1_u32, 2, 3] {

--- a/showcases/std/kernel/persistence-fsm/main.rs
+++ b/showcases/std/kernel/persistence-fsm/main.rs
@@ -178,7 +178,7 @@ fn main() {
     move || GuardianActor { child: None, observed: observed.clone() }
   });
   let config = ActorSystemConfig::new(StdTickDriver::default()).with_extension_installers(installers);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let termination = system.when_terminated();
   let mut guardian = system.user_guardian_ref();
 

--- a/showcases/std/kernel/persistence/main.rs
+++ b/showcases/std/kernel/persistence/main.rs
@@ -111,7 +111,7 @@ fn main() {
     move || GuardianActor { observed: observed.clone() }
   });
   let config = ActorSystemConfig::new(StdTickDriver::default()).with_extension_installers(installers);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));

--- a/showcases/std/kernel/routing/main.rs
+++ b/showcases/std/kernel/routing/main.rs
@@ -71,7 +71,7 @@ fn main() {
     move || RouterGuardian { records: records.clone() }
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));

--- a/showcases/std/kernel/supervision/main.rs
+++ b/showcases/std/kernel/supervision/main.rs
@@ -86,7 +86,7 @@ fn main() {
     move || ParentActor { events: events.clone() }
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));

--- a/showcases/std/legacy/child_lifecycle/main.rs
+++ b/showcases/std/legacy/child_lifecycle/main.rs
@@ -135,9 +135,8 @@ fn parent() -> Behavior<ParentCommand> {
 fn main() {
   use std::thread;
 
-  let props = TypedProps::from_behavior_factory(parent);
-  let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let system = TypedActorSystem::create_from_behavior_factory(parent, ActorSystemConfig::new(StdTickDriver::default()))
+    .expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/child_lifecycle/main.rs
+++ b/showcases/std/legacy/child_lifecycle/main.rs
@@ -137,7 +137,7 @@ fn main() {
 
   let props = TypedProps::from_behavior_factory(parent);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/classic_logging/main.rs
+++ b/showcases/std/legacy/classic_logging/main.rs
@@ -68,7 +68,7 @@ fn main() {
   let subscriber = test_subscriber_handle(RecordingSubscriber::new(events.clone()));
   let props = Props::from_fn(|| LoggingActor);
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let _log_subscription = subscribe_kernel_tracing_logger(&system);
   let _subscription = system.event_stream().subscribe(&subscriber);
 

--- a/showcases/std/legacy/classic_timers/main.rs
+++ b/showcases/std/legacy/classic_timers/main.rs
@@ -50,7 +50,7 @@ fn main() {
     move || TimerActor::new(events.clone())
   });
   let system =
-    ActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    ActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
 
   system.user_guardian_ref().tell(AnyMessage::new(Start));
 

--- a/showcases/std/legacy/getting_started/main.rs
+++ b/showcases/std/legacy/getting_started/main.rs
@@ -36,7 +36,7 @@ fn main() {
   // アクターシステムを起動
   let props = TypedProps::from_behavior_factory(greeter);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/getting_started/main.rs
+++ b/showcases/std/legacy/getting_started/main.rs
@@ -8,7 +8,7 @@
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
   kernel::{actor::setup::ActorSystemConfig, event::logging::LogLevel},
-  typed::{Behavior, TypedActorSystem, TypedProps, dsl::Behaviors},
+  typed::{Behavior, TypedActorSystem, dsl::Behaviors},
 };
 use fraktor_showcases_std::subscribe_typed_tracing_logger;
 
@@ -34,9 +34,9 @@ fn greeter() -> Behavior<Command> {
 
 fn main() {
   // アクターシステムを起動
-  let props = TypedProps::from_behavior_factory(greeter);
   let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_behavior_factory(greeter, ActorSystemConfig::new(StdTickDriver::default()))
+      .expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/persistent_actor/main.rs
+++ b/showcases/std/legacy/persistent_actor/main.rs
@@ -128,7 +128,7 @@ fn main() {
   let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default()).with_extension_installers(installers);
 
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   let _log_subscription = subscribe_kernel_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/remote_lifecycle/main.rs
+++ b/showcases/std/legacy/remote_lifecycle/main.rs
@@ -29,7 +29,7 @@ async fn main() {
   let installer = ArcShared::new(RemotingExtensionInstaller::new(transport, remote_config));
   let installers = ExtensionInstallers::default().with_shared_extension_installer(installer);
   let config = ActorSystemConfig::new(StdTickDriver::default()).with_extension_installers(installers);
-  let system = ActorSystem::create_with_config(&props, config).expect("system");
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
   println!("remote_lifecycle initialized remoting extension for 127.0.0.1");
 
   system.terminate().expect("terminate");

--- a/showcases/std/legacy/request_reply/main.rs
+++ b/showcases/std/legacy/request_reply/main.rs
@@ -91,9 +91,11 @@ fn main() {
 
   let done = Arc::new(AtomicBool::new(false));
   let done_clone = done.clone();
-  let props = TypedProps::from_behavior_factory(move || requester(done_clone.clone()));
-  let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let system = TypedActorSystem::create_from_behavior_factory(
+    move || requester(done_clone.clone()),
+    ActorSystemConfig::new(StdTickDriver::default()),
+  )
+  .expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/request_reply/main.rs
+++ b/showcases/std/legacy/request_reply/main.rs
@@ -93,7 +93,7 @@ fn main() {
   let done_clone = done.clone();
   let props = TypedProps::from_behavior_factory(move || requester(done_clone.clone()));
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/routing/main.rs
+++ b/showcases/std/legacy/routing/main.rs
@@ -71,7 +71,7 @@ fn main() {
 
   let props = router_guardian(records, next_routee_index);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let mut router = system.user_guardian_ref();
 
   // 4つのワークメッセージを送信（2つのルーティーに分配される）

--- a/showcases/std/legacy/serialization/main.rs
+++ b/showcases/std/legacy/serialization/main.rs
@@ -257,7 +257,7 @@ fn main() {
 
   let props = Props::from_fn(|| NullActor).with_name("serialization-demo");
   let config = ActorSystemConfig::new(StdTickDriver::default()).with_extension_installers(installers);
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::create_from_props(&props, config).expect("actor system");
 
   let serialization: SerializationExtensionShared =
     (*system.extended().extension(&serialization_id).expect("extension registered")).clone();

--- a/showcases/std/legacy/stash/main.rs
+++ b/showcases/std/legacy/stash/main.rs
@@ -81,7 +81,7 @@ fn main() {
 
   let props = TypedProps::from_behavior_factory(|| buffering(0)).with_stash_mailbox();
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let mut actor = system.user_guardian_ref();
 
   // closed 状態で Buffer メッセージを送信（stash される）

--- a/showcases/std/legacy/state_management/main.rs
+++ b/showcases/std/legacy/state_management/main.rs
@@ -14,7 +14,7 @@ use core::time::Duration;
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
   kernel::{actor::setup::ActorSystemConfig, event::logging::LogLevel},
-  typed::{Behavior, TypedActorRef, TypedActorSystem, TypedProps, dsl::Behaviors},
+  typed::{Behavior, TypedActorRef, TypedActorSystem, dsl::Behaviors},
 };
 use fraktor_showcases_std::subscribe_typed_tracing_logger;
 
@@ -107,9 +107,9 @@ fn main() {
 fn run_counter() {
   use std::{thread, time::Instant};
 
-  let props = TypedProps::from_behavior_factory(|| counter(0));
   let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_behavior_factory(|| counter(0), ActorSystemConfig::new(StdTickDriver::default()))
+      .expect("system");
   let mut counter_ref = system.user_guardian_ref();
   let termination = system.when_terminated();
 
@@ -140,9 +140,9 @@ fn run_counter() {
 fn run_gate() {
   use std::{thread, time::Instant};
 
-  let props = TypedProps::from_behavior_factory(|| locked(0));
   let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_behavior_factory(|| locked(0), ActorSystemConfig::new(StdTickDriver::default()))
+      .expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let mut gate = system.user_guardian_ref();
   let termination = system.when_terminated();

--- a/showcases/std/legacy/state_management/main.rs
+++ b/showcases/std/legacy/state_management/main.rs
@@ -109,7 +109,7 @@ fn run_counter() {
 
   let props = TypedProps::from_behavior_factory(|| counter(0));
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let mut counter_ref = system.user_guardian_ref();
   let termination = system.when_terminated();
 
@@ -142,7 +142,7 @@ fn run_gate() {
 
   let props = TypedProps::from_behavior_factory(|| locked(0));
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let mut gate = system.user_guardian_ref();
   let termination = system.when_terminated();

--- a/showcases/std/legacy/stream_authoring_apis/main.rs
+++ b/showcases/std/legacy/stream_authoring_apis/main.rs
@@ -105,7 +105,7 @@ impl SubSourceOutletHandler<u32> for ExampleSubSourceHandler {
 fn main() {
   let props = Props::from_fn(|| GuardianActor);
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::create_from_props(&props, config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/legacy/stream_pipeline/main.rs
+++ b/showcases/std/legacy/stream_pipeline/main.rs
@@ -18,7 +18,7 @@ use fraktor_stream_core_rs::core::{
 
 fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::noop_with_config(config).expect("actor system");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("actor system");
   let mut mat =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   mat.start().expect("materializer start");

--- a/showcases/std/legacy/timers/main.rs
+++ b/showcases/std/legacy/timers/main.rs
@@ -99,7 +99,7 @@ fn main() {
 
   let props = TypedProps::from_behavior_factory(timer_demo);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/timers/main.rs
+++ b/showcases/std/legacy/timers/main.rs
@@ -18,7 +18,7 @@ use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
   kernel::{actor::setup::ActorSystemConfig, event::logging::LogLevel},
   typed::{
-    Behavior, TypedActorSystem, TypedProps,
+    Behavior, TypedActorSystem,
     dsl::{Behaviors, TimerKey},
   },
 };
@@ -97,9 +97,9 @@ fn timer_demo() -> Behavior<Command> {
 fn main() {
   use std::thread;
 
-  let props = TypedProps::from_behavior_factory(timer_demo);
   let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_behavior_factory(timer_demo, ActorSystemConfig::new(StdTickDriver::default()))
+      .expect("system");
   let _log_subscription = subscribe_typed_tracing_logger(&system);
   let termination = system.when_terminated();
 

--- a/showcases/std/legacy/typed_event_stream/main.rs
+++ b/showcases/std/legacy/typed_event_stream/main.rs
@@ -43,7 +43,7 @@ impl ActorRefSender for CollectorSender {
 fn main() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(StdTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(StdTickDriver::default()))
       .expect("system");
 
   let events = SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new());

--- a/showcases/std/legacy/typed_receptionist_router/main.rs
+++ b/showcases/std/legacy/typed_receptionist_router/main.rs
@@ -24,7 +24,7 @@ fn wait_until(mut condition: impl FnMut() -> bool) {
 fn main() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
   let system =
-    TypedActorSystem::<u32>::create_with_config(&guardian_props, ActorSystemConfig::new(StdTickDriver::default()))
+    TypedActorSystem::<u32>::create_from_props(&guardian_props, ActorSystemConfig::new(StdTickDriver::default()))
       .expect("system");
 
   let key = ServiceKey::<u32>::new("typed-receptionist-router-example");

--- a/showcases/std/stream/basics/main.rs
+++ b/showcases/std/stream/basics/main.rs
@@ -9,7 +9,7 @@ use fraktor_stream_core_rs::core::{
 
 fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::noop_with_config(config).expect("actor system");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/composition/main.rs
+++ b/showcases/std/stream/composition/main.rs
@@ -9,7 +9,7 @@ use fraktor_stream_core_rs::core::{
 
 fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::noop_with_config(config).expect("actor system");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/first-example/main.rs
+++ b/showcases/std/stream/first-example/main.rs
@@ -9,7 +9,7 @@ use fraktor_stream_core_rs::core::{
 
 fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::noop_with_config(config).expect("actor system");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/graphs/main.rs
+++ b/showcases/std/stream/graphs/main.rs
@@ -9,7 +9,7 @@ use fraktor_stream_core_rs::core::{
 
 fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::noop_with_config(config).expect("actor system");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/stream/rate/main.rs
+++ b/showcases/std/stream/rate/main.rs
@@ -10,7 +10,7 @@ use fraktor_stream_core_rs::core::{
 
 fn main() {
   let config = ActorSystemConfig::new(StdTickDriver::default());
-  let system = ActorSystem::noop_with_config(config).expect("actor system");
+  let system = ActorSystem::create_with_noop_guardian(config).expect("actor system");
   let mut materializer =
     ActorMaterializer::new(system, ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)));
   materializer.start().expect("materializer start");

--- a/showcases/std/typed/actor-discovery/main.rs
+++ b/showcases/std/typed/actor-discovery/main.rs
@@ -13,7 +13,7 @@ use fraktor_actor_core_rs::core::{
 
 fn main() {
   let guardian_props = TypedProps::<u32>::from_behavior_factory(Behaviors::ignore);
-  let system = TypedActorSystem::create_with_config(&guardian_props, ActorSystemConfig::new(StdTickDriver::default()))
+  let system = TypedActorSystem::create_from_props(&guardian_props, ActorSystemConfig::new(StdTickDriver::default()))
     .expect("system");
   let termination = system.when_terminated();
   let key = ServiceKey::<u32>::new("typed-discovery-example");

--- a/showcases/std/typed/actor-lifecycle/main.rs
+++ b/showcases/std/typed/actor-lifecycle/main.rs
@@ -62,7 +62,7 @@ fn main() {
     move || parent(events.clone())
   });
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut guardian = system.user_guardian_ref();
 

--- a/showcases/std/typed/actor-lifecycle/main.rs
+++ b/showcases/std/typed/actor-lifecycle/main.rs
@@ -57,12 +57,14 @@ fn parent(events: SharedLock<Vec<&'static str>>) -> Behavior<ParentCommand> {
 
 fn main() {
   let events = SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new());
-  let props = TypedProps::from_behavior_factory({
-    let events = events.clone();
-    move || parent(events.clone())
-  });
-  let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let system = TypedActorSystem::create_from_behavior_factory(
+    {
+      let events = events.clone();
+      move || parent(events.clone())
+    },
+    ActorSystemConfig::new(StdTickDriver::default()),
+  )
+  .expect("system");
   let termination = system.when_terminated();
   let mut guardian = system.user_guardian_ref();
 

--- a/showcases/std/typed/dispatchers/main.rs
+++ b/showcases/std/typed/dispatchers/main.rs
@@ -30,7 +30,7 @@ fn main() {
   })
   .with_dispatcher_from_config(DEFAULT_BLOCKING_DISPATCHER_ID);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut actor = system.user_guardian_ref();
 

--- a/showcases/std/typed/fault-tolerance/main.rs
+++ b/showcases/std/typed/fault-tolerance/main.rs
@@ -58,12 +58,14 @@ fn parent(events: SharedLock<Vec<&'static str>>) -> Behavior<ParentCommand> {
 
 fn main() {
   let events = SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new());
-  let props = TypedProps::from_behavior_factory({
-    let events = events.clone();
-    move || parent(events.clone())
-  });
-  let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let system = TypedActorSystem::create_from_behavior_factory(
+    {
+      let events = events.clone();
+      move || parent(events.clone())
+    },
+    ActorSystemConfig::new(StdTickDriver::default()),
+  )
+  .expect("system");
   let termination = system.when_terminated();
   let mut guardian = system.user_guardian_ref();
 

--- a/showcases/std/typed/fault-tolerance/main.rs
+++ b/showcases/std/typed/fault-tolerance/main.rs
@@ -63,7 +63,7 @@ fn main() {
     move || parent(events.clone())
   });
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut guardian = system.user_guardian_ref();
 

--- a/showcases/std/typed/first-example/main.rs
+++ b/showcases/std/typed/first-example/main.rs
@@ -29,7 +29,7 @@ fn main() {
     move || greeter(greetings.clone())
   });
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut guardian = system.user_guardian_ref();
 

--- a/showcases/std/typed/first-example/main.rs
+++ b/showcases/std/typed/first-example/main.rs
@@ -4,7 +4,7 @@ use std::{thread, time::Instant};
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
   kernel::actor::setup::ActorSystemConfig,
-  typed::{Behavior, TypedActorSystem, TypedProps, dsl::Behaviors},
+  typed::{Behavior, TypedActorSystem, dsl::Behaviors},
 };
 use fraktor_utils_core_rs::core::sync::{SharedLock, SpinSyncMutex};
 
@@ -24,12 +24,14 @@ fn greeter(greetings: SharedLock<Vec<&'static str>>) -> Behavior<Command> {
 
 fn main() {
   let greetings = SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new());
-  let props = TypedProps::from_behavior_factory({
-    let greetings = greetings.clone();
-    move || greeter(greetings.clone())
-  });
-  let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+  let system = TypedActorSystem::create_from_behavior_factory(
+    {
+      let greetings = greetings.clone();
+      move || greeter(greetings.clone())
+    },
+    ActorSystemConfig::new(StdTickDriver::default()),
+  )
+  .expect("system");
   let termination = system.when_terminated();
   let mut guardian = system.user_guardian_ref();
 

--- a/showcases/std/typed/fsm/main.rs
+++ b/showcases/std/typed/fsm/main.rs
@@ -4,7 +4,7 @@ use std::{thread, time::Instant};
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
   kernel::actor::setup::ActorSystemConfig,
-  typed::{Behavior, TypedActorRef, TypedActorSystem, TypedProps, dsl::Behaviors},
+  typed::{Behavior, TypedActorRef, TypedActorSystem, dsl::Behaviors},
 };
 
 #[derive(Clone)]
@@ -39,9 +39,9 @@ fn open(pass_count: u32) -> Behavior<Command> {
 }
 
 fn main() {
-  let props = TypedProps::from_behavior_factory(|| locked(0));
   let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_behavior_factory(|| locked(0), ActorSystemConfig::new(StdTickDriver::default()))
+      .expect("system");
   let termination = system.when_terminated();
   let mut gate = system.user_guardian_ref();
 

--- a/showcases/std/typed/fsm/main.rs
+++ b/showcases/std/typed/fsm/main.rs
@@ -41,7 +41,7 @@ fn open(pass_count: u32) -> Behavior<Command> {
 fn main() {
   let props = TypedProps::from_behavior_factory(|| locked(0));
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut gate = system.user_guardian_ref();
 

--- a/showcases/std/typed/interaction-patterns/main.rs
+++ b/showcases/std/typed/interaction-patterns/main.rs
@@ -4,7 +4,7 @@ use std::{thread, time::Instant};
 use fraktor_actor_adaptor_std_rs::std::{StdBlocker, tick_driver::StdTickDriver};
 use fraktor_actor_core_rs::core::{
   kernel::actor::setup::ActorSystemConfig,
-  typed::{Behavior, TypedActorRef, TypedActorSystem, TypedProps, dsl::Behaviors},
+  typed::{Behavior, TypedActorRef, TypedActorSystem, dsl::Behaviors},
 };
 
 #[derive(Clone)]
@@ -22,9 +22,9 @@ fn responder() -> Behavior<Command> {
 }
 
 fn main() {
-  let props = TypedProps::from_behavior_factory(responder);
   let system =
-    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_behavior_factory(responder, ActorSystemConfig::new(StdTickDriver::default()))
+      .expect("system");
   let termination = system.when_terminated();
   let mut responder = system.user_guardian_ref();
 

--- a/showcases/std/typed/interaction-patterns/main.rs
+++ b/showcases/std/typed/interaction-patterns/main.rs
@@ -24,7 +24,7 @@ fn responder() -> Behavior<Command> {
 fn main() {
   let props = TypedProps::from_behavior_factory(responder);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut responder = system.user_guardian_ref();
 

--- a/showcases/std/typed/mailboxes/main.rs
+++ b/showcases/std/typed/mailboxes/main.rs
@@ -30,7 +30,7 @@ fn main() {
   })
   .with_mailbox_bounded(capacity);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut actor = system.user_guardian_ref();
 

--- a/showcases/std/typed/routers/main.rs
+++ b/showcases/std/typed/routers/main.rs
@@ -51,7 +51,7 @@ fn main() {
   let next_index = SharedLock::new_with_driver::<SpinSyncMutex<_>>(0_usize);
   let props = router_props(records.clone(), next_index);
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut router = system.user_guardian_ref();
 

--- a/showcases/std/typed/stash/main.rs
+++ b/showcases/std/typed/stash/main.rs
@@ -58,7 +58,7 @@ fn open(total: i32) -> Behavior<Command> {
 fn main() {
   let props = TypedProps::from_behavior_factory(|| buffering(0)).with_stash_mailbox();
   let system =
-    TypedActorSystem::create_with_config(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
+    TypedActorSystem::create_from_props(&props, ActorSystemConfig::new(StdTickDriver::default())).expect("system");
   let termination = system.when_terminated();
   let mut actor = system.user_guardian_ref();
 

--- a/tests/e2e/tests/actor_runtime_boot.rs
+++ b/tests/e2e/tests/actor_runtime_boot.rs
@@ -125,7 +125,7 @@ fn actor_runtime_boot_wires_std_config_scheduler_logging_watch_stop_and_dead_let
     let terminated_log = terminated_log.clone();
     move || Guardian::new(deliveries.clone(), child_slot.clone(), terminated_log.clone())
   });
-  let system = ActorSystem::create_with_config(&props, config).expect("actor system");
+  let system = ActorSystem::create_from_props(&props, config).expect("actor system");
   let subscriber = subscriber_handle(LogRecorder::new(log_messages.clone()));
   let _subscription = system.subscribe_event_stream(&subscriber);
 


### PR DESCRIPTION
## Summary

`create_with_config` ファミリを `create_from_props` ファミリに改名し、convenience method として `TypedActorSystem::create_from_behavior_factory` を追加します。

## Changes

### Renames

| Before | After |
|---|---|
| `ActorSystem::create_with_config(props, config)` | `ActorSystem::create_from_props(props, config)` |
| `ActorSystem::create_with_config_and(props, config, configure)` | `ActorSystem::create_from_props_with_init(props, config, configure)` |
| `TypedActorSystem::create_with_config(props, config)` | `TypedActorSystem::create_from_props(props, config)` |

### Additions

- \`TypedActorSystem::create_from_behavior_factory<F, B>(guardian_factory, config) -> Result<Self, SpawnError>\`
  - Bounds: \`F: Fn() -> B + Send + Sync + 'static, B: Into<Behavior<M>>\`
  - 内部で \`TypedProps::from_behavior_factory\` → \`Self::create_from_props\` に委譲

## Rationale

- 命名の対称化: \`TypedProps::from_behavior_factory\` と語彙が一致し、\`create_from_<primary>_with_<option>\` の Rust 慣用パターンに乗る
- \`config\` は core レベルで必須なので、\`_with_config\` サフィックスは情報の重複として落とした
- \`_with_config_and\` の \`_and\` は意味が薄く、\`configure: F\` callback の用途を明示する \`_with_init\` に置換

## Compatibility

**Breaking change** (\`!\` in commit type)。pre-release のため互換 alias は提供しません。

## Verification

\`./scripts/ci-check.sh ai all\` が exit 0 で通過しています（fmt / dylint / clippy / unit / integration / no_std / examples / e2e）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it’s a breaking public API rename/removal across core system construction paths; behavior should be unchanged but downstream crates and examples must update and any missed call sites will fail to compile.
> 
> **Overview**
> Renames the actor-system construction API across the project: `ActorSystem::create_with_config` → `create_from_props`, `create_with_config_and` → `create_from_props_with_init`, and `noop_with_config` → `create_with_noop_guardian`, plus `new_started_from_config` → `create_started_from_config` (now hidden/internal), and updates all benches/tests/examples accordingly.
> 
> Removes the Pekko-style `*_with_setup` constructors and introduces `TypedActorSystem::create_from_behavior_factory` as a new convenience wrapper over `TypedProps::from_behavior_factory` + `create_from_props`.
> 
> Separately bumps the `codex` tool version in `mise.toml` and updates Codex configs to use the new `hooks` feature flag and persist `hooks.state` trusted hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df35b5be4665a5382ea2d05e08a82ef85c8f6e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->