### PR TITLE
feat(mailbox): introduce lock-free MPSC queue for unbounded user mail…

### DIFF
--- a/openspec/changes/lock-free-mailbox-user-queue/.openspec.yaml
+++ b/openspec/changes/lock-free-mailbox-user-queue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/lock-free-mailbox-user-queue/design.md
+++ b/openspec/changes/lock-free-mailbox-user-queue/design.md
@@ -1,0 +1,129 @@
+## Context
+
+現在の Mailbox scheduling state は `AtomicU32` / `AtomicBool` ベースで、実行権の獲得自体は lock-free に近い。一方で通常 user queue は `UnboundedMessageQueue` → `QueueStateHandle` → `SharedLock<QueueState<T>>` → `SyncQueueShared` → `SpinSyncMutex<SyncQueue<...>>` という経路を通り、さらに `Mailbox::enqueue_envelope` は close/cleanup race を避けるため通常 enqueue でも `put_lock` を取得している。
+
+このため、単に queue 内部を lock-free にしても `put_lock` が残る限り hot path の直列化は消えない。本 change では、通常 unbounded user queue に queue-local atomic close protocol を持たせ、通常 enqueue path から `put_lock` を外すところまでを同じ scope とする。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 通常 unbounded mailbox user queue の enqueue/dequeue hot path から shared lock を除去する。
+- 通常 enqueue path から `Mailbox::put_lock` を外し、close 後 enqueue rejection を queue-local atomic close protocol で保証する。
+- `MessageQueue` trait、`Envelope` payload、`Mailbox::run` の drain semantics は維持する。
+- unsafe は mailbox-local queue primitive に局所化し、公開 API は safe にする。
+- producer/consumer interleaving、drop safety、FIFO、exact-once delivery をテストで固定する。
+
+**Non-Goals:**
+
+- bounded queue の lock-free 化。
+- priority / stable-priority / control-aware queue の lock-free 化。
+- deque/prepend-capable queue の lock-free 化。
+- `SharedMessageQueue` / `BalancingDispatcher` の multi-consumer queue 置き換え。
+- `utils-core` への汎用 MPSC primitive 昇格。
+- ActorCell 排他制御や mailbox schedule state の構造整理。
+
+## Decisions
+
+### Decision 1: 初回スライスは mailbox-local primitive として実装する
+
+lock-free MPSC は汎用化できる可能性があるが、初回は `actor-core-kernel::dispatch::mailbox` 配下の mailbox-local primitive として実装する。
+
+理由:
+
+- close rejection と cleanup drain は Mailbox semantics と密接に結びついている。
+- unsafe の安全性契約を小さく保てる。
+- `utils-core` に昇格すると、汎用 API、feature/cfg、複数 consumer 誤用対策、error 型の安定化まで同時に設計する必要がある。
+
+代替案:
+
+- `utils-core` に最初から置く: 再利用性は高いが scope が広がり、Mailbox hot path 改善の着手が遅くなるため採用しない。
+
+### Decision 2: 対象は通常 unbounded FIFO queue のみ
+
+`UnboundedMessageQueue` を lock-free MPSC-backed に置き換える。bounded / deque / priority / control-aware queue は既存実装を維持する。
+
+理由:
+
+- 通常 unbounded FIFO は最も基本的な user queue で、overflow / priority / prepend の複合 semantics を持たない。
+- bounded overflow (`DropNewest` / `DropOldest`) や deque prepend は atomic queue だけでは完結せず、別の correctness problem になる。
+- `SharedMessageQueue` は multi-consumer 前提であり、MPSC の single-consumer 契約と一致しない。
+
+### Decision 3: close protocol は queue-local に持たせる
+
+通常 lock-free queue は `closed` flag と in-flight producer count を持つ。enqueue は producer guard を取得してから close を再確認し、close が勝った場合は push せずに `Closed` を返す。close/cleanup は `closed = true` を publish し、in-flight producer count が 0 になるまで待ってから drain する。
+
+概念的な流れ:
+
+```text
+offer(envelope)
+  if closed => Err(Closed)
+  producer_count += 1
+  if closed => producer_count -= 1; Err(Closed)
+  push node by CAS
+  len += 1
+  producer_count -= 1
+
+close_and_drain()
+  closed = true
+  wait producer_count == 0
+  drain pending/head lists
+```
+
+理由:
+
+- `put_lock` なしでも「cleanup が close を宣言した後に enqueue が成功して残る」race を防げる。
+- close は cold path なので、in-flight producer 待ちの spin は hot path に影響しない。
+- producer guard 取得後は allocation や user callback を行わず、panic による count leak を避ける。
+
+代替案:
+
+- `Mailbox::put_lock` を残す: correctness は簡単だが、lock-free queue を導入しても hot path の直列化が残るため採用しない。
+- close 後も push を許して cleanup が複数回 drain する: termination 境界が曖昧になり、post-close enqueue rejection contract と合わないため採用しない。
+
+### Decision 4: consumer 側の safety guard を持つ
+
+Mailbox state machine 上は通常 mailbox の runner は単一 consumer だが、`MessageQueue` trait は `&self` で `dequeue` を公開し、型だけでは concurrent dequeue を禁止できない。safe API で UB を起こさないため、primitive か wrapper は consumer-side guard を持ち、同時 dequeue / cleanup を直列化する。
+
+理由:
+
+- unsafe primitive の single-consumer 前提を safe trait の外へ漏らさない。
+- 通常運用では mailbox runner が単一 consumer なので、この guard は競合しない。
+
+### Decision 5: unsafe と検証の境界
+
+unsafe は node allocation / raw pointer link / `Box::from_raw` に限定する。各 unsafe block には SAFETY comment を付け、通常 unit/stress tests に加えて `miri` と `loom` の検証タスクを持つ。
+
+`loom` は atomic ordering と interleaving の検証に使う。`miri` は raw pointer ownership、double free、use-after-free、dangling pointer の検出に使う。
+
+## Risks / Trade-offs
+
+- [Risk] close protocol の producer count が漏れると cleanup が待ち続ける。  
+  Mitigation: producer guard は RAII で decrement し、guard 取得後に user code / allocation を実行しない。
+
+- [Risk] FIFO ordering が concurrent producer の CAS linearization とずれる。  
+  Mitigation: CAS 成功順を enqueue の linearization point とし、consumer は swapped list を reverse して処理する。producer ごとの FIFO と exact-once を stress/loom tests で固定する。
+
+- [Risk] `MessageQueue` trait の safe API と MPSC single-consumer 契約がずれる。  
+  Mitigation: consumer-side guard を置き、concurrent dequeue が UB にならない構造にする。
+
+- [Risk] bounded/deque/priority queue が残るため、すべての mailbox user queue から lock が消えるわけではない。  
+  Mitigation: 初回 scope を通常 unbounded FIFO に限定し、他 queue は別 change で扱う。
+
+- [Risk] `loom` の cfg/test wiring が過剰に複雑になる。  
+  Mitigation: primitive 専用の小さな model tests に限定し、production code に loom-specific abstraction を広く漏らさない。
+
+## Migration Plan
+
+1. lock-free queue primitive を mailbox-local module として追加する。
+2. `UnboundedMessageQueue` を新 primitive に差し替える。
+3. 通常 unbounded queue の enqueue/cleanup path から `put_lock` 依存を外す。
+4. 既存 mailbox tests を通し、close/rejection/drain behavior が変わっていないことを確認する。
+5. queue 専用 stress tests、`miri`、`loom` を追加して検証する。
+
+Rollback は `UnboundedMessageQueue` を既存 `QueueStateHandle` backing に戻し、通常 enqueue path の `put_lock` 分岐を復旧することで行う。
+
+## Open Questions
+
+- `loom` を Cargo dev-dependency として追加するか、既存の検証 tooling に隔離するか。
+- producer count の待機は単純 spin で十分か、cold path でも backoff helper を使うか。

--- a/openspec/changes/lock-free-mailbox-user-queue/proposal.md
+++ b/openspec/changes/lock-free-mailbox-user-queue/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Mailbox の scheduling はすでに atomic 化されているが、標準の user message queue は hot path の enqueue/dequeue を shared lock と `put_lock` 経由で直列化している。次の性能改善対象として、既存の mailbox drain / close / overflow semantics を維持したまま、通常 FIFO user queue を mailbox-owned な lock-free MPSC queue に置き換える。
+
+## What Changes
+
+- 通常 unbounded mailbox 用に lock-free MPSC-backed FIFO user queue を追加する。
+- 通常 `enqueue_envelope` path では user queue mutation を `Mailbox::put_lock` から外し、queue 側の atomic close protocol で close 後 enqueue を拒否する。
+- public な `MessageQueue` contract と `Envelope` payload contract は変更しない。
+- bounded / priority / control-aware / deque-prepend 対応 queue は初回スライスの対象外にする。
+- bounded / deque / priority など lock-backed queue では、既存の `Mailbox::put_lock` による close 直列化を維持する。
+- FIFO preservation、exact-once dequeue、cleanup/drop safety、producer/consumer race を検証する並行テストを追加する。
+- unsafe queue primitive の検証として `miri` と `loom` のタスクを追加する。
+
+## Capabilities
+
+### New Capabilities
+
+- `lock-free-mailbox-user-queue`: 通常 mailbox user queue の lock-free MPSC behavior、safety boundary、既存 mailbox semantics との互換を規定する。
+
+### Modified Capabilities
+
+- `mailbox-runnable-drain`: 既存の `Mailbox::run` drain behavior を維持したまま、標準の通常 user queue が lock-free MPSC 実装で backing され得ることを明確化する。
+- `mailbox-close-semantics`: 通常 lock-free user queue では `put_lock` ではなく queue-local atomic close protocol で close 後 enqueue を拒否することを明確化する。
+
+## Impact
+
+- 影響するコード:
+  - `modules/actor-core-kernel/src/dispatch/mailbox/unbounded_message_queue.rs`
+  - `modules/actor-core-kernel/src/dispatch/mailbox/mailbox_queue_handles.rs`
+  - `modules/actor-core-kernel/src/dispatch/mailbox/mailbox_queue_state.rs`
+  - `modules/actor-core-kernel/src/dispatch/mailbox/base.rs`
+  - `modules/actor-core-kernel/src/dispatch/mailbox/` 配下の新しい mailbox-local queue primitive module
+- 検証:
+  - 既存 mailbox tests は引き続き適用する。
+  - queue 専用の並行テストを追加する。
+  - raw pointer ownership safety を `miri` で検証する。
+  - producer/consumer interleaving を可能な範囲で `loom` model test により検証する。
+- 依存関係:
+  - runtime dependency は追加しない。
+  - `loom` は dev-only の検証依存として追加するか、既存 test tooling の範囲に隔離する。

--- a/openspec/changes/lock-free-mailbox-user-queue/specs/lock-free-mailbox-user-queue/spec.md
+++ b/openspec/changes/lock-free-mailbox-user-queue/specs/lock-free-mailbox-user-queue/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: 通常 unbounded user queue は lock-free MPSC hot path を提供する
+
+通常 unbounded mailbox の user queue は、複数 producer からの enqueue と単一 mailbox runner による dequeue を、user queue 内部の `SharedLock` / `SharedRwLock` / mutex に依存せずに実行しなければならない (MUST)。この queue は `MessageQueue` trait と `Envelope` payload contract を維持しなければならない (MUST)。
+
+#### Scenario: 通常 unbounded mailbox は lock-free queue を使う
+- **WHEN** `MailboxPolicy::unbounded(None)` から通常 mailbox の user queue を作成する
+- **THEN** 作成される user queue は lock-free MPSC-backed FIFO queue である
+- **AND** enqueue / dequeue hot path は user queue 内部の `SharedLock` / `SharedRwLock` / mutex を取得しない
+
+#### Scenario: lock-free 化対象外の queue は既存 semantics を維持する
+- **WHEN** bounded / priority / stable-priority / control-aware / deque-prepend capable queue を作成する
+- **THEN** それらの queue は本 change で lock-free MPSC queue に置き換えてはならない (MUST NOT)
+- **AND** 既存の overflow / priority / control-aware / prepend semantics を維持しなければならない (MUST)
+
+### Requirement: lock-free user queue は FIFO と exact-once dequeue を保証する
+
+lock-free user queue は、enqueue に成功した `Envelope` を最大 1 回だけ dequeue しなければならない (MUST)。同一 producer が enqueue した envelopes は、producer 内の enqueue 成功順で dequeue されなければならない (MUST)。
+
+#### Scenario: single producer の FIFO が維持される
+- **WHEN** 1 producer が複数の envelopes を順番に enqueue する
+- **AND** mailbox runner が queue を drain する
+- **THEN** dequeue される envelopes は enqueue 成功順と同じ順序である
+- **AND** 各 envelope は 1 回だけ dequeue される
+
+#### Scenario: multiple producers の envelopes が loss/duplicate しない
+- **WHEN** 複数 producer が並行して envelopes を enqueue する
+- **AND** mailbox runner が queue を drain する
+- **THEN** enqueue に成功したすべての envelopes が 1 回だけ dequeue される
+- **AND** 同一 producer 内の envelopes は producer 内の enqueue 成功順を維持する
+
+### Requirement: lock-free user queue は queue-local atomic close protocol を持つ
+
+lock-free user queue は queue-local な atomic close protocol を持ち、close が publish された後の enqueue を拒否しなければならない (MUST)。close/cleanup は in-flight producer が完了するまで待ってから残留 envelopes を drain しなければならない (MUST)。
+
+#### Scenario: close 後 enqueue は Closed を返す
+- **WHEN** lock-free user queue を close する
+- **AND** その後 producer が envelope を enqueue する
+- **THEN** enqueue は `Closed` 相当の error を返す
+- **AND** envelope は queue に残ってはならない (MUST NOT)
+
+#### Scenario: close と競合した in-flight enqueue は lost message を作らない
+- **WHEN** producer が enqueue protocol に入った後に close が publish される
+- **THEN** producer は close を観測して enqueue を拒否するか、enqueue 成功済み envelope として cleanup drain に観測されなければならない (MUST)
+- **AND** cleanup 完了後に queue 内へ envelope が残ってはならない (MUST NOT)
+
+### Requirement: unsafe は lock-free queue primitive 内に局所化される
+
+lock-free user queue の unsafe code は queue primitive module 内に局所化され、public API は safe Rust API として提供されなければならない (MUST)。raw pointer ownership と atomic interleaving は `miri` および `loom` で検証可能でなければならない (MUST)。
+
+#### Scenario: unsafe block は primitive module の外に漏れない
+- **WHEN** lock-free user queue の実装を確認する
+- **THEN** raw pointer dereference / `Box::from_raw` / node unlink に関する unsafe block は queue primitive module 内に限られる
+- **AND** `MessageQueue` 実装や mailbox call site は unsafe を直接呼び出してはならない (MUST NOT)
+
+#### Scenario: verification task が primitive を検証する
+- **WHEN** lock-free user queue の検証タスクを実行する
+- **THEN** raw pointer ownership safety は `miri` で検証される
+- **AND** producer/consumer interleaving は `loom` model test で検証される

--- a/openspec/changes/lock-free-mailbox-user-queue/specs/mailbox-close-semantics/spec.md
+++ b/openspec/changes/lock-free-mailbox-user-queue/specs/mailbox-close-semantics/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Mailbox cleanup SHALL serialize close with mailbox-owned user queue mutation
+
+`Mailbox::become_closed_and_clean_up` は、mailbox-owned な lock-backed user queue mutation (`enqueue_envelope`, `enqueue_user`, `prepend_user_messages`) と close を直列化するために、**`user_queue_lock` / `put_lock` を取得してから `state.close()` 相当の close request を publish しなければならない**（MUST）。
+
+通常 lock-free user queue の場合、`Mailbox::become_closed_and_clean_up` は `user_queue_lock` / `put_lock` ではなく queue-local atomic close protocol によって enqueue と close を直列化しなければならない（MUST）。この場合、close request を publish した後、in-flight producer が完了するまで待ち、残留 user queue を drain / `clean_up()` しなければならない（MUST）。
+
+同じ close/cleanup protocol の中で以下を完了しなければならない（MUST）:
+
+- close request の publish
+- 必要なら user queue の drain
+- `self.user.clean_up()`
+
+これにより、cleanup が close を宣言した mailbox に対して、待機中または in-flight の producer / unstash 側が cleanup 完了後に queue mutation を完了してしまう race を防ぐ。
+
+#### Scenario: lock-backed queue cleanup closes under user_queue_lock
+- **WHEN** lock-backed user queue を持つ mailbox の cleanup 実装を確認する
+- **THEN** `user_queue_lock` / `put_lock` の取得が close request publish より前にある
+- **AND** close request publish の後に実行される user queue の drain / `clean_up()` は同じ lock 区間に含まれる
+
+#### Scenario: lock-free queue cleanup closes with queue-local protocol
+- **WHEN** lock-free user queue を持つ mailbox の cleanup 実装を確認する
+- **THEN** cleanup は通常 enqueue path の `user_queue_lock` / `put_lock` 取得に依存してはならない（MUST NOT）
+- **AND** queue-local atomic close protocol が close request を publish する
+- **AND** in-flight producer 完了後に残留 user queue の drain / `clean_up()` を行う
+
+### Requirement: enqueue_envelope SHALL re-check closed state after acquiring user_queue_lock
+
+`Mailbox::enqueue_envelope` は、lock-backed user queue に対しては fast path の `is_closed()` / `is_suspended()` check に加えて、**`user_queue_lock` / `put_lock` 取得後に `is_closed()` を再 check** しなければならない（MUST）。
+
+通常 lock-free user queue に対しては、`Mailbox::enqueue_envelope` は通常 enqueue path で `user_queue_lock` / `put_lock` を取得してはならない（MUST NOT）。代わりに、lock-free user queue の atomic close protocol が close 後 enqueue を拒否しなければならない（MUST）。
+
+lock-backed queue の lock 内再 check が true の場合、メソッドは `Err(SendError::Closed(envelope.into_payload()))` を返さなければならない（MUST）。`self.user.enqueue(envelope)` は実行してはならない（MUST NOT）。
+
+lock-free queue の atomic close protocol が close を観測した場合、メソッドは `Err(SendError::Closed(envelope.into_payload()))` 相当を返さなければならない（MUST）。envelope は cleanup 完了後の queue に残ってはならない（MUST NOT）。
+
+#### Scenario: Sequential enqueue after close returns Closed
+- **WHEN** mailbox を作成し `become_closed_and_clean_up()` を呼ぶ
+- **AND** `enqueue_envelope(Envelope::new(AnyMessage::new("msg")))` を呼ぶ
+- **THEN** 結果は `Err(SendError::Closed(_))` である
+
+#### Scenario: In-flight enqueue is rejected after cleanup wins the lock race
+- **WHEN** lock-backed queue の producer が fast path を通過した後、cleanup 側が `user_queue_lock` / `put_lock` を取得して close request と queue cleanup を完了する
+- **AND** その後 producer が `user_queue_lock` / `put_lock` を取得する
+- **THEN** producer は lock 内の `is_closed()` 再 check で `Err(SendError::Closed(_))` を返す
+- **AND** `self.user.enqueue(envelope)` は呼ばれない
+
+#### Scenario: In-flight lock-free enqueue is rejected or drained after cleanup wins close
+- **WHEN** lock-free queue の producer が enqueue protocol に入った後、cleanup 側が queue-local close protocol を publish する
+- **THEN** producer は `Err(SendError::Closed(_))` を返すか、enqueue 成功済み envelope として cleanup drain に観測される
+- **AND** cleanup 完了後にその envelope が user queue 内へ残ってはならない（MUST NOT）

--- a/openspec/changes/lock-free-mailbox-user-queue/specs/mailbox-runnable-drain/spec.md
+++ b/openspec/changes/lock-free-mailbox-user-queue/specs/mailbox-runnable-drain/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Mailbox::run は lock-free user queue backing でも既存 drain semantics を維持する
+
+`Mailbox::run` は、通常 user queue の backing が lock-free MPSC queue に変わっても、既存の system-first drain、user throughput limit、throughput deadline、suspend gating、post-drain reschedule semantics を維持しなければならない (MUST)。
+
+#### Scenario: lock-free backing でも system messages が先に drain される
+- **WHEN** mailbox が lock-free user queue を持つ
+- **AND** system messages と user envelopes の両方が queued されている
+- **THEN** `Mailbox::run(throughput, throughput_deadline)` は user envelopes より先に system messages を drain しなければならない (MUST)
+- **AND** user envelopes は既存どおり throughput / deadline / suspension に従って処理されなければならない (MUST)
+
+#### Scenario: lock-free backing でも post-drain reschedule が維持される
+- **WHEN** `Mailbox::run` 中に producer が lock-free user queue へ enqueue する
+- **AND** enqueue が mailbox running state と競合する
+- **THEN** drain 完了後に pending reschedule または queue 残量が観測され、dispatcher は既存どおり mailbox を再 schedule できなければならない (MUST)

--- a/openspec/changes/lock-free-mailbox-user-queue/tasks.md
+++ b/openspec/changes/lock-free-mailbox-user-queue/tasks.md
@@ -1,0 +1,31 @@
+## 1. 現状固定と設計確認
+
+- [ ] 1.1 `UnboundedMessageQueue` / `QueueStateHandle` / `Mailbox::enqueue_envelope` の現行 lock 経路をテストまたはコードコメントで確認する
+- [ ] 1.2 通常 unbounded queue、bounded queue、deque queue、priority queue の選択経路を確認し、初回 scope が通常 unbounded queue のみであることを固定する
+- [ ] 1.3 close 後 enqueue rejection、in-flight enqueue vs cleanup、post-drain reschedule の既存テストを確認し、不足分を regression test として追加する
+
+## 2. Lock-free Queue Primitive
+
+- [ ] 2.1 mailbox-local module として lock-free MPSC queue primitive を追加する
+- [ ] 2.2 producer guard を RAII 化し、close protocol 中に in-flight producer count が漏れないようにする
+- [ ] 2.3 queue-local atomic close protocol を実装し、close 後 enqueue が `Closed` 相当を返すようにする
+- [ ] 2.4 consumer-side guard を実装し、`MessageQueue` の safe `&self` API から concurrent dequeue されても UB が起きないようにする
+- [ ] 2.5 raw pointer / node ownership に関する unsafe block を primitive module 内に局所化し、各 unsafe block に SAFETY comment を付ける
+
+## 3. Mailbox Integration
+
+- [ ] 3.1 `UnboundedMessageQueue` を lock-free MPSC primitive backing に差し替える
+- [ ] 3.2 通常 unbounded queue の `enqueue_envelope` path から `put_lock` 取得を外す
+- [ ] 3.3 lock-backed queue では既存の `put_lock` close serialization を維持する
+- [ ] 3.4 `clean_up` / `become_closed` 経路で lock-free queue の close-and-drain protocol を呼ぶ
+- [ ] 3.5 `Mailbox::run` の system-first drain、throughput、deadline、suspend、post-drain reschedule semantics が変わっていないことを確認する
+
+## 4. Verification
+
+- [ ] 4.1 lock-free queue の FIFO / exact-once / close rejection / cleanup drain unit tests を追加する
+- [ ] 4.2 複数 producer と mailbox runner 相当 consumer の stress test を追加する
+- [ ] 4.3 `loom` model test の配置と dev-dependency/cfg 方針を決め、producer/consumer interleaving を検証する
+- [ ] 4.4 `miri` で primitive の raw pointer ownership safety を検証できるテストを追加する
+- [ ] 4.5 `cargo test -p fraktor-actor-core-kernel-rs dispatch::mailbox` を通す
+- [ ] 4.6 `cargo clippy -p fraktor-actor-core-kernel-rs --all-targets --all-features -- -D warnings` を通す
+- [ ] 4.7 OpenSpec validation を通す


### PR DESCRIPTION
…boxes

Define a lock-free MPSC queue primitive for standard unbounded user mailboxes, replacing `put_lock`-backed serialization with a queue-local atomic close protocol. Enhance performance by eliminating shared locking in the enqueue/dequeue hot path. Maintain existing mailbox drain, close, and rejection semantics. Add specs, verification tasks (`miri`, `loom`), and tests to validate FIFO, exact-once guarantees, and race conditions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenSpec change with no runtime code modifications; low risk aside from potential misalignment with future implementation work.
> 
> **Overview**
> Adds a new OpenSpec change set defining the proposed **lock-free MPSC-backed unbounded mailbox user queue** and its queue-local atomic close/cleanup protocol, including FIFO/exact-once requirements and verification expectations (`miri`/`loom`).
> 
> Updates mailbox close/drain specifications to explicitly distinguish *lock-backed* (`put_lock`-serialized) queues from the new *lock-free* queue behavior, and includes a design doc and implementation/verification task checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7d2cc638644aad32b6f3f2831fbf5ace75ed79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->