### PR TITLE
docs(readme): update project structure overview

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -12,31 +12,41 @@
 
 [English](README.md)
 
-fraktor-rs は、Pekko と Proto.Actor に着想を得たアクターモデルを、`no_std` ターゲットとホストランタイムの両方で扱うための、仕様駆動のアクターランタイムです。
+fraktor-rs は、Apache Pekko と Proto.Actor に着想を得た、仕様駆動の Rust アクターランタイムです。
+ランタイムは `no_std` の core クレートと `std` の adaptor クレートに分けて開発されており、可搬性の高い状態機械と契約を、Tokio、ネットワーク、ホストランタイムの binding から分離しています。
 
-組み込み向けの軽量な実行環境から、標準ライブラリを利用できるホスト環境まで、同じ設計思想とワークスペース構成のもとで一貫したアクターモデルを提供することを目指しています。
+ルートの `fraktor-rs` クレートは、現時点ではプロジェクトメタデータの公開とパッケージ名の予約を担っています。
+ランタイム API は [`modules/`](modules) 配下の workspace クレートにあり、動作を確認する最短の入口は実行可能な [`fraktor-showcases-std`](showcases/std) の example 群です。
 
 ## 特徴
 
-- ワークスペース全体で `core` / `std` の構造を共有し、同じアクターモデルを組み込み環境とホスト環境の両方で扱えます
-- `utils` / `actor` / `persistence` / `remote` / `cluster` / `stream` の 6 つのクレートと、主要な利用シナリオを試せる showcase 群を備えています
-- ライフサイクル、supervision、death watch、actor path、remoting、typed/untyped bridge など、Pekko / Proto.Actor 由来の主要な意味論を取り込んでいます
-- steering、カスタム dylint ルール、CI スクリプトを含む仕様駆動ワークフローにより、変更を一貫した形で管理できます
+- actor kernel、typed actor、persistence、remote、cluster、stream、共通 utilities を `no_std` core クレートとして提供します
+- `std` adaptor クレートが、Tokio executor、TCP transport、std lock、materializer、cluster delivery helper などのホスト依存部分を分離します
+- actor system、supervision、death watch、routing、dispatcher、mailbox、event stream、serialization、remoting、clustering、persistence、stream processing など、Pekko / Proto.Actor 由来の意味論を取り込んでいます
+- std showcase で、legacy typed flow、Pekko classic/kernel example、typed example、stream example、advanced remote/persistence scenario を実行できます
+- OpenSpec artifact、リポジトリルール、カスタム dylint、CI スクリプトにより、設計意図、モジュール境界、実装チェックをそろえています
 
 ## クイックスタート
 
 ### 必要なもの
 
 - `rustup`
-- Rust toolchain `nightly-2025-12-01`
-- フルチェックを実行する場合は `cargo-dylint`、`rustc-dev`、`llvm-tools-preview`
+- Rust toolchain `nightly-2025-12-01` ([`rust-toolchain.toml`](rust-toolchain.toml) で固定)
+- フルローカルチェックを実行する場合は `cargo-dylint`、`rustc-dev`、`llvm-tools-preview`
 
 ### インストール
 
 ```bash
-rustup toolchain install nightly-2025-12-01 --component rustfmt --component clippy
 git clone git@github.com:j5ik2o/fraktor-rs.git
 cd fraktor-rs
+rustup toolchain install nightly-2025-12-01 --component rustfmt --component clippy
+```
+
+dylint を含むフル検証を行う場合:
+
+```bash
+rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2025-12-01
+cargo install cargo-dylint dylint-link
 ```
 
 ### 実行
@@ -45,60 +55,99 @@ cd fraktor-rs
 cargo run -p fraktor-showcases-std --example getting_started
 ```
 
+その他の example:
+
+```bash
+cargo run -p fraktor-showcases-std --example typed_first_example
+cargo run -p fraktor-showcases-std --example stream_first_example
+cargo run -p fraktor-showcases-std --features advanced --example remote_lifecycle
+```
+
 ### 検証
 
 ```bash
-cargo test -p fraktor-actor-core-kernel-rs --features "std test-support tokio-executor"
-./scripts/ci-check.sh all
+cargo test -p fraktor-rs
+./scripts/ci-check.sh ai all
 ```
+
+## 使い方
+
+ルート facade が統合ランタイムモジュールを公開するまでは、必要な API 領域を持つクレートを直接使います。
+
+| 領域 | クレート |
+| --- | --- |
+| Utilities | [`fraktor-utils-core-rs`](modules/utils-core), [`fraktor-utils-adaptor-std-rs`](modules/utils-adaptor-std) |
+| Actor runtime | [`fraktor-actor-core-kernel-rs`](modules/actor-core-kernel), [`fraktor-actor-core-typed-rs`](modules/actor-core-typed), [`fraktor-actor-adaptor-std-rs`](modules/actor-adaptor-std) |
+| Persistence | [`fraktor-persistence-core-rs`](modules/persistence-core) |
+| Remote | [`fraktor-remote-core-rs`](modules/remote-core), [`fraktor-remote-adaptor-std-rs`](modules/remote-adaptor-std) |
+| Cluster | [`fraktor-cluster-core-rs`](modules/cluster-core), [`fraktor-cluster-adaptor-std-rs`](modules/cluster-adaptor-std) |
+| Streams | [`fraktor-stream-core-kernel-rs`](modules/stream-core-kernel), [`fraktor-stream-core-actor-typed-rs`](modules/stream-core-actor-typed), [`fraktor-stream-adaptor-std-rs`](modules/stream-adaptor-std) |
+
+showcase クレートは、実行可能な flow の現時点の利用インデックスです。
+
+```bash
+cargo run -p fraktor-showcases-std --example request_reply
+cargo run -p fraktor-showcases-std --example kernel_supervision
+cargo run -p fraktor-showcases-std --example typed_actor_lifecycle
+cargo run -p fraktor-showcases-std --example stream_graphs
+```
+
+example の一覧と必要な feature は [`showcases/std/README.md`](showcases/std/README.md) を参照してください。
 
 ## ワークスペース構成
 
-ワークスペースは以下のクレートで構成されています。
-
-| クレート | 役割 |
+| パス | 役割 |
 | --- | --- |
-| [`modules/utils`](modules/utils) | 可搬性の高い基本プリミティブ、ランタイム補助ユーティリティ、アトミック操作、同期機構、タイマー |
-| [`modules/actor`](modules/actor) | ActorSystem、メールボックス、supervision、型付き API、スケジューラ、EventStream |
-| [`modules/persistence`](modules/persistence) | Event Sourcing、ジャーナル、スナップショットストア、永続アクター支援 |
-| [`modules/remote`](modules/remote) | Remoting 拡張、エンドポイント管理、トランスポートアダプタ、障害検知 |
-| [`modules/cluster`](modules/cluster) | メンバーシップ管理、ID 解決、配置、トポロジー、pub-sub、ECS 統合 |
-| [`modules/stream`](modules/stream) | アクターシステム上に構築されたリアクティブストリーム |
-| [`modules/actor/examples`](modules/actor/examples) | typed event stream、classic timers、classic logging などのアクター利用例 |
-| [`showcases/std`](showcases/std) | getting started、request/reply、timers、routing、persistence、remoting、clustering などの統合サンプル |
-
-よく使う実行例:
-
-```bash
-# 標準的な showcase
-cargo run -p fraktor-showcases-std --example request_reply
-
-# 高度な showcase
-cargo run -p fraktor-showcases-std --example remote_messaging --features advanced
-```
+| [`src/`](src) | ルート `fraktor-rs` クレートの placeholder とパッケージメタデータ |
+| [`modules/utils-core`](modules/utils-core) | 可搬性の高い collection、sync primitive、time helper、atomic、network parsing |
+| [`modules/utils-adaptor-std`](modules/utils-adaptor-std) | 標準ライブラリ向け utility adaptor |
+| [`modules/actor-core-kernel`](modules/actor-core-kernel) | `no_std` の untyped actor kernel: actor ref、system、dispatch、routing、serialization、pattern、lifecycle |
+| [`modules/actor-core-typed`](modules/actor-core-typed) | `no_std` の typed actor facade、DSL、receptionist、pub-sub、delivery、typed event stream、typed system API |
+| [`modules/actor-adaptor-std`](modules/actor-adaptor-std) | Std/Tokio actor binding、executor、tick driver、time、event、pattern、test-support helper |
+| [`modules/persistence-core`](modules/persistence-core) | Event sourcing、journal、snapshot、persistent actor、persistent FSM、durable state、persistence extension |
+| [`modules/remote-core`](modules/remote-core) | `no_std` の remote address、association、envelope、provider、transport port、watcher、wire、failure-detector state machine |
+| [`modules/remote-adaptor-std`](modules/remote-adaptor-std) | Std remote extension installer、provider、Tokio TCP transport、I/O worker |
+| [`modules/cluster-core`](modules/cluster-core) | Cluster membership、identity、placement、pub-sub、grain、failure detection、topology、metrics、routing |
+| [`modules/cluster-adaptor-std`](modules/cluster-adaptor-std) | Std cluster API、local provider wrapping、Tokio gossip transport、pub-sub delivery、optional AWS ECS provider |
+| [`modules/stream-core-kernel`](modules/stream-core-kernel) | `no_std` の stream DSL、stage、materialization contract、graph shape、stream ref、queue、kill switch、supervision |
+| [`modules/stream-core-actor-typed`](modules/stream-core-actor-typed) | stream DSL 向け typed actor integration |
+| [`modules/stream-adaptor-std`](modules/stream-adaptor-std) | Std stream I/O と materializer adaptor |
+| [`showcases/std`](showcases/std) | ホスト環境向けの実行可能 example |
+| [`tests/e2e`](tests/e2e) | クロスクレート end-to-end test |
+| [`lints/`](lints) | プロジェクト構造と Rust 規約のためのカスタム dylint ルール |
+| [`openspec/`](openspec) | 仕様駆動設計 artifact、active change、accepted spec |
 
 ## ドキュメント
 
 - API ドキュメント: [docs.rs/fraktor-rs](https://docs.rs/fraktor-rs)
-- リポジトリ知識ベース: [DeepWiki](https://deepwiki.com/j5ik2o/fraktor-rs)
-- 現在の parity レポート:
+- Showcase index: [`showcases/std/README.md`](showcases/std/README.md)
+- リポジトリルール: [AGENTS.md](AGENTS.md), [`.agents/rules/project.md`](.agents/rules/project.md)
+- OpenSpec 設定: [`openspec/config.yaml`](openspec/config.yaml)
+- Lock-free design note: [`docs/guides/lock_free_design.md`](docs/guides/lock_free_design.md)
+- 現在の gap report:
   - [Actor](docs/gap-analysis/actor-gap-analysis.md)
+  - [Actor mailbox](docs/gap-analysis/actor-mailbox-gap-analysis.md)
   - [Remote](docs/gap-analysis/remote-gap-analysis.md)
   - [Cluster](docs/gap-analysis/cluster-gap-analysis.md)
   - [Persistence](docs/gap-analysis/persistence-gap-analysis.md)
   - [Stream](docs/gap-analysis/stream-gap-analysis.md)
+- 参照実装:
+  - [`references/pekko`](references/pekko)
+  - [`references/protoactor-go`](references/protoactor-go)
 
 ## サポート
 
 - Issues: [GitHub Issues](https://github.com/j5ik2o/fraktor-rs/issues)
-- 実装ルールの基準: [AGENTS.md](AGENTS.md)
+- リポジトリ知識ベース: [DeepWiki](https://deepwiki.com/j5ik2o/fraktor-rs)
 
 ## コントリビューション
 
-- 実装前に、このリポジトリの仕様駆動ワークフローに従って要件と設計を整理してください
-- プロジェクト全体のルールは [`.kiro/steering`](.kiro/steering) と [AGENTS.md](AGENTS.md) を参照してください
-- PR の前に `./scripts/ci-check.sh all` を実行してください
-- runtime、remoting、cluster、stream に影響がある場合は、PR 説明に明記してください
+- コード変更前に [AGENTS.md](AGENTS.md) と [`.agents/rules/`](.agents/rules) 配下の scoped rule を読んでください
+- 振る舞いに影響する変更では OpenSpec を使い、OpenSpec コマンドは `mise exec -- openspec ...` 経由で実行してください
+- `*-core` クレートは `no_std` を維持し、ホスト依存の runtime、network、time、Tokio 関連は `*-adaptor-std` クレートに配置してください
+- 実行可能 example は `modules/**/examples` ではなく [`showcases/std`](showcases/std) に置いてください
+- 開発中は対象を絞ったチェックを実行し、PR 前には `./scripts/ci-check.sh ai all` を実行してください
+- [`CHANGELOG.md`](CHANGELOG.md) は GitHub Actions で生成されるため、手動編集しないでください
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -11,31 +11,41 @@
 
 [日本語版](README.ja.md)
 
-fraktor-rs is a specification-driven actor runtime that brings Pekko- and Proto.Actor-inspired semantics to both `no_std` targets and host runtimes.
+fraktor-rs is a specification-driven Rust actor runtime inspired by Apache Pekko and Proto.Actor.
+The runtime is developed as `no_std` core crates plus `std` adaptor crates, keeping portable state machines and contracts separate from Tokio, networking, and host-runtime bindings.
 
-It is designed to let you work with a consistent actor model across embedded-friendly environments and standard host environments, while sharing the same overall architecture and workspace structure.
+The root `fraktor-rs` crate currently publishes project metadata and reserves the package name.
+Runtime APIs live in the workspace crates under [`modules/`](modules), and the fastest way to inspect behavior is through the runnable [`fraktor-showcases-std`](showcases/std) examples.
 
 ## Highlights
 
-- Shared `core`/`std` module structure across the workspace, so the same actor model can be used on embedded targets and on Tokio-based hosts.
-- Six focused crates for `utils`, `actor`, `persistence`, `remote`, `cluster`, and `stream`, plus runnable showcases for common scenarios.
-- Pekko / Proto.Actor-inspired semantics for lifecycle, supervision, death watch, actor paths, remoting, and typed/untyped bridging.
-- A specification-driven workflow supported by steering, custom dylint rules, and CI scripts for consistent change management.
+- Portable `no_std` core crates for actor kernel, typed actors, persistence, remote, cluster, streams, and shared utilities.
+- `std` adaptor crates isolate host-specific concerns such as Tokio executors, TCP transport, std locks, materializers, and cluster delivery helpers.
+- Pekko / Proto.Actor-inspired semantics for actor systems, supervision, death watch, routing, dispatchers, mailboxes, event streams, serialization, remoting, clustering, persistence, and stream processing.
+- Runnable std showcases cover legacy typed flows, Pekko classic/kernel examples, typed examples, stream examples, and advanced remote/persistence scenarios.
+- OpenSpec artifacts, repository rules, custom dylint checks, and CI scripts keep design intent, module boundaries, and implementation checks aligned.
 
 ## Quickstart
 
 ### Requirements
 
 - `rustup`
-- Rust toolchain `nightly-2025-12-01`
-- `cargo-dylint`, `rustc-dev`, and `llvm-tools-preview` if you want to run the full local checks
+- Rust toolchain `nightly-2025-12-01` (pinned by [`rust-toolchain.toml`](rust-toolchain.toml))
+- `cargo-dylint`, `rustc-dev`, and `llvm-tools-preview` for the full local check suite
 
 ### Install
 
 ```bash
-rustup toolchain install nightly-2025-12-01 --component rustfmt --component clippy
 git clone git@github.com:j5ik2o/fraktor-rs.git
 cd fraktor-rs
+rustup toolchain install nightly-2025-12-01 --component rustfmt --component clippy
+```
+
+For full dylint-backed verification:
+
+```bash
+rustup component add rustc-dev llvm-tools-preview --toolchain nightly-2025-12-01
+cargo install cargo-dylint dylint-link
 ```
 
 ### Run
@@ -44,60 +54,99 @@ cd fraktor-rs
 cargo run -p fraktor-showcases-std --example getting_started
 ```
 
+More examples:
+
+```bash
+cargo run -p fraktor-showcases-std --example typed_first_example
+cargo run -p fraktor-showcases-std --example stream_first_example
+cargo run -p fraktor-showcases-std --features advanced --example remote_lifecycle
+```
+
 ### Verify
 
 ```bash
-cargo test -p fraktor-actor-core-kernel-rs --features "std test-support tokio-executor"
-./scripts/ci-check.sh all
+cargo test -p fraktor-rs
+./scripts/ci-check.sh ai all
 ```
 
-## Workspace layout
+## Usage
 
-The workspace is organized around the following crates:
+Until the root facade exposes consolidated runtime modules, use the crate that owns the API area you need:
 
-| Crate | Purpose |
+| Area | Crates |
 | --- | --- |
-| [`modules/utils`](modules/utils) | Portable primitives, runtime helper utilities, atomics, synchronization, and timers |
-| [`modules/actor`](modules/actor) | ActorSystem, mailboxes, supervision, typed APIs, scheduler, and EventStream |
-| [`modules/persistence`](modules/persistence) | Event sourcing, journals, snapshot stores, and persistent actor support |
-| [`modules/remote`](modules/remote) | Remoting extensions, endpoint management, transport adapters, and failure detection |
-| [`modules/cluster`](modules/cluster) | Membership, identity lookup, placement, topology, pub-sub, and ECS integration |
-| [`modules/stream`](modules/stream) | Reactive stream primitives built on top of the actor system |
-| [`modules/actor/examples`](modules/actor/examples) | Focused actor examples such as typed event streams, classic timers, and classic logging |
-| [`showcases/std`](showcases/std) | Runnable integrated examples including getting started, request/reply, timers, routing, persistence, remoting, and clustering |
+| Utilities | [`fraktor-utils-core-rs`](modules/utils-core), [`fraktor-utils-adaptor-std-rs`](modules/utils-adaptor-std) |
+| Actor runtime | [`fraktor-actor-core-kernel-rs`](modules/actor-core-kernel), [`fraktor-actor-core-typed-rs`](modules/actor-core-typed), [`fraktor-actor-adaptor-std-rs`](modules/actor-adaptor-std) |
+| Persistence | [`fraktor-persistence-core-rs`](modules/persistence-core) |
+| Remote | [`fraktor-remote-core-rs`](modules/remote-core), [`fraktor-remote-adaptor-std-rs`](modules/remote-adaptor-std) |
+| Cluster | [`fraktor-cluster-core-rs`](modules/cluster-core), [`fraktor-cluster-adaptor-std-rs`](modules/cluster-adaptor-std) |
+| Streams | [`fraktor-stream-core-kernel-rs`](modules/stream-core-kernel), [`fraktor-stream-core-actor-typed-rs`](modules/stream-core-actor-typed), [`fraktor-stream-adaptor-std-rs`](modules/stream-adaptor-std) |
 
-Common entrypoints:
+The showcase crate is the current usage index for executable flows:
 
 ```bash
-# Standard showcase
 cargo run -p fraktor-showcases-std --example request_reply
-
-# Advanced showcase
-cargo run -p fraktor-showcases-std --example remote_messaging --features advanced
+cargo run -p fraktor-showcases-std --example kernel_supervision
+cargo run -p fraktor-showcases-std --example typed_actor_lifecycle
+cargo run -p fraktor-showcases-std --example stream_graphs
 ```
+
+See [`showcases/std/README.md`](showcases/std/README.md) for the full example list and feature requirements.
+
+## Workspace Layout
+
+| Path | Purpose |
+| --- | --- |
+| [`src/`](src) | Root `fraktor-rs` crate placeholder and package metadata |
+| [`modules/utils-core`](modules/utils-core) | Portable collections, sync primitives, time helpers, atomics, and network parsing |
+| [`modules/utils-adaptor-std`](modules/utils-adaptor-std) | Standard-library utility adapters |
+| [`modules/actor-core-kernel`](modules/actor-core-kernel) | `no_std` untyped actor kernel: actor refs, systems, dispatch, routing, serialization, patterns, and lifecycle |
+| [`modules/actor-core-typed`](modules/actor-core-typed) | `no_std` typed actor facade, DSL, receptionist, pub-sub, delivery, typed event stream, and typed system APIs |
+| [`modules/actor-adaptor-std`](modules/actor-adaptor-std) | Std/Tokio actor bindings, executors, tick drivers, time, event, pattern, and test-support helpers |
+| [`modules/persistence-core`](modules/persistence-core) | Event sourcing, journals, snapshots, persistent actors, persistent FSM, durable state, and persistence extensions |
+| [`modules/remote-core`](modules/remote-core) | `no_std` remote address, association, envelope, provider, transport port, watcher, wire, and failure-detector state machines |
+| [`modules/remote-adaptor-std`](modules/remote-adaptor-std) | Std remote extension installers, providers, Tokio TCP transport, and I/O workers |
+| [`modules/cluster-core`](modules/cluster-core) | Cluster membership, identity, placement, pub-sub, grains, failure detection, topology, metrics, and routing |
+| [`modules/cluster-adaptor-std`](modules/cluster-adaptor-std) | Std cluster API, local provider wrapping, Tokio gossip transport, pub-sub delivery, and optional AWS ECS provider |
+| [`modules/stream-core-kernel`](modules/stream-core-kernel) | `no_std` stream DSL, stages, materialization contracts, graph shapes, stream refs, queues, kill switches, and supervision |
+| [`modules/stream-core-actor-typed`](modules/stream-core-actor-typed) | Typed actor integrations for stream DSLs |
+| [`modules/stream-adaptor-std`](modules/stream-adaptor-std) | Std stream I/O and materializer adapters |
+| [`showcases/std`](showcases/std) | Runnable examples for host environments |
+| [`tests/e2e`](tests/e2e) | Cross-crate end-to-end tests |
+| [`lints/`](lints) | Custom dylint rules for project structure and Rust conventions |
+| [`openspec/`](openspec) | Specification-driven design artifacts, active changes, and accepted specs |
 
 ## Documentation
 
 - API docs: [docs.rs/fraktor-rs](https://docs.rs/fraktor-rs)
-- Repository knowledge base: [DeepWiki](https://deepwiki.com/j5ik2o/fraktor-rs)
-- Current parity reports:
+- Showcase index: [`showcases/std/README.md`](showcases/std/README.md)
+- Repository rules: [AGENTS.md](AGENTS.md), [`.agents/rules/project.md`](.agents/rules/project.md)
+- OpenSpec configuration: [`openspec/config.yaml`](openspec/config.yaml)
+- Lock-free design notes: [`docs/guides/lock_free_design.md`](docs/guides/lock_free_design.md)
+- Current gap reports:
   - [Actor](docs/gap-analysis/actor-gap-analysis.md)
+  - [Actor mailbox](docs/gap-analysis/actor-mailbox-gap-analysis.md)
   - [Remote](docs/gap-analysis/remote-gap-analysis.md)
   - [Cluster](docs/gap-analysis/cluster-gap-analysis.md)
   - [Persistence](docs/gap-analysis/persistence-gap-analysis.md)
   - [Stream](docs/gap-analysis/stream-gap-analysis.md)
+- Reference implementations:
+  - [`references/pekko`](references/pekko)
+  - [`references/protoactor-go`](references/protoactor-go)
 
-## Getting help
+## Getting Help
 
 - Issues: [GitHub Issues](https://github.com/j5ik2o/fraktor-rs/issues)
-- Source of truth for implementation rules: [AGENTS.md](AGENTS.md)
+- Repository knowledge base: [DeepWiki](https://deepwiki.com/j5ik2o/fraktor-rs)
 
 ## Contributing
 
-- Follow the repository's specification-driven workflow before implementation.
-- Refer to [`.kiro/steering`](.kiro/steering) and [AGENTS.md](AGENTS.md) for project-wide rules.
-- Run `./scripts/ci-check.sh all` before opening a PR.
-- Clearly describe any impact on runtime, remoting, cluster, or stream behavior in the PR.
+- Read [AGENTS.md](AGENTS.md) and the scoped rules under [`.agents/rules/`](.agents/rules) before changing code.
+- Use OpenSpec for behavior-affecting changes; run OpenSpec commands through `mise exec -- openspec ...`.
+- Keep `*-core` crates `no_std`; place host-specific runtime, network, time, and Tokio work in `*-adaptor-std` crates.
+- Put executable examples in [`showcases/std`](showcases/std), not under `modules/**/examples`.
+- Run targeted checks while developing and `./scripts/ci-check.sh ai all` before opening a PR.
+- Do not edit [`CHANGELOG.md`](CHANGELOG.md) manually; it is generated by GitHub Actions.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Update README.md and README.ja.md to reflect the current workspace crate split and root crate status.
- Refresh quickstart, example commands, verification guidance, and documentation links.
- Replace stale references to removed module paths and examples with current project rules and OpenSpec docs.

## Verification
- cargo metadata --format-version 1 --no-deps
- cargo test -p fraktor-rs
- git diff --check
- README stale-reference check with rg
- README linked-path existence check
- ./scripts/ci-check.sh ai all

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes updating README guidance and links; no runtime code or behavior is modified.
> 
> **Overview**
> Updates `README.md` and `README.ja.md` to reflect the current workspace split into `no_std` core crates and `std` adaptor crates, and clarifies that the root `fraktor-rs` crate is currently a metadata/name placeholder.
> 
> Refreshes quickstart and verification instructions (toolchain pinning, optional dylint setup, example run commands, and `./scripts/ci-check.sh ai all`), replaces the old crate list with an area-based mapping + expanded workspace layout table, and adds/updates documentation + contribution links (OpenSpec, repository rules, new gap report, and reference implementations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54deef3b15af4cc8e72f34d4aacd36df58740894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->