### PR TITLE
ci: default workflow runner to ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,15 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Runner to use for this manual CI run
+        required: true
+        default: ubuntu-latest
+        type: choice
+        options:
+          - ubuntu-latest
+          - self-hosted
 env:
   CARGO_TERM_COLOR: always
   CARGO_BUILD_JOBS: "4"
@@ -16,9 +25,9 @@ env:
   CARGO_NET_OFFLINE: false
   DYLINT_VERSION: "4.1.0"
   RUST_TOOLCHAIN: nightly-2025-12-01
-  # NOTE: CARGO_HOME, RUSTUP_HOME, and TMPDIR are set per-job via the
-  # `./.github/actions/setup-isolated-rust` composite action. They are NOT
-  # pinned at the workflow level because:
+  # NOTE: On self-hosted runners, CARGO_HOME, RUSTUP_HOME, and TMPDIR are set
+  # per-job via the `./.github/actions/setup-isolated-rust` composite action.
+  # They are NOT pinned at the workflow level because:
   #   1. `${{ github.workspace }}/.cargo` is a *fixed* path inside each
   #      runner's `_work/<repo>` directory. On self-hosted runners that
   #      reuse the same workspace between successive jobs, stale state
@@ -48,11 +57,12 @@ jobs:
   # Format check (fastest, prerequisite for other jobs)
   format:
     name: Format Check
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Setup isolated CARGO_HOME / RUSTUP_HOME / TMPDIR
+        if: ${{ runner.environment == 'self-hosted' }}
         uses: ./.github/actions/setup-isolated-rust
       - name: Setup Rust toolchain (nightly)
         uses: dtolnay/rust-toolchain@master
@@ -67,7 +77,7 @@ jobs:
   # Lint checks
   lint:
     name: Lint Check
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs: format
     strategy:
       matrix:
@@ -80,6 +90,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Setup isolated CARGO_HOME / RUSTUP_HOME / TMPDIR
+        if: ${{ runner.environment == 'self-hosted' }}
         uses: ./.github/actions/setup-isolated-rust
       - name: Setup Rust toolchain (nightly)
         uses: dtolnay/rust-toolchain@master
@@ -101,7 +112,7 @@ jobs:
   # - performance / benchmark は CI の正しさゲートに含めない。
   test:
     name: Test (${{ matrix.target.name }})
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs: format
     env:
       TEST_TIME_FACTOR: "2.0"
@@ -119,6 +130,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Setup isolated CARGO_HOME / RUSTUP_HOME / TMPDIR
+        if: ${{ runner.environment == 'self-hosted' }}
         uses: ./.github/actions/setup-isolated-rust
       - name: Setup Rust toolchain (nightly)
         uses: dtolnay/rust-toolchain@master
@@ -139,7 +151,7 @@ jobs:
   # Integration / E2E 層はここで PR ごとに検証する。
   integration-e2e:
     name: Integration / E2E
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs: test
     env:
       TEST_TIME_FACTOR: "2.0"
@@ -148,6 +160,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Setup isolated CARGO_HOME / RUSTUP_HOME / TMPDIR
+        if: ${{ runner.environment == 'self-hosted' }}
         uses: ./.github/actions/setup-isolated-rust
       - name: Setup Rust toolchain (nightly)
         uses: dtolnay/rust-toolchain@master
@@ -168,7 +181,7 @@ jobs:
   # 通常テストとは別ジョブで実行して artifact に保存する。
   coverage:
     name: Coverage Report
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs: integration-e2e
     permissions:
       contents: read
@@ -180,6 +193,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Setup isolated CARGO_HOME / RUSTUP_HOME / TMPDIR
+        if: ${{ runner.environment == 'self-hosted' }}
         uses: ./.github/actions/setup-isolated-rust
       - name: Setup Rust toolchain (nightly)
         uses: dtolnay/rust-toolchain@master
@@ -213,12 +227,13 @@ jobs:
   # Documentation build
   docs:
     name: Documentation
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs: format
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Setup isolated CARGO_HOME / RUSTUP_HOME / TMPDIR
+        if: ${{ runner.environment == 'self-hosted' }}
         uses: ./.github/actions/setup-isolated-rust
       - name: Setup Rust toolchain (nightly)
         uses: dtolnay/rust-toolchain@master
@@ -234,12 +249,13 @@ jobs:
   # Examples build
   examples:
     name: Examples
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs: format
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
       - name: Setup isolated CARGO_HOME / RUSTUP_HOME / TMPDIR
+        if: ${{ runner.environment == 'self-hosted' }}
         uses: ./.github/actions/setup-isolated-rust
       - name: Setup Rust toolchain (nightly)
         uses: dtolnay/rust-toolchain@master
@@ -255,7 +271,7 @@ jobs:
   # All jobs completion check
   ci-success:
     name: CI Success
-    runs-on: self-hosted
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs:
       - format
       - lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
   CARGO_BUILD_JOBS: "4"
   RUSTFLAGS: -D warnings
   CARGO_NET_OFFLINE: false
-  DYLINT_VERSION: "4.1.0"
+  DYLINT_VERSION: "6.0.0"
   RUST_TOOLCHAIN: nightly-2025-12-01
   # NOTE: On self-hosted runners, CARGO_HOME, RUSTUP_HOME, and TMPDIR are set
   # per-job via the `./.github/actions/setup-isolated-rust` composite action.

--- a/lints/ambiguous-suffix-lint/Cargo.toml
+++ b/lints/ambiguous-suffix-lint/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 dylint_linting = "6"
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/cfg-std-forbid-lint/Cargo.toml
+++ b/lints/cfg-std-forbid-lint/Cargo.toml
@@ -14,4 +14,4 @@ syn = { version = "2", features = ["full", "parsing", "visit"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/let-underscore-forbid-lint/Cargo.toml
+++ b/lints/let-underscore-forbid-lint/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 dylint_linting = "6"
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/mod-file-lint/Cargo.toml
+++ b/lints/mod-file-lint/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 dylint_linting = "6"
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/module-examples-lint/Cargo.toml
+++ b/lints/module-examples-lint/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 dylint_linting = "6"
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/module-wiring-lint/Cargo.toml
+++ b/lints/module-wiring-lint/Cargo.toml
@@ -14,4 +14,4 @@ quote = "1"
 syn = { version = "2", features = ["full", "parsing"] }
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/redundant-fqcn-lint/Cargo.toml
+++ b/lints/redundant-fqcn-lint/Cargo.toml
@@ -14,4 +14,4 @@ proc-macro2 = { version = "1", features = ["span-locations"] }
 syn = { version = "2", features = ["full", "parsing", "visit"] }
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/rustdoc-lint/Cargo.toml
+++ b/lints/rustdoc-lint/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 dylint_linting = "6"
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/tests-location-lint/Cargo.toml
+++ b/lints/tests-location-lint/Cargo.toml
@@ -14,4 +14,4 @@ quote = "1"
 syn = { version = "2", features = ["full", "parsing"] }
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/type-per-file-lint/Cargo.toml
+++ b/lints/type-per-file-lint/Cargo.toml
@@ -13,4 +13,4 @@ dylint_linting = "6"
 heck = "0.5"
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/lints/use-placement-lint/Cargo.toml
+++ b/lints/use-placement-lint/Cargo.toml
@@ -14,4 +14,4 @@ syn = { version = "2", features = ["full", "parsing", "visit"] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 
 [dev-dependencies]
-dylint_testing = "5"
+dylint_testing = "6"

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -346,6 +346,31 @@ prepare_ci_target_dir() {
   PREPARED_CI_TARGET_DIR="${target_dir}"
 }
 
+DYLINT_CARGO_WRAPPER_DIR=""
+
+prepare_dylint_cargo_wrapper() {
+  if [[ -n "${DYLINT_CARGO_WRAPPER_DIR}" ]]; then
+    return 0
+  fi
+
+  # dylint_testing sanitizes RUSTUP_TOOLCHAIN before spawning `cargo`.
+  # Keep child cargo builds on the pinned rustup toolchain even though this
+  # script also prepends the toolchain bin directory to PATH.
+  local wrapper_dir="${REPO_ROOT}/target/ci-check/dylint-cargo-wrapper"
+  mkdir -p "${wrapper_dir}"
+
+  local wrapper="${wrapper_dir}/cargo"
+  cat > "${wrapper}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export RUSTUP_TOOLCHAIN="${PINNED_TOOLCHAIN}"
+exec rustup run "${PINNED_TOOLCHAIN}" cargo "\$@"
+EOF
+  chmod +x "${wrapper}"
+
+  DYLINT_CARGO_WRAPPER_DIR="${wrapper_dir}"
+}
+
 should_guard_cargo_command() {
   local subcommand="${1:-}"
   case "${subcommand}" in
@@ -832,6 +857,9 @@ run_lint() {
 run_dylint() {
   ensure_rustc_components_installed || return 1
   ensure_dylint_installed || return 1
+  prepare_dylint_cargo_wrapper || return 1
+
+  local dylint_cargo_path="${DYLINT_CARGO_WRAPPER_DIR}:${PATH}"
 
   local -a lint_filters
   lint_filters=()
@@ -1003,11 +1031,11 @@ run_dylint() {
 
     local -a build_cmd=("${DEFAULT_CARGO_CMD[@]}" -v build --manifest-path "${lint_path}/Cargo.toml" --release)
     log_step "$(render_command "${build_cmd[@]}")"
-    env -u CARGO_TARGET_DIR CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" "${build_cmd[@]}" || return 1
+    env -u CARGO_TARGET_DIR CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" PATH="${dylint_cargo_path}" "${build_cmd[@]}" || return 1
 
     local -a test_cmd=("${DEFAULT_CARGO_CMD[@]}" -v test --manifest-path "${lint_path}/Cargo.toml" -- test ui -- --quiet)
     log_step "$(render_command "${test_cmd[@]}")"
-    env -u CARGO_TARGET_DIR CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" "${test_cmd[@]}" || return 1
+    env -u CARGO_TARGET_DIR CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" PATH="${dylint_cargo_path}" "${test_cmd[@]}" || return 1
 
     local dylib_ext
     dylib_ext="$(get_dylib_extension)"
@@ -1158,9 +1186,9 @@ PY
     fi
     log_step "$(render_cargo_command "${log_main_cmd[@]}") (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
     if [[ ${#trailing_args[@]} -gt 0 ]]; then
-      RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${main_invocation[@]}" -- "${trailing_args[@]}" || return 1
+      PATH="${dylint_cargo_path}" RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${main_invocation[@]}" -- "${trailing_args[@]}" || return 1
     else
-      RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${main_invocation[@]}" || return 1
+      PATH="${dylint_cargo_path}" RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${main_invocation[@]}" || return 1
     fi
   fi
 
@@ -1185,7 +1213,7 @@ PY
       fqcn_tests_cargo_args+=("${trailing_args[@]}")
     fi
     log_step "$(render_cargo_command dylint "${fqcn_tests_invocation[@]}" -- "${fqcn_tests_cargo_args[@]}") (redundant-fqcn-lint --tests pass, RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
-    RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${fqcn_tests_invocation[@]}" -- "${fqcn_tests_cargo_args[@]}" || return 1
+    PATH="${dylint_cargo_path}" RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${fqcn_tests_invocation[@]}" -- "${fqcn_tests_cargo_args[@]}" || return 1
   fi
 
   if [[ ${#hardware_targets[@]} -gt 0 ]]; then
@@ -1198,9 +1226,9 @@ PY
       fi
       log_step "$(render_cargo_command "${log_pkg_cmd[@]}") (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
       if [[ ${#trailing_args[@]} -gt 0 ]]; then
-        RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${pkg_invocation[@]}" -- "${trailing_args[@]}" || return 1
+        PATH="${dylint_cargo_path}" RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${pkg_invocation[@]}" -- "${trailing_args[@]}" || return 1
       else
-        RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${pkg_invocation[@]}" || return 1
+        PATH="${dylint_cargo_path}" RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${pkg_invocation[@]}" || return 1
       fi
     done
   fi
@@ -1237,7 +1265,7 @@ PY
         feature_trailing+=("${trailing_args[@]}")
       fi
       log_step "$(render_cargo_command "${log_feature_cmd[@]}") (RUSTFLAGS=${rustflags_value}, CARGO_INCREMENTAL=${dylint_incremental})"
-      RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${feature_invocation[@]}" -- "${feature_trailing[@]}" || return 1
+      PATH="${dylint_cargo_path}" RUSTFLAGS="${rustflags_value}" CARGO_INCREMENTAL="${dylint_incremental}" DYLINT_LIBRARY_PATH="${dylint_library_path}" DYLD_FALLBACK_LIBRARY_PATH="${dynlib_path}" LD_LIBRARY_PATH="${dynlib_path}" CARGO_NET_OFFLINE="${CARGO_NET_OFFLINE:-true}" run_cargo dylint "${feature_invocation[@]}" -- "${feature_trailing[@]}" || return 1
     done
   fi
 }

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -779,7 +779,7 @@ ensure_rustc_components_installed() {
 }
 
 ensure_dylint_installed() {
-  local desired_version="${DYLINT_VERSION:-5.0.0}"
+  local desired_version="${DYLINT_VERSION:-6.0.0}"
   local current_version=""
 
   if command -v cargo-dylint >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- default CI jobs to `ubuntu-latest` for push, pull_request, and schedule events
- add a manual `workflow_dispatch` runner choice so `self-hosted` runs only when explicitly selected
- run the isolated Rust setup action only on self-hosted runners
- align CI/local cargo-dylint installation and lint UI-test dependencies to `6.0.0`
- keep dylint UI-test child `cargo` invocations on the pinned rustup toolchain even after `dylint_testing` sanitizes `RUSTUP_TOOLCHAIN`

## Verification
- `mise exec -- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`
- `bash -n scripts/ci-check.sh`
- `git diff --check -- .github/workflows/ci.yml scripts/ci-check.sh`
- forced empty-driver-cache reproduction: `PATH="$(dirname "$(rustup which --toolchain nightly-2025-12-01 cargo)"):$PATH" DYLINT_DRIVER_PATH="$(mktemp -d)" DYLINT_VERSION=6.0.0 CARGO_NET_OFFLINE=false ./scripts/ci-check.sh dylint mod-file-lint`
- `DYLINT_VERSION=6.0.0 CARGO_NET_OFFLINE=false ./scripts/ci-check.sh dylint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8dd7835a1414403db4814f805f66ceb3138181bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI ワークフローを更新し、手動実行時に実行環境を選択できるように改善しました
  * 開発ツールのバージョンを更新しました（複数のテスト依存関係を v5 から v6 へ）
  * ツールチェーンのピンニング処理を改善し、CI チェックスクリプトの堅牢性を向上させました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1776)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->