### PR TITLE
[codex] Add actor-core-kernel mailbox benchmarks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -156,12 +156,21 @@ cargo run -q -p fraktor-actor-core-kernel-rs --example logger_subscriber_std --f
 '''
 
 [tasks.actor-core-perf]
-description = "Actor core throughput harness (perf_mailbox)"
+description = "Actor core benchmark build check"
 workspace = false
 script = '''
 #!/usr/bin/env bash
 set -euo pipefail
-cargo test -p fraktor-actor-core-kernel-rs --features std --test perf_mailbox
+cargo check -p fraktor-actor-core-kernel-rs --benches
+'''
+
+[tasks.actor-core-bench]
+description = "Run actor core mailbox Criterion benchmarks"
+workspace = false
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+cargo bench -p fraktor-actor-core-kernel-rs --bench mailbox
 '''
 
 [tasks.actor-core-story]

--- a/docs/plan/2026-05-10-actor-core-kernel-benchmark-infra.md
+++ b/docs/plan/2026-05-10-actor-core-kernel-benchmark-infra.md
@@ -1,0 +1,41 @@
+# actor-core-kernel ベンチマーク基盤整備計画
+
+## Summary
+
+`actor-core-kernel` に Criterion ベースの mailbox/queue マイクロベンチを追加する。初期スコープは actor 実行器込みではなく、`actor-core-kernel` 単体で測れる mailbox 中心に限定する。CI/通常チェックでは実測せず、`cargo check --benches` によるビルド保証までにする。
+
+## Key Changes
+
+- `modules/actor-core-kernel/Cargo.toml` に `[[bench]] name = "mailbox"` を追加し、`harness = false` を指定する。既存の `criterion` / `critical-section/std` dev-dependencies を使い、新規依存は追加しない。
+- `modules/actor-core-kernel/benches/mailbox.rs` を新設し、以下の Criterion group を作る。
+  - `message_queue_enqueue`: `UnboundedMessageQueue`、`BoundedMessageQueue`、`UnboundedControlAwareMessageQueue`、priority queue の batch enqueue。
+  - `message_queue_drain`: 事前投入した batch を `MessageQueue::dequeue` で drain。
+  - `mailbox_enqueue`: `Mailbox::new(MailboxPolicy::unbounded(None))` と bounded policy の `enqueue_user` wrapper overhead。
+  - `mailbox_overflow`: bounded capacity 超過時の `DropNewest` / `DropOldest` 経路。
+- batch size は初期値 `[1, 64, 1024]`、Criterion のローカル実測デフォルトは通常設定、smoke 実行は `--warm-up-time 0.1 --measurement-time 0.2 --sample-size 10` を使う。
+- private な `LockFreeMpscQueue` は公開しない。ベンチは公開済みの `MessageQueue` 実装と `Mailbox` API だけを使う。
+- `Makefile.toml` の壊れている `actor-core-perf` を、存在しない `perf_mailbox` テストと存在しない `std` feature から切り離す。
+  - `actor-core-perf`: `cargo check -p fraktor-actor-core-kernel-rs --benches`
+  - `actor-core-bench`: `cargo bench -p fraktor-actor-core-kernel-rs --bench mailbox`
+- `scripts/ci-check.sh` の default `all` には実測を追加しない。`perf|bench|performance` 経路に actor-core-kernel の `cargo check --benches` だけを追加する。
+
+## Interfaces
+
+- 公開 Rust API の追加・変更はしない。
+- 新しい実行インターフェース:
+  - ビルド確認: `cargo check -p fraktor-actor-core-kernel-rs --benches`
+  - 実測: `cargo bench -p fraktor-actor-core-kernel-rs --bench mailbox`
+  - 軽量 smoke 実測: `cargo bench -p fraktor-actor-core-kernel-rs --bench mailbox -- --warm-up-time 0.1 --measurement-time 0.2 --sample-size 10`
+
+## Test Plan
+
+- `cargo check -p fraktor-actor-core-kernel-rs --benches`
+- `cargo bench -p fraktor-actor-core-kernel-rs --bench mailbox -- --warm-up-time 0.1 --measurement-time 0.2 --sample-size 10`
+- `cargo clippy -p fraktor-actor-core-kernel-rs --benches -- -D warnings`
+- 既存 mailbox 回帰確認として `cargo test -p fraktor-actor-core-kernel-rs dispatch::mailbox`
+
+## Assumptions
+
+- 初期スコープは mailbox/queue の基盤測定に限定し、spawn/tell/ping-pong は既存の `actor-adaptor-std` bench 側に残す。
+- ベンチ結果の閾値判定は導入しない。性能回帰検出はまず人間が Criterion レポートを比較する運用にする。
+- `actor-core-kernel` の no_std production 境界は変えない。bench target だけが std 環境で動く。

--- a/modules/actor-core-kernel/Cargo.toml
+++ b/modules/actor-core-kernel/Cargo.toml
@@ -84,5 +84,10 @@ path = "tests/system_events.rs"
 name = "system_lifecycle"
 path = "tests/system_lifecycle.rs"
 
+[[bench]]
+name = "mailbox"
+path = "benches/mailbox.rs"
+harness = false
+
 [lints]
 workspace = true

--- a/modules/actor-core-kernel/benches/mailbox.rs
+++ b/modules/actor-core-kernel/benches/mailbox.rs
@@ -1,0 +1,255 @@
+use core::num::NonZeroUsize;
+use std::hint::black_box;
+
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use fraktor_actor_core_kernel_rs::{
+  actor::messaging::AnyMessage,
+  dispatch::mailbox::{
+    BoundedMessageQueue, Envelope, Mailbox, MailboxOverflowStrategy, MailboxPolicy, MessagePriorityGenerator,
+    MessageQueue, UnboundedControlAwareMessageQueue, UnboundedMessageQueue, UnboundedPriorityMessageQueue,
+    UnboundedPriorityMessageQueueState, UnboundedPriorityMessageQueueStateShared,
+  },
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+const BATCH_SIZES: [usize; 3] = [1, 64, 1024];
+
+struct PayloadPriorityGenerator;
+
+impl MessagePriorityGenerator for PayloadPriorityGenerator {
+  fn priority(&self, message: &AnyMessage) -> i32 {
+    message.payload().downcast_ref::<i32>().copied().unwrap_or(i32::MAX)
+  }
+}
+
+fn capacity(value: usize) -> NonZeroUsize {
+  NonZeroUsize::new(value).expect("benchmark capacity must be non-zero")
+}
+
+fn unbounded_queue() -> UnboundedMessageQueue {
+  UnboundedMessageQueue::new()
+}
+
+fn bounded_queue(size: usize) -> BoundedMessageQueue {
+  BoundedMessageQueue::new(capacity(size), MailboxOverflowStrategy::DropNewest)
+}
+
+fn control_aware_queue() -> UnboundedControlAwareMessageQueue {
+  UnboundedControlAwareMessageQueue::new()
+}
+
+fn priority_queue() -> UnboundedPriorityMessageQueue {
+  let generator: ArcShared<dyn MessagePriorityGenerator> = ArcShared::new(PayloadPriorityGenerator);
+  let state_shared = UnboundedPriorityMessageQueueStateShared::new(UnboundedPriorityMessageQueueState::new());
+  UnboundedPriorityMessageQueue::new(generator, state_shared)
+}
+
+fn enqueue_normal_batch(queue: &dyn MessageQueue, batch_size: usize) {
+  for sequence in 0..batch_size {
+    queue.enqueue(Envelope::new(AnyMessage::new(sequence as u64))).expect("enqueue benchmark message");
+  }
+}
+
+fn enqueue_control_aware_batch(queue: &dyn MessageQueue, batch_size: usize) {
+  for sequence in 0..batch_size {
+    let message =
+      if sequence % 4 == 0 { AnyMessage::control(sequence as u64) } else { AnyMessage::new(sequence as u64) };
+    queue.enqueue(Envelope::new(message)).expect("enqueue benchmark message");
+  }
+}
+
+fn enqueue_priority_batch(queue: &dyn MessageQueue, batch_size: usize) {
+  for sequence in 0..batch_size {
+    queue.enqueue(Envelope::new(AnyMessage::new((batch_size - sequence) as i32))).expect("enqueue benchmark message");
+  }
+}
+
+fn drain_queue(queue: &dyn MessageQueue) {
+  while let Some(envelope) = queue.dequeue() {
+    black_box(envelope);
+  }
+}
+
+fn bench_message_queue_enqueue(c: &mut Criterion) {
+  let mut group = c.benchmark_group("message_queue_enqueue");
+
+  for batch_size in BATCH_SIZES {
+    group.throughput(Throughput::Elements(batch_size as u64));
+
+    group.bench_with_input(format!("unbounded_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        unbounded_queue,
+        |queue| {
+          enqueue_normal_batch(&queue, batch_size);
+          black_box(queue);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+
+    group.bench_with_input(format!("bounded_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        || bounded_queue(batch_size),
+        |queue| {
+          enqueue_normal_batch(&queue, batch_size);
+          black_box(queue);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+
+    group.bench_with_input(format!("control_aware_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        control_aware_queue,
+        |queue| {
+          enqueue_control_aware_batch(&queue, batch_size);
+          black_box(queue);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+
+    group.bench_with_input(format!("priority_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        priority_queue,
+        |queue| {
+          enqueue_priority_batch(&queue, batch_size);
+          black_box(queue);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+  }
+
+  group.finish();
+}
+
+fn bench_message_queue_drain(c: &mut Criterion) {
+  let mut group = c.benchmark_group("message_queue_drain");
+
+  for batch_size in BATCH_SIZES {
+    group.throughput(Throughput::Elements(batch_size as u64));
+
+    group.bench_with_input(format!("unbounded_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        || {
+          let queue = unbounded_queue();
+          enqueue_normal_batch(&queue, batch_size);
+          queue
+        },
+        |queue| drain_queue(&queue),
+        BatchSize::SmallInput,
+      );
+    });
+
+    group.bench_with_input(format!("bounded_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        || {
+          let queue = bounded_queue(batch_size);
+          enqueue_normal_batch(&queue, batch_size);
+          queue
+        },
+        |queue| drain_queue(&queue),
+        BatchSize::SmallInput,
+      );
+    });
+
+    group.bench_with_input(format!("control_aware_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        || {
+          let queue = control_aware_queue();
+          enqueue_control_aware_batch(&queue, batch_size);
+          queue
+        },
+        |queue| drain_queue(&queue),
+        BatchSize::SmallInput,
+      );
+    });
+
+    group.bench_with_input(format!("priority_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        || {
+          let queue = priority_queue();
+          enqueue_priority_batch(&queue, batch_size);
+          queue
+        },
+        |queue| drain_queue(&queue),
+        BatchSize::SmallInput,
+      );
+    });
+  }
+
+  group.finish();
+}
+
+fn bench_mailbox_enqueue(c: &mut Criterion) {
+  let mut group = c.benchmark_group("mailbox_enqueue");
+
+  for batch_size in BATCH_SIZES {
+    group.throughput(Throughput::Elements(batch_size as u64));
+
+    group.bench_with_input(format!("unbounded_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        || Mailbox::new(MailboxPolicy::unbounded(None)),
+        |mailbox| {
+          for sequence in 0..batch_size {
+            mailbox.enqueue_user(AnyMessage::new(sequence as u64)).expect("enqueue benchmark message");
+          }
+          black_box(mailbox);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+
+    group.bench_with_input(format!("bounded_batch_{batch_size}"), &batch_size, |b, &batch_size| {
+      b.iter_batched(
+        || Mailbox::new(MailboxPolicy::bounded(capacity(batch_size), MailboxOverflowStrategy::DropNewest, None)),
+        |mailbox| {
+          for sequence in 0..batch_size {
+            mailbox.enqueue_user(AnyMessage::new(sequence as u64)).expect("enqueue benchmark message");
+          }
+          black_box(mailbox);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+  }
+
+  group.finish();
+}
+
+fn bench_mailbox_overflow(c: &mut Criterion) {
+  let mut group = c.benchmark_group("mailbox_overflow");
+
+  for overflow in [MailboxOverflowStrategy::DropNewest, MailboxOverflowStrategy::DropOldest] {
+    let overflow_name = match overflow {
+      | MailboxOverflowStrategy::DropNewest => "drop_newest",
+      | MailboxOverflowStrategy::DropOldest => "drop_oldest",
+      | MailboxOverflowStrategy::Grow => "grow",
+    };
+
+    group.bench_function(overflow_name, |b| {
+      b.iter_batched(
+        || Mailbox::new(MailboxPolicy::bounded(capacity(64), overflow, None)),
+        |mailbox| {
+          for sequence in 0..128 {
+            mailbox.enqueue_user(AnyMessage::new(sequence as u64)).expect("enqueue benchmark message");
+          }
+          black_box(mailbox);
+        },
+        BatchSize::SmallInput,
+      );
+    });
+  }
+
+  group.finish();
+}
+
+criterion_group!(
+  mailbox,
+  bench_message_queue_enqueue,
+  bench_message_queue_drain,
+  bench_mailbox_enqueue,
+  bench_mailbox_overflow
+);
+criterion_main!(mailbox);

--- a/modules/actor-core-kernel/benches/mailbox.rs
+++ b/modules/actor-core-kernel/benches/mailbox.rs
@@ -221,13 +221,9 @@ fn bench_mailbox_enqueue(c: &mut Criterion) {
 fn bench_mailbox_overflow(c: &mut Criterion) {
   let mut group = c.benchmark_group("mailbox_overflow");
 
-  for overflow in [MailboxOverflowStrategy::DropNewest, MailboxOverflowStrategy::DropOldest] {
-    let overflow_name = match overflow {
-      | MailboxOverflowStrategy::DropNewest => "drop_newest",
-      | MailboxOverflowStrategy::DropOldest => "drop_oldest",
-      | MailboxOverflowStrategy::Grow => "grow",
-    };
-
+  for (overflow, overflow_name) in
+    [(MailboxOverflowStrategy::DropNewest, "drop_newest"), (MailboxOverflowStrategy::DropOldest, "drop_oldest")]
+  {
     group.bench_function(overflow_name, |b| {
       b.iter_batched(
         || Mailbox::new(MailboxPolicy::bounded(capacity(64), overflow, None)),

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1545,6 +1545,9 @@ PY
 }
 
 run_perf() {
+  log_step "cargo check -p fraktor-actor-core-kernel-rs --benches"
+  run_cargo check -p fraktor-actor-core-kernel-rs --benches || return 1
+
   log_step "cargo test -p fraktor-actor-core-kernel-rs stress_scheduler_handles_"
   run_cargo test -p fraktor-actor-core-kernel-rs stress_scheduler_handles_ || return 1
 


### PR DESCRIPTION
## Summary

- Add a Criterion `mailbox` benchmark target for `fraktor-actor-core-kernel-rs`.
- Cover mailbox/message-queue enqueue, drain, enqueue wrapper overhead, and bounded overflow paths.
- Replace the stale `actor-core-perf` Makefile target with a bench build check and add an explicit `actor-core-bench` target.
- Add actor-core-kernel bench build coverage to the `perf|bench|performance` CI helper path without adding benchmark execution to default CI.

## Impact

This gives `actor-core-kernel` a local benchmark baseline for mailbox internals while keeping production `no_std` boundaries unchanged. CI remains focused on build verification rather than noisy performance thresholds.

## Validation

- `cargo check -p fraktor-actor-core-kernel-rs --benches`
- `cargo bench -p fraktor-actor-core-kernel-rs --bench mailbox -- --warm-up-time 0.1 --measurement-time 0.2 --sample-size 10`
- `cargo clippy -p fraktor-actor-core-kernel-rs --benches -- -D warnings`
- `cargo test -p fraktor-actor-core-kernel-rs dispatch::mailbox`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds benchmark-only code and wiring plus CI/make targets for `cargo check --benches`, without changing production runtime logic or APIs.
> 
> **Overview**
> Adds a new Criterion `mailbox` benchmark target for `fraktor-actor-core-kernel-rs`, covering message-queue enqueue/drain, mailbox enqueue overhead, and bounded overflow paths across multiple batch sizes.
> 
> Updates developer/CI tooling to support this: `Cargo.toml` registers the bench, `Makefile.toml` replaces the stale `actor-core-perf` target with a `cargo check --benches` build check and adds an `actor-core-bench` runner, and `scripts/ci-check.sh` includes the bench build check in the `perf|bench|performance` path (without adding benchmark execution to the default `all` flow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 281bd0ffa0071ea9e1175d510da66224f09d8040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * メールボックスおよびメッセージキューのパフォーマンスベンチマークスイートを追加しました。複数のキュータイプとバッチサイズでの性能測定が可能になります。

* **Chores**
  * ベンチマーク検証プロセスをCI パイプラインに統合しました。
  * ベンチマークインフラストラクチャ計画ドキュメントを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1752)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->