### PR TITLE
[codex] Clarify circuit breaker config panic test

### DIFF
--- a/modules/actor-core-kernel/src/actor/setup/circuit_breaker_config/tests.rs
+++ b/modules/actor-core-kernel/src/actor/setup/circuit_breaker_config/tests.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+use std::panic;
 
 use crate::actor::setup::CircuitBreakerConfig;
 
@@ -11,7 +12,8 @@ fn default_matches_pekko_registry_defaults() {
 }
 
 #[test]
-#[should_panic(expected = "max_failures must be greater than zero")]
 fn rejects_zero_max_failures() {
-  assert_eq!(CircuitBreakerConfig::new(0, Duration::from_secs(1)).max_failures(), 0);
+  let result = panic::catch_unwind(|| CircuitBreakerConfig::new(0, Duration::from_secs(1)));
+
+  assert!(result.is_err());
 }


### PR DESCRIPTION
## Summary

- Address the missed review feedback from PR #1750 discussion `discussion_r3214447314`.
- Replace the unreachable-looking `#[should_panic]` assertion with an explicit `panic::catch_unwind(...).is_err()` check.

## Validation

- `cargo test -p fraktor-actor-core-kernel-rs actor::setup::circuit_breaker_config::tests::rejects_zero_max_failures`
- `cargo clippy -p fraktor-actor-core-kernel-rs --all-targets --all-features -- -D warnings`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that refines how a panic is asserted without altering production logic.
> 
> **Overview**
> Refactors `rejects_zero_max_failures` to explicitly capture the panic from `CircuitBreakerConfig::new(0, ...)` using `std::panic::catch_unwind` and assert `is_err()`, replacing the previous `#[should_panic]`-style expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968a9c80ea0e09c2690bcb72e03ba554dc638060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->