### PR TITLE
docs(guides): fix CQS/internal-mutability handling in lock-free guide

### DIFF
--- a/docs/guides/lock_free_design.md
+++ b/docs/guides/lock_free_design.md
@@ -156,113 +156,173 @@ impl MailboxState {
 | 項目 | `SharedLock<T>` バック | `AtomicU*` バック |
 |---|---|---|
 | 命名 | `*Shared` | `*Shared` |
-| 内側の純粋ロジック | `pub struct Xyz`（`&mut self`、CQS 純粋） | `pub struct XyzInner`（`&mut self`、CQS 純粋） |
-| 外側の共有ラッパー | `with_read` / `with_write` クロージャ API | `try_*` クロージャ API |
+| 内側の型 | `pub struct Xyz`（`&mut self` メソッドを持つ可変な状態オブジェクト） | `pub enum Xyz`（不変な値型 + 純粋遷移関数 `self -> Option<Self>`） |
+| 外側が内側を含む形 | `inner: SharedLock<Xyz>`（`Xyz` を構造的に保持） | `raw: AtomicU8`（`Xyz as u8` を保持。遷移関数は `Xyz` から借りる） |
+| 外側のロジック呼び出し | `inner.with_write(\|x\| x.method())` | `raw.fetch_update(\|v\| Xyz::from_u8(v)?.method().map(\|s\| s as u8))` |
 | 内部可変性の根拠 | Shared ラッパーパターン | **同左**（手段が CAS に変わるだけ） |
 
-### 正しい2層構造
+### Shared ラッパーの本質: 「内側を含む」関係
+
+Shared ラッパーパターンの本質は **「外側が内側を構造的に含み、内側のロジックを共有経由で呼び出せるようにする」** ことである。`SharedLock<T>` 版では：
+
+```rust
+pub struct Xyz { /* state */ }
+impl Xyz { pub fn do_something(&mut self) { /* logic */ } }
+
+pub struct XyzShared {
+    inner: SharedLock<Xyz>,                // ← Xyz を「含んでいる」
+}
+impl XyzShared {
+    pub fn do_something(&self) {
+        self.inner.with_write(|x| x.do_something());  // ← 内側のロジックを呼ぶ
+    }
+}
+```
+
+ここで重要なのは：
+- `XyzShared` は `Xyz` を **構造的に含んでいる**（フィールドとして保持）
+- 遷移ロジックは `Xyz` 側の単一の真実
+- `XyzShared` はそれを共有経由で実行可能にする外殻にすぎない
+- **`Xyz` を消したら `XyzShared` は意味を失う**（ロジックがなくなる）
+
+この関係を atomic-backed に持ち込むには、内側を **pure value type + pure transition functions** にして、Shared 側が `fetch_update` でその関数を CAS 経由で適用する設計にする。
+
+### 正しい構造: pure value + atomic Shared wrapper
 
 `MailboxState` を例に：
 
 ```rust
-// === 1. 純粋な状態機械ロジック ===
-// &mut self を取り、CQS 純粋。テスト時はこちらを直接使える。
-pub struct MailboxStateInner {
-    value: u8,
+use core::sync::atomic::Ordering::{AcqRel, Acquire};
+use portable_atomic::AtomicU8;
+
+// === 内側: 純粋な値型 + 純粋な遷移関数 ===
+// 状態セマンティクスの単一の真実。並行性ゼロでテスト可能。
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum MailboxState {
+    Idle      = 0,
+    Scheduled = 1,
+    Running   = 2,
+    Closed    = 3,
 }
 
-impl MailboxStateInner {
-    pub fn try_schedule(&mut self) -> bool {
-        if self.value == IDLE {
-            self.value = SCHEDULED;
-            true
-        } else {
-            false
+impl MailboxState {
+    fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::Idle),
+            1 => Some(Self::Scheduled),
+            2 => Some(Self::Running),
+            3 => Some(Self::Closed),
+            _ => None,
         }
     }
-    pub fn try_acquire(&mut self) -> bool { /* SCHEDULED→RUNNING */ }
-    pub fn release(&mut self, more_messages: bool) { /* RUNNING→IDLE/SCHEDULED */ }
+
+    /// 状態遷移は self -> Option<Self> の純粋関数。
+    /// 不変な値変換なので CQS の対象外（&mut self も &self もない）。
+    pub fn schedule(self) -> Option<Self> {
+        match self { Self::Idle => Some(Self::Scheduled), _ => None }
+    }
+    pub fn acquire(self) -> Option<Self> {
+        match self { Self::Scheduled => Some(Self::Running), _ => None }
+    }
+    pub fn release(self, more_messages: bool) -> Option<Self> {
+        match self {
+            Self::Running => Some(if more_messages { Self::Scheduled } else { Self::Idle }),
+            _ => None,
+        }
+    }
 }
 
-// === 2. Shared ラッパー（atomic-backed）===
-// SharedLock<MailboxStateInner> の最適化版。
-// &self での mutation は Shared ラッパーパターンの規約に準拠している。
+// === 外側: Atomic Shared wrapper ===
+// MailboxState を atomically 保持し、その遷移関数を CAS 経由で適用する。
+// 遷移ロジックは MailboxState 側にしかない。ここでは再実装しない。
 pub struct MailboxStateShared {
-    inner: AtomicU8,
+    raw: AtomicU8,  // 中身は MailboxState as u8
 }
 
 impl MailboxStateShared {
-    /// `SharedLock::with_write` の atomic 版。
-    /// 違いは「ロックを取る → クロージャ実行 → 解放」が
-    ///       「CAS で勝つ → on_won 実行」に変わっただけ。
+    pub fn new(initial: MailboxState) -> Self {
+        Self { raw: AtomicU8::new(initial as u8) }
+    }
+
+    /// MailboxState::schedule を atomic に適用。勝者だけが on_won を実行。
     pub fn try_schedule(&self, on_won: impl FnOnce()) {
-        if self.inner.compare_exchange(IDLE, SCHEDULED, AcqRel, Acquire).is_ok() {
+        let result = self.raw.fetch_update(AcqRel, Acquire, |v| {
+            MailboxState::from_u8(v)?.schedule().map(|s| s as u8)
+        });
+        if result.is_ok() {
             on_won();
         }
     }
 
+    /// MailboxState::acquire → ユーザーロジック → MailboxState::release を CAS で適用。
     pub fn try_run<R>(
         &self,
-        on_acquired: impl FnOnce() -> RunResult<R>,
+        on_acquired: impl FnOnce() -> RunOutcome<R>,
     ) -> Option<R> {
-        if self.inner.compare_exchange(SCHEDULED, RUNNING, AcqRel, Acquire).is_err() {
-            return None;
-        }
-        let RunResult { value, next } = on_acquired();
-        match next {
-            NextState::Idle       => self.inner.store(IDLE,      Release),
-            NextState::Reschedule => self.inner.store(SCHEDULED, Release),
-        }
+        // acquire 相: SCHEDULED→RUNNING を CAS
+        self.raw.fetch_update(AcqRel, Acquire, |v| {
+            MailboxState::from_u8(v)?.acquire().map(|s| s as u8)
+        }).ok()?;
+
+        let RunOutcome { value, more_messages } = on_acquired();
+
+        // release 相: RUNNING→IDLE/SCHEDULED を CAS
+        // RUNNING は排他確保済みなので必ず成功する
+        self.raw.fetch_update(AcqRel, Acquire, |v| {
+            MailboxState::from_u8(v)?.release(more_messages).map(|s| s as u8)
+        }).expect("RUNNING is exclusive; release must succeed");
+
         Some(value)
     }
 }
-```
 
-**この構造の利点**:
-- `MailboxStateInner` は `&mut self` で CQS を完全に満たし、純粋関数として単体テスト可能
-- `MailboxStateShared` は **Shared ラッパー規約** に準拠（命名 / API 形 / 内部可変性の根拠）
-- 「内部可変性は Shared ラッパーパターンが唯一の許容ケース」という規約と整合
-- 実装手段（ロック vs CAS）の選択は性能要件で決められ、API の形は同じ
-
-### bool 返却 vs クロージャ API の選択
-
-`MailboxStateInner::try_schedule(&mut self) -> bool` は **CQS違反**（Command + 値返却）。これは `Vec::pop` 同型の許容例外として認められる。
-
-ただし **共有経由で呼ばれる API（`MailboxStateShared`）はクロージャ版に統一すべき**：
-
-```rust
-// ❌ Shared ラッパー側に bool を漏らすと「ask-then-act」を誘発
-impl MailboxStateShared {
-    pub fn try_schedule(&self) -> bool { ... }  // 呼び側が if 分岐する設計に逆戻り
-}
-
-// ✅ クロージャ版で「Tell, Don't Ask」を強制
-impl MailboxStateShared {
-    pub fn try_schedule(&self, on_won: impl FnOnce()) { ... }
+pub struct RunOutcome<R> {
+    pub value: R,
+    pub more_messages: bool,
 }
 ```
 
-### 設計原則として一般化
+### この構造で何が解決するか
 
-> **CAS を含む並行プリミティブを設計する際は：**
->
-> 1. **2層構造** にする：純粋ロジック（`*Inner`、`&mut self`、CQS 純粋）+ Shared ラッパー（`*Shared`、`&self`、CAS 内部可変性）
-> 2. **内部ロジック** は `&mut self` で CQS を満たし、単体テスト可能にする
-> 3. **Shared ラッパー** は Shared ラッパーパターン規約に準拠（命名 / API 形）
-> 4. **API 表面** はクロージャベースで「Tell, Don't Ask」を強制する
-> 5. **`Option<R>` の戻り値** は `Vec::pop` 同型の許容例外
-> 6. **bool 戻り値の `&self` 状態変更メソッドは設計途中の兆候** — クロージャ API へ置換
+```
+┌─────────────────────────────────────────────┐
+│ MailboxState (pure value type)               │
+│   - 状態セマンティクスの単一の真実           │
+│   - 遷移ルール（schedule/acquire/release）   │
+│   - 単体テスト可能（並行性ゼロ）              │
+└──────────────────┬──────────────────────────┘
+                   │ 借用される
+                   ↓
+┌─────────────────────────────────────────────┐
+│ MailboxStateShared (atomic wrapper)          │
+│   - MailboxState を atomically 保持          │
+│   - fetch_update で遷移を atomic に適用       │
+│   - MailboxState なしでは存在意義がない      │
+└─────────────────────────────────────────────┘
+```
+
+| 項目 | 結果 |
+|---|---|
+| **内側と外側の関係性** | 外側が内側の遷移関数を借りる。**外側は内側なしでは意味を持たない** |
+| **遷移ロジックの単一の真実** | `MailboxState` のみ。重複ゼロ |
+| **CQS** | `MailboxState` の遷移は pure function（`self -> Option<Self>`）で CQS の対象外 |
+| **内部可変性の根拠** | `MailboxStateShared` は Shared ラッパー規約に準拠（内側の値型を atomically 包む） |
+| **テスト容易性** | `MailboxState::schedule()` 等は並行性ゼロで単体テスト可能 |
+| **`SharedLock<T>` との対応** | `with_write(\|x\| x.method())` ↔ `fetch_update(\|v\| logic(v))` の対応関係が明確 |
+
+**重要**: 内側を「`&mut self` で状態を持つ struct」にしないこと。それでは外側との関係が「2つの並行実装」になり、ロジックが重複する。**内側を「不変な値型 + 純粋関数」にする** のが atomic-backed Shared の正しい形。
 
 ### 既存規約との整合
 
 | 既存規約 | 本パターンとの整合 |
 |---|---|
-| **内部可変性は Shared ラッパーパターンが唯一の許容ケース**（`immutability-policy.md`） | `*Shared` + `*Inner` の2層構造で準拠。実装手段がロックから CAS に変わるだけ |
+| **内部可変性は Shared ラッパーパターンが唯一の許容ケース**（`immutability-policy.md`） | 内側の値型を外側の `*Shared` が atomic に保持し、内側の遷移関数を `fetch_update` で借りて適用する。実装手段がロックから CAS に変わるだけ |
 | **`*Shared` 命名**（`naming-conventions.md`） | atomic-backed な共有型は必ず `*Shared` を付ける |
-| **`&mut self` 原則**（`cqs-principle.md`） | `*Inner` 側で完全に満たす。`*Shared` は Shared ラッパー規約の枠内で `&self` を許容 |
+| **`&mut self` 原則**（`cqs-principle.md`） | 内側を不変な値型 + 純粋関数（`self -> Option<Self>`）にすることで、`&mut self` も `&self` も発生せず CQS の対象外となる |
 | `SharedAccess::with_read` / `with_write` クロージャ API | `try_schedule(\|\| ...)` / `try_run(\|\| ...)` は同じ思想の atomic 版 |
 | ガード/ロックを外部に返さない | 排他権がクロージャ内に閉じる。外に漏れない |
-| CQS違反は人間許可で例外許容（`Vec::pop` 相当） | `*Inner::try_*(&mut self) -> bool`、`*Shared::try_run -> Option<R>` ともに同型 |
+| CQS違反は人間許可で例外許容（`Vec::pop` 相当） | `*Shared::try_run -> Option<R>` は `Vec::pop -> Option<T>` と同型 |
 | Tell, Don't Ask | bool 返却して呼び側で分岐する代わりに、勝った場合の動作をクロージャで渡す |
 
 ## 適用するコンポーネントの優先順位
@@ -271,7 +331,7 @@ impl MailboxStateShared {
 
 | コンポーネント | 推奨パターン | 優先度 |
 |---|---|---|
-| Mailbox 状態機械 | ④ Atomic state machine（`*Inner` + `*Shared` の2層構造、`AtomicU8` バック） | **最高** |
+| Mailbox 状態機械 | ④ Atomic state machine（pure value + `*Shared` atomic wrapper） | **最高** |
 | Mailbox メッセージキュー | ② Ownership transfer（lock-free MPSC） | **最高** |
 | ActorCell の排他制御 | ④ の CAS 勝者にのみ `&mut` を与える | **最高** |
 | Run-queue（scheduler） | std: tokio に委譲 / no_std: 自前 bounded ring | 高 |
@@ -290,8 +350,9 @@ impl MailboxStateShared {
 Step 1. 現状の SharedLock 設計のままベンチを取る（基準線）
         → 効果測定の前提
 
-Step 2. Mailbox 状態機械を `*Inner` + `*Shared` の2層構造へ
-        → 純粋ロジック（&mut self）+ atomic-backed Shared ラッパー
+Step 2. Mailbox 状態機械を pure value enum + atomic Shared wrapper へ
+        → 内側は不変な値型（self -> Option<Self> の純粋遷移関数）
+        → 外側は AtomicU8 + fetch_update で内側の遷移関数を atomic に適用
         → unsafe ゼロ・依存ゼロ・最小リスク
         → これだけで SharedLock<Mailbox> が消え、規約とも整合
 
@@ -390,7 +451,7 @@ fn init(&self) -> Result<(), E> {
 ### 5. 単層構造の atomic 型（Shared ラッパー規約を素通り）
 
 ```rust
-// ❌ *Shared 命名でない / 純粋ロジック層が分離されていない
+// ❌ *Shared 命名でない / 内側の値型と関係性がない
 //   → 内部可変性の根拠（Shared ラッパーパターン）に準拠していない
 pub struct MailboxState(AtomicU8);
 
@@ -399,13 +460,51 @@ impl MailboxState {
 }
 ```
 
-**修正**: 2層構造にする。
-- `MailboxStateInner`（`&mut self`、純粋ロジック、CQS純粋）
-- `MailboxStateShared`（`&self`、CAS、クロージャ API）
+**修正**: 内側を pure value type にして、外側がそれを atomically 包む構造にする。
 
-これで内部可変性が Shared ラッパーパターン規約の枠内に収まる。
+```rust
+// 内側: 純粋な値型 + 純粋な遷移関数
+pub enum MailboxState { Idle, Scheduled, Running, Closed }
+impl MailboxState {
+    pub fn schedule(self) -> Option<Self> { ... }
+}
 
-### 6. unsafe を広範囲にばらまく
+// 外側: 内側を atomically 保持し、内側の遷移関数を fetch_update で借りる
+pub struct MailboxStateShared { raw: AtomicU8 }
+impl MailboxStateShared {
+    pub fn try_schedule(&self, on_won: impl FnOnce()) {
+        if self.raw.fetch_update(AcqRel, Acquire, |v| {
+            MailboxState::from_u8(v)?.schedule().map(|s| s as u8)
+        }).is_ok() { on_won(); }
+    }
+}
+```
+
+### 6. 内側と外側が無関係な「並行する2実装」
+
+```rust
+// ❌ 「2層構造」を装っているが、Inner と Shared が遷移ロジックを重複保有
+//   どちらも単独で完結し、お互いに必要としない = Shared ラッパーになっていない
+pub struct MailboxStateInner { value: u8 }
+impl MailboxStateInner {
+    pub fn try_schedule(&mut self) -> bool { /* IDLE→SCHEDULED */ }
+}
+
+pub struct MailboxStateShared { inner: AtomicU8 }
+impl MailboxStateShared {
+    pub fn try_schedule(&self) {
+        // ↓ Inner と同じロジックを CAS 版で再実装している
+        self.inner.compare_exchange(IDLE, SCHEDULED, ...);
+    }
+}
+```
+
+**修正**: Shared ラッパーは内側を **構造的に含み**、内側のロジックを **借りる** 関係にする。
+- `*Shared` の構造体フィールドが内側の値を atomically 保持する
+- 遷移ルールは内側の純粋関数のみが定義する
+- `*Shared` は `fetch_update` で内側の関数を渡して適用する
+
+### 7. unsafe を広範囲にばらまく
 
 ```rust
 // ❌ 公開関数が unsafe で、呼び出し側全てに契約が伝染

--- a/docs/guides/lock_free_design.md
+++ b/docs/guides/lock_free_design.md
@@ -325,6 +325,224 @@ pub struct RunOutcome<R> {
 | CQS違反は人間許可で例外許容（`Vec::pop` 相当） | `*Shared::try_run -> Option<R>` は `Vec::pop -> Option<T>` と同型 |
 | Tell, Don't Ask | bool 返却して呼び側で分岐する代わりに、勝った場合の動作をクロージャで渡す |
 
+## enum 化できないケースの戦略
+
+`pure value + atomic Shared wrapper` は **小さな離散状態（≤8 byte 程度の Copy 型）** にしか適用できない。状態が大きい・コレクションを含む・部分的に可変、といったケースでは別パターンに切り替える必要がある。
+
+### 適用境界の判定フロー
+
+```
+1. 状態は Copy 可能で 1〜8 byte に収まるか？
+   ├─ Yes → enum + AtomicU* + fetch_update（前述のパターン）
+   └─ No  → 次へ
+
+2. 状態は immutable に保てるか（更新時は全置換でよいか）？
+   ├─ Yes → A. RCU 風 snapshot（後述）
+   └─ No  → 次へ
+
+3. 状態の主成分はコレクション（Vec / HashMap）か？
+   ├─ Yes → B. Sharding（既述）or persistent collection + snapshot
+   └─ No  → 次へ
+
+4. 状態のフィールドごとに更新頻度が大きく違うか？
+   ├─ Yes → C. フィールド単位に分解して各々最適な同期手段を選ぶ
+   └─ No  → 次へ
+
+5. 単純な数値カウンタ・統計値か？
+   ├─ Yes → D. AtomicU* を直接使う（ラッパー不要）
+   └─ No  → SharedLock<T> のまま据え置き（ホットでなければ問題ない）
+```
+
+### A. RCU 風 snapshot（大きい immutable struct）
+
+**適用条件**: 状態が複数フィールドを持つが、更新時に全体を置換できる。読み込みが圧倒的に多く、書き込みが稀（読み : 書き ≧ 100 : 1）。
+
+```rust
+use fraktor_utils_core_rs::core::sync::{ArcShared, DefaultRwLock, SharedAccess, SharedRwLock};
+
+// 内側: immutable な値オブジェクト（DDD で言う value object）
+#[derive(Debug)]
+pub struct RoutingTable {
+    routes: Vec<Route>,
+    default: Option<Endpoint>,
+}
+
+impl RoutingTable {
+    pub fn lookup(&self, key: &Key) -> Option<&Endpoint> { /* pure */ }
+    /// 新しい Route を加えた **新しいテーブル** を返す（self は変更しない）
+    pub fn with_added(&self, r: Route) -> Self { /* clone + push */ }
+}
+
+// 外側: ArcShared<RoutingTable> を atomic に差し替える Shared ラッパー
+//   - 読み込み: ArcShared を clone するだけ（refcount + 1）。lock 区間は短い
+//   - 書き込み: 新規 ArcShared を作成して swap。古い snapshot は refcount 0 で解放
+pub struct RoutingTableShared {
+    inner: SharedRwLock<ArcShared<RoutingTable>>,
+}
+
+impl RoutingTableShared {
+    pub fn read(&self) -> ArcShared<RoutingTable> {
+        self.inner.with_read(|t| t.clone())  // refcount inc のみ。lock は瞬間
+    }
+
+    /// 内側の純粋関数を借りて新規 snapshot を作成し、atomic に差し替える
+    pub fn update(&self, mutate: impl FnOnce(&RoutingTable) -> RoutingTable) {
+        self.inner.with_write(|t| *t = ArcShared::new(mutate(&**t)));
+    }
+}
+```
+
+**コスト**:
+- 読み込み: `ArcShared::clone`（refcount inc 1回）+ 短い RwLock read。実用上 wait-free に近い
+- 書き込み: 新規 snapshot 1個分の割り当て + RwLock write。**ここでアロケーションが発生する**が、書き込みは稀なので許容
+- メモリ: 古い snapshot を参照しているリーダーがいる間、新旧両方が残る（refcount 0 で解放）
+
+**完全 wait-free にしたいなら** `arc-swap` 相当を自前で（`AtomicPtr<T>` + hazard pointer 風）実装する選択肢もあるが、複雑度が跳ね上がるので **まず brief-lock 版で実測してから判断する**。
+
+### B. コレクションを含む状態
+
+**適用条件**: 状態の主成分が `Vec<T>` / `HashMap<K, V>` で、要素単位の更新が頻繁。
+
+```rust
+// 選択肢 1: Sharding（書き込みも一定量ある場合・実装が単純）
+//   既出の ShardedRegistry パターンを使う
+pub struct ConnectionTable {
+    shards: [SharedRwLock<HashMap<ConnId, Connection>>; 64],
+}
+
+// 選択肢 2: persistent collection + snapshot（読み : 書き比率が極端な場合）
+//   im::HashMap などの persistent data structure は構造共有で clone が cheap
+//   A の RoutingTable パターンと組み合わせる
+pub struct ConfigTableShared {
+    inner: SharedRwLock<ArcShared<im::HashMap<ConfigKey, ConfigValue>>>,
+}
+```
+
+**選び方**:
+- 書き込み頻度が高い → Sharding（A の snapshot は書き込みが重い）
+- 読み込みが極端に多く全体スナップショットが欲しい → persistent + snapshot
+- 単純な lookup だけで構造共有が要らない → Sharding
+
+### C. フィールド単位への分解
+
+**適用条件**: 1つの struct に「ホットなカウンタ」「コールドな設定」「immutable な構成情報」が混在している。これを丸ごと `SharedLock` で守ると、ホット更新がコールド読み込みと競合する。
+
+```rust
+// ❌ 一つの SharedLock で全部を守る → 更新頻度が違うフィールド同士が競合
+pub struct ConnectionStateShared {
+    inner: SharedLock<ConnectionState>,  // bytes_sent の更新が config 読み込みをブロック
+}
+
+struct ConnectionState {
+    bytes_sent: u64,           // ホット: 受信ごとに更新
+    bytes_recv: u64,           // ホット: 送信ごとに更新
+    last_error: Option<Error>, // コールド: エラー時のみ
+    config: ArcShared<Config>, // immutable: 接続後変わらない
+}
+
+// ✅ フィールドごとに最適な同期手段を選ぶ
+pub struct ConnectionStateShared {
+    bytes_sent: AtomicU64,                       // D のパターン
+    bytes_recv: AtomicU64,                       // D のパターン
+    last_error: SharedRwLock<Option<Error>>,     // SharedLock（コールド）
+    config: ArcShared<Config>,                    // immutable（同期不要）
+}
+```
+
+**判断基準**:
+- 更新頻度が桁違いに違うフィールドは絶対に分ける
+- ただし「同時に変わるべき」フィールドは一緒に保持する（不変条件）
+- 不変条件と性能のトレードオフは設計判断（迷ったら不変条件優先）
+
+### D. 数値カウンタ・統計値
+
+**適用条件**: 単純なカウンタ・累計・最大最小など、原子操作プリミティブで完結する処理。
+
+```rust
+// ラッパーすら作らず、フィールドとして直接 AtomicU64 を持つ
+pub struct MailboxMetrics {
+    enqueued:  AtomicU64,
+    dispatched: AtomicU64,
+    dropped:   AtomicU64,
+}
+
+impl MailboxMetrics {
+    pub fn record_enqueue(&self)    { self.enqueued.fetch_add(1, Ordering::Relaxed); }
+    pub fn record_dispatch(&self)   { self.dispatched.fetch_add(1, Ordering::Relaxed); }
+    pub fn record_drop(&self)       { self.dropped.fetch_add(1, Ordering::Relaxed); }
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        MetricsSnapshot {
+            enqueued:  self.enqueued.load(Ordering::Relaxed),
+            dispatched: self.dispatched.load(Ordering::Relaxed),
+            dropped:   self.dropped.load(Ordering::Relaxed),
+        }
+    }
+}
+```
+
+**注意点**:
+- フィールド間の整合性は **保証されない**（snapshot 中に他フィールドが変わる）。総和が一致する必要がない統計値ならこれで十分
+- 整合スナップショットが必要なら A の RCU パターンへ
+- `Ordering::Relaxed` は計測用途には十分。同期効果が必要なら `Acquire`/`Release`/`AcqRel` を選ぶ
+
+### E. 大きい状態機械（variant にデータが付随）
+
+**適用条件**: enum の各 variant が固有のデータを持ち、AtomicU8 に収まらない。
+
+```rust
+pub enum Connection {
+    Connecting { started_at: Instant, attempts: u32 },
+    Established { since: Instant, bytes_sent: u64 },
+    Closing    { reason: CloseReason },
+    Closed,
+}
+```
+
+選択肢：
+
+| アプローチ | 仕組み | 向き不向き |
+|---|---|---|
+| **discriminant 分離** | `AtomicU8` で variant タグだけ持ち、各 variant のデータは別フィールド | データの読み出しに整合性が必要なら不可 |
+| **A. RCU snapshot** | `Connection` 全体を `ArcShared` で保持し snapshot 差し替え | 書き込みが稀ならこれが第一選択 |
+| **C. 分解** | hot な数値（`bytes_sent`）は AtomicU64、状態は別管理 | 設計が分かりにくくなりがち |
+| **SharedLock** | hot でなければ素直にロック | コールドパスならこれで十分 |
+
+**判断順序**: ホットでないなら `SharedLock` → 読み込みが圧倒的に多いなら RCU → 数値だけ hot で他は安定なら分解。
+
+### 適用パターン早見表
+
+| 状態の特徴 | 推奨パターン | アロケーション |
+|---|---|---|
+| 1〜8 byte の離散状態 | **enum + AtomicU* + fetch_update** | ゼロ |
+| 大きい immutable struct（全置換） | **A. RCU snapshot**（`SharedRwLock<ArcShared<T>>`） | 書き込み時のみ |
+| Vec / HashMap で要素更新が頻繁 | **B. Sharding** | 通常通り |
+| Vec / HashMap で全体 snapshot 必要 | **B. persistent + snapshot** | 構造共有で削減 |
+| ホット/コールドが混在 | **C. フィールド分解** | 各々最適化 |
+| 単純な数値カウンタ | **D. AtomicU* 直接** | ゼロ |
+| variant データ付き状態機械 | **E. ホットさで判断** | パターン依存 |
+| ホットでない複雑な状態 | **SharedLock のまま** | 通常通り |
+
+### アンチパターン: enum 化の無理強い
+
+「enum で書ければゼロアロケーション」という結論を逆手に取って、**本来 enum 化すべきでない状態を無理に enum 化しない**。
+
+```rust
+// ❌ 大きいデータを 1 byte に押し込めず、
+//    別フィールドの「附属データ」と組み合わせる設計にしない
+pub enum ConnState { Idle, Active, Closed }
+
+pub struct ConnectionShared {
+    state: AtomicU8,
+    // ↓ state と整合する必要がある「附属データ」を別管理してしまう
+    last_active: SharedLock<Option<Instant>>,
+    error_log:   SharedLock<Vec<Error>>,
+}
+// → state と附属データの整合性が壊れる読み出しが起きる（partial snapshot）
+```
+
+**修正**: 整合性が必要な状態は A の RCU パターンで丸ごと snapshot にする、もしくは整合性を諦めて C の分解で性能を取る。**「enum + 附属データ」は最悪の中間**。
+
+
 ## 適用するコンポーネントの優先順位
 
 ホットさが高い順。ロックフリー化の ROI が高いものから着手する。
@@ -334,10 +552,13 @@ pub struct RunOutcome<R> {
 | Mailbox 状態機械 | ④ Atomic state machine（pure value + `*Shared` atomic wrapper） | **最高** |
 | Mailbox メッセージキュー | ② Ownership transfer（lock-free MPSC） | **最高** |
 | ActorCell の排他制御 | ④ の CAS 勝者にのみ `&mut` を与える | **最高** |
+| Mailbox メトリクス | D. AtomicU* 直接（カウンタのみ） | 高 |
 | Run-queue（scheduler） | std: tokio に委譲 / no_std: 自前 bounded ring | 高 |
-| Registry（PID→ActorRef） | ③ Sharding（既存 `SharedRwLock` 活用） | 中 |
+| Registry（PID→ActorRef） | ③ Sharding（既存 `SharedRwLock` 活用）or A. RCU snapshot | 中 |
+| RoutingTable / Cluster membership | A. RCU snapshot（`SharedRwLock<ArcShared<T>>`） | 中 |
 | Children / Watchers | 親アクターが排他所有 → ロック不要 | （該当なし） |
-| Supervision strategy | 構築後 immutable → `Arc<dyn>` で十分 | （該当なし） |
+| Supervision strategy | 構築後 immutable → `ArcShared<dyn>` で十分 | （該当なし） |
+| Connection / Session 状態 | E. variant データ付き状態機械（ホットさで判断） | 中〜低 |
 | Config / membership 変更 | `SharedLock` のまま | 低（コールド） |
 
 「ホットパスにロックがあること」が問題であり、ロックそのものが悪ではない。コールドパスは `SharedLock` のままが正解。

--- a/docs/guides/lock_free_design.md
+++ b/docs/guides/lock_free_design.md
@@ -101,14 +101,28 @@ struct ShardedRegistry<K, V> {
 
 これがホットパスのロックフリー化の中核。次節で詳述する。
 
-## CQSとの両立（最重要）
+## CQS と内部可変性の両立（最重要）
 
-CAS は本質的に「読み取り + 書き込み」を不可分に行うため、**プリミティブ内部では CQS 違反が必須**である。CQS を守って Q と C を分離した瞬間に TOCTOU レースが発生し、正しく動かない。
+ロックフリー化は CQS 原則と **2つの次元** で衝突する：
+
+```
+次元 A: TOCTOU レース回避のために CAS が必要
+        → check と act を分離できない（Q と C の分離不可能性）
+
+次元 B: AtomicU* に対する操作はシグネチャが &self
+        → CQS が要求する「Command は &mut self」を満たせない（内部可変性問題）
+```
+
+両方とも **既存規約の枠内で正当化できる**。順に整理する。
+
+### 次元 A: CQS の Q/C 分離不可能性
+
+CAS は本質的に「読み取り + 書き込み」を不可分に行うため、Q と C を分離した瞬間に TOCTOU レースが発生する。
 
 ```rust
 // ❌ CQS純粋だが並行下で壊れる
-fn state(&self) -> u8 { self.0.load(...) }  // Query
-fn set(&self, s: u8) { self.0.store(s, ...) }  // Command
+fn state(&self) -> u8 { self.0.load(...) }    // Query
+fn set(&mut self, s: u8) { self.0.store(s, ...) }  // Command
 
 if state() == IDLE {        // ← この瞬間
     set(SCHEDULED);          // ← この瞬間に他スレッドが先に書いてるかも (TOCTOU)
@@ -117,76 +131,138 @@ if state() == IDLE {        // ← この瞬間
 
 これは `Vec::pop` / `Iterator::next` と同じ系統の **「分離不可能な CQS 例外」** で、`.agents/rules/rust/cqs-principle.md` の許容例外節に該当する。
 
-### ただし API 表面に違反を漏らさない
+### 次元 B: 内部可変性は Shared ラッパーパターンの枠内に収める
 
-プリミティブ内部の CQS 違反は避けられないが、**API 表面はクロージャパターンで CQS 純粋に保てる**。これが本ガイドの中心的洞察。
+`AtomicU*` の `compare_exchange` は `&self` で呼び出せる。これは **内部可変性** であり、`.agents/rules/rust/immutability-policy.md` は内部可変性を **「Shared ラッパーパターンが唯一の許容ケース」** と定めている。
 
-#### Bad: API表面に CQS 違反が漏れる
+つまり `AtomicU*` バックの型を雑に書くと、規約違反になる：
 
 ```rust
-// ❌ 状態変更 + bool 返却 = CQS違反が公開API
-impl MailboxState {
-    pub fn mark_scheduled(&self) -> bool {
-        self.0.compare_exchange(IDLE, SCHEDULED, AcqRel, Acquire).is_ok()
-    }
-}
+// ❌ 命名・構造が Shared ラッパーパターンに準拠していない
+//   → 規約上の根拠なしに内部可変性を使っている
+pub struct MailboxState(AtomicU8);
 
-// 呼び出し側もCQS違反を引きずる
-if state.mark_scheduled() {
-    executor.enqueue(self);  // ask-then-act
+impl MailboxState {
+    pub fn try_schedule(&self, on_won: impl FnOnce()) { /* &self で mutate */ }
 }
 ```
 
-#### Good: クロージャパターンで違反を内部に閉じ込める
+**正しい解釈**: `AtomicU*` バックの型は **Shared ラッパーパターンの一実装** である。
+
+> `SharedLock<T>` がロックで内部可変性を提供するのに対し、
+> `AtomicU*` バックの `*Shared` 型は CAS で内部可変性を提供する。
+> **両者は規約上同じ地位であり、命名・構造の規約も同じく適用される**。
+
+| 項目 | `SharedLock<T>` バック | `AtomicU*` バック |
+|---|---|---|
+| 命名 | `*Shared` | `*Shared` |
+| 内側の純粋ロジック | `pub struct Xyz`（`&mut self`、CQS 純粋） | `pub struct XyzInner`（`&mut self`、CQS 純粋） |
+| 外側の共有ラッパー | `with_read` / `with_write` クロージャ API | `try_*` クロージャ API |
+| 内部可変性の根拠 | Shared ラッパーパターン | **同左**（手段が CAS に変わるだけ） |
+
+### 正しい2層構造
+
+`MailboxState` を例に：
 
 ```rust
-// ✅ 戻り値 () の Command。CQS純粋。
-impl MailboxState {
-    /// IDLE→SCHEDULED への遷移を試みる。勝者だけが `on_won` を実行する。
+// === 1. 純粋な状態機械ロジック ===
+// &mut self を取り、CQS 純粋。テスト時はこちらを直接使える。
+pub struct MailboxStateInner {
+    value: u8,
+}
+
+impl MailboxStateInner {
+    pub fn try_schedule(&mut self) -> bool {
+        if self.value == IDLE {
+            self.value = SCHEDULED;
+            true
+        } else {
+            false
+        }
+    }
+    pub fn try_acquire(&mut self) -> bool { /* SCHEDULED→RUNNING */ }
+    pub fn release(&mut self, more_messages: bool) { /* RUNNING→IDLE/SCHEDULED */ }
+}
+
+// === 2. Shared ラッパー（atomic-backed）===
+// SharedLock<MailboxStateInner> の最適化版。
+// &self での mutation は Shared ラッパーパターンの規約に準拠している。
+pub struct MailboxStateShared {
+    inner: AtomicU8,
+}
+
+impl MailboxStateShared {
+    /// `SharedLock::with_write` の atomic 版。
+    /// 違いは「ロックを取る → クロージャ実行 → 解放」が
+    ///       「CAS で勝つ → on_won 実行」に変わっただけ。
     pub fn try_schedule(&self, on_won: impl FnOnce()) {
-        if self.0.compare_exchange(IDLE, SCHEDULED, AcqRel, Acquire).is_ok() {
+        if self.inner.compare_exchange(IDLE, SCHEDULED, AcqRel, Acquire).is_ok() {
             on_won();
         }
     }
 
-    /// SCHEDULED→RUNNING の獲得を試みる。勝者だけがクロージャ内で
-    /// 排他所有権に基づく処理を実行できる。
     pub fn try_run<R>(
         &self,
         on_acquired: impl FnOnce() -> RunResult<R>,
     ) -> Option<R> {
-        if self.0.compare_exchange(SCHEDULED, RUNNING, AcqRel, Acquire).is_err() {
+        if self.inner.compare_exchange(SCHEDULED, RUNNING, AcqRel, Acquire).is_err() {
             return None;
         }
         let RunResult { value, next } = on_acquired();
         match next {
-            NextState::Idle       => self.0.store(IDLE,      Release),
-            NextState::Reschedule => self.0.store(SCHEDULED, Release),
+            NextState::Idle       => self.inner.store(IDLE,      Release),
+            NextState::Reschedule => self.inner.store(SCHEDULED, Release),
         }
         Some(value)
     }
 }
+```
 
-// 呼び出し側: Tell, Don't Ask
-state.try_schedule(|| executor.enqueue(self));
+**この構造の利点**:
+- `MailboxStateInner` は `&mut self` で CQS を完全に満たし、純粋関数として単体テスト可能
+- `MailboxStateShared` は **Shared ラッパー規約** に準拠（命名 / API 形 / 内部可変性の根拠）
+- 「内部可変性は Shared ラッパーパターンが唯一の許容ケース」という規約と整合
+- 実装手段（ロック vs CAS）の選択は性能要件で決められ、API の形は同じ
+
+### bool 返却 vs クロージャ API の選択
+
+`MailboxStateInner::try_schedule(&mut self) -> bool` は **CQS違反**（Command + 値返却）。これは `Vec::pop` 同型の許容例外として認められる。
+
+ただし **共有経由で呼ばれる API（`MailboxStateShared`）はクロージャ版に統一すべき**：
+
+```rust
+// ❌ Shared ラッパー側に bool を漏らすと「ask-then-act」を誘発
+impl MailboxStateShared {
+    pub fn try_schedule(&self) -> bool { ... }  // 呼び側が if 分岐する設計に逆戻り
+}
+
+// ✅ クロージャ版で「Tell, Don't Ask」を強制
+impl MailboxStateShared {
+    pub fn try_schedule(&self, on_won: impl FnOnce()) { ... }
+}
 ```
 
 ### 設計原則として一般化
 
 > **CAS を含む並行プリミティブを設計する際は：**
 >
-> 1. **内部実装** では CQS を破るしかない（CAS の本質）
-> 2. **API 表面** ではクロージャパターンで違反を内部に閉じ込める
-> 3. **`Option<R>` の戻り値** は「成功時のみ値が存在する」という構造的表現で、`Vec::pop` と同型の許容例外
-> 4. **bool 戻り値の状態変更メソッドは設計途中の兆候** — クロージャ API への置換を検討する
+> 1. **2層構造** にする：純粋ロジック（`*Inner`、`&mut self`、CQS 純粋）+ Shared ラッパー（`*Shared`、`&self`、CAS 内部可変性）
+> 2. **内部ロジック** は `&mut self` で CQS を満たし、単体テスト可能にする
+> 3. **Shared ラッパー** は Shared ラッパーパターン規約に準拠（命名 / API 形）
+> 4. **API 表面** はクロージャベースで「Tell, Don't Ask」を強制する
+> 5. **`Option<R>` の戻り値** は `Vec::pop` 同型の許容例外
+> 6. **bool 戻り値の `&self` 状態変更メソッドは設計途中の兆候** — クロージャ API へ置換
 
 ### 既存規約との整合
 
 | 既存規約 | 本パターンとの整合 |
 |---|---|
+| **内部可変性は Shared ラッパーパターンが唯一の許容ケース**（`immutability-policy.md`） | `*Shared` + `*Inner` の2層構造で準拠。実装手段がロックから CAS に変わるだけ |
+| **`*Shared` 命名**（`naming-conventions.md`） | atomic-backed な共有型は必ず `*Shared` を付ける |
+| **`&mut self` 原則**（`cqs-principle.md`） | `*Inner` 側で完全に満たす。`*Shared` は Shared ラッパー規約の枠内で `&self` を許容 |
 | `SharedAccess::with_read` / `with_write` クロージャ API | `try_schedule(\|\| ...)` / `try_run(\|\| ...)` は同じ思想の atomic 版 |
 | ガード/ロックを外部に返さない | 排他権がクロージャ内に閉じる。外に漏れない |
-| CQS違反は人間許可で例外許容（`Vec::pop` 相当） | `try_run -> Option<R>` は `Vec::pop -> Option<T>` と同型 |
+| CQS違反は人間許可で例外許容（`Vec::pop` 相当） | `*Inner::try_*(&mut self) -> bool`、`*Shared::try_run -> Option<R>` ともに同型 |
 | Tell, Don't Ask | bool 返却して呼び側で分岐する代わりに、勝った場合の動作をクロージャで渡す |
 
 ## 適用するコンポーネントの優先順位
@@ -195,7 +271,7 @@ state.try_schedule(|| executor.enqueue(self));
 
 | コンポーネント | 推奨パターン | 優先度 |
 |---|---|---|
-| Mailbox 状態機械 | ④ Atomic state machine（`AtomicU8` + クロージャ API） | **最高** |
+| Mailbox 状態機械 | ④ Atomic state machine（`*Inner` + `*Shared` の2層構造、`AtomicU8` バック） | **最高** |
 | Mailbox メッセージキュー | ② Ownership transfer（lock-free MPSC） | **最高** |
 | ActorCell の排他制御 | ④ の CAS 勝者にのみ `&mut` を与える | **最高** |
 | Run-queue（scheduler） | std: tokio に委譲 / no_std: 自前 bounded ring | 高 |
@@ -214,9 +290,10 @@ state.try_schedule(|| executor.enqueue(self));
 Step 1. 現状の SharedLock 設計のままベンチを取る（基準線）
         → 効果測定の前提
 
-Step 2. Mailbox 状態機械を AtomicU8 + クロージャ API へ
+Step 2. Mailbox 状態機械を `*Inner` + `*Shared` の2層構造へ
+        → 純粋ロジック（&mut self）+ atomic-backed Shared ラッパー
         → unsafe ゼロ・依存ゼロ・最小リスク
-        → これだけで SharedLock<Mailbox> が消える
+        → これだけで SharedLock<Mailbox> が消え、規約とも整合
 
 Step 3. Mailbox queue を lock-free MPSC へ
         → unsafe を1ファイルに局所化、loom + miri で検証
@@ -310,7 +387,25 @@ fn init(&self) -> Result<(), E> {
 
 **修正**: コールドパスは `SharedLock` で素直に書く。
 
-### 5. unsafe を広範囲にばらまく
+### 5. 単層構造の atomic 型（Shared ラッパー規約を素通り）
+
+```rust
+// ❌ *Shared 命名でない / 純粋ロジック層が分離されていない
+//   → 内部可変性の根拠（Shared ラッパーパターン）に準拠していない
+pub struct MailboxState(AtomicU8);
+
+impl MailboxState {
+    pub fn try_schedule(&self) { /* &self で mutate */ }
+}
+```
+
+**修正**: 2層構造にする。
+- `MailboxStateInner`（`&mut self`、純粋ロジック、CQS純粋）
+- `MailboxStateShared`（`&self`、CAS、クロージャ API）
+
+これで内部可変性が Shared ラッパーパターン規約の枠内に収まる。
+
+### 6. unsafe を広範囲にばらまく
 
 ```rust
 // ❌ 公開関数が unsafe で、呼び出し側全てに契約が伝染


### PR DESCRIPTION
## 概要

#1739 で追加した `docs/guides/lock_free_design.md` に **CQS と内部可変性ポリシーの観点で重大な欠陥** があったため修正する。

レビュー指摘:
> CQS では、書き込みメソッドは `&mut self` や `mut self` であるべきですよね。なのにそれが無視されたガイドになってませんか

その通りで、ガイドが TOCTOU 軸（CAS の Q/C 分離不可能性）にしか触れておらず、`&mut self` vs `&self` 軸（内部可変性問題）を素通りしていた。

## 問題

提示していた設計例:

```rust
pub struct MailboxState(AtomicU8);

impl MailboxState {
    pub fn try_schedule(&self, on_won: impl FnOnce()) {
        if self.0.compare_exchange(IDLE, SCHEDULED, AcqRel, Acquire).is_ok() {
            on_won();
        }
    }
}
```

- `&self` で `AtomicU8` 経由の内部状態 mutation を行っている
- これは **内部可変性** であり、`.agents/rules/rust/immutability-policy.md` が定める
  「内部可変性は Shared ラッパーパターンが唯一の許容ケース」を素通りしている
- 命名・構造が `*Shared` 規約に準拠していない

## 修正内容

### 1. CQS との衝突を2軸で整理

| 次元 | 内容 | 解決 |
|---|---|---|
| **A** | TOCTOU 回避のため CAS が必要（Q/C 分離不可能） | `Vec::pop` 同型の許容例外として認める |
| **B** | `AtomicU*` 操作のシグネチャが `&self`（CQS の `&mut self` 原則と衝突） | atomic-backed 型を Shared ラッパーパターンの一実装として位置付ける |

### 2. atomic-backed Shared ラッパーの再定義

> `SharedLock<T>` がロックで内部可変性を提供するのに対し、
> `AtomicU*` バックの `*Shared` 型は CAS で内部可変性を提供する。
> **両者は規約上同じ地位**であり、命名・構造の規約も同じく適用される。

### 3. 正しい2層構造の提示

```rust
// === 1. 純粋ロジック（&mut self、CQS 純粋）===
pub struct MailboxStateInner { value: u8 }

impl MailboxStateInner {
    pub fn try_schedule(&mut self) -> bool { ... }
}

// === 2. Shared ラッパー（&self、CAS、Shared 規約準拠）===
pub struct MailboxStateShared { inner: AtomicU8 }

impl MailboxStateShared {
    pub fn try_schedule(&self, on_won: impl FnOnce()) {
        if self.inner.compare_exchange(IDLE, SCHEDULED, AcqRel, Acquire).is_ok() {
            on_won();
        }
    }
}
```

### 4. その他の整合修正

- アンチパターンに「単層構造の atomic 型（Shared 規約素通り）」を追加
- 既存規約整合表に `immutability-policy.md` / `naming-conventions.md` / `cqs-principle.md` の `&mut self` 原則を追加
- 適用優先順位と段階的移行アプローチを 2層構造前提に更新

## 影響範囲

- `docs/guides/lock_free_design.md` の修正のみ
- コード変更なし
- 既存規約の解釈を強化する内容で、規約自体の変更はない
- 修正前のガイドに従って書かれたコードは存在しない（ガイド自体が直近マージ）

## 確認事項

- [ ] 2層構造（`*Inner` + `*Shared`）の命名・責務分離方針で問題ないか
- [ ] atomic-backed 型を Shared ラッパーパターンの一実装と位置付ける解釈が、`immutability-policy.md` の意図と整合しているか
- [ ] ガイドの記述粒度・分量がプロジェクト方針と合うか

## 関連

- #1739 （修正対象のガイドを追加した PR）
- `.agents/rules/rust/immutability-policy.md`
- `.agents/rules/rust/cqs-principle.md`
- `.agents/rules/rust/naming-conventions.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_018VCCzbfniD4KNiDkxgVYnt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change, but it materially changes the recommended lock-free design pattern and naming/structure guidance; risk is limited to potential downstream confusion if reviewers disagree with the interpretation.
> 
> **Overview**
> Clarifies the lock-free guide’s CQS story by splitting the conflict into **(A) CAS is inherently check+act** (TOCTOU avoidance) and **(B) atomics mutate via `&self`**, then explicitly justifying (B) via the project’s *Shared wrapper pattern*.
> 
> Replaces the prior “single atomic wrapper type” example with a **two-layer pattern**: a `Copy` **pure value enum** that owns all transition rules (`self -> Option<Self>`) plus an atomic `*Shared` wrapper that applies those transitions via `fetch_update`, keeping internal mutability and naming (`*Shared`) compliant.
> 
> Expands the guide with decision guidance for cases that can’t be `enum`-encoded (RCU-style snapshots, sharding, field decomposition, direct counters, large state machines) and updates the migration steps, component priority table, and anti-pattern section accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1001b06001d9432badec809f8fd620f5e0a04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * ロックフリー設計ガイドを大幅拡充。設計パターン、実装戦略、アンチパターンに関する詳細な指針とコード例を追加し、より実践的な移行手順を提供しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1741)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->