### PR TITLE
[codex] Fix ci-check unit sleep exclude

### DIFF
--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1400,7 +1400,7 @@ check_unit_sleep() {
     --glob '!modules/cluster-adaptor-std/src/tokio_gossip_transport/**'
     --glob '!modules/actor-core-kernel/src/core/kernel/system/coordinated_shutdown/tests.rs'
     --glob '!modules/actor-core-kernel/src/core/kernel/dispatch/dispatcher/tests.rs'
-    --glob '!modules/actor-core-kernel/src/core/kernel/actor/scheduler/tick_driver/tests/test_tick_driver.rs'
+    --glob '!modules/actor-core-kernel/src/actor/scheduler/tick_driver/tests/test_tick_driver.rs'
   )
 
   local violations=""


### PR DESCRIPTION
## Summary

- Fix the stale `check-unit-sleep` allowlist path for the tick driver tests.
- Keep the real-time sleep exception scoped to the current `actor/scheduler/tick_driver` test path.

## Root Cause

`scripts/ci-check.sh all` failed in Phase 1 because the allowlist still referenced the old `src/core/kernel/actor/...` location after the test moved to `src/actor/...`.

## Validation

- `scripts/ci-check.sh check-unit-sleep`
- `scripts/ci-check.sh all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to CI grep exclusion paths that only affects the `check-unit-sleep` gate and should reduce false failures.
> 
> **Overview**
> Fixes the `check-unit-sleep` CI gate by updating the allowlisted exclusion for the tick driver test file to its new location (`modules/actor-core-kernel/src/actor/scheduler/tick_driver/tests/test_tick_driver.rs`), preventing the sleep/timeout scan from flagging that moved test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4eedd9623c1135313e2cc5317c8b4f6d47b59b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI スキャン設定を更新し、テスト実行時の除外パス設定を改善しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1743)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->