### PR TITLE
docs(openspec): propose sibling _test.rs layout

### DIFF
--- a/openspec/changes/adopt-sibling-test-files/.openspec.yaml
+++ b/openspec/changes/adopt-sibling-test-files/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/adopt-sibling-test-files/design.md
+++ b/openspec/changes/adopt-sibling-test-files/design.md
@@ -1,0 +1,117 @@
+## Context
+
+現在の unit test 規約は `#[cfg(test)] mod tests;` と nested `<module>/tests.rs` により、test を production file の外へ分離している。この方式は inline test の混入を防げる一方で、production file と同名の directory が実サブモジュール用なのか、test file だけの置き場なのか判別しづらい。
+
+Rust では次の形にすれば、module 名を `tests` のまま維持しつつ、物理ファイルだけを sibling に移せる。
+
+```rust
+#[cfg(test)]
+#[path = "hoge_test.rs"]
+mod tests;
+```
+
+これにより `tests` は `hoge` の子 module のままなので、既存の `use super::*;` pattern や parent の private item へのアクセスは維持できる。物理ファイルは明確に test-only と分かる名前になり、test のためだけの `hoge/` directory は不要になる。
+
+## Goals / Non-Goals
+
+**Goals:**
+- crate 内 unit test を sibling `*_test.rs` に置き、物理的に test-only と分かる状態にする。
+- test を production file へ書かせず、Dylint による別ファイル強制を維持する。
+- `tests.rs` だけを置くための `hoge/` directory を作らない。
+- `#[path = ...]` の利用を、この layout に必要な test module pattern だけに限定する。
+- rules、skills、lint docs、lint fixtures、source files を一貫した migration として更新する。
+
+**Non-Goals:**
+- すべての test を integration test crate へ移すこと。
+- 任意の `#[path = ...]` module wiring を許可すること。
+- Rust module 名を `tests` から `<module>_test` へ変えること。
+- production file 内の inline `#[test]` function や inline `mod tests { ... }` 禁止を緩めること。
+- no_std-sensitive crate で `tests/` へ移すべき `std::*` 依存 test logic を `src/` に残すこと。
+
+## Decisions
+
+### 1. `mod tests` と制約付き sibling path を使う
+
+production file は次の形を使う。
+
+```rust
+#[cfg(test)]
+#[path = "hoge_test.rs"]
+mod tests;
+```
+
+module 名は `hoge_test` ではなく `tests` のままにする。これにより既存 test module は production module の子として残り、test file 内の移行差分を最小化できる。
+
+**検討した代替案**
+- `#[path = "hoge_test.rs"] mod hoge_test;`
+  - module 名が変わり、test 側の差分が増えるため却下。
+- `mod hoge_test;`
+  - production 側に見える module 名になり、標準的な `tests` という意図が薄れるため却下。
+- `<module>/tests.rs` を維持する。
+  - directory ambiguity そのものが今回解決したい問題であるため却下。
+
+### 2. `#[path = ...]` は test module wiring だけに許可する
+
+`module-wiring-lint` は現状すべての `#[path = ...]` attribute を拒否している。この方針は維持し、任意の path wiring は拒否したまま、以下をすべて満たす場合だけ狭く例外許可する。
+
+- item が `mod tests;` である。
+- item が `#[cfg(test)]` で gate されている。
+- path literal に directory separator が含まれない。
+- path literal が `<declaring_file_stem>_test.rs` と一致する。
+- declaring file が `hoge.rs` や `lib.rs` のような通常の Rust source file である。
+
+例:
+- `hoge.rs` は `#[path = "hoge_test.rs"] mod tests;` を許可する。
+- `lib.rs` は `#[path = "lib_test.rs"] mod tests;` を許可する。
+- `hoge.rs` は `#[path = "tests.rs"] mod tests;` を拒否する。
+- `hoge.rs` は `#[path = "shared/hoge_test.rs"] mod tests;` を拒否する。
+- `hoge.rs` は `#[path = "hoge_test.rs"] mod helper;` を拒否する。
+
+**検討した代替案**
+- `#[cfg(test)]` 配下の `#[path = ...]` をすべて許可する。
+  - test layout の用途を超えて module wiring rule を弱めるため却下。
+
+### 3. `tests-location-lint` が `_test.rs` を認識する
+
+separate-tests lint は `*_test.rs` を test-only file として扱う必要がある。そうしないと test file を production source として読み、内部の `#[test]` function を報告してしまう。
+
+また、`#[cfg(test)]` の直後に制約付き `#[path = "..._test.rs"] mod tests;` が続く宣言を、正しい production-side hook として扱う必要がある。対応する nested `tests.rs` layout が残っている legacy `#[cfg(test)] mod tests;` は migration target とする。
+
+**検討した代替案**
+- 旧 layout と新 layout の両方を無期限に受け入れる。
+  - release 前の repository で legacy compatibility path を残さない方針のため却下。
+
+### 4. 関連 lint の ignore logic を更新する
+
+`type-per-file-lint` と `ambiguous-suffix-lint` はすでに `tests.rs`、`*_tests.rs`、`tests/` directory を無視している。test helper type や test helper name が production type / production name rule で判定されないよう、`*_test.rs` も同様に無視する。
+
+**検討した代替案**
+- test helper にも production lint rule をすべて適用する。
+  - test file では fixture や helper の形が production より緩くなることがあり、production と同じ制約を課すと過剰設計になりやすいため却下。
+
+### 5. no_std-sensitive な std 依存 test は `src/` 外に置く
+
+この change は crate 内 unit test のファイル形状だけを変える。no_std-sensitive crate の std 依存 test logic は、安全に `src/` に残せない場合 `tests/` または分離された fixture へ置く、という既存 rule は上書きしない。
+
+## Risks / Trade-offs
+
+- [新 layout は `#[path = ...]` に依存する] → 例外条件を厳密にし、許可例・拒否例の両方を Dylint UI fixture で検証する。
+- [migration が多くの file に触れる] → crate / module batch ごとに移行し、各 batch 後に targeted test を実行する。
+- [root module test には専用規約が必要] → `lib.rs` には `lib_test.rs` を使い、rules と lint tests に明記する。
+- [`*_test.rs` が production-oriented lint の ignore list から漏れる] → 現在 `tests.rs` または `*_tests.rs` を特別扱いしている lint をすべて更新する。
+- [no_std source tree rule が `_test.rs` なら std test を許すと誤読される] → std 依存 no_std test は引き続き `tests/` へ移すことを rules / specs に明記する。
+
+## Migration Plan
+
+1. rules と skill references を `<module>/tests.rs` から `<module>_test.rs` へ更新する。
+2. Dylint implementation と UI fixture を更新する。
+   - `tests-location-lint`
+   - `module-wiring-lint`
+   - `type-per-file-lint`
+   - `ambiguous-suffix-lint`
+3. 既存の `src/**/tests.rs` を移行する。
+   - `hoge/tests.rs` → `hoge_test.rs`
+   - parent `hoge.rs`: `#[cfg(test)] mod tests;` → `#[cfg(test)] #[path = "hoge_test.rs"] mod tests;`
+   - root `src/tests.rs` → `src/lib_test.rs` に移し、`lib.rs` を更新する。
+4. batch ごとに targeted Dylint check と crate test を実行する。
+5. 最終的に `./scripts/ci-check.sh ai all` を実行する。

--- a/openspec/changes/adopt-sibling-test-files/proposal.md
+++ b/openspec/changes/adopt-sibling-test-files/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+現在の unit test 配置は `hoge.rs` と `hoge/tests.rs` の組み合わせであり、`hoge/` が実サブモジュール用ディレクトリなのか、テストファイルだけを置くためのディレクトリなのか判別しづらい。この曖昧さによりナビゲーション性が落ち、AI エージェントが編集時に production file と test file のリスク差を見誤りやすくなる。
+
+## What Changes
+
+- **BREAKING**: crate 内 unit test の配置を `<module>/tests.rs` から sibling の `<module>_test.rs` へ変更する。
+- production file は test module を次の形で宣言する。
+  ```rust
+  #[cfg(test)]
+  #[path = "hoge_test.rs"]
+  mod tests;
+  ```
+- Rust module 名は `tests` のまま維持し、既存の `use super::*;` ベースの test file に必要な変更を最小化する。
+- `.agents/rules/**/*.md` と関連 skill 参照を更新し、AI エージェントが sibling `_test.rs` layout で test を作成・移行するようにする。
+- Dylint を更新し、test は別ファイル必須のまま、test 専用の制約付き `#[path = "..._test.rs"] mod tests;` だけを許可する。
+- 既存の `src/**/tests.rs` を sibling `*_test.rs` へ移行し、runtime behavior は変更しない。
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+- `source-test-layout-hygiene`: crate 内 unit test を nested `tests.rs` から production file の sibling `*_test.rs` へ移し、Dylint で新 layout を強制する。
+
+## Impact
+
+- 影響する rule:
+  - `.agents/rules/rust/*.md`
+  - `.agents/rules/*.md` references that mention `tests.rs`
+  - fraktor の module / test layout を生成・レビューする skill documentation
+- 影響する lint:
+  - `lints/tests-location-lint`
+  - `lints/module-wiring-lint`
+  - `lints/type-per-file-lint`
+  - `lints/ambiguous-suffix-lint`
+  - 上記 lint の README / SPEC / UI fixture
+- 影響する source:
+  - `modules/**/src/**/tests.rs`
+  - 現在 `#[cfg(test)] mod tests;` を宣言している parent production file
+- 検証:
+  - 変更した各 lint の targeted Dylint UI test
+  - 代表的な migration batch ごとの対象 crate test
+  - 最終 `./scripts/ci-check.sh ai all`

--- a/openspec/changes/adopt-sibling-test-files/specs/source-test-layout-hygiene/spec.md
+++ b/openspec/changes/adopt-sibling-test-files/specs/source-test-layout-hygiene/spec.md
@@ -1,0 +1,54 @@
+## MODIFIED Requirements
+
+### Requirement: no_std-sensitive な production source tree は std 依存 test logic を含んではならない
+no_std-sensitive な crate の production source tree は、`std::*` 依存の test-only code を `src/` 配下へ保持してはならない（MUST NOT）。std 依存の test logic は `tests/` 配下へ移すか、production path と分離された test fixture に切り出さなければならない（MUST）。
+
+#### Scenario: core crate の std 依存 test は `tests/` へ移される
+- **WHEN** no_std-sensitive な crate で `std::panic` や `std::thread` を必要とする test を追加または整理する
+- **THEN** その test は `src/` 配下ではなく `tests/` 配下に置かれる
+
+#### Scenario: production module には実装と test hook だけが残る
+- **WHEN** `src/` 配下の crate 内 unit test を production file から分離する
+- **THEN** production module には runtime implementation と `#[cfg(test)] #[path = "<module>_test.rs"] mod tests;` hook だけが残る
+- **AND** test body / test helper / test fixture は production file 本体へ書かれない
+
+## ADDED Requirements
+
+### Requirement: crate 内 unit test は sibling `_test.rs` に置く
+`src/` 配下に残す crate 内 unit test は、対象 production file と同じディレクトリの sibling `<module>_test.rs` に置かなければならない（MUST）。`<module>/tests.rs` のためだけにディレクトリを作ってはならない（MUST NOT）。production file は test module を `tests` という module name で宣言し、物理ファイルだけを `#[path = "<module>_test.rs"]` で指定しなければならない（MUST）。
+
+#### Scenario: leaf module の unit test は sibling file に置かれる
+- **WHEN** `hoge.rs` の crate 内 unit test を追加または移設する
+- **THEN** test body は `hoge_test.rs` に置かれる
+- **AND** `hoge.rs` は `#[cfg(test)] #[path = "hoge_test.rs"] mod tests;` で test module を有効化する
+
+#### Scenario: test-only directory は作られない
+- **WHEN** `hoge.rs` に実サブモジュールがない状態で unit test だけを追加する
+- **THEN** `hoge/` directory は作られない
+- **AND** `hoge/tests.rs` は作られない
+
+#### Scenario: crate root の unit test は `lib_test.rs` に置かれる
+- **WHEN** `src/lib.rs` の crate 内 unit test を追加または移設する
+- **THEN** test body は `src/lib_test.rs` に置かれる
+- **AND** `src/lib.rs` は `#[cfg(test)] #[path = "lib_test.rs"] mod tests;` で test module を有効化する
+
+### Requirement: Dylint は sibling test layout を強制する
+custom Dylint は、production file 内の inline test を禁止し続けなければならない（MUST）。同時に、test-only `#[path = "..._test.rs"] mod tests;` だけを許可し、その他の `#[path = ...]` module wiring は禁止し続けなければならない（MUST）。
+
+#### Scenario: production file の inline test は拒否される
+- **WHEN** production file に `#[cfg(test)] mod tests { ... }` または `#[test]` function が書かれる
+- **THEN** `tests-location-lint` は sibling `<module>_test.rs` へ移すよう報告する
+
+#### Scenario: 制約付き test path attribute は許可される
+- **WHEN** `hoge.rs` に `#[cfg(test)] #[path = "hoge_test.rs"] mod tests;` が書かれる
+- **THEN** `tests-location-lint` は `#[cfg(test)]` item として報告しない
+- **AND** `module-wiring-lint` は `#[path = "hoge_test.rs"]` を報告しない
+
+#### Scenario: 任意の path attribute は拒否される
+- **WHEN** `hoge.rs` に `#[path = "helper.rs"] mod helper;` または `#[cfg(test)] #[path = "shared/hoge_test.rs"] mod tests;` が書かれる
+- **THEN** `module-wiring-lint` は path attribute の module wiring を報告する
+
+#### Scenario: `_test.rs` file は production-oriented lint から test-only として扱われる
+- **WHEN** `hoge_test.rs` に test helper type や test helper name が存在する
+- **THEN** `tests.rs` を既に無視している production-oriented lint は `*_test.rs` も無視する（MUST）
+- **AND** `type-per-file-lint` と `ambiguous-suffix-lint` は `*_test.rs` から production naming または type-placement violation を報告してはならない（MUST NOT）

--- a/openspec/changes/adopt-sibling-test-files/tasks.md
+++ b/openspec/changes/adopt-sibling-test-files/tasks.md
@@ -1,0 +1,43 @@
+## 1. ルールとドキュメント
+
+- [ ] 1.1 `.agents/rules/**/*.md` の `<module>/tests.rs` 参照を sibling `<module>_test.rs` へ更新する。
+- [ ] 1.2 rule example を `#[cfg(test)] #[path = "<module>_test.rs"] mod tests;` に更新する。
+- [ ] 1.3 fraktor の module / test layout を生成・レビューする skill documentation を更新する。対象には `creating-fraktor-modules`、`designing-fraktor-shared-types`、`reviewing-fraktor-types`、`tests.rs` に触れる package / refactoring reference を含める。
+- [ ] 1.4 test-file ignore pattern または test-location guidance を説明している lint README / SPEC を更新する。
+
+## 2. Dylint 挙動
+
+- [ ] 2.1 `tests-location-lint` を更新し、`*_test.rs` file を test-only file として扱う。
+- [ ] 2.2 `tests-location-lint` を更新し、`#[cfg(test)] #[path = "<module>_test.rs"] mod tests;` を production-side hook として許可する。
+- [ ] 2.3 `tests-location-lint` の diagnostic を更新し、inline test を `<module>_test.rs` へ移すよう AI エージェントへ指示する。
+- [ ] 2.4 `module-wiring-lint` を更新し、module が `tests`、item が `#[cfg(test)]`、path が `<declaring_file_stem>_test.rs` と一致する制約付き test path attribute だけを許可する。
+- [ ] 2.5 `module-wiring-lint` は、non-test module、directory path、file stem 不一致、`#[cfg(test)]` 欠落を含む任意の `#[path = ...]` を引き続き拒否する。
+- [ ] 2.6 `type-per-file-lint` を更新し、`tests.rs` と `*_tests.rs` と同様に `*_test.rs` を無視する。
+- [ ] 2.7 `ambiguous-suffix-lint` を更新し、`tests.rs` と `*_tests.rs` と同様に `*_test.rs` を無視する。
+
+## 3. Dylint テスト
+
+- [ ] 3.1 `tests-location-lint` の UI fixture を追加または更新し、許可される sibling `_test.rs` layout と拒否される inline test を検証する。
+- [ ] 3.2 `module-wiring-lint` の UI fixture を追加または更新し、`#[cfg(test)] #[path = "hoge_test.rs"] mod tests;` が許可されることを検証する。
+- [ ] 3.3 `module-wiring-lint` の UI fixture を追加または更新し、拒否される path attribute variant を検証する。
+- [ ] 3.4 `type-per-file-lint` の UI fixture を追加または更新し、`*_test.rs` 内の public test helper type が無視されることを検証する。
+- [ ] 3.5 `ambiguous-suffix-lint` の UI fixture を追加または更新し、`*_test.rs` 内の test helper name が無視されることを検証する。
+- [ ] 3.6 変更したすべての lint について targeted Dylint UI test を実行する。
+
+## 4. Source 移行
+
+- [ ] 4.1 現在の `modules/**/src/**/tests.rs` file を棚卸しし、crate ごとに migration batch を分ける。
+- [ ] 4.2 nested `hoge/tests.rs` を sibling `hoge_test.rs` へ、小さな crate / module batch 単位で移行する。
+- [ ] 4.3 各 parent production file を `#[cfg(test)] mod tests;` から `#[cfg(test)] #[path = "<module>_test.rs"] mod tests;` へ更新する。
+- [ ] 4.4 root `src/tests.rs` を `src/lib_test.rs` へ移行し、対応する `lib.rs` hook を更新する。
+- [ ] 4.5 migration 中、既存 test assertion、helper visibility、runtime behavior を維持する。
+- [ ] 4.6 no_std-sensitive crate で安全に crate-internal `_test.rs` として残せない std 依存 test は、引き続き `tests/` 配下に置く。
+
+## 5. Verification
+
+- [ ] 5.1 移行した batch ごとに crate-level test を実行する。
+- [ ] 5.2 `./scripts/ci-check.sh dylint tests-location-lint` を実行する。
+- [ ] 5.3 `./scripts/ci-check.sh dylint module-wiring-lint` を実行する。
+- [ ] 5.4 `./scripts/ci-check.sh dylint type-per-file-lint` を実行する。
+- [ ] 5.5 `./scripts/ci-check.sh dylint ambiguous-suffix-lint` を実行する。
+- [ ] 5.6 最終確認として `./scripts/ci-check.sh ai all` を実行する。

--- a/showcases/std/Cargo.toml
+++ b/showcases/std/Cargo.toml
@@ -53,7 +53,7 @@ path = "legacy/tests/routing_surface.rs"
 name = "shared_lock_showcase_surface"
 path = "legacy/tests/shared_lock_showcase_surface.rs"
 
-# --- Basic examples ---
+# --- Basic examples: legacy ---
 
 [[example]]
 name = "getting_started"
@@ -123,7 +123,7 @@ name = "persistent_actor"
 path = "legacy/persistent_actor/main.rs"
 required-features = ["advanced"]
 
-# --- Strangler fig examples: Pekko classic/kernel ---
+# --- Strangler fig examples: kernel ---
 
 [[example]]
 name = "kernel_first_example"
@@ -217,7 +217,7 @@ path = "typed/dispatchers/main.rs"
 name = "typed_mailboxes"
 path = "typed/mailboxes/main.rs"
 
-# --- Strangler fig examples: Pekko streams ---
+# --- Strangler fig examples: streams ---
 
 [[example]]
 name = "stream_first_example"


### PR DESCRIPTION
## 概要

- crate 内 unit test の配置を `<module>/tests.rs` から sibling `<module>_test.rs` へ移す OpenSpec change を追加
- `#[cfg(test)] #[path = "<module>_test.rs"] mod tests;` を前提に、Dylint / rules / skill / migration task の更新方針を整理
- std showcase の example title も更新

## 検証

- `mise exec -- openspec status --change adopt-sibling-test-files`
- `git diff --check -- openspec/changes/adopt-sibling-test-files`

## 備考

- 実装本体ではなく、OpenSpec change 作成が中心です。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds OpenSpec documentation/specs and migration tasks only, plus comment-only edits in `showcases/std/Cargo.toml`, with no runtime or lint implementation changes in this PR.
> 
> **Overview**
> Introduces a new OpenSpec change (`adopt-sibling-test-files`) that **proposes migrating crate-internal unit tests** from nested `<module>/tests.rs` to sibling `<module>_test.rs`, using `#[cfg(test)] #[path = "<module>_test.rs"] mod tests;` while keeping the module name `tests`.
> 
> Adds/updates spec requirements and a concrete migration plan (including intended Dylint rule adjustments and `_test.rs` ignore behavior), and makes minor section-title comment tweaks in `showcases/std/Cargo.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6643069c0a5b3a6f86d2c1fbb1153366c54cade4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * サンプルおよびテストスイートの構成コメントを整理しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1769)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->