### PR TITLE
Add lock-free mailbox user queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ libraries = [
 
 [workspace.lints.rust]
 unused_must_use = "deny"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fraktor_disable_tell)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fraktor_disable_tell)', 'cfg(loom)'] }
 
 [workspace.lints.clippy]
 let_underscore_must_use = "deny"
@@ -108,6 +108,7 @@ erased-serde = { version = "0.4", default-features = false, features = ["alloc"]
 bincode = { version = "2.0.1", default-features = false, features = ["alloc", "serde"] }
 bytes = { version = "1.7", default-features = false }
 libm = { version = "0.2", default-features = false }
+loom = "0.7"
 spin = { version = "0.10", default-features = false }
 static_assertions = "1.1.0"
 static_cell = "2"

--- a/modules/actor-core-kernel/Cargo.toml
+++ b/modules/actor-core-kernel/Cargo.toml
@@ -37,6 +37,9 @@ bincode = { workspace = true }
 futures = { workspace = true, features = ["alloc"] }
 tracing = { workspace = true, default-features = false }
 
+[target.'cfg(loom)'.dependencies]
+loom = { workspace = true }
+
 [dev-dependencies]
 criterion = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "test-util"] }
@@ -47,6 +50,7 @@ tracing = { workspace = true, features = ["std"] }
 fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 fraktor-utils-adaptor-std-rs = { workspace = true }
 fraktor-utils-core-rs = { workspace = true, features = ["debug-locks"] }
+loom = { workspace = true }
 
 [[test]]
 name = "actor_path_e2e"

--- a/modules/actor-core-kernel/src/dispatch/mailbox.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox.rs
@@ -41,6 +41,7 @@ mod drop_oldest_outcome;
 mod enqueue_error;
 mod enqueue_outcome;
 mod envelope;
+mod lock_free_mpsc_queue;
 mod mailbox_cleanup_policy;
 /// Monotonic clock callback type for throughput deadline enforcement.
 mod mailbox_clock;

--- a/modules/actor-core-kernel/src/dispatch/mailbox/base.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/base.rs
@@ -557,6 +557,11 @@ impl Mailbox {
   /// accepts the envelope so that suspended actors still buffer inbound
   /// messages and observe them once resumed.
   ///
+  /// Lock-backed user queues still use `put_lock` for the authoritative close
+  /// re-check. The standard unbounded user queue uses its queue-local atomic
+  /// close protocol instead, so its enqueue hot path does not acquire
+  /// `put_lock`.
+  ///
   /// # Errors
   ///
   /// Returns an error only for true enqueue failures (the mailbox is closed,
@@ -573,7 +578,11 @@ impl Mailbox {
     if self.is_closed() {
       return Err(SendError::closed(envelope.into_payload()));
     }
-    self.enqueue_envelope_locked(envelope)
+    if self.user.requires_put_lock_for_enqueue() {
+      self.enqueue_envelope_locked(envelope)
+    } else {
+      self.enqueue_envelope_unlocked(envelope)
+    }
   }
 
   /// Locked critical section of [`Self::enqueue_envelope`].
@@ -594,6 +603,15 @@ impl Mailbox {
       self.user.enqueue(envelope)
     });
 
+    self.complete_enqueue(enqueue_result)
+  }
+
+  fn enqueue_envelope_unlocked(&self, envelope: Envelope) -> Result<(), SendError> {
+    let enqueue_result = self.user.enqueue(envelope);
+    self.complete_enqueue(enqueue_result)
+  }
+
+  fn complete_enqueue(&self, enqueue_result: Result<EnqueueOutcome, EnqueueError>) -> Result<(), SendError> {
     match enqueue_result {
       | Ok(EnqueueOutcome::Accepted) => {
         self.publish_metrics();
@@ -809,6 +827,7 @@ impl Mailbox {
     let pid = self.pid();
     let system_state = self.system_state();
     let user_len_after_cleanup = self.put_lock.with_lock(|_| {
+      self.user.close_for_cleanup();
       // MB-H2 (Pekko parity): `Mailbox.cleanUp()` は user queue のクリーンアップ方針とは無関係に
       // system queue を必ず DeadLetters へ drain する。各 mailbox は自身専用の `SystemQueue` を
       // 所有しており共有されないため、`LeaveSharedQueue` であっても pending な

--- a/modules/actor-core-kernel/src/dispatch/mailbox/base/tests.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/base/tests.rs
@@ -984,6 +984,43 @@ fn mailbox_prepend_user_messages_deque_returns_closed_after_mailbox_close() {
   assert!(matches!(result, Err(SendError::Closed(_))), "expected Closed, got {result:?}");
 }
 
+#[test]
+fn unbounded_enqueue_does_not_wait_for_put_lock() {
+  use std::{
+    sync::{Arc, mpsc},
+    thread,
+    time::Duration,
+  };
+
+  let mailbox = Arc::new(Mailbox::new(MailboxPolicy::unbounded(None)));
+  let (lock_held_tx, lock_held_rx) = mpsc::channel();
+  let (release_lock_tx, release_lock_rx) = mpsc::channel();
+  let mailbox_for_lock = Arc::clone(&mailbox);
+  let lock_handle = thread::spawn(move || {
+    mailbox_for_lock.put_lock.with_lock(|_| {
+      lock_held_tx.send(()).expect("lock signal should be sent");
+      release_lock_rx.recv().expect("release signal should be received");
+    });
+  });
+  lock_held_rx.recv().expect("lock holder should start");
+
+  let mailbox_for_enqueue = Arc::clone(&mailbox);
+  let (result_tx, result_rx) = mpsc::channel();
+  let enqueue_handle = thread::spawn(move || {
+    let result = mailbox_for_enqueue.enqueue_user(AnyMessage::new("lock-free"));
+    result_tx.send(result).expect("enqueue result should be sent");
+  });
+
+  let result =
+    result_rx.recv_timeout(Duration::from_millis(200)).expect("unbounded enqueue must not wait for put_lock");
+  assert!(result.is_ok(), "unbounded enqueue must succeed while put_lock is held: {result:?}");
+
+  release_lock_tx.send(()).expect("release signal should be sent");
+  enqueue_handle.join().expect("enqueue thread should finish");
+  lock_handle.join().expect("lock holder should finish");
+  assert_eq!(mailbox.user_len(), 1);
+}
+
 /// Regression for the "cleanup wins the lock race" scenario: a producer
 /// that has already passed the fast path and is executing the locked
 /// critical section must observe the authoritative `is_closed()` re-check
@@ -994,14 +1031,16 @@ fn mailbox_prepend_user_messages_deque_returns_closed_after_mailbox_close() {
 /// while still holding the lock. Once the lock is released, the producer must
 /// observe the under-lock `is_closed()` re-check and fail with `Closed`.
 #[test]
-fn cleanup_close_wins_against_inflight_enqueue() {
+fn lock_backed_cleanup_close_wins_against_inflight_enqueue() {
+  use core::num::NonZeroUsize;
   use std::{
     sync::{Arc, mpsc},
     thread,
     time::Duration,
   };
 
-  let mailbox = Arc::new(Mailbox::new(MailboxPolicy::unbounded(None)));
+  let capacity = NonZeroUsize::new(8).expect("capacity");
+  let mailbox = Arc::new(Mailbox::new(MailboxPolicy::bounded(capacity, MailboxOverflowStrategy::DropNewest, None)));
   let (lock_held_tx, lock_held_rx) = mpsc::channel();
   let (release_lock_tx, release_lock_rx) = mpsc::channel();
   let mailbox_for_lock = Arc::clone(&mailbox);
@@ -1039,7 +1078,55 @@ fn cleanup_close_wins_against_inflight_enqueue() {
   assert_eq!(mailbox.user_len(), 0, "no phantom message should be in the queue");
 }
 
-/// Same invariant as [`cleanup_close_wins_against_inflight_enqueue`] but
+#[test]
+fn unbounded_cleanup_close_race_leaves_no_user_messages() {
+  use std::{
+    sync::{
+      Arc, Barrier,
+      atomic::{AtomicUsize, Ordering},
+    },
+    thread,
+  };
+
+  const PRODUCERS: usize = 4;
+  const ITEMS_PER_PRODUCER: usize = 500;
+
+  let mailbox = Arc::new(Mailbox::new(MailboxPolicy::unbounded(None)));
+  let barrier = Arc::new(Barrier::new(PRODUCERS + 1));
+  let producers_started = Arc::new(AtomicUsize::new(0));
+  let mut handles = Vec::new();
+  for producer in 0..PRODUCERS {
+    let mailbox_for_enqueue = Arc::clone(&mailbox);
+    let barrier_for_enqueue = Arc::clone(&barrier);
+    let producers_started_for_enqueue = Arc::clone(&producers_started);
+    handles.push(thread::spawn(move || {
+      barrier_for_enqueue.wait();
+      producers_started_for_enqueue.fetch_add(1, Ordering::SeqCst);
+      let base = producer * ITEMS_PER_PRODUCER;
+      for seq in 0..ITEMS_PER_PRODUCER {
+        if mailbox_for_enqueue.enqueue_user(AnyMessage::new(base + seq)).is_err() {
+          break;
+        }
+      }
+    }));
+  }
+
+  barrier.wait();
+  while producers_started.load(Ordering::SeqCst) == 0 {
+    thread::yield_now();
+  }
+  mailbox.become_closed();
+
+  for handle in handles {
+    handle.join().expect("producer should finish");
+  }
+
+  assert_eq!(mailbox.user_len(), 0, "cleanup must not leave lock-free user messages behind");
+  let result = mailbox.enqueue_user(AnyMessage::new("after-close"));
+  assert!(matches!(result, Err(SendError::Closed(_))), "post-close enqueue must be rejected: {result:?}");
+}
+
+/// Same invariant as [`lock_backed_cleanup_close_wins_against_inflight_enqueue`] but
 /// exercising the deque-only prepend path used by
 /// `ActorCell::unstash_*`.
 #[test]

--- a/modules/actor-core-kernel/src/dispatch/mailbox/lock_free_mpsc_queue.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/lock_free_mpsc_queue.rs
@@ -1,0 +1,239 @@
+//! Mailbox-local lock-free MPSC queue primitive.
+
+#[cfg(test)]
+mod tests;
+
+use alloc::boxed::Box;
+#[cfg(not(loom))]
+use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+use core::{marker::PhantomData, ptr};
+
+#[cfg(loom)]
+use loom::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
+
+struct Node<T> {
+  message: T,
+  next:    *mut Node<T>,
+}
+
+impl<T> Node<T> {
+  fn new(message: T) -> *mut Self {
+    Box::into_raw(Box::new(Self { message, next: ptr::null_mut() }))
+  }
+}
+
+/// Lock-free MPSC queue used by the standard unbounded mailbox user queue.
+pub(crate) struct LockFreeMpscQueue<T> {
+  head:            AtomicPtr<Node<T>>,
+  pending:         AtomicPtr<Node<T>>,
+  len:             AtomicUsize,
+  in_flight:       AtomicUsize,
+  closed:          AtomicBool,
+  consumer_active: AtomicBool,
+  _marker:         PhantomData<T>,
+}
+
+// SAFETY: the queue transfers owned `T` values between producer threads and the
+// consumer without exposing shared references to `T`; requiring `T: Send` is
+// sufficient for both moving the queue and sharing queue references.
+unsafe impl<T: Send> Send for LockFreeMpscQueue<T> {}
+unsafe impl<T: Send> Sync for LockFreeMpscQueue<T> {}
+
+impl<T> Default for LockFreeMpscQueue<T> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<T> LockFreeMpscQueue<T> {
+  /// Creates an empty queue.
+  #[must_use]
+  #[cfg(not(loom))]
+  pub(crate) const fn new() -> Self {
+    Self {
+      head:            AtomicPtr::new(ptr::null_mut()),
+      pending:         AtomicPtr::new(ptr::null_mut()),
+      len:             AtomicUsize::new(0),
+      in_flight:       AtomicUsize::new(0),
+      closed:          AtomicBool::new(false),
+      consumer_active: AtomicBool::new(false),
+      _marker:         PhantomData,
+    }
+  }
+
+  /// Creates an empty queue.
+  #[must_use]
+  #[cfg(loom)]
+  pub(crate) fn new() -> Self {
+    Self {
+      head:            AtomicPtr::new(ptr::null_mut()),
+      pending:         AtomicPtr::new(ptr::null_mut()),
+      len:             AtomicUsize::new(0),
+      in_flight:       AtomicUsize::new(0),
+      closed:          AtomicBool::new(false),
+      consumer_active: AtomicBool::new(false),
+      _marker:         PhantomData,
+    }
+  }
+
+  /// Pushes an item unless the queue-local close protocol has closed the queue.
+  pub(crate) fn push(&self, message: T) -> Result<(), T> {
+    let Some(_guard) = self.enter_producer() else {
+      return Err(message);
+    };
+
+    let node = Node::new(message);
+    self.len.fetch_add(1, Ordering::Release);
+    loop {
+      let current_head = self.head.load(Ordering::Acquire);
+      // SAFETY: `node` is uniquely owned by this producer until the compare-exchange succeeds.
+      // Updating its next pointer does not touch any node reachable from the queue.
+      unsafe {
+        (*node).next = current_head;
+      }
+      if self.head.compare_exchange(current_head, node, Ordering::AcqRel, Ordering::Acquire).is_ok() {
+        return Ok(());
+      }
+    }
+  }
+
+  /// Pops one item in FIFO order.
+  #[must_use]
+  pub(crate) fn pop(&self) -> Option<T> {
+    let _guard = self.enter_consumer();
+    self.pop_with_consumer_held()
+  }
+
+  /// Publishes close and waits for every producer that entered the protocol.
+  pub(crate) fn close(&self) {
+    self.closed.store(true, Ordering::SeqCst);
+    while self.in_flight.load(Ordering::SeqCst) != 0 {
+      spin_loop();
+    }
+  }
+
+  /// Closes the queue and drops all queued items.
+  pub(crate) fn close_and_drain(&self) {
+    self.close();
+    let _guard = self.enter_consumer();
+    while self.pop_with_consumer_held().is_some() {}
+  }
+
+  /// Returns the current queue length.
+  #[must_use]
+  pub(crate) fn len(&self) -> usize {
+    self.len.load(Ordering::Acquire)
+  }
+
+  fn enter_producer(&self) -> Option<ProducerGuard<'_>> {
+    self.in_flight.fetch_add(1, Ordering::SeqCst);
+    if self.closed.load(Ordering::SeqCst) {
+      self.in_flight.fetch_sub(1, Ordering::SeqCst);
+      None
+    } else {
+      Some(ProducerGuard { in_flight: &self.in_flight })
+    }
+  }
+
+  fn enter_consumer(&self) -> ConsumerGuard<'_> {
+    while self.consumer_active.compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed).is_err() {
+      spin_loop();
+    }
+    ConsumerGuard { consumer_active: &self.consumer_active }
+  }
+
+  fn pop_with_consumer_held(&self) -> Option<T> {
+    let pending = self.pending.load(Ordering::Acquire);
+    if !pending.is_null() {
+      return Some(self.pop_pending_node(pending));
+    }
+
+    let head = self.head.swap(ptr::null_mut(), Ordering::AcqRel);
+    if head.is_null() {
+      return None;
+    }
+
+    self.pending.store(Self::reverse_list(head), Ordering::Release);
+    let pending = self.pending.load(Ordering::Acquire);
+    if pending.is_null() { None } else { Some(self.pop_pending_node(pending)) }
+  }
+
+  fn pop_pending_node(&self, node_ptr: *mut Node<T>) -> T {
+    // SAFETY: the consumer guard gives this method exclusive access to `pending`.
+    // `node_ptr` was read from `pending`, which only contains nodes allocated by `Node::new`.
+    let node = unsafe { Box::from_raw(node_ptr) };
+    let Node { message, next } = *node;
+    self.pending.store(next, Ordering::Release);
+    self.len.fetch_sub(1, Ordering::Release);
+    message
+  }
+
+  fn reverse_list(mut head: *mut Node<T>) -> *mut Node<T> {
+    let mut prev = ptr::null_mut();
+    while !head.is_null() {
+      // SAFETY: `head` is part of the chain just removed from `self.head`.
+      // The consumer owns this detached chain while reversing it.
+      let next = unsafe { (*head).next };
+      // SAFETY: the detached chain is exclusively owned by this consumer.
+      unsafe {
+        (*head).next = prev;
+      }
+      prev = head;
+      head = next;
+    }
+    prev
+  }
+
+  unsafe fn free_chain(mut head: *mut Node<T>) {
+    while !head.is_null() {
+      // SAFETY: `head` is a valid node in a chain allocated by `Node::new`.
+      let next = unsafe { (*head).next };
+      // SAFETY: each node in the chain is visited once, so ownership is restored once.
+      drop(unsafe { Box::from_raw(head) });
+      head = next;
+    }
+  }
+}
+
+impl<T> Drop for LockFreeMpscQueue<T> {
+  fn drop(&mut self) {
+    let head = self.head.swap(ptr::null_mut(), Ordering::Relaxed);
+    let pending = self.pending.swap(ptr::null_mut(), Ordering::Relaxed);
+    // SAFETY: `drop` has exclusive access to the queue, so no producer or consumer can
+    // concurrently mutate the detached chains.
+    unsafe {
+      Self::free_chain(head);
+      Self::free_chain(pending);
+    }
+  }
+}
+
+#[cfg(loom)]
+fn spin_loop() {
+  loom::sync::atomic::spin_loop_hint();
+}
+
+#[cfg(not(loom))]
+fn spin_loop() {
+  core::hint::spin_loop();
+}
+
+struct ProducerGuard<'a> {
+  in_flight: &'a AtomicUsize,
+}
+
+impl Drop for ProducerGuard<'_> {
+  fn drop(&mut self) {
+    self.in_flight.fetch_sub(1, Ordering::SeqCst);
+  }
+}
+
+struct ConsumerGuard<'a> {
+  consumer_active: &'a AtomicBool,
+}
+
+impl Drop for ConsumerGuard<'_> {
+  fn drop(&mut self) {
+    self.consumer_active.store(false, Ordering::Release);
+  }
+}

--- a/modules/actor-core-kernel/src/dispatch/mailbox/lock_free_mpsc_queue/tests.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/lock_free_mpsc_queue/tests.rs
@@ -1,0 +1,288 @@
+use alloc::{vec, vec::Vec};
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use crate::dispatch::mailbox::lock_free_mpsc_queue::LockFreeMpscQueue;
+
+#[test]
+fn default_constructs_empty_queue() {
+  let queue = LockFreeMpscQueue::<u32>::default();
+
+  assert_eq!(queue.len(), 0);
+  assert!(queue.pop().is_none());
+}
+
+#[test]
+fn single_producer_fifo_and_exact_once() {
+  let queue = LockFreeMpscQueue::new();
+  for value in 0..5_u32 {
+    queue.push(value).expect("push succeeds");
+  }
+
+  assert_eq!(queue.len(), 5);
+  let drained: Vec<u32> = (0..5).map(|_| queue.pop().expect("queued value")).collect();
+
+  assert_eq!(drained, vec![0, 1, 2, 3, 4]);
+  assert!(queue.pop().is_none());
+  assert_eq!(queue.len(), 0);
+}
+
+#[test]
+fn close_rejects_later_push() {
+  let queue = LockFreeMpscQueue::new();
+  queue.close();
+
+  let rejected = queue.push(7_u32).expect_err("closed queue rejects");
+
+  assert_eq!(rejected, 7);
+  assert_eq!(queue.len(), 0);
+  assert!(queue.pop().is_none());
+}
+
+#[test]
+fn close_and_drain_removes_pending_items() {
+  let queue = LockFreeMpscQueue::new();
+  for value in 0..8_u32 {
+    queue.push(value).expect("push succeeds");
+  }
+
+  queue.close_and_drain();
+
+  assert_eq!(queue.len(), 0);
+  assert!(queue.pop().is_none());
+}
+
+#[test]
+fn close_waits_for_entered_producer_guard() {
+  use std::{sync::mpsc, thread, time::Duration};
+
+  let queue = Arc::new(LockFreeMpscQueue::<u32>::new());
+  let producer_guard = queue.enter_producer().expect("producer enters before close");
+  let (started_tx, started_rx) = mpsc::channel();
+  let (finished_tx, finished_rx) = mpsc::channel();
+
+  let queue_for_close = Arc::clone(&queue);
+  let handle = thread::spawn(move || {
+    started_tx.send(()).expect("close start signal");
+    queue_for_close.close();
+    finished_tx.send(()).expect("close finish signal");
+  });
+
+  started_rx.recv().expect("close starts");
+  assert!(finished_rx.recv_timeout(Duration::from_millis(10)).is_err(), "close must wait for producer guard");
+
+  drop(producer_guard);
+  finished_rx.recv_timeout(Duration::from_secs(1)).expect("close finishes after producer guard drops");
+  handle.join().expect("close thread joins");
+}
+
+#[test]
+fn multiple_producers_exact_once_and_per_producer_fifo() {
+  use std::{sync::Barrier, thread};
+
+  const PRODUCERS: u64 = 4;
+  const ITEMS_PER_PRODUCER: u64 = 200;
+  const TOTAL: usize = (PRODUCERS * ITEMS_PER_PRODUCER) as usize;
+
+  let queue = Arc::new(LockFreeMpscQueue::new());
+  let barrier = Arc::new(Barrier::new(PRODUCERS as usize));
+  let mut handles = Vec::new();
+  for producer in 0..PRODUCERS {
+    let q = Arc::clone(&queue);
+    let b = Arc::clone(&barrier);
+    handles.push(thread::spawn(move || {
+      b.wait();
+      let base = producer * ITEMS_PER_PRODUCER;
+      for seq in 0..ITEMS_PER_PRODUCER {
+        q.push(base + seq).expect("push succeeds");
+      }
+    }));
+  }
+
+  for handle in handles {
+    handle.join().expect("producer joins");
+  }
+
+  let mut drained = Vec::with_capacity(TOTAL);
+  while let Some(value) = queue.pop() {
+    drained.push(value);
+  }
+
+  assert_eq!(drained.len(), TOTAL);
+  for producer in 0..PRODUCERS {
+    let base = producer * ITEMS_PER_PRODUCER;
+    let end = base + ITEMS_PER_PRODUCER;
+    let producer_values: Vec<u64> = drained.iter().copied().filter(|value| *value >= base && *value < end).collect();
+    assert_eq!(producer_values.len(), ITEMS_PER_PRODUCER as usize);
+    for window in producer_values.windows(2) {
+      assert!(window[0] < window[1], "producer {producer} FIFO order must be preserved");
+    }
+  }
+
+  let mut sorted = drained;
+  sorted.sort_unstable();
+  let expected: Vec<u64> =
+    (0..PRODUCERS).flat_map(|p| (0..ITEMS_PER_PRODUCER).map(move |s| p * ITEMS_PER_PRODUCER + s)).collect();
+  assert_eq!(sorted, expected);
+  assert_eq!(queue.len(), 0);
+}
+
+#[test]
+fn concurrent_dequeue_is_serialized_and_exact_once() {
+  use std::{sync::Barrier, thread};
+
+  const ITEMS: u64 = 500;
+  const CONSUMERS: usize = 4;
+
+  let queue = Arc::new(LockFreeMpscQueue::new());
+  for value in 0..ITEMS {
+    queue.push(value).expect("push succeeds");
+  }
+
+  let barrier = Arc::new(Barrier::new(CONSUMERS));
+  let mut handles = Vec::new();
+  for _ in 0..CONSUMERS {
+    let q = Arc::clone(&queue);
+    let b = Arc::clone(&barrier);
+    handles.push(thread::spawn(move || {
+      b.wait();
+      let mut values = Vec::new();
+      while let Some(value) = q.pop() {
+        values.push(value);
+      }
+      values
+    }));
+  }
+
+  let mut drained: Vec<u64> = handles.into_iter().flat_map(|handle| handle.join().expect("consumer joins")).collect();
+  drained.sort_unstable();
+
+  assert_eq!(drained, (0..ITEMS).collect::<Vec<_>>());
+  assert_eq!(queue.len(), 0);
+}
+
+#[test]
+fn close_racing_with_producers_leaves_no_residual_items() {
+  use std::{sync::Barrier, thread};
+
+  const PRODUCERS: usize = 4;
+  const ITEMS_PER_PRODUCER: usize = 500;
+
+  let queue = Arc::new(LockFreeMpscQueue::new());
+  let barrier = Arc::new(Barrier::new(PRODUCERS + 1));
+  let producers_started = Arc::new(AtomicUsize::new(0));
+  let mut handles = Vec::new();
+  for producer in 0..PRODUCERS {
+    let q = Arc::clone(&queue);
+    let b = Arc::clone(&barrier);
+    let started = Arc::clone(&producers_started);
+    handles.push(thread::spawn(move || {
+      b.wait();
+      started.fetch_add(1, Ordering::SeqCst);
+      let base = producer * ITEMS_PER_PRODUCER;
+      for seq in 0..ITEMS_PER_PRODUCER {
+        if q.push(base + seq).is_err() {
+          break;
+        }
+      }
+    }));
+  }
+
+  barrier.wait();
+  while producers_started.load(Ordering::SeqCst) == 0 {
+    thread::yield_now();
+  }
+  queue.close_and_drain();
+
+  for handle in handles {
+    handle.join().expect("producer joins");
+  }
+
+  assert_eq!(queue.len(), 0);
+  assert!(queue.pop().is_none());
+  assert!(queue.push(usize::MAX).is_err());
+}
+
+#[test]
+fn drop_releases_each_queued_item_once() {
+  struct DropCounter {
+    drops: Arc<AtomicUsize>,
+  }
+
+  impl Drop for DropCounter {
+    fn drop(&mut self) {
+      self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+  }
+
+  let drops = Arc::new(AtomicUsize::new(0));
+  {
+    let queue = LockFreeMpscQueue::new();
+    for _ in 0..10 {
+      assert!(queue.push(DropCounter { drops: Arc::clone(&drops) }).is_ok());
+    }
+    drop(queue.pop());
+    assert_eq!(drops.load(Ordering::SeqCst), 1);
+  }
+
+  assert_eq!(drops.load(Ordering::SeqCst), 10);
+}
+
+#[cfg(loom)]
+mod loom_tests {
+  use crate::dispatch::mailbox::lock_free_mpsc_queue::LockFreeMpscQueue;
+
+  #[test]
+  fn producer_guard_close_interleaving_rejects_or_drains() {
+    loom::model(|| {
+      use loom::{
+        sync::{
+          Arc,
+          atomic::{AtomicUsize, Ordering},
+        },
+        thread,
+      };
+
+      const FIRST: usize = 0b01;
+      const SECOND: usize = 0b10;
+
+      let queue = Arc::new(LockFreeMpscQueue::new());
+      let accepted = Arc::new(AtomicUsize::new(0));
+
+      let producer_queue = Arc::clone(&queue);
+      let producer_accepted = Arc::clone(&accepted);
+      let producer = thread::spawn(move || {
+        if producer_queue.push(FIRST).is_ok() {
+          producer_accepted.fetch_or(FIRST, Ordering::SeqCst);
+        }
+
+        thread::yield_now();
+
+        if producer_queue.push(SECOND).is_ok() {
+          producer_accepted.fetch_or(SECOND, Ordering::SeqCst);
+        }
+      });
+
+      let closer_queue = Arc::clone(&queue);
+      let closer = thread::spawn(move || {
+        thread::yield_now();
+        closer_queue.close();
+      });
+
+      producer.join().expect("producer joins");
+      closer.join().expect("closer joins");
+
+      let mut drained_mask = 0;
+      let mut drained_count = 0;
+      while let Some(value) = queue.pop() {
+        drained_mask |= value;
+        drained_count += 1;
+      }
+
+      let accepted_mask = accepted.load(Ordering::SeqCst);
+      assert_eq!(drained_mask, accepted_mask);
+      assert_eq!(drained_count, accepted_mask.count_ones() as usize);
+      assert!(queue.push(0b100).is_err());
+    });
+  }
+}

--- a/modules/actor-core-kernel/src/dispatch/mailbox/mailboxes/tests.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/mailboxes/tests.rs
@@ -1,5 +1,7 @@
 use core::num::NonZeroUsize;
 
+use fraktor_utils_core_rs::sync::ArcShared;
+
 use super::*;
 use crate::{
   actor::{
@@ -8,6 +10,14 @@ use crate::{
   },
   dispatch::mailbox::{EnqueueOutcome, Envelope, MailboxOverflowStrategy, MailboxPolicy, MailboxRegistryError},
 };
+
+struct ConstantPriority;
+
+impl MessagePriorityGenerator for ConstantPriority {
+  fn priority(&self, _message: &AnyMessage) -> i32 {
+    0
+  }
+}
 
 #[test]
 fn register_and_resolve_mailbox() {
@@ -48,6 +58,53 @@ fn create_message_queue_uses_registered_mailbox_policy() {
     matches!(overflow_result, Ok(EnqueueOutcome::Rejected(_))),
     "DropNewest overflow must surface Ok(Rejected), got {overflow_result:?}",
   );
+}
+
+#[test]
+fn unbounded_policy_selects_lock_free_user_queue() {
+  let queue = create_message_queue_from_policy(MailboxPolicy::unbounded(None));
+
+  assert!(!queue.requires_put_lock_for_enqueue(), "default unbounded mailbox must use the queue-local close protocol");
+  assert!(queue.as_deque().is_none(), "default unbounded queue must not acquire deque semantics");
+}
+
+#[test]
+fn bounded_queue_selection_keeps_lock_backed_enqueue_path() {
+  let capacity = NonZeroUsize::new(2).expect("capacity");
+
+  let bounded =
+    create_message_queue_from_policy(MailboxPolicy::bounded(capacity, MailboxOverflowStrategy::DropNewest, None));
+  assert!(bounded.requires_put_lock_for_enqueue());
+}
+
+#[test]
+fn deque_queue_selection_keeps_lock_backed_enqueue_path() {
+  let deque_config = MailboxConfig::default().with_requirement(MailboxRequirement::requires_deque());
+  let deque = create_message_queue_from_config(&deque_config).expect("deque queue");
+  assert!(deque.requires_put_lock_for_enqueue());
+  assert!(deque.as_deque().is_some());
+}
+
+#[test]
+fn control_aware_queue_selection_keeps_lock_backed_enqueue_path() {
+  let control_config = MailboxConfig::default().with_requirement(MailboxRequirement::requires_control_aware());
+  let control_aware = create_message_queue_from_config(&control_config).expect("control-aware queue");
+  assert!(control_aware.requires_put_lock_for_enqueue());
+}
+
+#[test]
+fn priority_queue_selection_keeps_lock_backed_enqueue_path() {
+  let priority_config = MailboxConfig::default().with_priority_generator(ArcShared::new(ConstantPriority));
+  let priority = create_message_queue_from_config(&priority_config).expect("priority queue");
+  assert!(priority.requires_put_lock_for_enqueue());
+}
+
+#[test]
+fn stable_priority_queue_selection_keeps_lock_backed_enqueue_path() {
+  let stable_priority_config =
+    MailboxConfig::default().with_priority_generator(ArcShared::new(ConstantPriority)).with_stable_priority(true);
+  let stable_priority = create_message_queue_from_config(&stable_priority_config).expect("stable priority queue");
+  assert!(stable_priority.requires_put_lock_for_enqueue());
 }
 
 #[test]

--- a/modules/actor-core-kernel/src/dispatch/mailbox/message_queue.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/message_queue.rs
@@ -57,6 +57,14 @@ pub trait MessageQueue: Send + Sync {
   /// Clears remaining envelopes from the queue during shutdown.
   fn clean_up(&self);
 
+  /// Publishes any queue-local close state before terminal mailbox cleanup drains the queue.
+  fn close_for_cleanup(&self) {}
+
+  /// Returns whether [`Mailbox`](super::Mailbox) must serialize enqueue with its put lock.
+  fn requires_put_lock_for_enqueue(&self) -> bool {
+    true
+  }
+
   /// Returns the deque capability when this queue supports front-of-queue insertion.
   ///
   /// The default returns `None`. Override this in deque-capable queue implementations

--- a/modules/actor-core-kernel/src/dispatch/mailbox/unbounded_message_queue.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/unbounded_message_queue.rs
@@ -1,27 +1,32 @@
-//! Unbounded message queue backed by a growable deque.
+//! Unbounded message queue backed by a mailbox-local lock-free MPSC queue.
 
 #[cfg(test)]
 mod tests;
 
-use fraktor_utils_core_rs::collections::queue::QueueError;
-
 use super::{
-  QueueStateHandle, enqueue_error::EnqueueError, enqueue_outcome::EnqueueOutcome, envelope::Envelope,
-  message_queue::MessageQueue, policy::MailboxPolicy,
+  enqueue_error::EnqueueError, enqueue_outcome::EnqueueOutcome, envelope::Envelope,
+  lock_free_mpsc_queue::LockFreeMpscQueue, message_queue::MessageQueue,
 };
+use crate::actor::error::SendError;
 
 /// Unbounded message queue that grows as needed.
 pub struct UnboundedMessageQueue {
-  handle: QueueStateHandle<Envelope>,
+  queue: LockFreeMpscQueue<Envelope>,
 }
 
 impl UnboundedMessageQueue {
   /// Creates a new unbounded message queue.
   #[must_use]
+  #[cfg(not(loom))]
+  pub const fn new() -> Self {
+    Self { queue: LockFreeMpscQueue::new() }
+  }
+
+  /// Creates a new unbounded message queue.
+  #[must_use]
+  #[cfg(loom)]
   pub fn new() -> Self {
-    let policy = MailboxPolicy::unbounded(None);
-    let handle = QueueStateHandle::new_user(&policy);
-    Self { handle }
+    Self { queue: LockFreeMpscQueue::new() }
   }
 }
 
@@ -33,25 +38,29 @@ impl Default for UnboundedMessageQueue {
 
 impl MessageQueue for UnboundedMessageQueue {
   fn enqueue(&self, envelope: Envelope) -> Result<EnqueueOutcome, EnqueueError> {
-    match self.handle.offer(envelope) {
-      | Ok(_) => Ok(EnqueueOutcome::Accepted),
-      | Err(error) => Err(EnqueueError::new(super::map_user_envelope_queue_error(error))),
+    match self.queue.push(envelope) {
+      | Ok(()) => Ok(EnqueueOutcome::Accepted),
+      | Err(envelope) => Err(EnqueueError::new(SendError::closed(envelope.into_payload()))),
     }
   }
 
   fn dequeue(&self) -> Option<Envelope> {
-    match self.handle.poll() {
-      | Ok(envelope) => Some(envelope),
-      | Err(QueueError::Empty | QueueError::Disconnected | QueueError::WouldBlock) => None,
-      | Err(_) => None,
-    }
+    self.queue.pop()
   }
 
   fn number_of_messages(&self) -> usize {
-    self.handle.len()
+    self.queue.len()
   }
 
   fn clean_up(&self) {
-    while self.dequeue().is_some() {}
+    self.queue.close_and_drain();
+  }
+
+  fn close_for_cleanup(&self) {
+    self.queue.close();
+  }
+
+  fn requires_put_lock_for_enqueue(&self) -> bool {
+    false
   }
 }

--- a/modules/actor-core-kernel/src/dispatch/mailbox/unbounded_message_queue/tests.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/unbounded_message_queue/tests.rs
@@ -1,5 +1,5 @@
 use crate::{
-  actor::messaging::AnyMessage,
+  actor::{error::SendError, messaging::AnyMessage},
   dispatch::mailbox::{
     envelope::Envelope, message_queue::MessageQueue, unbounded_message_queue::UnboundedMessageQueue,
   },
@@ -36,5 +36,24 @@ fn should_clean_up_all_messages() {
   assert_eq!(queue.number_of_messages(), 5);
 
   queue.clean_up();
+  assert_eq!(queue.number_of_messages(), 0);
+}
+
+#[test]
+fn should_not_require_mailbox_put_lock_for_enqueue() {
+  let queue = UnboundedMessageQueue::new();
+
+  assert!(!queue.requires_put_lock_for_enqueue());
+}
+
+#[test]
+fn should_reject_enqueue_after_cleanup_closes_queue() {
+  let queue = UnboundedMessageQueue::new();
+  queue.clean_up();
+
+  let result = queue.enqueue(Envelope::new(AnyMessage::new("closed")));
+  let error = result.expect_err("closed unbounded queue must reject enqueue");
+
+  assert!(matches!(error.error(), SendError::Closed(_)));
   assert_eq!(queue.number_of_messages(), 0);
 }

--- a/openspec/changes/lock-free-mailbox-user-queue/tasks.md
+++ b/openspec/changes/lock-free-mailbox-user-queue/tasks.md
@@ -1,31 +1,31 @@
 ## 1. 現状固定と設計確認
 
-- [ ] 1.1 `UnboundedMessageQueue` / `QueueStateHandle` / `Mailbox::enqueue_envelope` の現行 lock 経路をテストまたはコードコメントで確認する
-- [ ] 1.2 通常 unbounded queue、bounded queue、deque queue、priority queue の選択経路を確認し、初回 scope が通常 unbounded queue のみであることを固定する
-- [ ] 1.3 close 後 enqueue rejection、in-flight enqueue vs cleanup、post-drain reschedule の既存テストを確認し、不足分を regression test として追加する
+- [x] 1.1 `UnboundedMessageQueue` / `QueueStateHandle` / `Mailbox::enqueue_envelope` の現行 lock 経路をテストまたはコードコメントで確認する
+- [x] 1.2 通常 unbounded queue、bounded queue、deque queue、priority queue の選択経路を確認し、初回 scope が通常 unbounded queue のみであることを固定する
+- [x] 1.3 close 後 enqueue rejection、in-flight enqueue vs cleanup、post-drain reschedule の既存テストを確認し、不足分を regression test として追加する
 
 ## 2. Lock-free Queue Primitive
 
-- [ ] 2.1 mailbox-local module として lock-free MPSC queue primitive を追加する
-- [ ] 2.2 producer guard を RAII 化し、close protocol 中に in-flight producer count が漏れないようにする
-- [ ] 2.3 queue-local atomic close protocol を実装し、close 後 enqueue が `Closed` 相当を返すようにする
-- [ ] 2.4 consumer-side guard を実装し、`MessageQueue` の safe `&self` API から concurrent dequeue されても UB が起きないようにする
-- [ ] 2.5 raw pointer / node ownership に関する unsafe block を primitive module 内に局所化し、各 unsafe block に SAFETY comment を付ける
+- [x] 2.1 mailbox-local module として lock-free MPSC queue primitive を追加する
+- [x] 2.2 producer guard を RAII 化し、close protocol 中に in-flight producer count が漏れないようにする
+- [x] 2.3 queue-local atomic close protocol を実装し、close 後 enqueue が `Closed` 相当を返すようにする
+- [x] 2.4 consumer-side guard を実装し、`MessageQueue` の safe `&self` API から concurrent dequeue されても UB が起きないようにする
+- [x] 2.5 raw pointer / node ownership に関する unsafe block を primitive module 内に局所化し、各 unsafe block に SAFETY comment を付ける
 
 ## 3. Mailbox Integration
 
-- [ ] 3.1 `UnboundedMessageQueue` を lock-free MPSC primitive backing に差し替える
-- [ ] 3.2 通常 unbounded queue の `enqueue_envelope` path から `put_lock` 取得を外す
-- [ ] 3.3 lock-backed queue では既存の `put_lock` close serialization を維持する
-- [ ] 3.4 `clean_up` / `become_closed` 経路で lock-free queue の close-and-drain protocol を呼ぶ
-- [ ] 3.5 `Mailbox::run` の system-first drain、throughput、deadline、suspend、post-drain reschedule semantics が変わっていないことを確認する
+- [x] 3.1 `UnboundedMessageQueue` を lock-free MPSC primitive backing に差し替える
+- [x] 3.2 通常 unbounded queue の `enqueue_envelope` path から `put_lock` 取得を外す
+- [x] 3.3 lock-backed queue では既存の `put_lock` close serialization を維持する
+- [x] 3.4 `clean_up` / `become_closed` 経路で lock-free queue の close-and-drain protocol を呼ぶ
+- [x] 3.5 `Mailbox::run` の system-first drain、throughput、deadline、suspend、post-drain reschedule semantics が変わっていないことを確認する
 
 ## 4. Verification
 
-- [ ] 4.1 lock-free queue の FIFO / exact-once / close rejection / cleanup drain unit tests を追加する
-- [ ] 4.2 複数 producer と mailbox runner 相当 consumer の stress test を追加する
-- [ ] 4.3 `loom` model test の配置と dev-dependency/cfg 方針を決め、producer/consumer interleaving を検証する
-- [ ] 4.4 `miri` で primitive の raw pointer ownership safety を検証できるテストを追加する
-- [ ] 4.5 `cargo test -p fraktor-actor-core-kernel-rs dispatch::mailbox` を通す
+- [x] 4.1 lock-free queue の FIFO / exact-once / close rejection / cleanup drain unit tests を追加する
+- [x] 4.2 複数 producer と mailbox runner 相当 consumer の stress test を追加する
+- [x] 4.3 `loom` model test の配置と dev-dependency/cfg 方針を決め、producer/consumer interleaving を検証する
+- [x] 4.4 `miri` で primitive の raw pointer ownership safety を検証できるテストを追加する
+- [x] 4.5 `cargo test -p fraktor-actor-core-kernel-rs dispatch::mailbox` を通す
 - [ ] 4.6 `cargo clippy -p fraktor-actor-core-kernel-rs --all-targets --all-features -- -D warnings` を通す
-- [ ] 4.7 OpenSpec validation を通す
+- [x] 4.7 OpenSpec validation を通す


### PR DESCRIPTION
## Summary
- Add a mailbox-local lock-free MPSC queue primitive for unbounded user queues
- Let unbounded mailbox enqueue bypass the mailbox put lock while preserving cleanup close/drain semantics
- Add concurrency, loom, Miri-oriented, and mailbox policy regression tests
- Update OpenSpec task progress for lock-free-mailbox-user-queue

## Verification
- cargo fmt
- cargo test -p fraktor-actor-core-kernel-rs dispatch::mailbox
- RUSTFLAGS="--cfg loom" cargo test -p fraktor-actor-core-kernel-rs dispatch::mailbox::lock_free_mpsc_queue::tests::loom_tests --lib
- cargo +nightly-2025-12-01 miri test -p fraktor-actor-core-kernel-rs dispatch::mailbox::lock_free_mpsc_queue::tests::drop_releases_each_queued_item_once --lib
- cargo clippy -p fraktor-actor-core-kernel-rs --lib --all-features -- -D warnings

## Known issue
- cargo clippy -p fraktor-actor-core-kernel-rs --all-targets --all-features -- -D warnings still fails on existing non-mailbox test lints unrelated to this change, so OpenSpec task 4.6 remains unchecked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new lock-free queue implemented with raw pointers/atomics and changes mailbox enqueue/cleanup concurrency semantics; bugs here could cause message loss, leaks, or hangs under contention despite added tests.
> 
> **Overview**
> Switches the default *unbounded* mailbox user queue to a new mailbox-local **lock-free MPSC** primitive and updates `Mailbox::enqueue_envelope` to bypass `put_lock` for queues that opt out of lock-serialized enqueue.
> 
> Adds a queue-local close protocol (`MessageQueue::close_for_cleanup` + `requires_put_lock_for_enqueue`) so cleanup can reliably stop producers and drain the unbounded queue without leaving residual messages, while keeping lock-backed behavior for bounded/deque/control-aware/priority queues.
> 
> Expands test coverage with new unit/concurrency/`loom` model tests for the lock-free queue and mailbox-level regressions (enqueue not blocked by `put_lock`, cleanup/enqueue races), and wires in `loom` as a workspace dependency + cfg lint allow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e50f775a052fcb29e6c688263d3f1b5ab392082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * アクターコアのメールボックス実装を刷新し、アンバウンドメールボックスをロックフリーのキューで駆動するようにしてエンキュー/デキュー性能を改善しました。
  * クリーンアップとクローズ処理の安定化（並行時の競合処理向上）。

* **Tests**
  * シャットダウン／クリーンアップ競合やエンキュー振る舞いを検証する回帰・並行テストを多数追加。

* **Chores**
  * 開発用の並行性検査ツール設定を更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1745)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->