### PR TITLE
chore(make): remove stale script tasks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -22,45 +22,6 @@ fi
 cargo +"${CHANNEL}" fmt
 '''
 
-[tasks.sort-dependencies]
-workspace = false
-command = "rust-script"
-args = ["scripts/sort_dependencies.rs"]
-
-
-[tasks.check-source-policy]
-description = "Enforce source policy: ban mod.rs and one top-level type/trait per file (workspace-aware, ignores tests.rs/lib.rs/main.rs)"
-workspace = false
-command = "rust-script"
-args = ["scripts/check_source_policy.rs"]
-
-
-[tasks.check-impl-co-location]
-description = "Ensure struct definitions and inherent impl blocks live in the same file"
-workspace = false
-command = "rust-script"
-args = ["scripts/check_impl_co_location.rs"]
-
-
-[tasks.check-package-exposure]
-description = "Enforce Java-style package re-exports (no deep crate:: paths or wildcard exports)"
-workspace = false
-command = "rust-script"
-args = ["scripts/check_package_exposure.rs"]
-
-
-[tasks.check-reexport-hierarchy]
-description = "Verify that modules only re-export their descendants"
-workspace = false
-command = "rust-script"
-args = ["scripts/check_reexport_hierarchy.rs"]
-
-[tasks.check-module-wiring]
-description = "Verify parent modules re-export leaf types without leaking pub mod"
-workspace = false
-command = "rust-script"
-args = ["scripts/check_module_wiring.rs"]
-
 [tasks.coverage-grcov]
 description = "Generate code coverage report using grcov"
 workspace = false
@@ -81,13 +42,6 @@ description = "Run lifetime regression suite (tests + coverage)"
 workspace = false
 category = "Test"
 dependencies = ["coverage"]
-
-[tasks.cyclomatic]
-description = "Report heuristic cyclomatic complexity for key crates"
-workspace = false
-category = "Lint"
-command = "rust-script"
-args = ["scripts/cyclomatic.rs"]
 
 [tasks.ci-check]
 description = "Run full CI validation pipeline"
@@ -117,11 +71,6 @@ if [ ${#ARGS[@]} -gt 0 ] && [ "${ARGS[0]}" = "--" ]; then
 fi
 ./scripts/ci-check.sh dylint "${ARGS[@]}"
 '''
-
-[tasks.codex]
-description = "Report heuristic cyclomatic complexity for key crates"
-workspace = false
-command = "./scripts/run-codex.sh"
 
 [tasks.actor-core-us1]
 description = "Actor core US1: ping/pong pipeline (tests + examples)"


### PR DESCRIPTION
## Summary
- remove cargo-make tasks that referenced deleted scripts/*.rs files
- remove stale codex task that referenced deleted scripts/run-codex.sh

## Verification
- cargo make --list-all-steps
- confirmed stale task/script references are absent from the task list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes `cargo-make` tasks that referenced deleted scripts, with no runtime or library code changes.
> 
> **Overview**
> Cleans up `Makefile.toml` by removing stale `cargo-make` tasks that referenced deleted `scripts/*.rs` checks (dependency sorting/source policy/module wiring/re-export checks) and other removed tooling (`cyclomatic`, `codex`).
> 
> This reduces CI/task-list noise by leaving only currently supported build/test/coverage and actor-core workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baef3beab4e791d8784cb6ce049a306c52b4c5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->