### PR TITLE
chore(make): remove redundant ci task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -132,15 +132,6 @@ dependencies = [
   "actor-core-perf",
 ]
 
-[tasks.actor-core-ci]
-description = "Run full CI for actor-core (scripts/ci-check.sh all)"
-workspace = false
-script = '''
-#!/usr/bin/env bash
-set -euo pipefail
-./scripts/ci-check.sh all
-'''
-
 [tasks.actor-tell-disabled-check]
 description = "Build fraktor-actor-core-kernel-rs core targets with tell API disabled via --cfg fraktor_disable_tell"
 workspace = false


### PR DESCRIPTION
## Summary
- remove the redundant actor-core-ci cargo-make task
- keep ci-check as the single full CI entry point

## Verification
- cargo make --list-all-steps
- confirmed ci-check remains and actor-core-ci / ci aliases are absent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a redundant `cargo-make` task without changing build/test logic, leaving `ci-check` as the single entry point for full CI.
> 
> **Overview**
> Removes the `actor-core-ci` task from `Makefile.toml`, consolidating full CI execution under the existing `ci-check` task (which calls `scripts/ci-check.sh`).
> 
> This reduces duplicate CI entry points without changing the underlying CI script or actor-core pipelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4139afbf113a0128effb72d41877e690a7fb403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->