### PR TITLE
[codex] Restore Codecov project coverage

### DIFF
--- a/modules/actor-core-kernel/src/actor/setup/circuit_breaker_config/tests.rs
+++ b/modules/actor-core-kernel/src/actor/setup/circuit_breaker_config/tests.rs
@@ -12,6 +12,18 @@ fn default_matches_pekko_registry_defaults() {
 }
 
 #[test]
+fn with_methods_return_updated_copy() {
+  let base = CircuitBreakerConfig::default();
+
+  let config = base.with_max_failures(7).with_reset_timeout(Duration::from_secs(45));
+
+  assert_eq!(base.max_failures(), 5);
+  assert_eq!(base.reset_timeout(), Duration::from_secs(30));
+  assert_eq!(config.max_failures(), 7);
+  assert_eq!(config.reset_timeout(), Duration::from_secs(45));
+}
+
+#[test]
 fn rejects_zero_max_failures() {
   let result = panic::catch_unwind(|| CircuitBreakerConfig::new(0, Duration::from_secs(1)));
 


### PR DESCRIPTION
## Summary

- Recover Codecov project coverage by exercising the existing `CircuitBreakerConfig` copy/update methods.
- Keep production code unchanged and cover the previously missing `with_max_failures` / `with_reset_timeout` paths.

## Context

- The linked commit `537766570f7f5fed8d89d6a9831ed45a5eebf1e9` still has a legacy `codecov/project` commit status failure: `87.86% (-0.03%) compared to 968a9c8`.
- GitHub Actions checks on that commit are green, so this PR targets the remaining Codecov project-status drop only.

## Validation

- `cargo test -p fraktor-actor-core-kernel-rs actor::setup::circuit_breaker_config::tests`
- `cargo fmt --check`
- `cargo llvm-cov -p fraktor-actor-core-kernel-rs --features fraktor-actor-core-kernel-rs/alloc --no-clean --lib --json --output-path target/coverage/circuit_breaker_config.json -- actor::setup::circuit_breaker_config::tests`
- `git diff --check`
- `cargo clippy -p fraktor-actor-core-kernel-rs --all-targets --all-features -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a unit test that exercises `with_max_failures`/`with_reset_timeout` chaining; production code is unchanged, so behavior risk is minimal.
> 
> **Overview**
> Improves test coverage for `CircuitBreakerConfig` by adding a new unit test that verifies `with_max_failures` and `with_reset_timeout` return an updated copy while leaving the original config unchanged.
> 
> No production logic changes; this is purely a test addition to exercise previously uncovered code paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0db2ec7ebae38fe93916588e718bd8c7f6d8c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

該当するカテゴリがありません。このリリースには、エンドユーザーに見える変更が含まれていません。テストの改善のみが含まれており、製品の機能や動作に直接的な変更はありません。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1754)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->