### PR TITLE
[codex] add remote phase2 OpenSpec change

### DIFF
--- a/openspec/changes/remote-phase2-medium-gaps/.openspec.yaml
+++ b/openspec/changes/remote-phase2-medium-gaps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/remote-phase2-medium-gaps/design.md
+++ b/openspec/changes/remote-phase2-medium-gaps/design.md
@@ -1,0 +1,158 @@
+## Context
+
+`remote-gap-analysis.md` の Phase 2 は medium gap を 2 件に絞っている。1 つ目は `RemoteRouterConfig` の `ConsistentHashingPool` が serializer で `NotSerializable` になる点、2 つ目は `RemoteConfig` に保持済みの advanced settings が実際の送受信処理に十分反映されていない点である。
+
+現行コードでは `ConsistentHashingPool::new(nr_of_instances, hash_key_mapper)` が任意クロージャを保持する。これはプロセス外へ安全に表現できないため、`MiscMessageSerializer` は `ConsistentHashingPool` を明示的に拒否している。一方で `ConsistentHashingRoutingLogic` は `ConsistentHashableEnvelope` の明示 `hash_key` を優先するため、この経路だけなら wire 表現できる。
+
+`RemoteConfig` 側では `large_message_destinations`、`outbound_large_message_queue_size`、`inbound_lanes`、`outbound_lanes`、`compression_config` が既に型付きで保持されている。ただし `TcpRemoteTransport::from_config` が確実に適用しているのは主に bind / advertised address / frame size で、large-message 分離や lane 数はまだ送受信処理へ接続されていない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `RemoteRouterConfig` が wire-safe consistent-hashing pool を encode/decode できる。
+- 任意クロージャ mapper は `NotSerializable` のまま残し、lossy な代替表現を作らない。
+- `large_message_destinations` に一致する user message を通常 user queue と別枠で扱う。
+- `outbound_large_message_queue_size` を large-message queue の上限として使う。
+- `outbound_lanes` を peer ごとの writer lane 数として反映する。
+- `inbound_lanes` を TCP reader から remote event sender への dispatch lane 数として反映する。
+- compression 設定は保持のみの契約を維持し、wire 圧縮を暗黙に有効化しない。
+
+**Non-Goals:**
+
+- 任意 `hash_key_mapper` closure の serialization。
+- `AnyMessage` payload に対する direct `ConsistentHashable` trait-object dispatch。
+- 任意 actor message serialization。
+- ACK/NACK redelivery。
+- remote DeathWatch / `AddressTerminated` 統合。
+- remote deployment daemon。
+- compression table advertisement / wire-level compression。
+- Pekko Artery wire compatibility。
+
+## Decisions
+
+### Decision 1: consistent-hashing は explicit envelope key だけ wire-safe とする
+
+`ConsistentHashingPool` に wire-safe constructor を追加し、内部 mapper 種別を識別できるようにする。候補名は `ConsistentHashingPool::new_envelope_hash_key(nr_of_instances)` とする。
+
+この pool は次の意味を持つ。
+
+- message が `ConsistentHashableEnvelope` の場合は `hash_key()` を使う。
+- envelope でない message の fallback は固定値を返す。
+- fallback は任意 payload の安定 hash ではないため、利用者は consistent-hashing 対象 message を明示 envelope で送る必要がある。
+
+```
+RemoteRouterConfig
+  └─ RemoteRouterPool::ConsistentHashing
+       ├─ EnvelopeHashKey     -> serializable
+       └─ CustomClosure       -> NotSerializable
+```
+
+Rationale:
+
+- 任意クロージャは wire に載せられない。
+- `TypeId` や Rust 型名はプロセス間の安定 hash key にできない。
+- `ConsistentHashableEnvelope` の `u64` key は既に explicit な wire-safe 値である。
+
+### Decision 2: serializer は pool tag と mapper tag を分ける
+
+`MiscMessageSerializer` の `RemoteRouterConfig` encoding は、既存 pool tag に `ConsistentHashingPool` を追加し、consistent-hashing の場合だけ mapper tag を追加する。
+
+想定 wire layout:
+
+```text
+pool_tag
+nr_of_instances
+router_dispatcher
+optional_pool_payload
+nodes
+```
+
+`optional_pool_payload` は consistent-hashing pool の mapper tag を保持する。既存 `SmallestMailboxPool` / `RoundRobinPool` / `RandomPool` では空の payload として扱う。
+
+Rationale:
+
+- 既存 `RORRC` manifest を維持できる。
+- pool 固有 payload を明示すれば、将来の wire-safe mapper 追加時も `RemoteRouterConfig` 全体の意味を壊さない。
+- arbitrary closure を encode する余地は作らない。
+
+### Decision 3: large-message は local outbound scheduling のみを変える
+
+`Association::from_config` は large-message destination patterns と large-message queue limit を保持し、`Association::enqueue` が recipient path を見て queue class を決める。
+
+```
+OutboundEnvelope
+      │
+      ▼
+Association::enqueue
+      │
+      ├─ priority == System ─────────────▶ system queue
+      ├─ recipient matches large pattern ─▶ large-message queue
+      └─ otherwise ──────────────────────▶ user queue
+
+drain order:
+  system -> user -> large-message
+```
+
+Rationale:
+
+- `EnvelopePdu` の priority wire layout は `System` / `User` のまま維持する。
+- large-message は送信側の queue 分離であり、受信側 wire priority を増やす必要はない。
+- system message を large-message queue に入れないことで DeathWatch / handshake / control 系を user payload より優先できる。
+
+### Decision 4: outbound lanes は peer connection 内の writer queue として扱う
+
+`TcpClient` は `outbound_lanes` 個の bounded writer queue を持ち、1 つの writer task が lane を公平に drain する。`TcpRemoteTransport::send` は envelope の recipient path、sender path、correlation id から lane index を安定選択する。
+
+```
+TcpRemoteTransport::send
+      │
+      ▼
+lane = hash(recipient, sender, correlation) % outbound_lanes
+      │
+      ▼
+TcpClient lane queue[N]
+      │
+      ▼
+single TCP writer task
+```
+
+Rationale:
+
+- lane 数を増やしても peer との TCP connection 数を増やさない。
+- 1 connection の writer task が最終書き込み順を制御するため、fraktor 独自 frame codec の前提を維持できる。
+- bounded queue を lane ごとに分けることで、大きい user payload が全 user traffic を詰まらせにくくなる。
+
+### Decision 5: inbound lanes は reader から remote event sender への dispatch lane とする
+
+TCP reader は decode 済み frame を `inbound_lanes` 個の dispatch lane に振り分ける。同一 association の frame は authority / actor path 由来の key で同じ lane に寄せる。各 lane は `RemoteEvent::InboundFrameReceived` を remote event sender へ送る。
+
+Rationale:
+
+- `Remote` 側の状態更新は引き続き single owner のままにできる。
+- TCP reader と event sender の間の backpressure / decode failure handling を lane 単位で観測できる。
+- 同一 association の frame を同一 lane に寄せることで、connection 内で発生する不要な reorder を避ける。
+
+### Decision 6: compression はこの change では wire behavior にしない
+
+`RemoteCompressionConfig` は Phase 3 の serializer registry / payload codec 設計の入力として保持する。現在の Phase 2 では compression config を transport / wire codec に接続しない。gap analysis はこの判断に合わせて、compression advertisement / table application を Phase 2 の完了条件から外す。
+
+Rationale:
+
+- 既存 `remote-core-settings` spec が wire-level compression を明示的に非対象としている。
+- 任意 actor message serialization が未配置のまま compression table を導入すると、圧縮対象の manifest / actor ref を確定できない。
+- 設定保持と wire behavior を混ぜない方が、Phase 3 の serializer registry 境界を明確にできる。
+
+## Risks / Trade-offs
+
+- **Risk: envelope-only consistent hashing が狭すぎる。**  
+  任意 mapper を wire に載せるより、明示 hash key を要求する方が安全である。direct `ConsistentHashable` dispatch は別 change で検討する。
+
+- **Risk: large-message queue が wire priority とずれる。**  
+  queue 分離は local scheduling の契約であり、wire priority は system/user のままにする。受信側で large-message として扱う機能は本 change に含めない。
+
+- **Risk: outbound lanes が実際の TCP 並列化ではない。**  
+  1 connection の writer task に集約するため書き込みは最終的に直列化される。ただし queue 分離による head-of-line blocking 緩和はできる。
+
+- **Risk: compression Phase 2 完了に見えない。**  
+  既存 spec と矛盾しないため、compression は「保持のみ」と明記し、gap analysis の Phase 2 項目を large-message / lanes / router serialization に修正する。

--- a/openspec/changes/remote-phase2-medium-gaps/proposal.md
+++ b/openspec/changes/remote-phase2-medium-gaps/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+`docs/gap-analysis/remote-gap-analysis.md` の Phase 2 には、medium gap として次の 2 件が残っている。
+
+- `consistent-hashing pool remote router serialization`
+- `advanced Artery settings` の実処理への反映
+
+remote は byte payload の二ノード配送まで到達しているが、`RemoteRouterConfig` は `ConsistentHashingPool` を wire に載せられず、`RemoteConfig` に保持済みの large-message / lane / compression 設定のうち一部は送受信処理へ反映されていない。このまま Phase 3 の任意 actor message serialization や DeathWatch に進むと、router / queue / transport worker の境界が未整理なまま hard gap に入る。
+
+## What Changes
+
+### 1. consistent-hashing pool remote router serialization
+
+`RemoteRouterConfig` の serializer は、wire-safe な consistent-hashing pool だけを encode/decode できるようにする。
+
+- `ConsistentHashableEnvelope` の明示 `hash_key` を使う built-in mapper を wire 表現の対象にする。
+- 任意クロージャの `hash_key_mapper` は引き続き wire 非対応とし、`NotSerializable` を返す。
+- `RemoteRouterConfig` の manifest は既存の `RORRC` を維持する。
+
+### 2. large-message / lane 設定の実処理反映
+
+`RemoteConfig` に保持済みの設定を、実際の送受信経路に接続する。
+
+- `large_message_destinations` に一致する user message を通常 user queue から分離し、`outbound_large_message_queue_size` を専用 queue 上限として使う。
+- `outbound_lanes` を per-peer outbound writer lane 数として使い、recipient / sender / correlation id から安定した lane を選ぶ。
+- `inbound_lanes` を TCP reader から `RemoteEvent` sender へ渡す dispatch lane 数として使い、同一 association の frame は同じ lane へ寄せる。
+
+### 3. compression 設定の扱いを固定する
+
+compression はこの change では wire 圧縮として有効化しない。既存 `remote-core-settings` spec は「compression settings は保持のみ、wire encoding / TCP framing / compression table は変更しない」と定めているため、本 change ではその境界を維持する。実際の compression advertisement / table application は、Phase 3 の serializer registry backed arbitrary user payload serialization と合わせて別 change で扱う。
+
+## Capabilities
+
+### New Capabilities
+
+- `actor-core-remote-router-serialization`
+  - `RemoteRouterConfig` が wire-safe consistent-hashing pool を round-trip できる。
+  - arbitrary closure mapper は wire 非対応のまま fail-fast する。
+
+### Modified Capabilities
+
+- `remote-core-association-state-machine`
+  - `Association` / `SendQueue` が large-message user lane を持ち、system / user / large-message の取り出し順を定義する。
+- `remote-core-settings`
+  - `RemoteConfig` の advanced settings は、保持だけでなく実処理へ反映される項目と保持のみの項目を区別する。
+- `remote-adaptor-std-tcp-transport`
+  - `TcpRemoteTransport::from_config` が inbound / outbound lane 数を送受信処理へ反映する。
+
+## Impact
+
+影響コード:
+
+- `modules/actor-core-kernel/src/routing/consistent_hashing_pool.rs`
+- `modules/actor-core-kernel/src/routing/remote_router_pool.rs`
+- `modules/actor-core-kernel/src/serialization/builtin/misc_message_serializer.rs`
+- `modules/remote-core/src/association/send_queue.rs`
+- `modules/remote-core/src/association/base.rs`
+- `modules/remote-adaptor-std/src/transport/tcp/`
+- `docs/gap-analysis/remote-gap-analysis.md`
+
+影響 spec:
+
+- `openspec/specs/remote-core-association-state-machine/spec.md`
+- `openspec/specs/remote-core-settings/spec.md`
+- `openspec/specs/remote-adaptor-std-tcp-transport/spec.md`
+- 新規 `actor-core-remote-router-serialization`
+
+非対象:
+
+- 任意クロージャの serialization
+- direct trait-object `ConsistentHashable` dispatch
+- serializer registry backed arbitrary user payload serialization
+- ACK/NACK redelivery
+- remote DeathWatch
+- remote deployment
+- wire-level compression / compression table advertisement
+- Pekko Artery byte compatibility

--- a/openspec/changes/remote-phase2-medium-gaps/specs/actor-core-remote-router-serialization/spec.md
+++ b/openspec/changes/remote-phase2-medium-gaps/specs/actor-core-remote-router-serialization/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: RemoteRouterConfig は wire-safe consistent-hashing pool を serialize できる
+
+`actor-core-kernel` の built-in misc serializer は、`RemoteRouterConfig` が wire-safe consistent-hashing pool を含む場合に encode/decode できなければならない (MUST)。wire-safe consistent-hashing pool は、`ConsistentHashableEnvelope` の明示 `hash_key` を routing key として使う built-in mapper に限定されなければならない (MUST)。
+
+任意クロージャの `hash_key_mapper` を持つ `ConsistentHashingPool` は serialize してはならない (MUST NOT)。その場合、serializer は `NotSerializable` を返さなければならない (MUST)。
+
+#### Scenario: envelope-hash-key consistent-hashing pool は round-trip できる
+
+- **GIVEN** `RemoteRouterConfig` が envelope-hash-key consistent-hashing pool と remote nodes を持つ
+- **WHEN** `MiscMessageSerializer` で encode し、`RORRC` manifest で decode する
+- **THEN** decoded value は `RemoteRouterConfig` である
+- **AND** local pool は `RemoteRouterPool::ConsistentHashing` として復元される
+- **AND** `nr_of_instances`、router dispatcher、remote nodes は元の値を保つ
+
+#### Scenario: arbitrary closure mapper は NotSerializable のまま
+
+- **GIVEN** `ConsistentHashingPool::new(n, |message| ...)` で作られた pool を含む `RemoteRouterConfig`
+- **WHEN** `MiscMessageSerializer::to_binary` を呼ぶ
+- **THEN** `Err(SerializationError::NotSerializable(_))` が返る
+- **AND** serializer は closure を型名、debug 文字列、固定値などへ変換して wire に載せない
+
+#### Scenario: unknown consistent-hashing mapper tag を拒否する
+
+- **GIVEN** encoded `RemoteRouterConfig` の consistent-hashing mapper tag が未定義値に書き換えられている
+- **WHEN** `MiscMessageSerializer` が decode する
+- **THEN** `Err(SerializationError::InvalidFormat)` が返る
+
+#### Scenario: envelope-hash-key mapper は explicit hash key を優先する
+
+- **GIVEN** envelope-hash-key consistent-hashing pool から router を作成する
+- **AND** message payload が `ConsistentHashableEnvelope` である
+- **WHEN** router が routee を選択する
+- **THEN** routing key は envelope の `hash_key()` から導出される
+- **AND** arbitrary closure mapper は要求されない

--- a/openspec/changes/remote-phase2-medium-gaps/specs/remote-adaptor-std-tcp-transport/spec.md
+++ b/openspec/changes/remote-phase2-medium-gaps/specs/remote-adaptor-std-tcp-transport/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: TcpRemoteTransport 型
+
+`fraktor_remote_adaptor_std_rs::transport::tcp::TcpRemoteTransport` 型が定義され、core の `RemoteTransport` trait を実装する SHALL。TCP ベースの std remote transport として、start / shutdown / handshake / control / envelope delivery / connection-loss notification を adapter 側の送受信処理に接続する。
+
+`TcpRemoteTransport::from_config` は `RemoteConfig` の canonical / bind / maximum frame size に加えて、inbound lane count と outbound lane count も transport 構成に反映しなければならない (MUST)。
+
+#### Scenario: RemoteTransport trait の実装
+
+- **WHEN** `TcpRemoteTransport` の trait 実装を検査する
+- **THEN** `impl RemoteTransport for TcpRemoteTransport` が存在し、core の全メソッド (`start`, `shutdown`, `send`, `send_control`, `send_handshake`, `schedule_handshake_timeout`, `addresses`, `default_address`, `local_address_for_remote`, `quarantine`) を実装している
+
+#### Scenario: from_config applies lane counts
+
+- **GIVEN** `RemoteConfig::new("127.0.0.1").with_inbound_lanes(3).with_outbound_lanes(4)`
+- **WHEN** `TcpRemoteTransport::from_config(system_name, config)` を呼ぶ
+- **THEN** transport は inbound dispatch lane count と outbound writer lane count をそれぞれ設定値から構成する
+
+### Requirement: outbound writer lanes
+
+std TCP adapter は peer ごとに `RemoteConfig::outbound_lanes()` で指定された数の outbound writer lane を構成しなければならない (MUST)。`TcpRemoteTransport::send` は envelope から stable lane key を導出し、対象 lane の bounded writer queue へ frame を enqueue しなければならない (MUST)。
+
+writer task は lanes を starvation なく drain し、最終的な TCP stream への write は同一 connection 内で行わなければならない (MUST)。lane queue が full の場合は `TransportError::Backpressure` または同等の retry-preserving error を返さなければならない (MUST)。
+
+#### Scenario: outbound_lanes one keeps existing behavior
+
+- **GIVEN** `outbound_lanes = 1`
+- **WHEN** connected peer へ複数 envelope を送る
+- **THEN** all frames は単一 writer lane に enqueue される
+- **AND** existing single-lane ordering と同等に送信される
+
+#### Scenario: stable lane selection
+
+- **GIVEN** `outbound_lanes > 1`
+- **AND** 同じ recipient path / sender path / correlation id を持つ envelope が複数ある
+- **WHEN** `TcpRemoteTransport::send` を呼ぶ
+- **THEN** それらの envelope は同じ outbound lane に enqueue される
+
+#### Scenario: lane backpressure is observable
+
+- **GIVEN** selected outbound lane の bounded queue が full である
+- **WHEN** `TcpRemoteTransport::send(envelope)` を呼ぶ
+- **THEN** retry-preserving error が返る
+- **AND** caller は元 envelope を再 enqueue できる
+
+### Requirement: inbound dispatch lanes
+
+std TCP adapter は accepted connection または outbound client reader から得た decoded frame を、`RemoteConfig::inbound_lanes()` で指定された数の inbound dispatch lane へ振り分けなければならない (MUST)。同一 association に属する frame は同じ lane key を使わなければならない (MUST)。
+
+各 inbound dispatch lane は `RemoteEvent::InboundFrameReceived` を remote event sender へ送る。remote event sender が closed の場合、dispatch lane は `TransportError::NotAvailable` または log で観測可能な failure を返さなければならない (MUST)。
+
+#### Scenario: same association uses same inbound lane
+
+- **GIVEN** inbound_lanes が 2 以上である
+- **AND** 2 つの inbound frame が同じ remote authority に属する
+- **WHEN** TCP reader が decoded frame を dispatch する
+- **THEN** 2 つの frame は同じ inbound lane へ送られる
+
+#### Scenario: inbound lane sender failure is observable
+
+- **GIVEN** remote event sender が closed している
+- **WHEN** inbound dispatch lane が frame を remote event sender へ送ろうとする
+- **THEN** failure は log または returned error path で観測できる
+
+### Requirement: outbound payload codec contract
+
+std TCP adapter は `OutboundEnvelope` の `AnyMessage` payload を wire payload bytes に変換する契約を明示しなければならない（MUST）。少なくとも `bytes::Bytes` と `Vec<u8>` の両方をサポートしなければならない（MUST）。任意の typed payload を暗黙に serialize してはならない（MUST NOT）。
+
+#### Scenario: サポート対象 bytes payload
+
+- **WHEN** outbound payload が `bytes::Bytes` または `Vec<u8>` として封筒化されている
+- **THEN** adapter はその bytes を `EnvelopePdu::payload` に設定する
+- **AND** 受信側は同じ bytes を合意済み payload 型の `AnyMessage` として復元できる
+
+#### Scenario: 任意 AnyMessage は暗黙 serialize されない
+
+- **WHEN** outbound payload が serializer contract に登録されていない任意の `AnyMessage` である
+- **THEN** adapter は bytes 変換を拒否する
+- **AND** `Debug` 文字列や型名を payload として代用してはならない

--- a/openspec/changes/remote-phase2-medium-gaps/specs/remote-core-association-state-machine/spec.md
+++ b/openspec/changes/remote-phase2-medium-gaps/specs/remote-core-association-state-machine/spec.md
@@ -1,0 +1,63 @@
+## MODIFIED Requirements
+
+### Requirement: SendQueue priority logic
+
+`Association` 内の `SendQueue` は system priority、normal user、large-message user の queue を持ち、system priority を最優先で取り出す SHALL。normal user と large-message user はどちらも wire 上は user message であり、large-message queue は送信側の local scheduling と capacity 分離のために使われる。
+
+`Association::next_outbound` と `Association::apply_backpressure` は内部の `SendQueue` に委譲することで、この priority / lane ロジックを公開する。
+
+#### Scenario: system queue の優先
+
+- **WHEN** system priority、normal user、large-message user のすべてに message があり、`Association::next_outbound()` を呼ぶ
+- **THEN** system priority の message が先に返される
+
+#### Scenario: normal user は large-message user より先に drain される
+
+- **WHEN** normal user と large-message user の両方の message が queue にあり、system priority message がない
+- **THEN** normal user message が large-message user message より先に返される
+
+#### Scenario: user queue の backpressure pause
+
+- **WHEN** `Association` に `apply_backpressure(BackpressureSignal::Apply)` を適用してから `next_outbound()` を呼ぶ
+- **THEN** normal user と large-message user の message は取り出されない
+- **AND** system priority message は取り出される
+
+#### Scenario: backpressure release
+
+- **WHEN** `apply_backpressure(BackpressureSignal::Release)` を適用してから `next_outbound()` を呼ぶ
+- **THEN** normal user と large-message user の message も取り出される
+
+### Requirement: Association は large-message destination settings を enqueue に反映する
+
+`Association::from_config` は `RemoteConfig::large_message_destinations()` と `RemoteConfig::outbound_large_message_queue_size()` を使って large-message enqueue policy を構成しなければならない (MUST)。
+
+`Association::enqueue` は `OutboundPriority::User` の envelope について recipient absolute path が configured large-message destination pattern に一致する場合、normal user queue ではなく large-message queue に offer しなければならない (MUST)。`OutboundPriority::System` の envelope は pattern に一致しても system queue に入らなければならない (MUST)。
+
+#### Scenario: matching user recipient は large-message queue に入る
+
+- **GIVEN** `RemoteConfig` に `/user/large-*` の large-message destination pattern が設定されている
+- **AND** `Association` がその config から作られている
+- **WHEN** recipient path `/user/large-worker` の user envelope を enqueue する
+- **THEN** envelope は large-message queue に入る
+- **AND** normal user queue capacity は消費しない
+
+#### Scenario: non-matching user recipient は normal user queue に入る
+
+- **GIVEN** `RemoteConfig` に `/user/large-*` の large-message destination pattern が設定されている
+- **WHEN** recipient path `/user/small-worker` の user envelope を enqueue する
+- **THEN** envelope は normal user queue に入る
+- **AND** large-message queue capacity は消費しない
+
+#### Scenario: system envelope は large-message pattern より優先される
+
+- **GIVEN** large-message destination pattern に一致する recipient path を持つ system envelope
+- **WHEN** `Association::enqueue` を呼ぶ
+- **THEN** envelope は system queue に入る
+- **AND** large-message queue capacity は消費しない
+
+#### Scenario: large-message queue capacity は config から来る
+
+- **GIVEN** `RemoteConfig::with_outbound_large_message_queue_size(1)` で作られた `Association`
+- **WHEN** matching user envelope を 2 件 enqueue する
+- **THEN** 1 件目は accepted になる
+- **AND** 2 件目は元 envelope を保持した queue-full outcome になる

--- a/openspec/changes/remote-phase2-medium-gaps/specs/remote-core-settings/spec.md
+++ b/openspec/changes/remote-phase2-medium-gaps/specs/remote-core-settings/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Artery advanced settings surface
+
+`fraktor_remote_core_rs::config::RemoteConfig` は Pekko Artery advanced settings の responsibility parity に必要な large-message、lane、compression の設定を型付き builder と accessor で保持する SHALL。これらの設定は fraktor-rs 独自 wire format の設定 surface であり、Pekko Artery wire protocol との byte compatibility を意味しない。
+
+large-message と lane 設定は、設定保持だけでなく `Association` および std TCP transport の送受信処理へ反映されなければならない (MUST)。compression 設定はこの capability では保持のみとし、wire-level compression は有効化してはならない (MUST NOT)。
+
+#### Scenario: large-message 設定を保持する
+
+- **WHEN** `RemoteConfig::new("localhost")` を作成し、large-message 用 builder を呼ぶ
+- **THEN** outbound large-message queue size と large-message destinations が `RemoteConfig` 内に保持され、対応する accessor で参照できる
+
+#### Scenario: invalid large-message queue size を拒否する
+
+- **WHEN** outbound large-message queue size に `0` を指定する
+- **THEN** `RemoteConfig` は invalid queue size として拒否し、zero-sized queue を保持しない
+
+#### Scenario: large-message settings は Association enqueue policy に渡される
+
+- **WHEN** `Association::from_config(local, remote, &config)` を呼ぶ
+- **THEN** `config.large_message_destinations()` と `config.outbound_large_message_queue_size()` は association の enqueue policy に反映される
+
+#### Scenario: lane settings を保持する
+
+- **WHEN** `RemoteConfig::new("localhost")` を作成し、`with_inbound_lanes` / `with_outbound_lanes` を呼ぶ
+- **THEN** inbound lane count と outbound lane count が `RemoteConfig` 内に保持され、対応する accessor で参照できる
+
+#### Scenario: invalid lane count を拒否する
+
+- **WHEN** inbound lane count または outbound lane count に `0` を指定する
+- **THEN** `RemoteConfig` は invalid lane count として拒否し、zero lane を保持しない
+
+#### Scenario: lane settings は TCP transport construction に渡される
+
+- **WHEN** `TcpRemoteTransport::from_config(system_name, config)` を呼ぶ
+- **THEN** `config.inbound_lanes()` と `config.outbound_lanes()` は transport の inbound dispatch / outbound writer lane 構成に反映される
+
+#### Scenario: compression 設定 surface を保持する
+
+- **WHEN** `RemoteConfig::new("localhost")` を作成し、compression 用 builder を呼ぶ
+- **THEN** compression settings が `RemoteConfig` 内に保持され、対応する accessor で参照できる
+
+#### Scenario: wire-level compression は有効化しない
+
+- **WHEN** compression settings を `RemoteConfig` に設定する
+- **THEN** `core/wire` の PDU encoding、TCP framing、compression table の wire 表現は変更されない
+- **AND** transport は payload bytes を compression table によって置換しない
+
+#### Scenario: no_std 境界を維持する
+
+- **WHEN** `modules/remote-core/src/config/` 配下の import を検査する
+- **THEN** `use std::` を含む行は存在せず、advanced settings は `core` と `alloc` の範囲で表現されている

--- a/openspec/changes/remote-phase2-medium-gaps/tasks.md
+++ b/openspec/changes/remote-phase2-medium-gaps/tasks.md
@@ -1,0 +1,70 @@
+## Phase 1: 境界確認
+
+- [ ] 1.1 `docs/gap-analysis/remote-gap-analysis.md` の Phase 2 / Phase 3 境界を確認する
+- [ ] 1.2 `MiscMessageSerializer` の `RemoteRouterConfig` encoding / decoding と既存 tests を確認する
+- [ ] 1.3 `ConsistentHashingPool` / `ConsistentHashingRoutingLogic` / `ConsistentHashableEnvelope` の現在の hash key precedence を確認する
+- [ ] 1.4 `RemoteConfig` の large-message / lanes / compression accessor と既存 settings spec を確認する
+- [ ] 1.5 `Association::from_config` / `SendQueue` / `TcpRemoteTransport::from_config` の設定適用箇所を確認する
+
+## Phase 2: wire-safe consistent-hashing pool
+
+- [ ] 2.1 `ConsistentHashingPool` に wire-safe envelope-hash-key constructor を追加する
+- [ ] 2.2 `ConsistentHashingPool` が mapper 種別を返せる crate-private query を追加する
+- [ ] 2.3 `RemoteRouterPool::ConsistentHashing` から mapper 種別を serializer が判定できるようにする
+- [ ] 2.4 arbitrary closure mapper は `NotSerializable` を返す既存挙動を維持する
+- [ ] 2.5 envelope-hash-key consistent-hashing pool の router creation が既存 routing logic と同じ precedence を保つことをテストする
+
+## Phase 3: RemoteRouterConfig serialization
+
+- [ ] 3.1 `MiscMessageSerializer` の `RemoteRouterConfig` wire format に consistent-hashing pool tag を追加する
+- [ ] 3.2 consistent-hashing pool 用 mapper tag を追加し、envelope-hash-key mapper だけを encode する
+- [ ] 3.3 decode 時に envelope-hash-key consistent-hashing pool を復元する
+- [ ] 3.4 unknown pool tag / unknown mapper tag / malformed payload を `InvalidFormat` として拒否する
+- [ ] 3.5 `RemoteRouterConfig` round-trip tests に consistent-hashing pool を追加する
+- [ ] 3.6 arbitrary closure mapper が `NotSerializable` になる regression test を維持する
+
+## Phase 4: large-message queue
+
+- [ ] 4.1 `SendQueue` に large-message user lane と capacity を追加する
+- [ ] 4.2 `SendQueue::with_limits` または新しい constructor で system / user / large-message capacity を設定できるようにする
+- [ ] 4.3 `Association::from_config` が `outbound_large_message_queue_size` と `large_message_destinations` を保持する
+- [ ] 4.4 `Association::enqueue` が user message の recipient path を pattern match し、large-message queue へ振り分ける
+- [ ] 4.5 system priority は large-message pattern に一致しても system queue へ入ることをテストする
+- [ ] 4.6 drain order が `system -> user -> large-message` であることをテストする
+- [ ] 4.7 large-message queue full 時は元 envelope を含む `QueueFull` になることをテストする
+
+## Phase 5: outbound lanes
+
+- [ ] 5.1 `TcpRemoteTransport::from_config` が `outbound_lanes` を `TcpClientConnectOptions` へ渡す
+- [ ] 5.2 `TcpClient` が lane 数分の bounded writer queue を持てるようにする
+- [ ] 5.3 `TcpClient::send` が lane key から stable lane を選び、該当 lane queue へ enqueue する
+- [ ] 5.4 writer task が lane queues を starvation なく drain する
+- [ ] 5.5 lane queue full は `TransportError::Backpressure` として返す
+- [ ] 5.6 `outbound_lanes = 1` では既存と同等の配送順になることをテストする
+- [ ] 5.7 `outbound_lanes > 1` で異なる lane が選ばれる payload を test-observable にする
+
+## Phase 6: inbound lanes
+
+- [ ] 6.1 `TcpRemoteTransport::from_config` が `inbound_lanes` を inbound dispatch 構成へ渡す
+- [ ] 6.2 inbound frame event channel を lane 数分に分割する
+- [ ] 6.3 TCP reader が authority / actor path 由来の stable key で inbound lane を選ぶ
+- [ ] 6.4 各 inbound lane が `RemoteEvent::InboundFrameReceived` を remote event sender へ送る
+- [ ] 6.5 same association の frame が同じ inbound lane に入ることをテストする
+- [ ] 6.6 lane sender failure が log または error path で観測できることをテストする
+
+## Phase 7: compression boundary / docs
+
+- [ ] 7.1 `RemoteCompressionConfig` はこの change で wire codec / TCP framing に接続しないことを確認する
+- [ ] 7.2 compression advertisement / table application を Phase 3 serializer registry 側の future item として design comment に残す
+- [ ] 7.3 `docs/gap-analysis/remote-gap-analysis.md` を更新し、Phase 2 完了条件から compression wire behavior を外す
+- [ ] 7.4 Phase 2 完了後の残 gap が Phase 3 hard gap へ集中していることを summary に反映する
+
+## Phase 8: verification
+
+- [ ] 8.1 `cargo test -p fraktor-actor-core-kernel-rs misc_message_serializer` を実行する
+- [ ] 8.2 `cargo test -p fraktor-actor-core-kernel-rs remote_router_config` を実行する
+- [ ] 8.3 `cargo test -p fraktor-remote-core-rs association` を実行する
+- [ ] 8.4 `cargo test -p fraktor-remote-adaptor-std-rs transport` を実行する
+- [ ] 8.5 `cargo test -p fraktor-remote-adaptor-std-rs two_node_actor_system_delivery` を実行する
+- [ ] 8.6 `openspec validate remote-phase2-medium-gaps --strict` を実行する
+- [ ] 8.7 実装完了時に `./scripts/ci-check.sh ai all` を実行する


### PR DESCRIPTION
## Summary

- Add the `remote-phase2-medium-gaps` OpenSpec change.
- Capture the Phase 2 plan for remote medium gaps: wire-safe consistent-hashing remote router serialization and concrete application of large-message / lane settings.
- Keep compression as settings-only in this change, with wire-level compression deferred to a later serializer-registry change.

## Validation

- `openspec validate remote-phase2-medium-gaps --strict`
- `openspec status --change remote-phase2-medium-gaps`

## Notes

`gh auth status` reports an invalid local GitHub token, so this PR was opened through the GitHub connector after pushing the branch with git.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds OpenSpec change documentation/spec requirements with no production code changes, so functional risk is low; main risk is spec mismatch with future implementation expectations.
> 
> **Overview**
> Adds a new OpenSpec change set, `remote-phase2-medium-gaps`, defining Phase 2 requirements and a work plan for closing two remote *medium gaps*.
> 
> The specs constrain `RemoteRouterConfig` serialization to a **wire-safe** consistent-hashing pool that uses `ConsistentHashableEnvelope` explicit `hash_key` (and continues to reject arbitrary closure mappers as `NotSerializable`), and require **large-message queue separation** plus **inbound/outbound lane counts** to be applied in `Association` and the std TCP transport. Compression is explicitly kept as **settings-only** (no wire behavior changes) and deferred to a later phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab3b9e11e6dd86fc3aa215b4d24190fa633ef80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->