### PR TITLE
docs: update actor gap analysis for split crates

### DIFF
--- a/docs/gap-analysis/actor-gap-analysis.md
+++ b/docs/gap-analysis/actor-gap-analysis.md
@@ -1,176 +1,177 @@
 # actor モジュール ギャップ分析
 
-更新日: 2026-04-24
-
-## 結論
-
-過去調査の「API parity はほぼ 100%」という判断は、限定された actor parity スコープでは妥当である。
-
-今回の初回調査で「ギャップ大」と見えた原因は、Pekko の `actor` / `actor-typed` 配下を raw に広く抽出し、Java / Scala / JVM 固有 API や transport 寄り API まで同じ指標へ混ぜたためである。以降の評価では、Rust で再現すべき actor ランタイム契約にスコープを限定する。
+更新日: 2026-05-11
 
 ## 比較スコープ定義
 
-### 対象に含めるもの
+この分析では、actor は旧 `actor-core` 内の kernel / typed サブディレクトリではなく、現行の分割済みクレートを parity 単位にする。
 
-fraktor-rs の actor parity 対象は、Pekko の実装を参考にしつつ、Rust の actor ランタイムとして意味を持つ公開契約に限定する。
+| 層 | fraktor-rs 側 | Pekko 側 | 扱い |
+|----|---------------|----------|------|
+| kernel | `modules/actor-core-kernel/src/` | `references/pekko/actor/src/main/scala/org/apache/pekko/actor/`, `references/pekko/actor/src/main/scala/org/apache/pekko/routing/`, `references/pekko/actor/src/main/scala/org/apache/pekko/pattern/`, `references/pekko/actor/src/main/scala/org/apache/pekko/event/` | classic / untyped actor runtime 契約 |
+| typed | `modules/actor-core-typed/src/` | `references/pekko/actor-typed/src/main/scala/org/apache/pekko/actor/typed/` | typed actor API と typed runtime 契約。ただし Java DSL は除外 |
+| std adaptor | `modules/actor-adaptor-std/src/` | Pekko の dispatcher / scheduler / logging 実装のうち Rust std adapter として意味を持つ契約 | tokio / thread / clock / tracing 等の adapter 実装 |
 
-| 分類 | Pekko 側の主な参照 | fraktor-rs 側の対応 |
+対象に含めるもの:
+
+| 分類 | Pekko 側の主な根拠 | fraktor-rs 側の対応 |
 |------|--------------------|---------------------|
-| classic / untyped actor core | `references/pekko/actor/` の actor core | `modules/actor-core/src/core/kernel/` |
-| typed actor core | `references/pekko/actor-typed/` の typed API | `modules/actor-core/src/core/typed/` |
-| supervision / lifecycle | fault handling, DeathWatch, signals | `modules/actor-core/src/core/kernel/`, `modules/actor-core/src/core/typed/` |
-| dispatch / mailbox | dispatcher, executor abstraction, mailbox contract | `modules/actor-core/src/core/kernel/`, `modules/actor-adaptor-std/src/` |
-| routing | classic / typed routing semantics | `modules/actor-core/src/core/kernel/`, `modules/actor-core/src/core/typed/` |
-| event / logging | event stream, dead letters, logging contract | `modules/actor-core/src/core/kernel/`, `modules/actor-adaptor-std/src/` |
-| pattern | ask, pipe, retry, graceful stop, circuit breaker | `modules/actor-core/src/core/kernel/`, `modules/actor-core/src/core/typed/` |
-| receptionist / discovery | typed receptionist, service key, listing | `modules/actor-core/src/core/typed/` |
-| delivery / pubsub | typed reliable delivery, local topic | `modules/actor-core/src/core/typed/` |
-| serialization contract | serializer trait, registry, manifest | `modules/actor-core/src/core/kernel/` |
-| coordinated shutdown | phase, task, termination contract | `modules/actor-core/src/core/kernel/` |
-| std adaptor | tokio / tracing / executor / scheduler adapter | `modules/actor-adaptor-std/src/` |
+| classic actor core | `Actor.scala`, `ActorRef.scala`, `ActorCell.scala`, `ActorSystem.scala`, `Props.scala`, `ActorPath.scala`, `ActorSelection.scala` | `modules/actor-core-kernel/src/actor/`, `modules/actor-core-kernel/src/system/` |
+| supervision / lifecycle / DeathWatch | `FaultHandling.scala`, `dungeon/DeathWatch.scala`, `MessageAndSignals.scala` | `modules/actor-core-kernel/src/actor/supervision/`, `modules/actor-core-kernel/src/actor/actor_cell.rs`, `modules/actor-core-typed/src/message_and_signals/` |
+| dispatch / mailbox | `dispatch/Mailbox.scala`, dispatcher abstractions | `modules/actor-core-kernel/src/dispatch/`, `modules/actor-adaptor-std/src/dispatch/` |
+| routing | `routing/*.scala`, typed `scaladsl/Routers.scala`, typed `internal/routing/*.scala` | `modules/actor-core-kernel/src/routing/`, `modules/actor-core-typed/src/dsl/routing/` |
+| event / logging | `event/EventStream.scala`, `event/Logging*.scala`, dead letters | `modules/actor-core-kernel/src/event/`, `modules/actor-adaptor-std/src/event/` |
+| pattern | `pattern/AskSupport.scala`, `RetrySupport.scala`, `GracefulStopSupport.scala`, `CircuitBreaker.scala` | `modules/actor-core-kernel/src/pattern/`, `modules/actor-core-typed/src/dsl/ask_pattern.rs`, `modules/actor-adaptor-std/src/pattern/` |
+| typed receptionist / pubsub / delivery | `typed/receptionist/Receptionist.scala`, `typed/pubsub/Topic.scala`, `typed/delivery/*.scala` | `modules/actor-core-typed/src/receptionist/`, `modules/actor-core-typed/src/pubsub/`, `modules/actor-core-typed/src/delivery/` |
+| serialization / extension / shutdown | Pekko serialization contract, extension registry, `CoordinatedShutdown.scala` | `modules/actor-core-kernel/src/serialization/`, `modules/actor-core-kernel/src/actor/extension/`, `modules/actor-core-kernel/src/system/coordinated_shutdown*` |
 
-### 対象外にするもの
-
-次は actor parity の対象外とする。理由は、Rust で同じ API を再現しても価値が低い、または JVM / Scala / Java 実装都合に強く依存するためである。
+対象外にするもの:
 
 | 対象外 | 理由 |
 |--------|------|
-| Java DSL: `AbstractActor`, `ReceiveBuilder`, `BehaviorBuilder`, `javadsl/*` | Java 継承 DSL / builder DSL であり、Rust では `Actor` trait と closure / typed `Behavior` で表現する |
-| `japi/*` | Java interop 専用 |
-| Scala implicit / package ops | Scala 構文拡張であり、Rust API として同型にする必要がない |
-| JVM reflection / classloader: `DynamicAccess`, `ReflectiveDynamicAccess`, `ClassLoaderObjectInputStream` | JVM 固有 |
-| HOCON dynamic loading / configurator facade | JVM 設定ロード方式に依存。Rust では builder / typed config で扱う |
-| Java serialization: `JavaSerializer`, `DisabledJavaSerializer` | JVM Java serialization 固有 |
-| JFR / flight recorder events | JVM observability 固有。Rust では tracing / metrics 側で扱う |
-| deprecated classic remoting / Netty / Aeron 固有実装 | 廃止または実装技術固有 |
-| Pekko IO / TCP / UDP / DNS | actor core ではなく transport / network adapter 責務として別スコープで扱う |
-| Pekko util 全体互換 | actor runtime に必要な `ByteString` 等のみ対象。汎用 util ライブラリ互換は対象外 |
+| Java DSL / Java interop: `AbstractActor`, `UntypedAbstractActor`, `ReceiveBuilder`, `javadsl/*`, `japi/*` | Java 継承 DSL / builder DSL であり、Rust では trait / builder / typed API に置き換える |
+| Scala implicit / package ops / syntax sugar | Rust API として同型にする必要がない |
+| JVM reflection / classloader / HOCON dynamic loading | JVM 実装方式に依存する |
+| Java serialization / JFR / flight recorder | JVM 固有。Rust 側は serialization trait と tracing adapter を対象にする |
+| deprecated classic remoting / Netty / Aeron 固有実装 | remote / transport の別スコープ |
+| Pekko IO / TCP / UDP / DNS | actor core ではなく transport / network adapter の別スコープ。`modules/actor-core-kernel/src/io.rs` は private placeholder のため parity 分母に入れない |
+| `*-tests`, `*-testkit`, `*-tck`, `src/test`, `multi-jvm` | ユーザーが testkit 調査を明示していないため除外 |
+
+raw declaration count は参考値であり、parity 分母には使わない。
 
 ## サマリー
 
 | 指標 | 値 |
 |------|-----|
-| 分析スコープ | Rust actor runtime parity |
-| parity 対象 API 数 | 101 |
-| fraktor-rs 対応数 | 101 |
-| 公開 API カバレッジ | 101/101 (100%) |
-| 公開 API ギャップ | 0 |
-| high ギャップ | 0 |
-| medium ギャップ | 1 |
-| medium ギャップ内容 | remote / cluster 連携後の `AddressTerminated` DeathWatch 統合 |
-| スタブ検出 | `todo!()` / `unimplemented!()` は actor-core / actor-adaptor-std で 0 件 |
+| Pekko 固定スコープ対象概念 | 114 |
+| fraktor-rs 固定スコープ対応概念 | 111 |
+| 固定スコープ概念カバレッジ | 111/114 (97.4%) |
+| raw Pekko public type declarations | 672 参考値（classic/routing/pattern/event: 415, typed: 257。Java DSL / JFR 等の除外前 raw） |
+| raw Pekko public method declarations | 3008 参考値（classic/routing/pattern/event: 2036, typed: 972） |
+| raw Rust public type declarations | 601 参考値（kernel: 450, typed: 133, std: 18） |
+| raw Rust public method declarations | 2496 参考値（kernel: 1858, typed: 608, std: 30） |
+| hard / medium / easy / trivial gap | 0 / 3 / 0 / 0 |
+| `todo!()` / `unimplemented!()` / `panic!("not implemented")` | 0 件 |
+| コメント上の TODO / placeholder | 4 件。うち parity ギャップ扱いは 3 件 |
 
 ## 層別カバレッジ
 
-| 層 | parity 対象数 | fraktor-rs 対応数 | カバレッジ |
-|----|---------------|------------------|-----------|
-| core / untyped kernel | 39 | 39 | 100% |
-| core / typed wrapper | 56 | 56 | 100% |
-| std / adaptor | 6 | 6 | 100% |
-| 合計 | 101 | 101 | 100% |
+| 層 | Pekko 対応範囲 | fraktor-rs 現状 | 評価 |
+|----|----------------|-----------------|------|
+| kernel | classic actor core, DeathWatch, supervision, routing, event, pattern, serialization, shutdown | `fraktor-actor-core-kernel-rs` として独立。主要公開契約は到達可能 | 主要 API は十分にカバー。termination 完了経路と remote `AddressTerminated` 統合が残る |
+| typed | typed ref/system/behavior/context, signal, router, receptionist, pubsub, delivery | `fraktor-actor-core-typed-rs` として独立し kernel に依存 | typed surface はほぼカバー。cluster receptionist 差分だけ部分実装 |
+| std adaptor | executor, scheduler driver, std clock, tracing logging, circuit breaker registry | `fraktor-actor-adaptor-std-rs` に隔離 | core/std 境界は妥当 |
 
-## カテゴリ別カバレッジ
+## カテゴリ別ギャップ
 
-| カテゴリ | 判定 | 備考 |
-|----------|------|------|
-| classic actor core | 実装済み | actor, context, ref, path, selection, props, system message, stash, timer |
-| supervision / fault handling | 実装済み | supervisor strategy, directive, restart policy, backoff supervisor |
-| typed core surface | 実装済み | typed ref, typed system, behavior, signal, interceptor, context |
-| dispatch / mailbox | 実装済み | dispatcher abstraction, mailbox contract, bounded / priority / control-aware mailbox |
-| event / logging | 実装済み | event stream, dead letter, logging adapter, std tracing integration |
-| pattern | 実装済み | ask, pipe, retry, graceful stop, circuit breaker |
-| classic routing | 実装済み | router, routee, routing logic, pool / group equivalent |
-| typed routing | 実装済み | pool, group, scatter-gather, tail-chopping, balancing |
-| receptionist / discovery | 実装済み | service key, receptionist command, listing, local registration |
-| scheduling / timers | 実装済み | scheduler, timer scheduler, receive timeout |
-| ref / resolution | 実装済み | actor path, actor selection, identify / identity |
-| delivery / pubsub | 実装済み | producer / consumer controller, durable producer queue, topic |
-| serialization | 実装済み | serializer trait, manifest, registry, transport information |
-| extension | 実装済み | extension id, setup, registry |
-| coordinated shutdown | 実装済み | phase, task, reason, termination |
-| std adaptor | 実装済み | tokio executor, threaded executor, scheduler, tracing subscriber |
+ギャップ（未対応・部分実装・n/a）のみテーブルに列挙する。実装済みはカテゴリの件数カウントに含める。
 
-## 残存ギャップ
+### classic actor core 実装済み 12/12 (100%)
 
-### AC-M4b: DeathWatch の remote `AddressTerminated` 統合
+該当ギャップなし。`Actor`, `ActorContext`, `ActorRef`, `ActorPath`, `ActorSelection`, `Props`, `ActorSystem`, address / deploy / child / spawn / stash 相当は kernel に存在する。
 
-| 項目 | 内容 |
-|------|------|
-| 種別 | 内部セマンティクスギャップ |
-| Pekko 側の根拠 | remote address termination を DeathWatch に流し、監視対象 actor へ一度だけ termination を通知する |
-| fraktor-rs 側の現状 | local DeathWatch は実装済み。remote / cluster の address termination 連携は後続モジュール依存 |
-| 実装先 | core + remote / cluster integration |
-| 難易度 | medium |
-| 優先度 | remote / cluster の基盤確定後 |
+### supervision / lifecycle / DeathWatch 実装済み 8/10 (80%)
 
-この項目は公開 API ギャップではない。remote / cluster が actor runtime に接続された段階で、内部イベント経路として実装する。
+| Pekko API / 概念 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|------------------|-----------|-------------|----------|--------|------|
+| parent termination completion (`finishTerminate`) | `references/pekko/actor/src/main/scala/org/apache/pekko/actor/ActorCell.scala`, `references/pekko/actor/src/main/scala/org/apache/pekko/actor/FaultHandling.scala` | 部分実装: `modules/actor-core-kernel/src/actor/actor_cell.rs:1163`, `modules/actor-core-kernel/src/actor/children_container.rs:188` | kernel | medium | `ChildrenContainer::remove_child_and_get_state_change` は `Termination` を返せるが、`handle_death_watch_notification` が `finish_terminate(pid)` へ接続していない |
+| remote `AddressTerminated` DeathWatch integration | `references/pekko/actor/src/main/scala/org/apache/pekko/actor/Actor.scala:136`, `references/pekko/actor/src/main/scala/org/apache/pekko/actor/dungeon/DeathWatch.scala:218`, `references/pekko/actor/src/main/scala/org/apache/pekko/event/AddressTerminatedTopic.scala:34` | 部分実装: DeathWatch 基本経路と system message serializer はあるが remote / cluster address termination topic が未統合 | kernel + remote / cluster integration | medium | local DeathWatch は実装済み。remote / cluster の node termination を `Terminated` へ一度だけ翻訳する経路が残る |
 
-### classic kernel public surface の整理
+### typed core surface 実装済み 12/12 (100%)
 
-| 項目 | 内容 |
-|------|------|
-| 種別 | 内部構造ギャップ |
-| 現状 | classic kernel の補助型が public surface に広く露出している |
-| 問題 | 外部 API と内部実装詳細の境界がやや曖昧 |
-| 推奨 | 外部契約として必要な型と `pub(crate)` に落とせる補助型を分離する |
-| 難易度 | medium |
-| 優先度 | API 追加よりも構造整理タスクとして扱う |
+該当ギャップなし。`TypedActorRef`, `TypedActorSystem`, `Behavior`, `BehaviorInterceptor`, typed `ActorContext`, signals, typed props, dispatcher / mailbox selector, actor-ref resolver は `actor-core-typed` に分離済み。
 
-この項目も Pekko parity の公開 API 不足ではない。今後の保守性を上げるための構造改善候補である。
+### dispatch / mailbox 実装済み 10/10 (100%)
 
-## raw 抽出結果の扱い
+該当ギャップなし。core の `Executor`, `ExecutorFactory`, `Mailbox`, `MailboxType`, `MailboxRequirement`, `MailboxPolicy`, dispatcher registry と、std の tokio / threaded / pinned / affinity executor adapter が分離されている。
 
-今回の初回調査では、参考値として次の raw 抽出を行った。
+### routing 実装済み 11/11 (100%)
 
-| 指標 | 値 |
-|------|-----|
-| Pekko `actor` + `actor-typed` raw 公開型数 | 756 unique |
-| fraktor-rs actor raw 公開型数 | 472 unique |
-| 直接同名カバレッジ | 134/756 (17.7%) |
+該当ギャップなし。classic routing は `RoundRobin`, `Random`, `ConsistentHashing`, `SmallestMailbox`, `Pool`, `Group`, `Routee`, `Router`, `RemoteRouter*` を kernel に持つ。typed routing は `Routers`, `PoolRouter`, `GroupRouter`, `TailChopping`, `ScatterGatherFirstCompleted`, `BalancingPool`, `Resizer` を typed に持つ。
 
-この数値は parity 指標として使わない。理由は、次のような対象外 API を含むためである。
+### event / logging 実装済み 8/8 (100%)
 
-- Java DSL / javadsl / japi
-- Scala implicit / package ops
-- JVM reflection / classloader
-- HOCON dynamic loading
-- Java serialization
-- JFR events
-- deprecated classic remoting
-- Pekko IO / TCP / UDP / DNS
-- actor runtime に不要な Pekko util 全体互換
+該当ギャップなし。`EventStream`, subscriber, dead letter, unhandled message, lifecycle/remoting event, logging adapter, logger subscriber, tracing subscriber adapter が確認できる。
 
-raw 抽出は「Pekko ディレクトリ内に存在する名前の棚卸し」としては有用だが、「Rust actor runtime parity の達成率」としては不適切である。
+### pattern 実装済み 5/5 (100%)
+
+該当ギャップなし。classic `ask`, timeout completion, `retry`, `graceful_stop`, `CircuitBreaker` と typed `AskPattern` が存在する。std registry は `modules/actor-adaptor-std/src/pattern/` に分離されている。
+
+### receptionist / discovery 実装済み 4/5 (80%)
+
+| Pekko API / 概念 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|------------------|-----------|-------------|----------|--------|------|
+| `Listing.servicesWereAddedOrRemoved` の cluster reachability 差分 | `references/pekko/actor-typed/src/main/scala/org/apache/pekko/actor/typed/receptionist/Receptionist.scala:425`, `references/pekko/actor-typed/src/main/scala/org/apache/pekko/actor/typed/internal/receptionist/ReceptionistMessages.scala:75` | 部分実装: `modules/actor-core-typed/src/receptionist/listing.rs:108` | actor-core-typed + cluster integration | medium | 現在は local-only として常に `true`。clustered receptionist reachability が入ると add/remove 差分を持つ必要がある |
+
+### scheduling / timers 実装済み 5/5 (100%)
+
+該当ギャップなし。kernel `Scheduler`, cancellable registry, receive timeout, classic timer scheduler と typed `TimerScheduler` が存在する。`modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs:1` は doc 上 placeholder と書かれているが、実体は timer wheel ベース実装を持つためギャップにはしない。
+
+### ref / resolution 実装済み 4/4 (100%)
+
+該当ギャップなし。classic `Identify` / `ActorIdentity`, actor path parser/formatter, actor selection resolver, typed `ActorRefResolver` / setup が存在する。
+
+### delivery / pubsub 実装済み 9/9 (100%)
+
+該当ギャップなし。`ProducerController`, `ConsumerController`, `WorkPullingProducerController`, durable queue, sequence number, confirmation qualifier, message sent state, typed `Topic`, `TopicCommand` が `actor-core-typed` に存在する。
+
+### serialization contract 実装済み 9/9 (100%)
+
+該当ギャップなし。`Serializer`, `SerializerWithStringManifest`, `ByteBufferSerializer`, async serializer, registry, extension, setup builder, serialized message, transport information が kernel に存在する。Java serialization そのものは対象外。
+
+### extension 実装済み 3/3 (100%)
+
+該当ギャップなし。kernel extension trait / id / installer と typed `ExtensionSetup`, typed receptionist extension が存在する。
+
+### coordinated shutdown 実装済み 5/5 (100%)
+
+該当ギャップなし。`CoordinatedShutdown`, phase, reason, installer, error が kernel に存在する。
+
+### std adaptor 実装済み 6/6 (100%)
+
+該当ギャップなし。`TokioExecutor`, `ThreadedExecutor`, `PinnedExecutor`, `AffinityExecutor`, `TokioTickDriver`, `StdClock`, tracing logger subscriber が std adaptor にある。
+
+## 内部モジュール構造ギャップ
+
+API ギャップは 3/114 と少ないため、内部構造も確認した。
+
+| 構造ギャップ | Pekko側の根拠 | fraktor-rs側の現状 | 推奨アクション | 難易度 | 緊急度 | 備考 |
+|-------------|---------------|--------------------|----------------|--------|--------|------|
+| termination completion の集約点不足 | `ActorCell.finishTerminate` / `FaultHandling.handleChildTerminated` 相当 | `actor_cell.rs` と `children_container.rs` に `Termination` 遷移の受け皿はあるが、`finish_terminate` 呼び出しが未配線 | `ActorCell` 内に termination 完了処理を集約し、`SuspendReason::Termination` 返却時に呼ぶ | medium | high | local lifecycle parity の残り。remote / cluster より先に閉じられる |
+| remote address termination event の経路不足 | `AddressTerminatedTopic`, `DeathWatch.addressTerminated`, remote / cluster watcher | kernel event stream, remoting lifecycle event, system message serializer はあるが、remote / cluster から DeathWatch へ流す topic / hook が未完成 | kernel に address-terminated 契約を置き、remote / cluster が publish する adapter を接続する | medium | medium | remote / cluster の責務確定後に接続するのが自然 |
+| typed receptionist reachability diff の保持不足 | typed `Receptionist.Listing.servicesWereAddedOrRemoved` | `Listing` は local-only として常に `true` を返す | `Listing` に add/remove diff または差分フラグを保持し、clustered receptionist 実装から設定する | medium | medium | cluster receptionist 導入時の typed API セマンティクス差分 |
+| kernel public surface の広さ | Pekko は public API と `private[pekko]` internal を明確に分ける | `modules/actor-core-kernel/src/actor.rs` が `ActorCell`, `ActorShared`, `ChildRef` など低レベル型を public re-export している | 外部契約として必要な型と `pub(crate)` / internal に落とせる型を棚卸しする | medium | low | parity 不足ではなく保守性改善。pre-release なので破壊的整理は可能 |
 
 ## 実装優先度
 
 ### Phase 1: trivial / easy
 
-公開 API parity 対象では該当なし。
+該当なし。
 
 ### Phase 2: medium
 
-- remote / cluster 基盤確定後に `AddressTerminated` を DeathWatch へ統合する（core + remote / cluster）
-- classic kernel の public surface を整理し、内部補助型を `pub(crate)` 化する（core/kernel）
+- parent termination completion (`finish_terminate`) を `SuspendReason::Termination` 経路へ配線する（kernel）
+- remote `AddressTerminated` を DeathWatch へ統合する（kernel + remote / cluster integration）
+- `Listing.services_were_added_or_removed` に cluster reachability の add/remove 差分を反映する（actor-core-typed + cluster integration）
 
 ### Phase 3: hard
 
-公開 API parity 対象では該当なし。
+該当なし。
 
 ### 対象外（n/a）
 
-- Java DSL / javadsl / japi
-- Scala implicit / package ops
-- JVM reflection / classloader
-- HOCON dynamic loading
-- Java serialization
-- JFR / flight recorder
-- deprecated classic remoting
+- Java DSL / `javadsl/*` / `japi/*`
+- Scala implicit / package ops / syntax sugar
+- JVM reflection / classloader / HOCON loading
+- Java serialization / JFR / flight recorder
+- deprecated classic remoting / Netty / Aeron 固有実装
 - Pekko IO / TCP / UDP / DNS
-- actor runtime に不要な Pekko util 全体互換
+- testkit / TCK / tests
 
 ## まとめ
 
-actor モジュールの Rust actor runtime parity は、公開 API レベルでは 101/101 で達成済みと評価する。残っている主な作業は、公開 API 追加ではなく、remote / cluster 連携後の DeathWatch 内部セマンティクスと classic kernel の public surface 整理である。
+actor モジュールは、分割後の `actor-core-kernel` / `actor-core-typed` / `actor-adaptor-std` を基準に見ても、公開 API parity は 111/114 (97.4%) まで到達している。今回の主な修正点は、旧 `actor-core` 内部サブディレクトリ前提を捨て、現行クレート分割をスコープ定義と層別カバレッジに反映したこと。
 
-今後の調査では、Pekko の raw ディレクトリ抽出結果をそのまま parity 分母にしない。まず「Rust で再現すべき公開契約」と「JVM / Scala / Java / transport 固有で対象外にする契約」を固定し、そのスコープ内でギャップを評価する。
+低コストで parity を前進できる代表は `finish_terminate` 配線と typed receptionist の差分フラグ保持である。主要ギャップは remote / cluster 連携後の `AddressTerminated` DeathWatch 統合で、これは actor 単体というより remote / cluster integration の境界タスクになる。
+
+次のボトルネックは公開 API 追加ではなく、termination / reachability の内部イベント経路と kernel public surface の整理にある。


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update that re-scopes the parity analysis to the split crates and revises reported metrics; no runtime/logic changes.
> 
> **Overview**
> Updates the actor gap analysis document to treat the split crates (kernel/typed/std adaptor) as the parity unit instead of the old `actor-core` subdirectories, and refreshes the scope tables to match those crate boundaries.
> 
> Replaces the previous 101/101 API-parity summary with a fixed-scope concept coverage view (111/114) plus raw declaration counts as *reference-only*, and expands the gap section to explicitly call out the remaining medium gaps (termination completion wiring, remote `AddressTerminated`→DeathWatch integration, and typed receptionist reachability diffs) along with updated priorities/exclusions (e.g., tests/testkits excluded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba54460ea1a418044c0750dd06df34746c58bd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->