### PR TITLE
Ccn refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,81 @@ jobs:
           name: fraktor-coverage
           fail_ci_if_error: true
 
+  # Codecov の外部 status が完了し、失敗していないことを CI Success に伝播する。
+  codecov-status:
+    name: Codecov Status
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
+    needs: coverage
+    if: always()
+    permissions:
+      contents: read
+      checks: read
+    steps:
+      - name: Wait for Codecov status checks
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
+          CODECOV_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+        with:
+          script: |
+            const coverageResult = process.env.COVERAGE_RESULT;
+            if (coverageResult !== "success") {
+              throw new Error(`coverage failed or was skipped: ${coverageResult}`);
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const ref = process.env.CODECOV_SHA;
+            const requiredChecks = ["codecov/project"];
+
+            if (process.env.IS_PULL_REQUEST === "true") {
+              requiredChecks.push("codecov/patch");
+            } else {
+              core.info("Skipping codecov/patch outside pull_request events");
+            }
+
+            for (const checkName of requiredChecks) {
+              await waitForCheck(checkName);
+            }
+
+            async function waitForCheck(checkName) {
+              for (let attempt = 1; attempt <= 60; attempt += 1) {
+                const response = await github.rest.checks.listForRef({
+                  owner,
+                  repo,
+                  ref,
+                  check_name: checkName,
+                  per_page: 100,
+                });
+                const run = response.data.check_runs
+                  .filter((checkRun) => checkRun.name === checkName)
+                  .sort((left, right) => {
+                    const rightTime = Date.parse(right.started_at || right.created_at);
+                    const leftTime = Date.parse(left.started_at || left.created_at);
+                    return rightTime - leftTime;
+                  })[0];
+
+                if (run) {
+                  core.info(`${checkName}: status=${run.status} conclusion=${run.conclusion || ""} url=${run.html_url}`);
+
+                  if (run.status === "completed") {
+                    if (run.conclusion === "success") {
+                      return;
+                    }
+
+                    throw new Error(`${checkName} failed with conclusion=${run.conclusion}`);
+                  }
+                } else {
+                  core.info(`${checkName}: waiting for Codecov check run (${attempt}/60)`);
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, 10000));
+              }
+
+              throw new Error(`${checkName} did not report within timeout`);
+            }
+
   # Documentation build
   docs:
     name: Documentation
@@ -278,6 +353,7 @@ jobs:
       - test
       - integration-e2e
       - coverage
+      - codecov-status
       - docs
       - examples
     if: always()
@@ -302,6 +378,10 @@ jobs:
           fi
           if [[ "${{ needs.coverage.result }}" != "success" ]]; then
             echo "coverage failed"
+            exit 1
+          fi
+          if [[ "${{ needs['codecov-status'].result }}" != "success" ]]; then
+            echo "codecov-status failed"
             exit 1
           fi
           if [[ "${{ needs.docs.result }}" != "success" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      statuses: read
     steps:
       - name: Wait for Codecov status checks
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
@@ -264,20 +265,7 @@ jobs:
 
             async function waitForCheck(checkName) {
               for (let attempt = 1; attempt <= 60; attempt += 1) {
-                const response = await github.rest.checks.listForRef({
-                  owner,
-                  repo,
-                  ref,
-                  check_name: checkName,
-                  per_page: 100,
-                });
-                const run = response.data.check_runs
-                  .filter((checkRun) => checkRun.name === checkName)
-                  .sort((left, right) => {
-                    const rightTime = Date.parse(right.started_at || right.created_at);
-                    const leftTime = Date.parse(left.started_at || left.created_at);
-                    return rightTime - leftTime;
-                  })[0];
+                const run = await latestCheckRun(checkName);
 
                 if (run) {
                   core.info(`${checkName}: status=${run.status} conclusion=${run.conclusion || ""} url=${run.html_url}`);
@@ -290,13 +278,47 @@ jobs:
                     throw new Error(`${checkName} failed with conclusion=${run.conclusion}`);
                   }
                 } else {
-                  core.info(`${checkName}: waiting for Codecov check run (${attempt}/60)`);
+                  const status = await latestCommitStatus(checkName);
+                  if (status) {
+                    core.info(`${checkName}: state=${status.state} url=${status.target_url || ""}`);
+
+                    if (status.state === "success") {
+                      return;
+                    }
+                    if (status.state === "failure" || status.state === "error") {
+                      throw new Error(`${checkName} failed with state=${status.state}`);
+                    }
+                  } else {
+                    core.info(`${checkName}: waiting for Codecov status (${attempt}/60)`);
+                  }
                 }
 
                 await new Promise((resolve) => setTimeout(resolve, 10000));
               }
 
               throw new Error(`${checkName} did not report within timeout`);
+            }
+
+            async function latestCheckRun(checkName) {
+              const response = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref,
+                check_name: checkName,
+                per_page: 100,
+              });
+              return response.data.check_runs
+                .filter((checkRun) => checkRun.name === checkName)
+                .sort((left, right) => {
+                  const rightTime = Date.parse(right.started_at || right.created_at);
+                  const leftTime = Date.parse(left.started_at || left.created_at);
+                  return rightTime - leftTime;
+                })[0];
+            }
+
+            async function latestCommitStatus(checkName) {
+              const response = await github.rest.repos.getCombinedStatusForRef({ owner, repo, ref });
+              return response.data.statuses.find((status) => status.context === checkName);
             }
 
   # Documentation build

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
-# PR の追加変更行は base coverage からの低下を許可せず、
+# PR の追加変更行は未カバーを許可せず、
 # project 全体の微小低下では PR を落とさない。
 coverage:
   status:
@@ -10,7 +10,7 @@ coverage:
         informational: false
     patch:
       default:
-        target: auto
+        target: 100%
         threshold: 0%
         if_not_found: failure
         informational: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,11 +1,16 @@
-# PR の追加変更行は 90% 以上を要求しつつ、
-# project 全体の 0.01% 程度の微小低下では PR を落とさない。
+# PR の追加変更行は base coverage からの低下を許可せず、
+# project 全体の微小低下では PR を落とさない。
 coverage:
   status:
     project:
       default:
         target: auto
         threshold: 0.02
+        if_not_found: failure
+        informational: false
     patch:
       default:
-        target: 90%
+        target: auto
+        threshold: 0%
+        if_not_found: failure
+        informational: false

--- a/modules/actor-core-kernel/src/dispatch/mailbox/system_queue_test.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/system_queue_test.rs
@@ -44,6 +44,25 @@ fn len_tracks_push_and_pop_operations() {
   assert_eq!(queue.len(), 0);
 }
 
+#[test]
+#[should_panic(expected = "unexpected message variant")]
+fn collect_fifo_consumer_values_panics_on_unexpected_message() {
+  let queue = Arc::new(SystemQueue::new());
+  queue.push(SystemMessage::Stop);
+  let barrier = Arc::new(Barrier::new(1));
+  let done = Arc::new(AtomicBool::new(true));
+
+  let _ = collect_fifo_consumer_values(queue, barrier, done);
+}
+
+#[test]
+fn collect_all_fifo_values_includes_remaining_queue_items() {
+  let queue = SystemQueue::new();
+  queue.push(SystemMessage::Watch(Pid::new(42, 0)));
+
+  assert_eq!(collect_all_fifo_values(&queue, Vec::new()), vec![42]);
+}
+
 /// Regression test for GitHub issue #126: concurrent pushers + poppers must
 /// preserve per-producer FIFO order. The old `return_to_head()` broke this by
 /// reinserting the reversed chain one node at a time, interleaving with new pushes.
@@ -133,12 +152,7 @@ fn assert_producer_fifo(consumer_index: usize, producer: u64, sequence: &[u64]) 
   let end = base + ITEMS_PER_PRODUCER;
   let producer_items: Vec<u64> = sequence.iter().copied().filter(|&value| value >= base && value < end).collect();
   for window in producer_items.windows(2) {
-    assert!(
-      window[0] < window[1],
-      "FIFO violated: consumer {consumer_index}, producer {producer}: {v0} before {v1}",
-      v0 = window[0],
-      v1 = window[1],
-    );
+    assert!(window[0] < window[1], "FIFO violated for consumer {consumer_index}, producer {producer}",);
   }
 }
 

--- a/modules/actor-core-kernel/src/dispatch/mailbox/system_queue_test.rs
+++ b/modules/actor-core-kernel/src/dispatch/mailbox/system_queue_test.rs
@@ -1,7 +1,19 @@
+use core::sync::atomic::{AtomicBool, Ordering};
+use std::{
+  sync::{Arc, Barrier},
+  thread::{self, JoinHandle},
+};
+
 use crate::{
   actor::{Pid, messaging::system_message::SystemMessage},
   dispatch::mailbox::system_queue::SystemQueue,
 };
+
+const PRODUCERS: u64 = 4;
+const ITEMS_PER_PRODUCER: u64 = 200;
+const TOTAL: usize = (PRODUCERS * ITEMS_PER_PRODUCER) as usize;
+const CONSUMERS: usize = 2;
+const ROUNDS: usize = 50;
 
 #[test]
 fn fifo_ordering_is_preserved() {
@@ -37,55 +49,13 @@ fn len_tracks_push_and_pop_operations() {
 /// reinserting the reversed chain one node at a time, interleaving with new pushes.
 #[test]
 fn concurrent_push_pop_preserves_per_producer_fifo() {
-  use core::sync::atomic::{AtomicBool, Ordering};
-  use std::{
-    sync::{Arc, Barrier},
-    thread,
-  };
-
-  const PRODUCERS: u64 = 4;
-  const ITEMS_PER_PRODUCER: u64 = 200;
-  const TOTAL: usize = (PRODUCERS * ITEMS_PER_PRODUCER) as usize;
-  const CONSUMERS: usize = 2;
-  const ROUNDS: usize = 50;
-
   for _ in 0..ROUNDS {
     let queue = Arc::new(SystemQueue::new());
     let done = Arc::new(AtomicBool::new(false));
     let barrier = Arc::new(Barrier::new((PRODUCERS as usize) + CONSUMERS));
 
-    let mut producer_handles = Vec::new();
-    for producer in 0..PRODUCERS {
-      let q = Arc::clone(&queue);
-      let b = Arc::clone(&barrier);
-      producer_handles.push(thread::spawn(move || {
-        b.wait();
-        let base = producer * ITEMS_PER_PRODUCER;
-        for seq in 0..ITEMS_PER_PRODUCER {
-          q.push(SystemMessage::Watch(Pid::new(base + seq, 0)));
-        }
-      }));
-    }
-
-    let mut consumer_handles = Vec::new();
-    for _ in 0..CONSUMERS {
-      let q = Arc::clone(&queue);
-      let b = Arc::clone(&barrier);
-      let d = Arc::clone(&done);
-      consumer_handles.push(thread::spawn(move || {
-        b.wait();
-        let mut collected = Vec::new();
-        loop {
-          match q.pop() {
-            | Some(SystemMessage::Watch(pid)) => collected.push(pid.value()),
-            | Some(_) => panic!("unexpected message variant"),
-            | None if d.load(Ordering::Acquire) => break,
-            | None => thread::yield_now(),
-          }
-        }
-        collected
-      }));
-    }
+    let producer_handles = spawn_fifo_producers(Arc::clone(&queue), Arc::clone(&barrier));
+    let consumer_handles = spawn_fifo_consumers(Arc::clone(&queue), Arc::clone(&barrier), Arc::clone(&done));
 
     for h in producer_handles {
       h.join().unwrap();
@@ -96,40 +66,103 @@ fn concurrent_push_pop_preserves_per_producer_fifo() {
 
     // Verify per-producer FIFO: within each consumer's output,
     // items from the same producer must appear in push order.
-    for (cidx, seq) in consumer_results.iter().enumerate() {
-      for producer in 0..PRODUCERS {
-        let base = producer * ITEMS_PER_PRODUCER;
-        let end = base + ITEMS_PER_PRODUCER;
-        let producer_items: Vec<u64> = seq.iter().copied().filter(|&v| v >= base && v < end).collect();
-        for w in producer_items.windows(2) {
-          assert!(
-            w[0] < w[1],
-            "FIFO violated: consumer {cidx}, producer {producer}: {v0} before {v1}",
-            v0 = w[0],
-            v1 = w[1],
-          );
-        }
-      }
-    }
+    assert_per_producer_fifo(&consumer_results);
+    assert_eq!(
+      collect_all_fifo_values(&queue, consumer_results),
+      expected_fifo_values(),
+      "all messages must be delivered exactly once"
+    );
+  }
+}
 
-    let mut all_values: Vec<u64> = consumer_results.into_iter().flatten().collect();
-    while let Some(msg) = queue.pop() {
-      if let SystemMessage::Watch(pid) = msg {
-        all_values.push(pid.value());
-      }
-    }
-
-    all_values.sort();
-    let mut expected: Vec<u64> = Vec::with_capacity(TOTAL);
-    for producer in 0..PRODUCERS {
+fn spawn_fifo_producers(queue: Arc<SystemQueue>, barrier: Arc<Barrier>) -> Vec<JoinHandle<()>> {
+  let mut handles = Vec::new();
+  for producer in 0..PRODUCERS {
+    let q = Arc::clone(&queue);
+    let b = Arc::clone(&barrier);
+    handles.push(thread::spawn(move || {
+      b.wait();
       let base = producer * ITEMS_PER_PRODUCER;
       for seq in 0..ITEMS_PER_PRODUCER {
-        expected.push(base + seq);
+        q.push(SystemMessage::Watch(Pid::new(base + seq, 0)));
       }
-    }
-    expected.sort();
-    assert_eq!(all_values, expected, "all messages must be delivered exactly once");
+    }));
   }
+  handles
+}
+
+fn spawn_fifo_consumers(
+  queue: Arc<SystemQueue>,
+  barrier: Arc<Barrier>,
+  done: Arc<AtomicBool>,
+) -> Vec<JoinHandle<Vec<u64>>> {
+  let mut handles = Vec::new();
+  for _ in 0..CONSUMERS {
+    let q = Arc::clone(&queue);
+    let b = Arc::clone(&barrier);
+    let d = Arc::clone(&done);
+    handles.push(thread::spawn(move || collect_fifo_consumer_values(q, b, d)));
+  }
+  handles
+}
+
+fn collect_fifo_consumer_values(queue: Arc<SystemQueue>, barrier: Arc<Barrier>, done: Arc<AtomicBool>) -> Vec<u64> {
+  barrier.wait();
+  let mut collected = Vec::new();
+  loop {
+    match queue.pop() {
+      | Some(SystemMessage::Watch(pid)) => collected.push(pid.value()),
+      | Some(_) => panic!("unexpected message variant"),
+      | None if done.load(Ordering::Acquire) => break,
+      | None => thread::yield_now(),
+    }
+  }
+  collected
+}
+
+fn assert_per_producer_fifo(consumer_results: &[Vec<u64>]) {
+  for (consumer_index, sequence) in consumer_results.iter().enumerate() {
+    for producer in 0..PRODUCERS {
+      assert_producer_fifo(consumer_index, producer, sequence);
+    }
+  }
+}
+
+fn assert_producer_fifo(consumer_index: usize, producer: u64, sequence: &[u64]) {
+  let base = producer * ITEMS_PER_PRODUCER;
+  let end = base + ITEMS_PER_PRODUCER;
+  let producer_items: Vec<u64> = sequence.iter().copied().filter(|&value| value >= base && value < end).collect();
+  for window in producer_items.windows(2) {
+    assert!(
+      window[0] < window[1],
+      "FIFO violated: consumer {consumer_index}, producer {producer}: {v0} before {v1}",
+      v0 = window[0],
+      v1 = window[1],
+    );
+  }
+}
+
+fn collect_all_fifo_values(queue: &SystemQueue, consumer_results: Vec<Vec<u64>>) -> Vec<u64> {
+  let mut all_values: Vec<u64> = consumer_results.into_iter().flatten().collect();
+  while let Some(msg) = queue.pop() {
+    if let SystemMessage::Watch(pid) = msg {
+      all_values.push(pid.value());
+    }
+  }
+  all_values.sort();
+  all_values
+}
+
+fn expected_fifo_values() -> Vec<u64> {
+  let mut expected = Vec::with_capacity(TOTAL);
+  for producer in 0..PRODUCERS {
+    let base = producer * ITEMS_PER_PRODUCER;
+    for seq in 0..ITEMS_PER_PRODUCER {
+      expected.push(base + seq);
+    }
+  }
+  expected.sort();
+  expected
 }
 
 /// Verify per-producer FIFO: items from each producer appear in the

--- a/modules/actor-core-kernel/src/serialization/builtin.rs
+++ b/modules/actor-core-kernel/src/serialization/builtin.rs
@@ -106,13 +106,24 @@ fn register_defaults_inner<F>(
 ) -> Result<(), SerializationError>
 where
   F: FnMut(&'static str, SerializerId), {
+  register_scalar_defaults(registry, &mut on_collision)?;
+  register_container_defaults(registry, &mut on_collision)?;
+  register_misc_defaults(registry, system_state, &mut on_collision)
+}
+
+fn register_scalar_defaults<F>(
+  registry: &ArcShared<SerializationRegistry>,
+  on_collision: &mut F,
+) -> Result<(), SerializationError>
+where
+  F: FnMut(&'static str, SerializerId), {
   register::<_, _>(
     registry,
     NULL_ID,
     NullSerializer::new(NULL_ID),
     "null",
     Some((TypeId::of::<()>(), "()".into())),
-    &mut on_collision,
+    on_collision,
   )?;
   register::<_, _>(
     registry,
@@ -120,7 +131,7 @@ where
     BoolSerializer::new(BOOL_ID),
     "bool",
     Some((TypeId::of::<bool>(), "bool".into())),
-    &mut on_collision,
+    on_collision,
   )?;
   register::<_, _>(
     registry,
@@ -128,7 +139,7 @@ where
     I32Serializer::new(I32_ID),
     "i32",
     Some((TypeId::of::<i32>(), "i32".into())),
-    &mut on_collision,
+    on_collision,
   )?;
   register::<_, _>(
     registry,
@@ -136,15 +147,24 @@ where
     StringSerializer::new(STRING_ID),
     "string",
     Some((TypeId::of::<String>(), "String".into())),
-    &mut on_collision,
+    on_collision,
   )?;
+  Ok(())
+}
+
+fn register_container_defaults<F>(
+  registry: &ArcShared<SerializationRegistry>,
+  on_collision: &mut F,
+) -> Result<(), SerializationError>
+where
+  F: FnMut(&'static str, SerializerId), {
   register::<_, _>(
     registry,
     BYTES_ID,
     BytesSerializer::new(BYTES_ID),
     "bytes",
     Some((TypeId::of::<Vec<u8>>(), "Vec<u8>".into())),
-    &mut on_collision,
+    on_collision,
   )?;
   register::<_, _>(
     registry,
@@ -152,7 +172,7 @@ where
     ByteStringSerializer::new(BYTE_STRING_ID),
     "byte_string",
     Some((TypeId::of::<ByteString>(), "ByteString".into())),
-    &mut on_collision,
+    on_collision,
   )?;
   register::<_, _>(
     registry,
@@ -160,7 +180,7 @@ where
     SystemMessageSerializer::new(SYSTEM_MESSAGE_ID),
     "system_message",
     Some((TypeId::of::<SystemMessage>(), "SystemMessage".into())),
-    &mut on_collision,
+    on_collision,
   )?;
   register::<_, _>(
     registry,
@@ -168,15 +188,25 @@ where
     MessageContainerSerializer::new(MESSAGE_CONTAINER_ID, registry.downgrade()),
     "message_container",
     Some((TypeId::of::<ActorSelectionMessage>(), "ActorSelectionMessage".into())),
-    &mut on_collision,
+    on_collision,
   )?;
+  Ok(())
+}
+
+fn register_misc_defaults<F>(
+  registry: &ArcShared<SerializationRegistry>,
+  system_state: Option<SystemStateWeak>,
+  on_collision: &mut F,
+) -> Result<(), SerializationError>
+where
+  F: FnMut(&'static str, SerializerId), {
   let misc_registered = register::<_, _>(
     registry,
     MISC_MESSAGE_ID,
     misc_message_serializer(MISC_MESSAGE_ID, registry.downgrade(), system_state),
     "misc_message",
     Some((TypeId::of::<Identify>(), "Identify".into())),
-    &mut on_collision,
+    on_collision,
   )?;
   if misc_registered {
     registry.register_binding(TypeId::of::<ActorIdentity>(), "ActorIdentity", MISC_MESSAGE_ID)?;

--- a/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
@@ -276,14 +276,12 @@ impl ProducerController {
       let runtime_settings = settings.clone();
       let runtime_load_state_adapter = load_state_adapter;
       Behaviors::receive_message(move |ctx, command: &ProducerControllerCommand<A>| {
-        Ok(receive_producer_controller_command(
-          ctx,
-          command,
-          &state,
-          &runtime_settings,
-          &self_ref,
-          &runtime_load_state_adapter,
-        ))
+        let command_context = ProducerCommandContext {
+          settings:           &runtime_settings,
+          self_ref:           &self_ref,
+          load_state_adapter: &runtime_load_state_adapter,
+        };
+        Ok(receive_producer_controller_command(ctx, command, &state, &command_context))
       })
     })
   }
@@ -301,23 +299,20 @@ fn receive_producer_controller_command<A>(
   ctx: &mut TypedActorContext<'_, ProducerControllerCommand<A>>,
   command: &ProducerControllerCommand<A>,
   state: &SharedLock<ProducerControllerState<A>>,
-  settings: &ProducerControllerConfig,
-  self_ref: &TypedActorRef<ProducerControllerCommand<A>>,
-  load_state_adapter: &Option<TypedActorRef<DurableProducerQueueState<A>>>,
+  command_context: &ProducerCommandContext<'_, A>,
 ) -> Behavior<ProducerControllerCommand<A>>
 where
   A: Clone + Send + Sync + 'static, {
-  let command_context = ProducerCommandContext { settings, self_ref, load_state_adapter };
   let mut stop_self = None::<String>;
   // ロック保持中に遅延アクションを収集し、ロック解放後に実行する。
   // メッセージアダプタ経由の再入デッドロックを回避するため。
   let deferred = state.with_lock(|state| {
     let mut deferred = Vec::new();
-    collect_producer_deferred_for_command(state, command, &command_context, &mut deferred, &mut stop_self);
-    maybe_schedule_resend_first(state, settings, self_ref, ctx);
+    collect_producer_deferred_for_command(state, command, command_context, &mut deferred, &mut stop_self);
+    maybe_schedule_resend_first(state, command_context.settings, command_context.self_ref, ctx);
     deferred
   });
-  execute_deferred(ctx, deferred, settings, self_ref);
+  execute_deferred(ctx, deferred, command_context.settings, command_context.self_ref);
   stop_producer_after_timeout(ctx, stop_self);
   Behaviors::same()
 }
@@ -356,7 +351,14 @@ fn collect_producer_deferred_for_command<A>(
       collect_on_durable_queue_message_stored(state, ack, deferred);
     },
     | ProducerControllerCommandKind::DurableQueueLoadTimedOut { attempt } => {
-      collect_producer_load_timeout(state, *attempt, command_context, deferred, stop_self);
+      collect_producer_load_timeout(
+        state,
+        *attempt,
+        command_context.settings,
+        command_context.load_state_adapter,
+        deferred,
+        stop_self,
+      );
     },
     | ProducerControllerCommandKind::DurableQueueStoreTimedOut { seq_nr, attempt } => {
       collect_producer_store_timeout(state, *seq_nr, *attempt, command_context.settings, deferred, stop_self);
@@ -441,7 +443,8 @@ fn collect_producer_durable_queue_loaded<A>(
 fn collect_producer_load_timeout<A>(
   state: &mut ProducerControllerState<A>,
   attempt: u32,
-  command_context: &ProducerCommandContext<'_, A>,
+  settings: &ProducerControllerConfig,
+  load_state_adapter: &Option<TypedActorRef<DurableProducerQueueState<A>>>,
   deferred: &mut Vec<DeferredAction<A>>,
   stop_self: &mut Option<String>,
 ) where
@@ -449,10 +452,10 @@ fn collect_producer_load_timeout<A>(
   if !state.awaiting_load {
     return;
   }
-  if attempt >= command_context.settings.durable_queue_retry_attempts() {
+  if attempt >= settings.durable_queue_retry_attempts() {
     *stop_self = Some(alloc::format!("ProducerController durable queue load timed out after {} attempts", attempt));
   } else if let (Some(durable_queue), Some(load_state_adapter)) =
-    (state.durable_queue.clone(), command_context.load_state_adapter.clone())
+    (state.durable_queue.clone(), load_state_adapter.clone())
   {
     deferred.push(DeferredAction::TellDurableQueue {
       target:  durable_queue,

--- a/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
@@ -276,142 +276,260 @@ impl ProducerController {
       let runtime_settings = settings.clone();
       let runtime_load_state_adapter = load_state_adapter;
       Behaviors::receive_message(move |ctx, command: &ProducerControllerCommand<A>| {
-        let mut stop_self = None::<String>;
-        // ロック保持中に遅延アクションを収集し、ロック解放後に実行する。
-        // メッセージアダプタ経由の再入デッドロックを回避するため。
-        let deferred = state.with_lock(|state| {
-          let mut deferred = Vec::new();
-          match command.kind() {
-            | ProducerControllerCommandKind::Start { producer } => {
-              state.producer = Some(producer.clone());
-              collect_request_next(state, &mut deferred);
-            },
-            | ProducerControllerCommandKind::RegisterConsumer { consumer_controller } => {
-              state.consumer_controller = Some(consumer_controller.clone());
-              // 新しい CC を登録する際にセッション状態をリセットする。
-              // 次のメッセージに first=true を付けて CC に状態リセットを促す。
-              state.send_first = true;
-              state.requested = false;
-              state.requested_seq_nr = 0;
-              state.awaiting_msg = false;
-              collect_request_next(state, &mut deferred);
-            },
-            | ProducerControllerCommandKind::Msg { message } => {
-              state.awaiting_msg = false;
-              collect_on_msg(state, message.clone(), &self_ref, &mut deferred);
-            },
-            | ProducerControllerCommandKind::Request { confirmed_seq_nr, request_up_to_seq_nr, support_resend } => {
-              let previous_confirmed_seq_nr = state.confirmed_seq_nr;
-              state.support_resend = *support_resend;
-              state.on_confirmed(*confirmed_seq_nr);
-              collect_store_confirmed(state, previous_confirmed_seq_nr, state.confirmed_seq_nr, &mut deferred);
-              state.requested_seq_nr = *request_up_to_seq_nr;
-              state.requested = true;
-              collect_request_next(state, &mut deferred);
-            },
-            | ProducerControllerCommandKind::Resend { from_seq_nr } => {
-              collect_resend(state, *from_seq_nr, &mut deferred);
-            },
-            | ProducerControllerCommandKind::Ack { confirmed_seq_nr } => {
-              let previous_confirmed_seq_nr = state.confirmed_seq_nr;
-              state.on_confirmed(*confirmed_seq_nr);
-              collect_store_confirmed(state, previous_confirmed_seq_nr, state.confirmed_seq_nr, &mut deferred);
-            },
-            | ProducerControllerCommandKind::DurableQueueLoaded { state: loaded } => {
-              state.current_seq_nr = loaded.current_seq_nr();
-              state.confirmed_seq_nr = loaded.highest_confirmed_seq_nr();
-              state.unconfirmed = loaded
-                .unconfirmed()
-                .iter()
-                .map(|sent| {
-                  SequencedMessage::new(
-                    state.producer_id.clone(),
-                    sent.seq_nr(),
-                    sent.message().clone(),
-                    false,
-                    sent.ack(),
-                    self_ref.clone(),
-                  )
-                })
-                .collect();
-              state.awaiting_load = false;
-              collect_request_next(state, &mut deferred);
-            },
-            | ProducerControllerCommandKind::DurableQueueMessageStored { ack } => {
-              collect_on_durable_queue_message_stored(state, ack, &mut deferred);
-            },
-            | ProducerControllerCommandKind::DurableQueueLoadTimedOut { attempt } => {
-              if state.awaiting_load {
-                if *attempt >= runtime_settings.durable_queue_retry_attempts() {
-                  stop_self =
-                    Some(alloc::format!("ProducerController durable queue load timed out after {} attempts", attempt));
-                } else if let (Some(durable_queue), Some(load_state_adapter)) =
-                  (state.durable_queue.clone(), runtime_load_state_adapter.clone())
-                {
-                  deferred.push(DeferredAction::TellDurableQueue {
-                    target:  durable_queue,
-                    message: DurableProducerQueueCommand::load_state(load_state_adapter),
-                    timeout: Some(DurableQueueTimeout::Load { attempt: attempt + 1 }),
-                  });
-                }
-              }
-            },
-            | ProducerControllerCommandKind::DurableQueueStoreTimedOut { seq_nr, attempt } => {
-              if let Some(pending_delivery) = state.pending_delivery.as_ref()
-                && pending_delivery.sequenced.seq_nr() == *seq_nr
-              {
-                if *attempt >= runtime_settings.durable_queue_retry_attempts() {
-                  stop_self = Some(alloc::format!(
-                    "ProducerController durable queue store timed out for seq_nr {} after {} attempts",
-                    seq_nr,
-                    attempt
-                  ));
-                } else if let (Some(durable_queue), Some(store_ack_adapter)) =
-                  (state.durable_queue.clone(), state.store_ack_adapter.clone())
-                {
-                  let sent = MessageSent::new(
-                    pending_delivery.sequenced.seq_nr(),
-                    pending_delivery.sequenced.message().clone(),
-                    pending_delivery.sequenced.ack(),
-                    NO_QUALIFIER,
-                    0,
-                  );
-                  deferred.push(DeferredAction::TellDurableQueue {
-                    target:  durable_queue,
-                    message: DurableProducerQueueCommand::store_message_sent(sent, store_ack_adapter),
-                    timeout: Some(DurableQueueTimeout::Store { seq_nr: *seq_nr, attempt: attempt + 1 }),
-                  });
-                }
-              }
-            },
-            | ProducerControllerCommandKind::ResendFirstUnconfirmed { seq_nr } => {
-              if state.resend_first_seq_nr == Some(*seq_nr) {
-                state.resend_first_seq_nr = None;
-              }
-              if let Some(first) = state.unconfirmed.first().cloned()
-                && first.seq_nr() == *seq_nr
-                && let Some(cc) = state.consumer_controller.clone()
-              {
-                deferred
-                  .push(DeferredAction::SendSequenced(cc, ConsumerControllerCommand::sequenced_msg(first.as_first())));
-              }
-            },
-          }
-          maybe_schedule_resend_first(state, &runtime_settings, &self_ref, ctx);
-          deferred
-        }); // ステートロックはここで解放される
-
-        execute_deferred(ctx, deferred, &runtime_settings, &self_ref);
-        if let Some(message) = stop_self {
-          ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
-          if let Err(error) = ctx.stop_self() {
-            let stop_message = alloc::format!("ProducerController failed to stop after timeout: {:?}", error);
-            ctx.system().emit_log(LogLevel::Warn, stop_message, Some(ctx.pid()), None);
-          }
-        }
-        Ok(Behaviors::same())
+        Ok(receive_producer_controller_command(
+          ctx,
+          command,
+          &state,
+          &runtime_settings,
+          &self_ref,
+          &runtime_load_state_adapter,
+        ))
       })
     })
+  }
+}
+
+struct ProducerCommandContext<'a, A>
+where
+  A: Clone + Send + Sync + 'static, {
+  settings:           &'a ProducerControllerConfig,
+  self_ref:           &'a TypedActorRef<ProducerControllerCommand<A>>,
+  load_state_adapter: &'a Option<TypedActorRef<DurableProducerQueueState<A>>>,
+}
+
+fn receive_producer_controller_command<A>(
+  ctx: &mut TypedActorContext<'_, ProducerControllerCommand<A>>,
+  command: &ProducerControllerCommand<A>,
+  state: &SharedLock<ProducerControllerState<A>>,
+  settings: &ProducerControllerConfig,
+  self_ref: &TypedActorRef<ProducerControllerCommand<A>>,
+  load_state_adapter: &Option<TypedActorRef<DurableProducerQueueState<A>>>,
+) -> Behavior<ProducerControllerCommand<A>>
+where
+  A: Clone + Send + Sync + 'static, {
+  let command_context = ProducerCommandContext { settings, self_ref, load_state_adapter };
+  let mut stop_self = None::<String>;
+  // ロック保持中に遅延アクションを収集し、ロック解放後に実行する。
+  // メッセージアダプタ経由の再入デッドロックを回避するため。
+  let deferred = state.with_lock(|state| {
+    let mut deferred = Vec::new();
+    collect_producer_deferred_for_command(state, command, &command_context, &mut deferred, &mut stop_self);
+    maybe_schedule_resend_first(state, settings, self_ref, ctx);
+    deferred
+  });
+  execute_deferred(ctx, deferred, settings, self_ref);
+  stop_producer_after_timeout(ctx, stop_self);
+  Behaviors::same()
+}
+
+fn collect_producer_deferred_for_command<A>(
+  state: &mut ProducerControllerState<A>,
+  command: &ProducerControllerCommand<A>,
+  command_context: &ProducerCommandContext<'_, A>,
+  deferred: &mut Vec<DeferredAction<A>>,
+  stop_self: &mut Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  match command.kind() {
+    | ProducerControllerCommandKind::Start { producer } => {
+      state.producer = Some(producer.clone());
+      collect_request_next(state, deferred);
+    },
+    | ProducerControllerCommandKind::RegisterConsumer { consumer_controller } => {
+      collect_producer_register_consumer(state, consumer_controller, deferred);
+    },
+    | ProducerControllerCommandKind::Msg { message } => {
+      state.awaiting_msg = false;
+      collect_on_msg(state, message.clone(), command_context.self_ref, deferred);
+    },
+    | ProducerControllerCommandKind::Request { confirmed_seq_nr, request_up_to_seq_nr, support_resend } => {
+      collect_producer_request(state, *confirmed_seq_nr, *request_up_to_seq_nr, *support_resend, deferred);
+    },
+    | ProducerControllerCommandKind::Resend { from_seq_nr } => collect_resend(state, *from_seq_nr, deferred),
+    | ProducerControllerCommandKind::Ack { confirmed_seq_nr } => {
+      collect_producer_ack(state, *confirmed_seq_nr, deferred);
+    },
+    | ProducerControllerCommandKind::DurableQueueLoaded { state: loaded } => {
+      collect_producer_durable_queue_loaded(state, loaded, command_context.self_ref, deferred);
+    },
+    | ProducerControllerCommandKind::DurableQueueMessageStored { ack } => {
+      collect_on_durable_queue_message_stored(state, ack, deferred);
+    },
+    | ProducerControllerCommandKind::DurableQueueLoadTimedOut { attempt } => {
+      collect_producer_load_timeout(state, *attempt, command_context, deferred, stop_self);
+    },
+    | ProducerControllerCommandKind::DurableQueueStoreTimedOut { seq_nr, attempt } => {
+      collect_producer_store_timeout(state, *seq_nr, *attempt, command_context.settings, deferred, stop_self);
+    },
+    | ProducerControllerCommandKind::ResendFirstUnconfirmed { seq_nr } => {
+      collect_producer_resend_first_unconfirmed(state, *seq_nr, deferred);
+    },
+  }
+}
+
+fn collect_producer_register_consumer<A>(
+  state: &mut ProducerControllerState<A>,
+  consumer_controller: &TypedActorRef<ConsumerControllerCommand<A>>,
+  deferred: &mut Vec<DeferredAction<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  state.consumer_controller = Some(consumer_controller.clone());
+  // 新しい CC を登録する際にセッション状態をリセットする。
+  // 次のメッセージに first=true を付けて CC に状態リセットを促す。
+  state.send_first = true;
+  state.requested = false;
+  state.requested_seq_nr = 0;
+  state.awaiting_msg = false;
+  collect_request_next(state, deferred);
+}
+
+fn collect_producer_request<A>(
+  state: &mut ProducerControllerState<A>,
+  confirmed_seq_nr: SeqNr,
+  request_up_to_seq_nr: SeqNr,
+  support_resend: bool,
+  deferred: &mut Vec<DeferredAction<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let previous_confirmed_seq_nr = state.confirmed_seq_nr;
+  state.support_resend = support_resend;
+  state.on_confirmed(confirmed_seq_nr);
+  collect_store_confirmed(state, previous_confirmed_seq_nr, state.confirmed_seq_nr, deferred);
+  state.requested_seq_nr = request_up_to_seq_nr;
+  state.requested = true;
+  collect_request_next(state, deferred);
+}
+
+fn collect_producer_ack<A>(
+  state: &mut ProducerControllerState<A>,
+  confirmed_seq_nr: SeqNr,
+  deferred: &mut Vec<DeferredAction<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let previous_confirmed_seq_nr = state.confirmed_seq_nr;
+  state.on_confirmed(confirmed_seq_nr);
+  collect_store_confirmed(state, previous_confirmed_seq_nr, state.confirmed_seq_nr, deferred);
+}
+
+fn collect_producer_durable_queue_loaded<A>(
+  state: &mut ProducerControllerState<A>,
+  loaded: &DurableProducerQueueState<A>,
+  self_ref: &TypedActorRef<ProducerControllerCommand<A>>,
+  deferred: &mut Vec<DeferredAction<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  state.current_seq_nr = loaded.current_seq_nr();
+  state.confirmed_seq_nr = loaded.highest_confirmed_seq_nr();
+  state.unconfirmed = loaded
+    .unconfirmed()
+    .iter()
+    .map(|sent| {
+      SequencedMessage::new(
+        state.producer_id.clone(),
+        sent.seq_nr(),
+        sent.message().clone(),
+        false,
+        sent.ack(),
+        self_ref.clone(),
+      )
+    })
+    .collect();
+  state.awaiting_load = false;
+  collect_request_next(state, deferred);
+}
+
+fn collect_producer_load_timeout<A>(
+  state: &mut ProducerControllerState<A>,
+  attempt: u32,
+  command_context: &ProducerCommandContext<'_, A>,
+  deferred: &mut Vec<DeferredAction<A>>,
+  stop_self: &mut Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if !state.awaiting_load {
+    return;
+  }
+  if attempt >= command_context.settings.durable_queue_retry_attempts() {
+    *stop_self = Some(alloc::format!("ProducerController durable queue load timed out after {} attempts", attempt));
+  } else if let (Some(durable_queue), Some(load_state_adapter)) =
+    (state.durable_queue.clone(), command_context.load_state_adapter.clone())
+  {
+    deferred.push(DeferredAction::TellDurableQueue {
+      target:  durable_queue,
+      message: DurableProducerQueueCommand::load_state(load_state_adapter),
+      timeout: Some(DurableQueueTimeout::Load { attempt: attempt + 1 }),
+    });
+  }
+}
+
+fn collect_producer_store_timeout<A>(
+  state: &mut ProducerControllerState<A>,
+  seq_nr: SeqNr,
+  attempt: u32,
+  settings: &ProducerControllerConfig,
+  deferred: &mut Vec<DeferredAction<A>>,
+  stop_self: &mut Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let Some(pending_delivery) = state.pending_delivery.as_ref() else {
+    return;
+  };
+  if pending_delivery.sequenced.seq_nr() != seq_nr {
+    return;
+  }
+  if attempt >= settings.durable_queue_retry_attempts() {
+    *stop_self = Some(alloc::format!(
+      "ProducerController durable queue store timed out for seq_nr {} after {} attempts",
+      seq_nr,
+      attempt
+    ));
+  } else if let (Some(durable_queue), Some(store_ack_adapter)) =
+    (state.durable_queue.clone(), state.store_ack_adapter.clone())
+  {
+    let sent = MessageSent::new(
+      pending_delivery.sequenced.seq_nr(),
+      pending_delivery.sequenced.message().clone(),
+      pending_delivery.sequenced.ack(),
+      NO_QUALIFIER,
+      0,
+    );
+    deferred.push(DeferredAction::TellDurableQueue {
+      target:  durable_queue,
+      message: DurableProducerQueueCommand::store_message_sent(sent, store_ack_adapter),
+      timeout: Some(DurableQueueTimeout::Store { seq_nr, attempt: attempt + 1 }),
+    });
+  }
+}
+
+fn collect_producer_resend_first_unconfirmed<A>(
+  state: &mut ProducerControllerState<A>,
+  seq_nr: SeqNr,
+  deferred: &mut Vec<DeferredAction<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if state.resend_first_seq_nr == Some(seq_nr) {
+    state.resend_first_seq_nr = None;
+  }
+  if let Some(first) = state.unconfirmed.first().cloned()
+    && first.seq_nr() == seq_nr
+    && let Some(cc) = state.consumer_controller.clone()
+  {
+    deferred.push(DeferredAction::SendSequenced(cc, ConsumerControllerCommand::sequenced_msg(first.as_first())));
+  }
+}
+
+fn stop_producer_after_timeout<A>(
+  ctx: &mut TypedActorContext<'_, ProducerControllerCommand<A>>,
+  message: Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let Some(message) = message else {
+    return;
+  };
+  ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
+  if let Err(error) = ctx.stop_self() {
+    let stop_message = alloc::format!("ProducerController failed to stop after timeout: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, stop_message, Some(ctx.pid()), None);
   }
 }
 

--- a/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller.rs
@@ -395,24 +395,15 @@ impl WorkPullingProducerController {
         s.durable_queue = durable_queue.clone();
         s.awaiting_load = durable_queue.is_some();
       });
-      if let (Some(mut durable_queue), Some(load_state_adapter)) =
-        (durable_queue.as_ref().cloned(), load_state_adapter.as_ref().cloned())
-        && let Err(error) = durable_queue.try_tell(DurableProducerQueueCommand::load_state(load_state_adapter))
-      {
-        let message =
-          alloc::format!("WorkPullingProducerController failed to request durable queue state: {:?}", error);
-        ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
+      if !start_wppc_durable_queue_load(
+        ctx,
+        &state,
+        durable_queue.as_ref(),
+        load_state_adapter.as_ref(),
+        durable_queue_request_timeout,
+        &self_ref,
+      ) {
         return Behaviors::stopped();
-      } else if state.with_lock(|state| state.awaiting_load)
-        && let Err(error) = ctx.schedule_once(
-          durable_queue_request_timeout,
-          self_ref.clone(),
-          WorkPullingProducerControllerCommand::durable_queue_load_timed_out(1),
-        )
-      {
-        let message =
-          alloc::format!("WorkPullingProducerController failed to schedule durable queue load timeout: {:?}", error);
-        ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
       }
 
       let producer_id_inner = producer_id.clone();
@@ -420,138 +411,315 @@ impl WorkPullingProducerController {
       let runtime_producer_controller_settings = producer_controller_settings.clone();
       let runtime_durable_queue_request_timeout = durable_queue_request_timeout;
       Behaviors::receive_message(move |ctx, command: &WorkPullingProducerControllerCommand<A>| {
-        let mut stop_self = None::<String>;
-        let mut timeout_warning = None::<String>;
-        let deferred = state.with_lock(|state| {
-          let mut deferred: Vec<WppcDeferredAction<A>> = Vec::new();
-          match command.kind() {
-            | WorkPullingProducerControllerCommandKind::Start { producer } => {
-              state.producer = Some(producer.clone());
-              collect_maybe_request_next(state, &mut deferred);
-            },
-            | WorkPullingProducerControllerCommandKind::Msg { message } => {
-              state.awaiting_msg = false;
-              collect_on_msg(state, message.clone(), &mut deferred);
-            },
-            | WorkPullingProducerControllerCommandKind::GetWorkerStats { reply_to } => {
-              let stats = WorkerStats::new(state.worker_count());
-              deferred.push(WppcDeferredAction::TellWorkerStats(reply_to.clone(), stats));
-            },
-            | WorkPullingProducerControllerCommandKind::WorkerListing { listing } => {
-              collect_on_worker_listing(
-                state,
-                listing,
-                &producer_id_inner,
-                &self_ref,
-                &runtime_producer_controller_settings,
-                &mut deferred,
-              );
-            },
-            | WorkPullingProducerControllerCommandKind::InternalDemand { request } => {
-              collect_on_internal_demand(state, request, &mut deferred);
-            },
-            | WorkPullingProducerControllerCommandKind::DurableQueueLoaded { state: loaded } => {
-              state.current_seq_nr = loaded.current_seq_nr();
-              state.awaiting_load = false;
-              for sent in loaded.unconfirmed() {
-                deferred.push(WppcDeferredAction::TellSelf(
-                  self_ref.clone(),
-                  WorkPullingProducerControllerCommand::replay_stored_message(sent.clone()),
-                ));
-              }
-              if loaded.unconfirmed().is_empty() {
-                collect_maybe_request_next(state, &mut deferred);
-              }
-            },
-            | WorkPullingProducerControllerCommandKind::DurableQueueMessageStored { ack } => {
-              collect_on_durable_queue_message_stored(state, ack, &self_ref, &mut deferred);
-            },
-            | WorkPullingProducerControllerCommandKind::DurableQueueLoadTimedOut { attempt } => {
-              if state.awaiting_load {
-                if *attempt >= runtime_producer_controller_settings.durable_queue_retry_attempts() {
-                  stop_self = Some(alloc::format!(
-                    "WorkPullingProducerController durable queue load timed out after {} attempts",
-                    attempt
-                  ));
-                } else if let (Some(durable_queue), Some(load_state_adapter)) =
-                  (state.durable_queue.clone(), runtime_load_state_adapter.clone())
-                {
-                  deferred.push(WppcDeferredAction::TellDurableQueue {
-                    target:  durable_queue,
-                    message: DurableProducerQueueCommand::load_state(load_state_adapter),
-                    timeout: Some(WppcDurableQueueTimeout::Load { attempt: attempt + 1 }),
-                  });
-                }
-              }
-            },
-            | WorkPullingProducerControllerCommandKind::DurableQueueStoreTimedOut { seq_nr, attempt } => {
-              if let Some(pending) = state.pending_stores.get(seq_nr) {
-                if *attempt >= runtime_producer_controller_settings.durable_queue_retry_attempts() {
-                  stop_self = Some(alloc::format!(
-                    "WorkPullingProducerController durable queue store timed out for seq_nr {} after {} attempts",
-                    seq_nr,
-                    attempt
-                  ));
-                } else if let (Some(durable_queue), Some(store_ack_adapter)) =
-                  (state.durable_queue.clone(), state.store_ack_adapter.clone())
-                {
-                  let sent = MessageSent::new(
-                    *seq_nr,
-                    pending.message.clone(),
-                    false,
-                    pending.confirmation_qualifier.clone(),
-                    0,
-                  );
-                  deferred.push(WppcDeferredAction::TellDurableQueue {
-                    target:  durable_queue,
-                    message: DurableProducerQueueCommand::store_message_sent(sent, store_ack_adapter),
-                    timeout: Some(WppcDurableQueueTimeout::Store { seq_nr: *seq_nr, attempt: attempt + 1 }),
-                  });
-                }
-              }
-            },
-            | WorkPullingProducerControllerCommandKind::WorkerDeliveryTimedOut { worker_key, worker_local_seq_nr } => {
-              if let Some(entry) = state.workers.remove(worker_key) {
-                if let Some(sent) = entry.in_flight.get(worker_local_seq_nr) {
-                  timeout_warning = Some(alloc::format!(
-                    "WorkPullingProducerController worker delivery timed out for worker {} local_seq_nr {} total_seq_nr {}; removing stalled worker and replaying in-flight messages",
-                    worker_key,
-                    worker_local_seq_nr,
-                    sent.seq_nr()
-                  ));
-                }
-                deferred.push(WppcDeferredAction::StopWorkerPc(entry.producer_controller.clone()));
-                for inflight in entry.in_flight.into_values() {
-                  deferred.push(WppcDeferredAction::TellSelf(
-                    self_ref.clone(),
-                    WorkPullingProducerControllerCommand::replay_stored_message(inflight),
-                  ));
-                }
-                collect_maybe_request_next(state, &mut deferred);
-              }
-            },
-            | WorkPullingProducerControllerCommandKind::ReplayStoredMessage { sent } => {
-              collect_on_replayed_message(state, sent.clone(), &mut deferred);
-            },
-          }
-          deferred
-        }); // ステートロックはここで解放される
-
-        execute_wppc_deferred(deferred, ctx, &state, internal_ask_timeout, runtime_durable_queue_request_timeout);
-        if let Some(message) = timeout_warning {
-          ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-        }
-        if let Some(message) = stop_self {
-          ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
-          if let Err(error) = ctx.stop_self() {
-            let stop_message =
-              alloc::format!("WorkPullingProducerController failed to stop after timeout: {:?}", error);
-            ctx.system().emit_log(LogLevel::Warn, stop_message, Some(ctx.pid()), None);
-          }
-        }
-        Ok(Behaviors::same())
+        let command_context = WorkPullingCommandContext {
+          producer_id:                  &producer_id_inner,
+          self_ref:                     &self_ref,
+          producer_controller_settings: &runtime_producer_controller_settings,
+          load_state_adapter:           &runtime_load_state_adapter,
+        };
+        Ok(receive_work_pulling_command(
+          ctx,
+          command,
+          &state,
+          &command_context,
+          internal_ask_timeout,
+          runtime_durable_queue_request_timeout,
+        ))
       })
     })
+  }
+}
+
+fn start_wppc_durable_queue_load<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  state: &SharedLock<WorkPullingState<A>>,
+  durable_queue: Option<&TypedActorRef<DurableProducerQueueCommand<A>>>,
+  load_state_adapter: Option<&TypedActorRef<DurableProducerQueueState<A>>>,
+  durable_queue_request_timeout: Duration,
+  self_ref: &TypedActorRef<WorkPullingProducerControllerCommand<A>>,
+) -> bool
+where
+  A: Clone + Send + Sync + 'static, {
+  if let (Some(durable_queue), Some(load_state_adapter)) = (durable_queue.cloned(), load_state_adapter.cloned())
+    && !request_wppc_durable_queue_load(ctx, durable_queue, load_state_adapter)
+  {
+    return false;
+  }
+  schedule_wppc_initial_load_timeout(ctx, state, durable_queue_request_timeout, self_ref);
+  true
+}
+
+fn request_wppc_durable_queue_load<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  mut durable_queue: TypedActorRef<DurableProducerQueueCommand<A>>,
+  load_state_adapter: TypedActorRef<DurableProducerQueueState<A>>,
+) -> bool
+where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(error) = durable_queue.try_tell(DurableProducerQueueCommand::load_state(load_state_adapter)) {
+    let message = alloc::format!("WorkPullingProducerController failed to request durable queue state: {:?}", error);
+    ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
+    return false;
+  }
+  true
+}
+
+fn schedule_wppc_initial_load_timeout<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  state: &SharedLock<WorkPullingState<A>>,
+  durable_queue_request_timeout: Duration,
+  self_ref: &TypedActorRef<WorkPullingProducerControllerCommand<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if state.with_lock(|state| state.awaiting_load)
+    && let Err(error) = ctx.schedule_once(
+      durable_queue_request_timeout,
+      self_ref.clone(),
+      WorkPullingProducerControllerCommand::durable_queue_load_timed_out(1),
+    )
+  {
+    let message =
+      alloc::format!("WorkPullingProducerController failed to schedule durable queue load timeout: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+struct WorkPullingCommandContext<'a, A>
+where
+  A: Clone + Send + Sync + 'static, {
+  producer_id:                  &'a str,
+  self_ref:                     &'a TypedActorRef<WorkPullingProducerControllerCommand<A>>,
+  producer_controller_settings: &'a ProducerControllerConfig,
+  load_state_adapter:           &'a Option<TypedActorRef<DurableProducerQueueState<A>>>,
+}
+
+fn receive_work_pulling_command<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  command: &WorkPullingProducerControllerCommand<A>,
+  state: &SharedLock<WorkPullingState<A>>,
+  command_context: &WorkPullingCommandContext<'_, A>,
+  internal_ask_timeout: Duration,
+  durable_queue_request_timeout: Duration,
+) -> Behavior<WorkPullingProducerControllerCommand<A>>
+where
+  A: Clone + Send + Sync + 'static, {
+  let mut stop_self = None::<String>;
+  let mut timeout_warning = None::<String>;
+  let deferred = state.with_lock(|state| {
+    let mut deferred: Vec<WppcDeferredAction<A>> = Vec::new();
+    collect_wppc_deferred_for_command(
+      state,
+      command,
+      command_context,
+      &mut deferred,
+      &mut stop_self,
+      &mut timeout_warning,
+    );
+    deferred
+  });
+  execute_wppc_deferred(deferred, ctx, state, internal_ask_timeout, durable_queue_request_timeout);
+  emit_wppc_timeout_warning(ctx, timeout_warning);
+  stop_wppc_after_command_timeout(ctx, stop_self);
+  Behaviors::same()
+}
+
+fn collect_wppc_deferred_for_command<A>(
+  state: &mut WorkPullingState<A>,
+  command: &WorkPullingProducerControllerCommand<A>,
+  command_context: &WorkPullingCommandContext<'_, A>,
+  deferred: &mut Vec<WppcDeferredAction<A>>,
+  stop_self: &mut Option<String>,
+  timeout_warning: &mut Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  match command.kind() {
+    | WorkPullingProducerControllerCommandKind::Start { producer } => {
+      state.producer = Some(producer.clone());
+      collect_maybe_request_next(state, deferred);
+    },
+    | WorkPullingProducerControllerCommandKind::Msg { message } => {
+      state.awaiting_msg = false;
+      collect_on_msg(state, message.clone(), deferred);
+    },
+    | WorkPullingProducerControllerCommandKind::GetWorkerStats { reply_to } => {
+      let stats = WorkerStats::new(state.worker_count());
+      deferred.push(WppcDeferredAction::TellWorkerStats(reply_to.clone(), stats));
+    },
+    | WorkPullingProducerControllerCommandKind::WorkerListing { listing } => {
+      collect_on_worker_listing(
+        state,
+        listing,
+        command_context.producer_id,
+        command_context.self_ref,
+        command_context.producer_controller_settings,
+        deferred,
+      );
+    },
+    | WorkPullingProducerControllerCommandKind::InternalDemand { request } => {
+      collect_on_internal_demand(state, request, deferred);
+    },
+    | WorkPullingProducerControllerCommandKind::DurableQueueLoaded { state: loaded } => {
+      collect_wppc_durable_queue_loaded(state, loaded, command_context.self_ref, deferred);
+    },
+    | WorkPullingProducerControllerCommandKind::DurableQueueMessageStored { ack } => {
+      collect_on_durable_queue_message_stored(state, ack, command_context.self_ref, deferred);
+    },
+    | WorkPullingProducerControllerCommandKind::DurableQueueLoadTimedOut { attempt } => {
+      collect_wppc_load_timeout(state, *attempt, command_context, deferred, stop_self);
+    },
+    | WorkPullingProducerControllerCommandKind::DurableQueueStoreTimedOut { seq_nr, attempt } => {
+      collect_wppc_store_timeout(
+        state,
+        *seq_nr,
+        *attempt,
+        command_context.producer_controller_settings,
+        deferred,
+        stop_self,
+      );
+    },
+    | WorkPullingProducerControllerCommandKind::WorkerDeliveryTimedOut { worker_key, worker_local_seq_nr } => {
+      collect_wppc_worker_delivery_timeout(
+        state,
+        *worker_key,
+        *worker_local_seq_nr,
+        command_context.self_ref,
+        deferred,
+        timeout_warning,
+      );
+    },
+    | WorkPullingProducerControllerCommandKind::ReplayStoredMessage { sent } => {
+      collect_on_replayed_message(state, sent.clone(), deferred);
+    },
+  }
+}
+
+fn collect_wppc_durable_queue_loaded<A>(
+  state: &mut WorkPullingState<A>,
+  loaded: &DurableProducerQueueState<A>,
+  self_ref: &TypedActorRef<WorkPullingProducerControllerCommand<A>>,
+  deferred: &mut Vec<WppcDeferredAction<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  state.current_seq_nr = loaded.current_seq_nr();
+  state.awaiting_load = false;
+  for sent in loaded.unconfirmed() {
+    deferred.push(WppcDeferredAction::TellSelf(
+      self_ref.clone(),
+      WorkPullingProducerControllerCommand::replay_stored_message(sent.clone()),
+    ));
+  }
+  if loaded.unconfirmed().is_empty() {
+    collect_maybe_request_next(state, deferred);
+  }
+}
+
+fn collect_wppc_load_timeout<A>(
+  state: &mut WorkPullingState<A>,
+  attempt: u32,
+  command_context: &WorkPullingCommandContext<'_, A>,
+  deferred: &mut Vec<WppcDeferredAction<A>>,
+  stop_self: &mut Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if !state.awaiting_load {
+    return;
+  }
+  if attempt >= command_context.producer_controller_settings.durable_queue_retry_attempts() {
+    *stop_self =
+      Some(alloc::format!("WorkPullingProducerController durable queue load timed out after {} attempts", attempt));
+  } else if let (Some(durable_queue), Some(load_state_adapter)) =
+    (state.durable_queue.clone(), command_context.load_state_adapter.clone())
+  {
+    deferred.push(WppcDeferredAction::TellDurableQueue {
+      target:  durable_queue,
+      message: DurableProducerQueueCommand::load_state(load_state_adapter),
+      timeout: Some(WppcDurableQueueTimeout::Load { attempt: attempt + 1 }),
+    });
+  }
+}
+
+fn collect_wppc_store_timeout<A>(
+  state: &mut WorkPullingState<A>,
+  seq_nr: u64,
+  attempt: u32,
+  producer_controller_settings: &ProducerControllerConfig,
+  deferred: &mut Vec<WppcDeferredAction<A>>,
+  stop_self: &mut Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let Some(pending) = state.pending_stores.get(&seq_nr) else {
+    return;
+  };
+  if attempt >= producer_controller_settings.durable_queue_retry_attempts() {
+    *stop_self = Some(alloc::format!(
+      "WorkPullingProducerController durable queue store timed out for seq_nr {} after {} attempts",
+      seq_nr,
+      attempt
+    ));
+  } else if let (Some(durable_queue), Some(store_ack_adapter)) =
+    (state.durable_queue.clone(), state.store_ack_adapter.clone())
+  {
+    let sent = MessageSent::new(seq_nr, pending.message.clone(), false, pending.confirmation_qualifier.clone(), 0);
+    deferred.push(WppcDeferredAction::TellDurableQueue {
+      target:  durable_queue,
+      message: DurableProducerQueueCommand::store_message_sent(sent, store_ack_adapter),
+      timeout: Some(WppcDurableQueueTimeout::Store { seq_nr, attempt: attempt + 1 }),
+    });
+  }
+}
+
+fn collect_wppc_worker_delivery_timeout<A>(
+  state: &mut WorkPullingState<A>,
+  worker_key: u64,
+  worker_local_seq_nr: u64,
+  self_ref: &TypedActorRef<WorkPullingProducerControllerCommand<A>>,
+  deferred: &mut Vec<WppcDeferredAction<A>>,
+  timeout_warning: &mut Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let Some(entry) = state.workers.remove(&worker_key) else {
+    return;
+  };
+  if let Some(sent) = entry.in_flight.get(&worker_local_seq_nr) {
+    *timeout_warning = Some(alloc::format!(
+      "WorkPullingProducerController worker delivery timed out for worker {} local_seq_nr {} total_seq_nr {}; removing stalled worker and replaying in-flight messages",
+      worker_key,
+      worker_local_seq_nr,
+      sent.seq_nr()
+    ));
+  }
+  deferred.push(WppcDeferredAction::StopWorkerPc(entry.producer_controller.clone()));
+  for inflight in entry.in_flight.into_values() {
+    deferred.push(WppcDeferredAction::TellSelf(
+      self_ref.clone(),
+      WorkPullingProducerControllerCommand::replay_stored_message(inflight),
+    ));
+  }
+  collect_maybe_request_next(state, deferred);
+}
+
+fn emit_wppc_timeout_warning<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  message: Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if let Some(message) = message {
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn stop_wppc_after_command_timeout<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  message: Option<String>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let Some(message) = message else {
+    return;
+  };
+  ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
+  if let Err(error) = ctx.stop_self() {
+    let stop_message = alloc::format!("WorkPullingProducerController failed to stop after timeout: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, stop_message, Some(ctx.pid()), None);
   }
 }
 
@@ -904,137 +1072,246 @@ pub(crate) fn execute_wppc_deferred<A>(
   A: Clone + Send + Sync + 'static, {
   let mut pending: VecDeque<WppcDeferredAction<A>> = actions.into_iter().collect();
   while let Some(action) = pending.pop_front() {
-    match action {
-      | WppcDeferredAction::TellWorker { mut target, message, worker_key, worker_local_seq_nr } => {
-        if let Err(error) = target.try_tell(message) {
-          let message =
-            alloc::format!("WorkPullingProducerController failed to send message to worker controller: {:?}", error);
-          ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-        } else if let Err(error) = ctx.schedule_once(
-          internal_ask_timeout,
-          ctx.self_ref(),
-          WorkPullingProducerControllerCommand::worker_delivery_timed_out(worker_key, worker_local_seq_nr),
-        ) {
-          let message =
-            alloc::format!("WorkPullingProducerController failed to schedule worker delivery timeout: {:?}", error);
-          ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-        }
-      },
-      | WppcDeferredAction::TellDurableQueue { mut target, message, timeout } => {
-        if let Err(error) = target.try_tell(message) {
-          let message = alloc::format!("WorkPullingProducerController failed to talk to durable queue: {:?}", error);
-          ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
-          if let Err(stop_error) = ctx.stop_self() {
-            let stop_message = alloc::format!(
-              "WorkPullingProducerController failed to stop after durable queue failure: {:?}",
-              stop_error
-            );
-            ctx.system().emit_log(LogLevel::Warn, stop_message, Some(ctx.pid()), None);
-          }
-        } else if let Some(timeout) = timeout {
-          let command = match timeout {
-            | WppcDurableQueueTimeout::Load { attempt } => {
-              WorkPullingProducerControllerCommand::durable_queue_load_timed_out(attempt)
-            },
-            | WppcDurableQueueTimeout::Store { seq_nr, attempt } => {
-              WorkPullingProducerControllerCommand::durable_queue_store_timed_out(seq_nr, attempt)
-            },
-          };
-          if let Err(error) = ctx.schedule_once(durable_queue_request_timeout, ctx.self_ref(), command) {
-            let message =
-              alloc::format!("WorkPullingProducerController failed to schedule durable queue timeout: {:?}", error);
-            ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-          }
-        }
-      },
-      | WppcDeferredAction::TellSelf(mut target, msg) => {
-        if let Err(error) = target.try_tell(msg) {
-          let message =
-            alloc::format!("WorkPullingProducerController failed to enqueue internal replay command: {:?}", error);
-          ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-        }
-      },
-      | WppcDeferredAction::TellWorkerStats(mut target, msg) => {
-        if let Err(error) = target.try_tell(msg) {
-          let message = alloc::format!("WorkPullingProducerController failed to send worker stats reply: {:?}", error);
-          ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-        }
-      },
-      | WppcDeferredAction::RequestNext(mut target, msg) => {
-        if let Err(error) = target.try_tell(msg) {
-          let message = alloc::format!("WorkPullingProducerController failed to request next work item: {:?}", error);
-          ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-        }
-      },
-      | WppcDeferredAction::StopWorkerPc(mut pc_ref) => {
-        if let Err(error) = stop_worker_producer_controller(&mut pc_ref) {
-          let message = alloc::format!("WorkPullingProducerController failed to stop worker controller: {:?}", error);
-          ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-        }
-      },
-      | WppcDeferredAction::SpawnWorker {
-        worker_ref,
-        producer_id: pc_producer_id,
-        demand_adapter,
-        producer_controller_settings,
-      } => {
-        // ワーカー PC を生成し、先に state に登録してから tell() する。
-        // インラインディスパッチで InternalDemand が即座に返るため、
-        // 登録前に tell() すると demand シグナルが消失する。
-        if let Some((entry, pc_ref)) =
-          spawn_worker_actor::<A>(ctx, &worker_ref, &pc_producer_id, &producer_controller_settings)
-        {
-          // 先にワーカーを登録する
-          state.with_lock(|state| {
-            state.workers.insert(pid_key(&worker_ref), entry);
-          });
-
-          // ワーカー PC に Start と RegisterConsumer を送信する。
-          // InternalDemand がインラインで処理され、state.workers に
-          // 登録済みなので demand シグナルが正しく反映される。
-          let mut pc_start = pc_ref.clone();
-          if let Err(error) = pc_start.try_tell(ProducerController::start(demand_adapter.clone())) {
-            let message =
-              alloc::format!("WorkPullingProducerController failed to start worker controller: {:?}", error);
-            ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-          }
-
-          let cc_ref = TypedActorRef::<ConsumerControllerCommand<A>>::from_untyped(worker_ref.clone());
-          let mut pc_reg = pc_ref;
-          if let Err(error) = pc_reg.try_tell(ProducerController::register_consumer(cc_ref)) {
-            let message = alloc::format!(
-              "WorkPullingProducerController failed to register worker consumer controller: {:?}",
-              error
-            );
-            ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
-          }
-
-          // バッファ済みメッセージを排出する
-          let drain_deferred = state.with_lock(|s| {
-            let mut drain_deferred = Vec::new();
-            collect_drain_buffered(s, &mut drain_deferred);
-            collect_maybe_request_next(s, &mut drain_deferred);
-            drain_deferred
-          });
-          pending.extend(drain_deferred);
-        }
-      },
-      | WppcDeferredAction::LogDropped { total_seq_nr, buffered_len, buffer_size, message_type } => {
-        ctx.system().emit_log(
-          LogLevel::Warn,
-          alloc::format!(
-            "WorkPullingProducerController dropped buffered message: seq_nr={}, buffered_len={}, buffer_size={}, message_type={}",
-            total_seq_nr,
-            buffered_len,
-            buffer_size,
-            message_type
-          ),
-          Some(ctx.pid()),
-          None,
-        );
-      },
-    }
+    execute_wppc_action(action, &mut pending, ctx, state, internal_ask_timeout, durable_queue_request_timeout);
   }
+}
+
+fn execute_wppc_action<A>(
+  action: WppcDeferredAction<A>,
+  pending: &mut VecDeque<WppcDeferredAction<A>>,
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  state: &SharedLock<WorkPullingState<A>>,
+  internal_ask_timeout: Duration,
+  durable_queue_request_timeout: Duration,
+) where
+  A: Clone + Send + Sync + 'static, {
+  match action {
+    | WppcDeferredAction::TellWorker { target, message, worker_key, worker_local_seq_nr } => {
+      execute_wppc_tell_worker(ctx, target, message, worker_key, worker_local_seq_nr, internal_ask_timeout);
+    },
+    | WppcDeferredAction::TellDurableQueue { target, message, timeout } => {
+      execute_wppc_tell_durable_queue(ctx, target, message, timeout, durable_queue_request_timeout);
+    },
+    | WppcDeferredAction::TellSelf(target, msg) => execute_wppc_tell_self(ctx, target, msg),
+    | WppcDeferredAction::TellWorkerStats(target, msg) => execute_wppc_tell_worker_stats(ctx, target, msg),
+    | WppcDeferredAction::RequestNext(target, msg) => execute_wppc_request_next(ctx, target, msg),
+    | WppcDeferredAction::StopWorkerPc(pc_ref) => execute_wppc_stop_worker_pc(ctx, pc_ref),
+    | WppcDeferredAction::SpawnWorker {
+      worker_ref,
+      producer_id: pc_producer_id,
+      demand_adapter,
+      producer_controller_settings,
+    } => {
+      execute_wppc_spawn_worker(
+        ctx,
+        state,
+        pending,
+        &worker_ref,
+        &pc_producer_id,
+        demand_adapter,
+        &producer_controller_settings,
+      );
+    },
+    | WppcDeferredAction::LogDropped { total_seq_nr, buffered_len, buffer_size, message_type } => {
+      emit_wppc_dropped_log(ctx, total_seq_nr, buffered_len, buffer_size, message_type);
+    },
+  }
+}
+
+fn execute_wppc_tell_worker<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  mut target: TypedActorRef<ProducerControllerCommand<A>>,
+  message: ProducerControllerCommand<A>,
+  worker_key: u64,
+  worker_local_seq_nr: u64,
+  internal_ask_timeout: Duration,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(error) = target.try_tell(message) {
+    let message =
+      alloc::format!("WorkPullingProducerController failed to send message to worker controller: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  } else if let Err(error) = ctx.schedule_once(
+    internal_ask_timeout,
+    ctx.self_ref(),
+    WorkPullingProducerControllerCommand::worker_delivery_timed_out(worker_key, worker_local_seq_nr),
+  ) {
+    let message =
+      alloc::format!("WorkPullingProducerController failed to schedule worker delivery timeout: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn execute_wppc_tell_durable_queue<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  mut target: TypedActorRef<DurableProducerQueueCommand<A>>,
+  message: DurableProducerQueueCommand<A>,
+  timeout: Option<WppcDurableQueueTimeout>,
+  durable_queue_request_timeout: Duration,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(error) = target.try_tell(message) {
+    let message = alloc::format!("WorkPullingProducerController failed to talk to durable queue: {:?}", error);
+    ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
+    stop_wppc_after_durable_queue_failure(ctx);
+  } else if let Some(timeout) = timeout {
+    schedule_wppc_durable_queue_timeout(ctx, timeout, durable_queue_request_timeout);
+  }
+}
+
+fn stop_wppc_after_durable_queue_failure<A>(ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>)
+where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(stop_error) = ctx.stop_self() {
+    let stop_message =
+      alloc::format!("WorkPullingProducerController failed to stop after durable queue failure: {:?}", stop_error);
+    ctx.system().emit_log(LogLevel::Warn, stop_message, Some(ctx.pid()), None);
+  }
+}
+
+fn schedule_wppc_durable_queue_timeout<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  timeout: WppcDurableQueueTimeout,
+  durable_queue_request_timeout: Duration,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let command = match timeout {
+    | WppcDurableQueueTimeout::Load { attempt } => {
+      WorkPullingProducerControllerCommand::durable_queue_load_timed_out(attempt)
+    },
+    | WppcDurableQueueTimeout::Store { seq_nr, attempt } => {
+      WorkPullingProducerControllerCommand::durable_queue_store_timed_out(seq_nr, attempt)
+    },
+  };
+  if let Err(error) = ctx.schedule_once(durable_queue_request_timeout, ctx.self_ref(), command) {
+    let message = alloc::format!("WorkPullingProducerController failed to schedule durable queue timeout: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn execute_wppc_tell_self<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  mut target: TypedActorRef<WorkPullingProducerControllerCommand<A>>,
+  msg: WorkPullingProducerControllerCommand<A>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(error) = target.try_tell(msg) {
+    let message =
+      alloc::format!("WorkPullingProducerController failed to enqueue internal replay command: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn execute_wppc_tell_worker_stats<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  mut target: TypedActorRef<WorkerStats>,
+  msg: WorkerStats,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(error) = target.try_tell(msg) {
+    let message = alloc::format!("WorkPullingProducerController failed to send worker stats reply: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn execute_wppc_request_next<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  mut target: TypedActorRef<WorkPullingProducerControllerRequestNext<A>>,
+  msg: WorkPullingProducerControllerRequestNext<A>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(error) = target.try_tell(msg) {
+    let message = alloc::format!("WorkPullingProducerController failed to request next work item: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn execute_wppc_stop_worker_pc<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  mut pc_ref: TypedActorRef<ProducerControllerCommand<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  if let Err(error) = stop_worker_producer_controller(&mut pc_ref) {
+    let message = alloc::format!("WorkPullingProducerController failed to stop worker controller: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn execute_wppc_spawn_worker<A>(
+  ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  state: &SharedLock<WorkPullingState<A>>,
+  pending: &mut VecDeque<WppcDeferredAction<A>>,
+  worker_ref: &ActorRef,
+  pc_producer_id: &str,
+  demand_adapter: TypedActorRef<ProducerControllerRequestNext<A>>,
+  producer_controller_settings: &ProducerControllerConfig,
+) where
+  A: Clone + Send + Sync + 'static, {
+  // ワーカー PC を生成し、先に state に登録してから tell() する。
+  // インラインディスパッチで InternalDemand が即座に返るため、
+  // 登録前に tell() すると demand シグナルが消失する。
+  if let Some((entry, pc_ref)) = spawn_worker_actor::<A>(ctx, worker_ref, pc_producer_id, producer_controller_settings)
+  {
+    state.with_lock(|state| {
+      state.workers.insert(pid_key(worker_ref), entry);
+    });
+    start_spawned_worker_pc(ctx, worker_ref, pc_ref, demand_adapter);
+    pending.extend(collect_after_worker_spawn(state));
+  }
+}
+
+fn start_spawned_worker_pc<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  worker_ref: &ActorRef,
+  pc_ref: TypedActorRef<ProducerControllerCommand<A>>,
+  demand_adapter: TypedActorRef<ProducerControllerRequestNext<A>>,
+) where
+  A: Clone + Send + Sync + 'static, {
+  let mut pc_start = pc_ref.clone();
+  if let Err(error) = pc_start.try_tell(ProducerController::start(demand_adapter)) {
+    let message = alloc::format!("WorkPullingProducerController failed to start worker controller: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+  let cc_ref = TypedActorRef::<ConsumerControllerCommand<A>>::from_untyped(worker_ref.clone());
+  let mut pc_reg = pc_ref;
+  if let Err(error) = pc_reg.try_tell(ProducerController::register_consumer(cc_ref)) {
+    let message =
+      alloc::format!("WorkPullingProducerController failed to register worker consumer controller: {:?}", error);
+    ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
+  }
+}
+
+fn collect_after_worker_spawn<A>(state: &SharedLock<WorkPullingState<A>>) -> Vec<WppcDeferredAction<A>>
+where
+  A: Clone + Send + Sync + 'static, {
+  state.with_lock(|s| {
+    let mut drain_deferred = Vec::new();
+    collect_drain_buffered(s, &mut drain_deferred);
+    collect_maybe_request_next(s, &mut drain_deferred);
+    drain_deferred
+  })
+}
+
+fn emit_wppc_dropped_log<A>(
+  ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
+  total_seq_nr: u64,
+  buffered_len: usize,
+  buffer_size: u32,
+  message_type: &'static str,
+) where
+  A: Clone + Send + Sync + 'static, {
+  ctx.system().emit_log(
+    LogLevel::Warn,
+    alloc::format!(
+      "WorkPullingProducerController dropped buffered message: seq_nr={}, buffered_len={}, buffer_size={}, message_type={}",
+      total_seq_nr,
+      buffered_len,
+      buffer_size,
+      message_type
+    ),
+    Some(ctx.pid()),
+    None,
+  );
 }
 
 fn stop_worker_producer_controller<A>(

--- a/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller.rs
@@ -395,13 +395,16 @@ impl WorkPullingProducerController {
         s.durable_queue = durable_queue.clone();
         s.awaiting_load = durable_queue.is_some();
       });
-      if !start_wppc_durable_queue_load(
-        ctx,
-        &state,
-        durable_queue.as_ref(),
-        load_state_adapter.as_ref(),
-        durable_queue_request_timeout,
-        &self_ref,
+      if matches!(
+        start_wppc_durable_queue_load(
+          ctx,
+          &state,
+          durable_queue.as_ref(),
+          load_state_adapter.as_ref(),
+          durable_queue_request_timeout,
+          &self_ref,
+        ),
+        DurableQueueLoadStart::Stop
       ) {
         return Behaviors::stopped();
       }
@@ -412,22 +415,22 @@ impl WorkPullingProducerController {
       let runtime_durable_queue_request_timeout = durable_queue_request_timeout;
       Behaviors::receive_message(move |ctx, command: &WorkPullingProducerControllerCommand<A>| {
         let command_context = WorkPullingCommandContext {
-          producer_id:                  &producer_id_inner,
-          self_ref:                     &self_ref,
+          producer_id: &producer_id_inner,
+          self_ref: &self_ref,
           producer_controller_settings: &runtime_producer_controller_settings,
-          load_state_adapter:           &runtime_load_state_adapter,
-        };
-        Ok(receive_work_pulling_command(
-          ctx,
-          command,
-          &state,
-          &command_context,
+          load_state_adapter: &runtime_load_state_adapter,
           internal_ask_timeout,
-          runtime_durable_queue_request_timeout,
-        ))
+          durable_queue_request_timeout: runtime_durable_queue_request_timeout,
+        };
+        Ok(receive_work_pulling_command(ctx, command, &state, &command_context))
       })
     })
   }
+}
+
+enum DurableQueueLoadStart {
+  Continue,
+  Stop,
 }
 
 fn start_wppc_durable_queue_load<A>(
@@ -437,31 +440,31 @@ fn start_wppc_durable_queue_load<A>(
   load_state_adapter: Option<&TypedActorRef<DurableProducerQueueState<A>>>,
   durable_queue_request_timeout: Duration,
   self_ref: &TypedActorRef<WorkPullingProducerControllerCommand<A>>,
-) -> bool
+) -> DurableQueueLoadStart
 where
   A: Clone + Send + Sync + 'static, {
   if let (Some(durable_queue), Some(load_state_adapter)) = (durable_queue.cloned(), load_state_adapter.cloned())
-    && !request_wppc_durable_queue_load(ctx, durable_queue, load_state_adapter)
+    && matches!(request_wppc_durable_queue_load(ctx, durable_queue, load_state_adapter), DurableQueueLoadStart::Stop)
   {
-    return false;
+    return DurableQueueLoadStart::Stop;
   }
   schedule_wppc_initial_load_timeout(ctx, state, durable_queue_request_timeout, self_ref);
-  true
+  DurableQueueLoadStart::Continue
 }
 
 fn request_wppc_durable_queue_load<A>(
   ctx: &TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
   mut durable_queue: TypedActorRef<DurableProducerQueueCommand<A>>,
   load_state_adapter: TypedActorRef<DurableProducerQueueState<A>>,
-) -> bool
+) -> DurableQueueLoadStart
 where
   A: Clone + Send + Sync + 'static, {
   if let Err(error) = durable_queue.try_tell(DurableProducerQueueCommand::load_state(load_state_adapter)) {
     let message = alloc::format!("WorkPullingProducerController failed to request durable queue state: {:?}", error);
     ctx.system().emit_log(LogLevel::Error, message, Some(ctx.pid()), None);
-    return false;
+    return DurableQueueLoadStart::Stop;
   }
-  true
+  DurableQueueLoadStart::Continue
 }
 
 fn schedule_wppc_initial_load_timeout<A>(
@@ -487,10 +490,12 @@ fn schedule_wppc_initial_load_timeout<A>(
 struct WorkPullingCommandContext<'a, A>
 where
   A: Clone + Send + Sync + 'static, {
-  producer_id:                  &'a str,
-  self_ref:                     &'a TypedActorRef<WorkPullingProducerControllerCommand<A>>,
+  producer_id: &'a str,
+  self_ref: &'a TypedActorRef<WorkPullingProducerControllerCommand<A>>,
   producer_controller_settings: &'a ProducerControllerConfig,
-  load_state_adapter:           &'a Option<TypedActorRef<DurableProducerQueueState<A>>>,
+  load_state_adapter: &'a Option<TypedActorRef<DurableProducerQueueState<A>>>,
+  internal_ask_timeout: Duration,
+  durable_queue_request_timeout: Duration,
 }
 
 fn receive_work_pulling_command<A>(
@@ -498,8 +503,6 @@ fn receive_work_pulling_command<A>(
   command: &WorkPullingProducerControllerCommand<A>,
   state: &SharedLock<WorkPullingState<A>>,
   command_context: &WorkPullingCommandContext<'_, A>,
-  internal_ask_timeout: Duration,
-  durable_queue_request_timeout: Duration,
 ) -> Behavior<WorkPullingProducerControllerCommand<A>>
 where
   A: Clone + Send + Sync + 'static, {
@@ -517,7 +520,7 @@ where
     );
     deferred
   });
-  execute_wppc_deferred(deferred, ctx, state, internal_ask_timeout, durable_queue_request_timeout);
+  execute_wppc_deferred(deferred, ctx, state, command_context);
   emit_wppc_timeout_warning(ctx, timeout_warning);
   stop_wppc_after_command_timeout(ctx, stop_self);
   Behaviors::same()
@@ -565,7 +568,14 @@ fn collect_wppc_deferred_for_command<A>(
       collect_on_durable_queue_message_stored(state, ack, command_context.self_ref, deferred);
     },
     | WorkPullingProducerControllerCommandKind::DurableQueueLoadTimedOut { attempt } => {
-      collect_wppc_load_timeout(state, *attempt, command_context, deferred, stop_self);
+      collect_wppc_load_timeout(
+        state,
+        *attempt,
+        command_context.producer_controller_settings,
+        command_context.load_state_adapter,
+        deferred,
+        stop_self,
+      );
     },
     | WorkPullingProducerControllerCommandKind::DurableQueueStoreTimedOut { seq_nr, attempt } => {
       collect_wppc_store_timeout(
@@ -616,7 +626,8 @@ fn collect_wppc_durable_queue_loaded<A>(
 fn collect_wppc_load_timeout<A>(
   state: &mut WorkPullingState<A>,
   attempt: u32,
-  command_context: &WorkPullingCommandContext<'_, A>,
+  producer_controller_settings: &ProducerControllerConfig,
+  load_state_adapter: &Option<TypedActorRef<DurableProducerQueueState<A>>>,
   deferred: &mut Vec<WppcDeferredAction<A>>,
   stop_self: &mut Option<String>,
 ) where
@@ -624,11 +635,11 @@ fn collect_wppc_load_timeout<A>(
   if !state.awaiting_load {
     return;
   }
-  if attempt >= command_context.producer_controller_settings.durable_queue_retry_attempts() {
+  if attempt >= producer_controller_settings.durable_queue_retry_attempts() {
     *stop_self =
       Some(alloc::format!("WorkPullingProducerController durable queue load timed out after {} attempts", attempt));
   } else if let (Some(durable_queue), Some(load_state_adapter)) =
-    (state.durable_queue.clone(), command_context.load_state_adapter.clone())
+    (state.durable_queue.clone(), load_state_adapter.clone())
   {
     deferred.push(WppcDeferredAction::TellDurableQueue {
       target:  durable_queue,
@@ -1062,17 +1073,23 @@ pub(crate) fn collect_on_durable_queue_message_stored<A>(
 }
 
 /// Executes deferred actions outside the state lock.
-pub(crate) fn execute_wppc_deferred<A>(
+fn execute_wppc_deferred<A>(
   actions: Vec<WppcDeferredAction<A>>,
   ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
   state: &SharedLock<WorkPullingState<A>>,
-  internal_ask_timeout: Duration,
-  durable_queue_request_timeout: Duration,
+  command_context: &WorkPullingCommandContext<'_, A>,
 ) where
   A: Clone + Send + Sync + 'static, {
   let mut pending: VecDeque<WppcDeferredAction<A>> = actions.into_iter().collect();
   while let Some(action) = pending.pop_front() {
-    execute_wppc_action(action, &mut pending, ctx, state, internal_ask_timeout, durable_queue_request_timeout);
+    execute_wppc_action(
+      action,
+      &mut pending,
+      ctx,
+      state,
+      command_context.internal_ask_timeout,
+      command_context.durable_queue_request_timeout,
+    );
   }
 }
 
@@ -1252,6 +1269,10 @@ fn execute_wppc_spawn_worker<A>(
   // 登録前に tell() すると demand シグナルが消失する。
   if let Some((entry, pc_ref)) = spawn_worker_actor::<A>(ctx, worker_ref, pc_producer_id, producer_controller_settings)
   {
+    // 1 回目の state.with_lock は spawn_worker_actor の結果を登録するためだけに使う。
+    // start_spawned_worker_pc のインラインディスパッチで InternalDemand
+    // が同期的に返る可能性があるため、 collect_after_worker_spawn の 2 回目の state.with_lock で
+    // pending work と request_next を安全に回収する。
     state.with_lock(|state| {
       state.workers.insert(pid_key(worker_ref), entry);
     });

--- a/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller_test.rs
+++ b/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller_test.rs
@@ -325,6 +325,17 @@ fn durable_queue_send_failure_stops_work_pulling_controller() {
     SharedLock::new_with_driver::<SpinSyncMutex<_>>(WorkPullingState::<u32>::new("test-producer".to_string(), 16));
   let durable_queue =
     TypedActorRef::from_untyped(crate::test_support::actor_ref_with_sender(Pid::new(999, 0), FailingSender));
+  let self_ref = make_typed_ref::<WorkPullingProducerControllerCommand<u32>>();
+  let producer_settings = ProducerControllerConfig::new();
+  let load_state_adapter = None;
+  let command_context = WorkPullingCommandContext {
+    producer_id: "test-producer",
+    self_ref: &self_ref,
+    producer_controller_settings: &producer_settings,
+    load_state_adapter: &load_state_adapter,
+    internal_ask_timeout: Duration::from_millis(1),
+    durable_queue_request_timeout: Duration::from_millis(1),
+  };
 
   execute_wppc_deferred(
     vec![WppcDeferredAction::TellDurableQueue {
@@ -334,8 +345,7 @@ fn durable_queue_send_failure_stops_work_pulling_controller() {
     }],
     &mut typed_ctx,
     &state,
-    Duration::from_millis(1),
-    Duration::from_millis(1),
+    &command_context,
   );
 
   assert_eq!(lifecycle.lock().as_slice(), &["pre_start", "post_stop"]);

--- a/modules/actor-core-typed/src/dsl/behaviors.rs
+++ b/modules/actor-core-typed/src/dsl/behaviors.rs
@@ -705,19 +705,31 @@ where
   }
 
   match options.logger_name() {
-    | Some(logger_name) => match options.level() {
-      | LogLevel::Trace => tracing::trace!(actor = %pid, logger_name, ?message, "received message"),
-      | LogLevel::Debug => tracing::debug!(actor = %pid, logger_name, ?message, "received message"),
-      | LogLevel::Info => tracing::info!(actor = %pid, logger_name, ?message, "received message"),
-      | LogLevel::Warn => tracing::warn!(actor = %pid, logger_name, ?message, "received message"),
-      | LogLevel::Error => tracing::error!(actor = %pid, logger_name, ?message, "received message"),
-    },
-    | None => match options.level() {
-      | LogLevel::Trace => tracing::trace!(actor = %pid, ?message, "received message"),
-      | LogLevel::Debug => tracing::debug!(actor = %pid, ?message, "received message"),
-      | LogLevel::Info => tracing::info!(actor = %pid, ?message, "received message"),
-      | LogLevel::Warn => tracing::warn!(actor = %pid, ?message, "received message"),
-      | LogLevel::Error => tracing::error!(actor = %pid, ?message, "received message"),
-    },
+    | Some(logger_name) => log_received_message_with_logger(options.level(), pid, logger_name, message),
+    | None => log_received_message_without_logger(options.level(), pid, message),
+  }
+}
+
+fn log_received_message_with_logger<M>(level: LogLevel, pid: Pid, logger_name: &str, message: &M)
+where
+  M: Debug, {
+  match level {
+    | LogLevel::Trace => tracing::trace!(actor = %pid, logger_name, ?message, "received message"),
+    | LogLevel::Debug => tracing::debug!(actor = %pid, logger_name, ?message, "received message"),
+    | LogLevel::Info => tracing::info!(actor = %pid, logger_name, ?message, "received message"),
+    | LogLevel::Warn => tracing::warn!(actor = %pid, logger_name, ?message, "received message"),
+    | LogLevel::Error => tracing::error!(actor = %pid, logger_name, ?message, "received message"),
+  }
+}
+
+fn log_received_message_without_logger<M>(level: LogLevel, pid: Pid, message: &M)
+where
+  M: Debug, {
+  match level {
+    | LogLevel::Trace => tracing::trace!(actor = %pid, ?message, "received message"),
+    | LogLevel::Debug => tracing::debug!(actor = %pid, ?message, "received message"),
+    | LogLevel::Info => tracing::info!(actor = %pid, ?message, "received message"),
+    | LogLevel::Warn => tracing::warn!(actor = %pid, ?message, "received message"),
+    | LogLevel::Error => tracing::error!(actor = %pid, ?message, "received message"),
   }
 }

--- a/modules/actor-core-typed/src/dsl/routing/pool_router.rs
+++ b/modules/actor-core-typed/src/dsl/routing/pool_router.rs
@@ -12,7 +12,8 @@ use portable_atomic::{AtomicU64, Ordering};
 
 use super::resizer::Resizer;
 use crate::{
-  TypedActorRef, behavior::Behavior, dsl::Behaviors, message_and_signals::BehaviorSignal, props::TypedProps,
+  TypedActorRef, actor::TypedActorContext, behavior::Behavior, dsl::Behaviors, message_and_signals::BehaviorSignal,
+  props::TypedProps,
 };
 
 #[cfg(test)]
@@ -156,164 +157,249 @@ where
     let routee_props_mapper = self.routee_props_mapper;
 
     Behaviors::setup(move |ctx| {
-      let bf = behavior_factory.clone();
-      let props = TypedProps::<M>::from_behavior_factory(move || {
-        let factory: &(dyn Fn() -> Behavior<M> + Send + Sync) = &*bf;
-        factory()
-      });
-      let props = if let Some(ref mapper) = routee_props_mapper { mapper(props) } else { props };
-
-      let mut routee_vec: Vec<TypedActorRef<M>> = Vec::with_capacity(pool_size);
-      for _ in 0..pool_size {
-        match ctx.spawn_child_watched(&props) {
-          | Ok(child) => routee_vec.push(child.into_actor_ref()),
-          | Err(e) => {
-            let msg = alloc::format!("pool router failed to spawn child: {:?}", e);
-            ctx.system().emit_log(LogLevel::Warn, msg, Some(ctx.pid()), None);
-            break;
-          },
-        }
-      }
-
+      let props = build_pool_routee_props(&behavior_factory, routee_props_mapper.as_ref());
+      let routee_vec = spawn_pool_routees(ctx, &props, pool_size);
       let props_for_resize = resizer.as_ref().map(|_| props.clone());
-
       let routees = SharedLock::new_with_driver::<DefaultMutex<_>>(routee_vec);
       let routees_for_msg = routees.clone();
       let routees_for_sig = routees;
-
-      let select_targets: ArcShared<RouteSelector<M>> = match strategy.clone() {
-        | PoolRouteStrategy::RoundRobin => {
-          let index = AtomicUsize::new(0);
-          ArcShared::new(move |guard: &[TypedActorRef<M>], _message: &M| {
-            let idx = index.fetch_add(1, Ordering::Relaxed) % guard.len();
-            vec![guard[idx].clone()]
-          })
-        },
-        | PoolRouteStrategy::Broadcast => ArcShared::new(|guard: &[TypedActorRef<M>], _message: &M| guard.to_vec()),
-        | PoolRouteStrategy::Random { seed } => {
-          let random_seed = AtomicU64::new(0);
-          ArcShared::new(move |guard: &[TypedActorRef<M>], _message: &M| {
-            let mixed_seed = random_seed.fetch_add(1, Ordering::Relaxed) ^ seed;
-            let idx = pseudo_random_index(mixed_seed, guard.len());
-            vec![guard[idx].clone()]
-          })
-        },
-        | PoolRouteStrategy::ConsistentHash { hash_fn } => {
-          ArcShared::new(move |guard: &[TypedActorRef<M>], message: &M| {
-            let idx = select_consistent_hash_index(guard, message, &*hash_fn);
-            vec![guard[idx].clone()]
-          })
-        },
-        | PoolRouteStrategy::SmallestMailbox => ArcShared::new(move |guard: &[TypedActorRef<M>], _message: &M| {
-          let idx = select_smallest_mailbox_index(guard);
-          vec![guard[idx].clone()]
-        }),
-      };
-
+      let select_targets = pool_route_selector(strategy.clone());
       let broadcast_predicate_for_message = broadcast_predicate.clone();
       let resizer_for_msg = resizer.clone();
       let message_counter = AtomicU64::new(0);
       Behaviors::receive_message(move |ctx, message: &M| {
         if let Some(ref resizer) = resizer_for_msg {
           let counter = message_counter.fetch_add(1, Ordering::Relaxed);
-          // Pekko `ResizablePoolCell` 相当の順序で呼び出す:
-          // 1. `is_time_for_resize` を先にチェック（軽量、通常 false）
-          // 2. true の場合のみ mailbox スナップショットを取り、`report_message_count` → `resize` を
-          //    **同じスナップショット** で実行する。
-          //
-          // `report_message_count` は内部で `check_time` を更新するため、先に
-          // 呼んでしまうと `is_time_for_resize` の時刻差判定が常にゼロとなり
-          // resize が発火しなくなる（Pekko も同様の順序制約を持つ。
-          // 参照: `OptimalSizeExploringResizer.scala:201-203, 262` および
-          // `Resizer.scala:286-309`）。
-          if resizer.is_time_for_resize(counter) {
-            let mailbox_sizes = routees_for_msg.with_lock(|routees| observe_routee_mailbox_sizes(routees.as_slice()));
-            resizer.report_message_count(&mailbox_sizes, counter);
-            let delta = resizer.resize(&mailbox_sizes);
-            if delta > 0 {
-              if let Some(ref resize_props) = props_for_resize {
-                let mut new_routees = Vec::new();
-                for _ in 0..delta {
-                  match ctx.spawn_child_watched(resize_props) {
-                    | Ok(child) => new_routees.push(child.into_actor_ref()),
-                    | Err(e) => {
-                      let msg = alloc::format!("pool router resize failed to spawn child: {:?}", e);
-                      ctx.system().emit_log(LogLevel::Warn, msg, Some(ctx.pid()), None);
-                      break;
-                    },
-                  }
-                }
-                if !new_routees.is_empty() {
-                  routees_for_msg.with_lock(|guard| {
-                    guard.extend(new_routees);
-                  });
-                }
-              }
-            } else if delta < 0 {
-              let abs_delta = (-delta) as usize;
-              // Pekko 原典 (`Resizer.scala:305` の `currentRoutees.drop(...)`) と同じく
-              // 末尾の routee を停止対象にする。
-              let to_stop: Vec<TypedActorRef<M>> = {
-                routees_for_msg.with_lock(|guard| {
-                  let remove_count = abs_delta.min(guard.len().saturating_sub(1));
-                  let split_at = guard.len() - remove_count;
-                  guard.split_off(split_at)
-                })
-              };
-              for routee in &to_stop {
-                if let Err(e) = ctx.stop_actor_by_ref(routee) {
-                  ctx.system().emit_log(
-                    LogLevel::Warn,
-                    alloc::format!("pool router failed to stop routee during resize: {:?}", e),
-                    Some(ctx.pid()),
-                    None,
-                  );
-                }
-              }
-            }
-          }
+          maybe_resize_pool(ctx, &routees_for_msg, &props_for_resize, resizer, counter);
         }
-
-        let targets = {
-          let guard = routees_for_msg.with_lock(|routees| routees.clone());
-          if guard.is_empty() {
-            return Ok(Behaviors::same());
-          }
-          if let Some(predicate) = broadcast_predicate_for_message.as_ref() {
-            if predicate(message) { guard.to_vec() } else { select_targets(&guard, message) }
-          } else {
-            select_targets(&guard, message)
-          }
+        let Some(targets) =
+          select_pool_targets(&routees_for_msg, &select_targets, &broadcast_predicate_for_message, message)
+        else {
+          return Ok(Behaviors::same());
         };
-        for mut target in targets {
-          if let Err(error) = target.try_tell(message.clone()) {
-            ctx.system().emit_log(
-              LogLevel::Warn,
-              alloc::format!("pool router failed to deliver message to routee: {:?}", error),
-              Some(ctx.pid()),
-              None,
-            );
-          }
-        }
+        deliver_pool_message(ctx, targets, message);
         Ok(Behaviors::same())
       })
-      .receive_signal(move |_ctx, signal| match signal {
-        | BehaviorSignal::Terminated(terminated) => {
-          let pid = terminated.pid();
-          let is_empty = routees_for_sig.with_lock(|guard| {
-            if let Some(pos) = guard.iter().position(|r| r.pid() == pid) {
-              guard.remove(pos);
-            }
-            guard.is_empty()
-          });
-          if is_empty {
-            return Ok(Behaviors::stopped());
-          }
-          Ok(Behaviors::same())
-        },
-        | _ => Ok(Behaviors::same()),
-      })
+      .receive_signal(move |_ctx, signal| Ok(handle_pool_signal(&routees_for_sig, signal)))
     })
+  }
+}
+
+fn build_pool_routee_props<M>(
+  behavior_factory: &ArcShared<dyn Fn() -> Behavior<M> + Send + Sync>,
+  routee_props_mapper: Option<&ArcShared<RouteePropsMapper<M>>>,
+) -> TypedProps<M>
+where
+  M: Send + Sync + Clone + 'static, {
+  let bf = behavior_factory.clone();
+  let props = TypedProps::<M>::from_behavior_factory(move || {
+    let factory: &(dyn Fn() -> Behavior<M> + Send + Sync) = &*bf;
+    factory()
+  });
+  if let Some(mapper) = routee_props_mapper { mapper(props) } else { props }
+}
+
+fn spawn_pool_routees<M>(
+  ctx: &mut TypedActorContext<'_, M>,
+  props: &TypedProps<M>,
+  pool_size: usize,
+) -> Vec<TypedActorRef<M>>
+where
+  M: Send + Sync + Clone + 'static, {
+  let mut routees = Vec::with_capacity(pool_size);
+  for _ in 0..pool_size {
+    match ctx.spawn_child_watched(props) {
+      | Ok(child) => routees.push(child.into_actor_ref()),
+      | Err(e) => {
+        let msg = alloc::format!("pool router failed to spawn child: {:?}", e);
+        ctx.system().emit_log(LogLevel::Warn, msg, Some(ctx.pid()), None);
+        break;
+      },
+    }
+  }
+  routees
+}
+
+fn pool_route_selector<M>(strategy: PoolRouteStrategy<M>) -> ArcShared<RouteSelector<M>>
+where
+  M: Send + Sync + Clone + 'static, {
+  match strategy {
+    | PoolRouteStrategy::RoundRobin => {
+      let index = AtomicUsize::new(0);
+      ArcShared::new(move |guard: &[TypedActorRef<M>], _message: &M| {
+        let idx = index.fetch_add(1, Ordering::Relaxed) % guard.len();
+        vec![guard[idx].clone()]
+      })
+    },
+    | PoolRouteStrategy::Broadcast => ArcShared::new(|guard: &[TypedActorRef<M>], _message: &M| guard.to_vec()),
+    | PoolRouteStrategy::Random { seed } => {
+      let random_seed = AtomicU64::new(0);
+      ArcShared::new(move |guard: &[TypedActorRef<M>], _message: &M| {
+        let mixed_seed = random_seed.fetch_add(1, Ordering::Relaxed) ^ seed;
+        let idx = pseudo_random_index(mixed_seed, guard.len());
+        vec![guard[idx].clone()]
+      })
+    },
+    | PoolRouteStrategy::ConsistentHash { hash_fn } => {
+      ArcShared::new(move |guard: &[TypedActorRef<M>], message: &M| {
+        let idx = select_consistent_hash_index(guard, message, &*hash_fn);
+        vec![guard[idx].clone()]
+      })
+    },
+    | PoolRouteStrategy::SmallestMailbox => ArcShared::new(move |guard: &[TypedActorRef<M>], _message: &M| {
+      let idx = select_smallest_mailbox_index(guard);
+      vec![guard[idx].clone()]
+    }),
+  }
+}
+
+fn maybe_resize_pool<M>(
+  ctx: &mut TypedActorContext<'_, M>,
+  routees: &SharedLock<Vec<TypedActorRef<M>>>,
+  props_for_resize: &Option<TypedProps<M>>,
+  resizer: &ArcShared<dyn Resizer>,
+  counter: u64,
+) where
+  M: Send + Sync + Clone + 'static, {
+  // Pekko `ResizablePoolCell` 相当の順序で呼び出す:
+  // 1. `is_time_for_resize` を先にチェック（軽量、通常 false）
+  // 2. true の場合のみ mailbox スナップショットを取り、`report_message_count` → `resize` を
+  //    **同じスナップショット** で実行する。
+  //
+  // `report_message_count` は内部で `check_time` を更新するため、先に
+  // 呼んでしまうと `is_time_for_resize` の時刻差判定が常にゼロとなり
+  // resize が発火しなくなる（Pekko も同様の順序制約を持つ。
+  // 参照: `OptimalSizeExploringResizer.scala:201-203, 262` および
+  // `Resizer.scala:286-309`）。
+  if !resizer.is_time_for_resize(counter) {
+    return;
+  }
+  let mailbox_sizes = routees.with_lock(|routees| observe_routee_mailbox_sizes(routees.as_slice()));
+  resizer.report_message_count(&mailbox_sizes, counter);
+  resize_pool_by_delta(ctx, routees, props_for_resize, resizer.resize(&mailbox_sizes));
+}
+
+fn resize_pool_by_delta<M>(
+  ctx: &mut TypedActorContext<'_, M>,
+  routees: &SharedLock<Vec<TypedActorRef<M>>>,
+  props_for_resize: &Option<TypedProps<M>>,
+  delta: i32,
+) where
+  M: Send + Sync + Clone + 'static, {
+  if delta > 0 {
+    if let Some(resize_props) = props_for_resize {
+      grow_pool_routees(ctx, routees, resize_props, delta);
+    }
+  } else if delta < 0 {
+    shrink_pool_routees(ctx, routees, delta);
+  }
+}
+
+fn grow_pool_routees<M>(
+  ctx: &mut TypedActorContext<'_, M>,
+  routees: &SharedLock<Vec<TypedActorRef<M>>>,
+  resize_props: &TypedProps<M>,
+  delta: i32,
+) where
+  M: Send + Sync + Clone + 'static, {
+  let mut new_routees = Vec::new();
+  for _ in 0..delta {
+    match ctx.spawn_child_watched(resize_props) {
+      | Ok(child) => new_routees.push(child.into_actor_ref()),
+      | Err(e) => {
+        let msg = alloc::format!("pool router resize failed to spawn child: {:?}", e);
+        ctx.system().emit_log(LogLevel::Warn, msg, Some(ctx.pid()), None);
+        break;
+      },
+    }
+  }
+  if !new_routees.is_empty() {
+    routees.with_lock(|guard| {
+      guard.extend(new_routees);
+    });
+  }
+}
+
+fn shrink_pool_routees<M>(ctx: &mut TypedActorContext<'_, M>, routees: &SharedLock<Vec<TypedActorRef<M>>>, delta: i32)
+where
+  M: Send + Sync + Clone + 'static, {
+  let abs_delta = (-delta) as usize;
+  // Pekko 原典 (`Resizer.scala:305` の `currentRoutees.drop(...)`) と同じく
+  // 末尾の routee を停止対象にする。
+  let to_stop: Vec<TypedActorRef<M>> = {
+    routees.with_lock(|guard| {
+      let remove_count = abs_delta.min(guard.len().saturating_sub(1));
+      let split_at = guard.len() - remove_count;
+      guard.split_off(split_at)
+    })
+  };
+  for routee in &to_stop {
+    stop_pool_routee(ctx, routee);
+  }
+}
+
+fn stop_pool_routee<M>(ctx: &mut TypedActorContext<'_, M>, routee: &TypedActorRef<M>)
+where
+  M: Send + Sync + Clone + 'static, {
+  if let Err(e) = ctx.stop_actor_by_ref(routee) {
+    ctx.system().emit_log(
+      LogLevel::Warn,
+      alloc::format!("pool router failed to stop routee during resize: {:?}", e),
+      Some(ctx.pid()),
+      None,
+    );
+  }
+}
+
+fn select_pool_targets<M>(
+  routees: &SharedLock<Vec<TypedActorRef<M>>>,
+  select_targets: &ArcShared<RouteSelector<M>>,
+  broadcast_predicate: &Option<ArcShared<BroadcastPredicate<M>>>,
+  message: &M,
+) -> Option<Vec<TypedActorRef<M>>>
+where
+  M: Send + Sync + Clone + 'static, {
+  let guard = routees.with_lock(|routees| routees.clone());
+  if guard.is_empty() {
+    return None;
+  }
+  if broadcast_predicate.as_ref().is_some_and(|predicate| predicate(message)) {
+    Some(guard)
+  } else {
+    Some(select_targets(&guard, message))
+  }
+}
+
+fn deliver_pool_message<M>(ctx: &TypedActorContext<'_, M>, targets: Vec<TypedActorRef<M>>, message: &M)
+where
+  M: Send + Sync + Clone + 'static, {
+  for mut target in targets {
+    if let Err(error) = target.try_tell(message.clone()) {
+      ctx.system().emit_log(
+        LogLevel::Warn,
+        alloc::format!("pool router failed to deliver message to routee: {:?}", error),
+        Some(ctx.pid()),
+        None,
+      );
+    }
+  }
+}
+
+fn handle_pool_signal<M>(routees: &SharedLock<Vec<TypedActorRef<M>>>, signal: &BehaviorSignal) -> Behavior<M>
+where
+  M: Send + Sync + Clone + 'static, {
+  match signal {
+    | BehaviorSignal::Terminated(terminated) => {
+      let pid = terminated.pid();
+      let is_empty = routees.with_lock(|guard| {
+        if let Some(pos) = guard.iter().position(|r| r.pid() == pid) {
+          guard.remove(pos);
+        }
+        guard.is_empty()
+      });
+      if is_empty { Behaviors::stopped() } else { Behaviors::same() }
+    },
+    | _ => Behaviors::same(),
   }
 }
 

--- a/modules/actor-core-typed/src/receptionist/extension.rs
+++ b/modules/actor-core-typed/src/receptionist/extension.rs
@@ -1,6 +1,10 @@
 //! Receptionist runtime implementation details.
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{
+  collections::BTreeMap,
+  string::{String, ToString},
+  vec::Vec,
+};
 use core::any::TypeId;
 
 use fraktor_actor_core_kernel_rs::{
@@ -40,6 +44,13 @@ pub(crate) struct ReceptionistExtensionId;
 pub(crate) enum WatchTarget {
   RegisteredActor(ActorRef),
   Subscriber(TypedActorRef<Listing>),
+}
+
+struct ReceptionistCommandContext<'a, Watch> {
+  state:        &'a mut ReceptionistState,
+  system:       &'a ActorSystem,
+  origin:       Option<Pid>,
+  watch_target: &'a mut Watch,
 }
 
 /// Receptionist actor that manages service registrations and subscriptions.
@@ -282,106 +293,177 @@ pub(crate) fn handle_command<Watch>(
 ) -> Result<(), ActorError>
 where
   Watch: FnMut(WatchTarget) -> Result<(), ActorError>, {
+  let mut context = ReceptionistCommandContext { state, system, origin, watch_target: &mut watch_target };
   match command {
     | ReceptionistCommand::Register { service_id, type_id, actor_ref, reply_to } => {
-      let key = (service_id.clone(), *type_id);
-      let already_registered = state
-        .registrations
-        .get(&key)
-        .is_some_and(|entry| entry.iter().any(|existing| existing.pid() == actor_ref.pid()));
-      if !already_registered {
-        watch_target(WatchTarget::RegisteredActor(actor_ref.clone()))?;
-        state.registrations.entry(key.clone()).or_default().push(actor_ref.clone());
-        notify_subscribers(&state.subscribers, &key, &state.registrations, system, origin);
-      }
-      if let Some(reply_to) = reply_to.clone() {
-        let ack = Registered::new(service_id.clone(), *type_id, actor_ref.clone());
-        try_send_registered_ack(reply_to, ack, system, origin);
-      }
+      handle_register_command(&mut context, service_id, *type_id, actor_ref, reply_to)?;
     },
     | ReceptionistCommand::Deregister { service_id, type_id, actor_ref, reply_to } => {
-      let key = (service_id.clone(), *type_id);
-      let mut registrations_updated = false;
-      let mut remove_key = false;
-      if let Some(entry) = state.registrations.get_mut(&key) {
-        let before = entry.len();
-        entry.retain(|existing| existing.pid() != actor_ref.pid());
-        registrations_updated = entry.len() != before;
-        remove_key = entry.is_empty();
-      }
-      if remove_key {
-        state.registrations.remove(&key);
-      }
-      if registrations_updated {
-        notify_subscribers(&state.subscribers, &key, &state.registrations, system, origin);
-      }
-      if let Some(reply_to) = reply_to.clone() {
-        let ack = Deregistered::new(service_id.clone(), *type_id, actor_ref.clone());
-        try_send_deregistered_ack(reply_to, ack, system, origin);
-      }
+      handle_deregister_command(&mut context, service_id, *type_id, actor_ref, reply_to);
     },
     | ReceptionistCommand::Subscribe { service_id, type_id, subscriber } => {
-      let key = (service_id.clone(), *type_id);
-      let current = state.registrations.get(&key).cloned().unwrap_or_default();
-      let listing = Listing::new(service_id.clone(), *type_id, current);
-      let mut typed_subscriber = subscriber.clone();
-      if let Err(error) = typed_subscriber.try_tell(listing) {
-        system.emit_log(
-          LogLevel::Warn,
-          alloc::format!(
-            "receptionist failed to send initial listing to subscriber {:?} for service_id={} type_id={:?}: {:?}",
-            subscriber.pid(),
-            service_id,
-            type_id,
-            error
-          ),
-          origin,
-          None,
-        );
-      }
-      let already_subscribed = state
-        .subscribers
-        .get(&key)
-        .is_some_and(|subscribers| subscribers.iter().any(|existing| existing.pid() == subscriber.pid()));
-      if !already_subscribed {
-        watch_target(WatchTarget::Subscriber(subscriber.clone()))?;
-        state.subscribers.entry(key).or_default().push(subscriber.clone());
-      }
+      handle_subscribe_command(&mut context, service_id, *type_id, subscriber)?;
     },
     | ReceptionistCommand::Unsubscribe { service_id, type_id, subscriber } => {
-      let key = (service_id.clone(), *type_id);
-      let mut remove_key = false;
-      if let Some(subscribers) = state.subscribers.get_mut(&key) {
-        subscribers.retain(|existing| existing.pid() != subscriber.pid());
-        remove_key = subscribers.is_empty();
-      }
-      if remove_key {
-        state.subscribers.remove(&key);
-      }
+      handle_unsubscribe_command(&mut context, service_id, *type_id, subscriber);
     },
     | ReceptionistCommand::Find { service_id, type_id, reply_to } => {
-      let key = (service_id.clone(), *type_id);
-      let current = state.registrations.get(&key).cloned().unwrap_or_default();
-      let listing = Listing::new(service_id.clone(), *type_id, current);
-      let mut reply_to = reply_to.clone();
-      if let Err(error) = reply_to.try_tell(listing) {
-        system.emit_log(
-          LogLevel::Warn,
-          alloc::format!(
-            "receptionist failed to reply with listing to {:?} for service_id={} type_id={:?}: {:?}",
-            reply_to.pid(),
-            service_id,
-            type_id,
-            error
-          ),
-          origin,
-          None,
-        );
-      }
+      handle_find_command(&mut context, service_id, *type_id, reply_to);
     },
   }
 
   Ok(())
+}
+
+fn handle_register_command<Watch>(
+  context: &mut ReceptionistCommandContext<'_, Watch>,
+  service_id: &str,
+  type_id: TypeId,
+  actor_ref: &ActorRef,
+  reply_to: &Option<TypedActorRef<Registered>>,
+) -> Result<(), ActorError>
+where
+  Watch: FnMut(WatchTarget) -> Result<(), ActorError>, {
+  let key = (service_id.to_string(), type_id);
+  let already_registered = context
+    .state
+    .registrations
+    .get(&key)
+    .is_some_and(|entry| entry.iter().any(|existing| existing.pid() == actor_ref.pid()));
+  if !already_registered {
+    (context.watch_target)(WatchTarget::RegisteredActor(actor_ref.clone()))?;
+    context.state.registrations.entry(key.clone()).or_default().push(actor_ref.clone());
+    notify_subscribers(&context.state.subscribers, &key, &context.state.registrations, context.system, context.origin);
+  }
+  if let Some(reply_to) = reply_to.clone() {
+    let ack = Registered::new(service_id.to_string(), type_id, actor_ref.clone());
+    try_send_registered_ack(reply_to, ack, context.system, context.origin);
+  }
+  Ok(())
+}
+
+fn handle_deregister_command<Watch>(
+  context: &mut ReceptionistCommandContext<'_, Watch>,
+  service_id: &str,
+  type_id: TypeId,
+  actor_ref: &ActorRef,
+  reply_to: &Option<TypedActorRef<Deregistered>>,
+) {
+  let key = (service_id.to_string(), type_id);
+  let registrations_updated = remove_receptionist_registration(context.state, &key, actor_ref);
+  if registrations_updated {
+    notify_subscribers(&context.state.subscribers, &key, &context.state.registrations, context.system, context.origin);
+  }
+  if let Some(reply_to) = reply_to.clone() {
+    let ack = Deregistered::new(service_id.to_string(), type_id, actor_ref.clone());
+    try_send_deregistered_ack(reply_to, ack, context.system, context.origin);
+  }
+}
+
+fn remove_receptionist_registration(state: &mut ReceptionistState, key: &RegistryKey, actor_ref: &ActorRef) -> bool {
+  let mut registrations_updated = false;
+  let mut remove_key = false;
+  if let Some(entry) = state.registrations.get_mut(key) {
+    let before = entry.len();
+    entry.retain(|existing| existing.pid() != actor_ref.pid());
+    registrations_updated = entry.len() != before;
+    remove_key = entry.is_empty();
+  }
+  if remove_key {
+    state.registrations.remove(key);
+  }
+  registrations_updated
+}
+
+fn handle_subscribe_command<Watch>(
+  context: &mut ReceptionistCommandContext<'_, Watch>,
+  service_id: &str,
+  type_id: TypeId,
+  subscriber: &TypedActorRef<Listing>,
+) -> Result<(), ActorError>
+where
+  Watch: FnMut(WatchTarget) -> Result<(), ActorError>, {
+  let key = (service_id.to_string(), type_id);
+  send_initial_listing(context, service_id, type_id, subscriber, &key);
+  let already_subscribed = context
+    .state
+    .subscribers
+    .get(&key)
+    .is_some_and(|subscribers| subscribers.iter().any(|existing| existing.pid() == subscriber.pid()));
+  if !already_subscribed {
+    (context.watch_target)(WatchTarget::Subscriber(subscriber.clone()))?;
+    context.state.subscribers.entry(key).or_default().push(subscriber.clone());
+  }
+  Ok(())
+}
+
+fn send_initial_listing<Watch>(
+  context: &ReceptionistCommandContext<'_, Watch>,
+  service_id: &str,
+  type_id: TypeId,
+  subscriber: &TypedActorRef<Listing>,
+  key: &RegistryKey,
+) {
+  let current = context.state.registrations.get(key).cloned().unwrap_or_default();
+  let listing = Listing::new(service_id.to_string(), type_id, current);
+  let mut typed_subscriber = subscriber.clone();
+  if let Err(error) = typed_subscriber.try_tell(listing) {
+    context.system.emit_log(
+      LogLevel::Warn,
+      alloc::format!(
+        "receptionist failed to send initial listing to subscriber {:?} for service_id={} type_id={:?}: {:?}",
+        subscriber.pid(),
+        service_id,
+        type_id,
+        error
+      ),
+      context.origin,
+      None,
+    );
+  }
+}
+
+fn handle_unsubscribe_command<Watch>(
+  context: &mut ReceptionistCommandContext<'_, Watch>,
+  service_id: &str,
+  type_id: TypeId,
+  subscriber: &TypedActorRef<Listing>,
+) {
+  let key = (service_id.to_string(), type_id);
+  let mut remove_key = false;
+  if let Some(subscribers) = context.state.subscribers.get_mut(&key) {
+    subscribers.retain(|existing| existing.pid() != subscriber.pid());
+    remove_key = subscribers.is_empty();
+  }
+  if remove_key {
+    context.state.subscribers.remove(&key);
+  }
+}
+
+fn handle_find_command<Watch>(
+  context: &mut ReceptionistCommandContext<'_, Watch>,
+  service_id: &str,
+  type_id: TypeId,
+  reply_to: &TypedActorRef<Listing>,
+) {
+  let key = (service_id.to_string(), type_id);
+  let current = context.state.registrations.get(&key).cloned().unwrap_or_default();
+  let listing = Listing::new(service_id.to_string(), type_id, current);
+  let mut reply_to = reply_to.clone();
+  if let Err(error) = reply_to.try_tell(listing) {
+    context.system.emit_log(
+      LogLevel::Warn,
+      alloc::format!(
+        "receptionist failed to reply with listing to {:?} for service_id={} type_id={:?}: {:?}",
+        reply_to.pid(),
+        service_id,
+        type_id,
+        error
+      ),
+      context.origin,
+      None,
+    );
+  }
 }
 
 fn try_send_registered_ack(

--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -25,16 +25,33 @@ use crate::{
 
 struct JournalPoll;
 
+type JournalWriteFuture = Pin<Box<dyn Future<Output = Result<(), JournalError>> + Send>>;
+type JournalReplayFuture = Pin<Box<dyn Future<Output = Result<Vec<PersistentRepr>, JournalError>> + Send>>;
+type JournalDeleteFuture = Pin<Box<dyn Future<Output = Result<(), JournalError>> + Send>>;
+type JournalHighestFuture = Pin<Box<dyn Future<Output = Result<u64, JournalError>> + Send>>;
+
+struct JournalPollContext<'a, J: Journal> {
+  journal:   &'a mut J,
+  retry_max: u32,
+}
+
+#[derive(Clone, Copy)]
+struct JournalReplayRequest {
+  from_sequence_nr: u64,
+  to_sequence_nr:   u64,
+  max:              u64,
+}
+
 enum JournalInFlight {
   Write {
-    future:      Pin<Box<dyn Future<Output = Result<(), JournalError>> + Send>>,
+    future:      JournalWriteFuture,
     messages:    Vec<PersistentRepr>,
     sender:      ActorRef,
     instance_id: u32,
     retry_count: u32,
   },
   Replay {
-    future:           Pin<Box<dyn Future<Output = Result<Vec<PersistentRepr>, JournalError>> + Send>>,
+    future:           JournalReplayFuture,
     sender:           ActorRef,
     persistence_id:   String,
     from_sequence_nr: u64,
@@ -43,14 +60,14 @@ enum JournalInFlight {
     retry_count:      u32,
   },
   Delete {
-    future:         Pin<Box<dyn Future<Output = Result<(), JournalError>> + Send>>,
+    future:         JournalDeleteFuture,
     sender:         ActorRef,
     persistence_id: String,
     to_sequence_nr: u64,
     retry_count:    u32,
   },
   Highest {
-    future:         Pin<Box<dyn Future<Output = Result<u64, JournalError>> + Send>>,
+    future:         JournalHighestFuture,
     sender:         ActorRef,
     persistence_id: String,
     retry_count:    u32,
@@ -184,47 +201,10 @@ where
   for<'a> J::ReplayFuture<'a>: Send + 'static,
   for<'a> J::DeleteFuture<'a>: Send + 'static,
   for<'a> J::HighestSeqNrFuture<'a>: Send + 'static, {
-  match &mut entry {
+  let mut poll_context = JournalPollContext { journal, retry_max };
+  let keep_pending = match &mut entry {
     | JournalInFlight::Write { future, messages, sender, instance_id, retry_count } => {
-      match Future::poll(future.as_mut(), cx) {
-        | Poll::Ready(Ok(())) => {
-          for repr in messages.iter().cloned() {
-            sender
-              .try_tell(AnyMessage::new(JournalResponse::WriteMessageSuccess { repr, instance_id: *instance_id }))
-              .map_err(|error| ActorError::from_send_error(&error))?;
-          }
-          sender
-            .try_tell(AnyMessage::new(JournalResponse::WriteMessagesSuccessful { instance_id: *instance_id }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-          Ok(None)
-        },
-        | Poll::Ready(Err(error)) => {
-          if *retry_count < retry_max {
-            *retry_count = retry_count.saturating_add(1);
-            *future = Box::pin(journal.write_messages(messages));
-            Ok(Some(entry))
-          } else {
-            for repr in messages.iter().cloned() {
-              sender
-                .try_tell(AnyMessage::new(JournalResponse::WriteMessageFailure {
-                  repr,
-                  cause: error.clone(),
-                  instance_id: *instance_id,
-                }))
-                .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            }
-            sender
-              .try_tell(AnyMessage::new(JournalResponse::WriteMessagesFailed {
-                cause:       error,
-                write_count: messages.len() as u64,
-                instance_id: *instance_id,
-              }))
-              .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            Ok(None)
-          }
-        },
-        | Poll::Pending => Ok(Some(entry)),
-      }
+      poll_write_entry(&mut poll_context, cx, future, messages, sender, *instance_id, retry_count)?
     },
     | JournalInFlight::Replay {
       future,
@@ -234,91 +214,259 @@ where
       to_sequence_nr,
       max,
       retry_count,
-    } => match Future::poll(future.as_mut(), cx) {
-      | Poll::Ready(Ok(messages)) => {
-        let mut highest = 0;
-        for repr in messages.iter().cloned() {
-          highest = repr.sequence_nr();
-          if repr.deleted() {
-            continue;
-          }
-          sender
-            .try_tell(AnyMessage::new(JournalResponse::ReplayedMessage { persistent_repr: repr }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-        }
-        sender
-          .try_tell(AnyMessage::new(JournalResponse::RecoverySuccess { highest_sequence_nr: highest }))
-          .map_err(|error| ActorError::from_send_error(&error))?;
-        Ok(None)
-      },
-      | Poll::Ready(Err(error)) => {
-        if *retry_count < retry_max {
-          *retry_count = retry_count.saturating_add(1);
-          *future = Box::pin(journal.replay_messages(persistence_id, *from_sequence_nr, *to_sequence_nr, *max));
-          Ok(Some(entry))
-        } else {
-          sender
-            .try_tell(AnyMessage::new(JournalResponse::ReplayMessagesFailure { cause: error }))
-            .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-          Ok(None)
-        }
-      },
-      | Poll::Pending => Ok(Some(entry)),
+    } => {
+      let request = JournalReplayRequest {
+        from_sequence_nr: *from_sequence_nr,
+        to_sequence_nr:   *to_sequence_nr,
+        max:              *max,
+      };
+      poll_replay_entry(&mut poll_context, cx, future, sender, persistence_id, request, retry_count)?
     },
     | JournalInFlight::Delete { future, sender, persistence_id, to_sequence_nr, retry_count } => {
-      match Future::poll(future.as_mut(), cx) {
-        | Poll::Ready(Ok(())) => {
-          sender
-            .try_tell(AnyMessage::new(JournalResponse::DeleteMessagesSuccess { to_sequence_nr: *to_sequence_nr }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-          Ok(None)
-        },
-        | Poll::Ready(Err(error)) => {
-          if *retry_count < retry_max {
-            *retry_count = retry_count.saturating_add(1);
-            *future = Box::pin(journal.delete_messages_to(persistence_id, *to_sequence_nr));
-            Ok(Some(entry))
-          } else {
-            sender
-              .try_tell(AnyMessage::new(JournalResponse::DeleteMessagesFailure {
-                cause:          error,
-                to_sequence_nr: *to_sequence_nr,
-              }))
-              .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            Ok(None)
-          }
-        },
-        | Poll::Pending => Ok(Some(entry)),
-      }
+      poll_delete_entry(&mut poll_context, cx, future, sender, persistence_id, *to_sequence_nr, retry_count)?
     },
     | JournalInFlight::Highest { future, sender, persistence_id, retry_count } => {
-      match Future::poll(future.as_mut(), cx) {
-        | Poll::Ready(Ok(sequence_nr)) => {
-          sender
-            .try_tell(AnyMessage::new(JournalResponse::HighestSequenceNr {
-              persistence_id: persistence_id.clone(),
-              sequence_nr,
-            }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-          Ok(None)
-        },
-        | Poll::Ready(Err(error)) => {
-          if *retry_count < retry_max {
-            *retry_count = retry_count.saturating_add(1);
-            *future = Box::pin(journal.highest_sequence_nr(persistence_id));
-            Ok(Some(entry))
-          } else {
-            sender
-              .try_tell(AnyMessage::new(JournalResponse::HighestSequenceNrFailure {
-                persistence_id: persistence_id.clone(),
-                cause:          error,
-              }))
-              .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            Ok(None)
-          }
-        },
-        | Poll::Pending => Ok(Some(entry)),
-      }
+      poll_highest_entry(&mut poll_context, cx, future, sender, persistence_id, retry_count)?
     },
+  };
+
+  if keep_pending { Ok(Some(entry)) } else { Ok(None) }
+}
+
+fn poll_write_entry<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  cx: &mut Context<'_>,
+  future: &mut JournalWriteFuture,
+  messages: &[PersistentRepr],
+  sender: &mut ActorRef,
+  instance_id: u32,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::WriteFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(())) => {
+      send_write_success(sender, messages, instance_id)?;
+      Ok(false)
+    },
+    | Poll::Ready(Err(error)) => {
+      retry_or_fail_write(poll_context, future, messages, sender, instance_id, retry_count, error)
+    },
+    | Poll::Pending => Ok(true),
   }
+}
+
+fn send_write_success(sender: &mut ActorRef, messages: &[PersistentRepr], instance_id: u32) -> Result<(), ActorError> {
+  for repr in messages.iter().cloned() {
+    sender
+      .try_tell(AnyMessage::new(JournalResponse::WriteMessageSuccess { repr, instance_id }))
+      .map_err(|error| ActorError::from_send_error(&error))?;
+  }
+  sender
+    .try_tell(AnyMessage::new(JournalResponse::WriteMessagesSuccessful { instance_id }))
+    .map_err(|error| ActorError::from_send_error(&error))
+}
+
+fn retry_or_fail_write<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  future: &mut JournalWriteFuture,
+  messages: &[PersistentRepr],
+  sender: &mut ActorRef,
+  instance_id: u32,
+  retry_count: &mut u32,
+  error: JournalError,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::WriteFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.journal.write_messages(messages));
+    return Ok(true);
+  }
+  send_write_failure(sender, messages, instance_id, error)?;
+  Ok(false)
+}
+
+fn send_write_failure(
+  sender: &mut ActorRef,
+  messages: &[PersistentRepr],
+  instance_id: u32,
+  error: JournalError,
+) -> Result<(), ActorError> {
+  for repr in messages.iter().cloned() {
+    sender
+      .try_tell(AnyMessage::new(JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id }))
+      .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  }
+  sender
+    .try_tell(AnyMessage::new(JournalResponse::WriteMessagesFailed {
+      cause: error,
+      write_count: messages.len() as u64,
+      instance_id,
+    }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))
+}
+
+fn poll_replay_entry<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  cx: &mut Context<'_>,
+  future: &mut JournalReplayFuture,
+  sender: &mut ActorRef,
+  persistence_id: &str,
+  request: JournalReplayRequest,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::ReplayFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(messages)) => {
+      send_replay_success(sender, &messages)?;
+      Ok(false)
+    },
+    | Poll::Ready(Err(error)) => {
+      retry_or_fail_replay(poll_context, future, sender, persistence_id, request, retry_count, error)
+    },
+    | Poll::Pending => Ok(true),
+  }
+}
+
+fn send_replay_success(sender: &mut ActorRef, messages: &[PersistentRepr]) -> Result<(), ActorError> {
+  let mut highest = 0;
+  for repr in messages.iter().cloned() {
+    highest = repr.sequence_nr();
+    if repr.deleted() {
+      continue;
+    }
+    sender
+      .try_tell(AnyMessage::new(JournalResponse::ReplayedMessage { persistent_repr: repr }))
+      .map_err(|error| ActorError::from_send_error(&error))?;
+  }
+  sender
+    .try_tell(AnyMessage::new(JournalResponse::RecoverySuccess { highest_sequence_nr: highest }))
+    .map_err(|error| ActorError::from_send_error(&error))
+}
+
+fn retry_or_fail_replay<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  future: &mut JournalReplayFuture,
+  sender: &mut ActorRef,
+  persistence_id: &str,
+  request: JournalReplayRequest,
+  retry_count: &mut u32,
+  error: JournalError,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::ReplayFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.journal.replay_messages(
+      persistence_id,
+      request.from_sequence_nr,
+      request.to_sequence_nr,
+      request.max,
+    ));
+    return Ok(true);
+  }
+  sender
+    .try_tell(AnyMessage::new(JournalResponse::ReplayMessagesFailure { cause: error }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  Ok(false)
+}
+
+fn poll_delete_entry<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  cx: &mut Context<'_>,
+  future: &mut JournalDeleteFuture,
+  sender: &mut ActorRef,
+  persistence_id: &str,
+  to_sequence_nr: u64,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::DeleteFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(())) => {
+      sender
+        .try_tell(AnyMessage::new(JournalResponse::DeleteMessagesSuccess { to_sequence_nr }))
+        .map_err(|error| ActorError::from_send_error(&error))?;
+      Ok(false)
+    },
+    | Poll::Ready(Err(error)) => {
+      retry_or_fail_delete(poll_context, future, sender, persistence_id, to_sequence_nr, retry_count, error)
+    },
+    | Poll::Pending => Ok(true),
+  }
+}
+
+fn retry_or_fail_delete<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  future: &mut JournalDeleteFuture,
+  sender: &mut ActorRef,
+  persistence_id: &str,
+  to_sequence_nr: u64,
+  retry_count: &mut u32,
+  error: JournalError,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::DeleteFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.journal.delete_messages_to(persistence_id, to_sequence_nr));
+    return Ok(true);
+  }
+  sender
+    .try_tell(AnyMessage::new(JournalResponse::DeleteMessagesFailure { cause: error, to_sequence_nr }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  Ok(false)
+}
+
+fn poll_highest_entry<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  cx: &mut Context<'_>,
+  future: &mut JournalHighestFuture,
+  sender: &mut ActorRef,
+  persistence_id: &str,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::HighestSeqNrFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(sequence_nr)) => {
+      sender
+        .try_tell(AnyMessage::new(JournalResponse::HighestSequenceNr {
+          persistence_id: persistence_id.into(),
+          sequence_nr,
+        }))
+        .map_err(|error| ActorError::from_send_error(&error))?;
+      Ok(false)
+    },
+    | Poll::Ready(Err(error)) => {
+      retry_or_fail_highest(poll_context, future, sender, persistence_id, retry_count, error)
+    },
+    | Poll::Pending => Ok(true),
+  }
+}
+
+fn retry_or_fail_highest<J: Journal>(
+  poll_context: &mut JournalPollContext<'_, J>,
+  future: &mut JournalHighestFuture,
+  sender: &mut ActorRef,
+  persistence_id: &str,
+  retry_count: &mut u32,
+  error: JournalError,
+) -> Result<bool, ActorError>
+where
+  for<'a> J::HighestSeqNrFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.journal.highest_sequence_nr(persistence_id));
+    return Ok(true);
+  }
+  sender
+    .try_tell(AnyMessage::new(JournalResponse::HighestSequenceNrFailure {
+      persistence_id: persistence_id.into(),
+      cause:          error,
+    }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  Ok(false)
 }

--- a/modules/persistence-core-kernel/src/persistent/persistent_actor_adapter.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistent_actor_adapter.rs
@@ -209,12 +209,101 @@ where
       && self.actor.persistence_context().state() == PersistentActorState::ProcessingCommands
   }
 
+  fn receive_journal_response(
+    &mut self,
+    ctx: &mut ActorContext<'_>,
+    response: &JournalResponse,
+  ) -> Result<(), ActorError> {
+    let current_instance_id = self.actor.persistence_context().instance_id();
+    let recovery_running = self.is_recovery_running();
+    self.actor.handle_journal_response(response);
+    self.update_recovery_timeout_after_journal_response(ctx, response)?;
+    if recovery_running {
+      self.fail_on_recovery_journal_failure(response)?;
+    }
+    Self::fail_on_current_write_failure(response, current_instance_id)?;
+    if self.should_unstash_after_journal_response(response, current_instance_id) {
+      // unstash_all は Result<usize, ActorError>。`?` でエラーを伝播したうえで
+      // 件数 usize は分岐に不要なため捨てる (式文扱い)。
+      ctx.unstash_all()?;
+    }
+    Ok(())
+  }
+
+  fn fail_on_recovery_journal_failure(&self, response: &JournalResponse) -> Result<(), ActorError> {
+    match response {
+      | JournalResponse::ReplayMessagesFailure { cause } => Err(ActorError::fatal(format!(
+        "persistent actor stopped after replay failure for persistence id {}: {:?}",
+        self.actor.persistence_id(),
+        cause
+      ))),
+      | JournalResponse::HighestSequenceNrFailure { persistence_id, cause } => Err(ActorError::fatal(format!(
+        "persistent actor stopped after highest sequence number lookup failure for persistence id {}: {:?}",
+        persistence_id, cause
+      ))),
+      | _ => Ok(()),
+    }
+  }
+
+  fn fail_on_current_write_failure(response: &JournalResponse, current_instance_id: u32) -> Result<(), ActorError> {
+    if let JournalResponse::WriteMessageFailure { repr, cause, instance_id } = response
+      && *instance_id == current_instance_id
+    {
+      return Err(ActorError::fatal(format!(
+        "persistent actor stopped after write failure for persistence id {} sequence number {}: {:?}",
+        repr.persistence_id(),
+        repr.sequence_nr(),
+        cause
+      )));
+    }
+    Ok(())
+  }
+
+  fn receive_snapshot_response(
+    &mut self,
+    ctx: &mut ActorContext<'_>,
+    response: &SnapshotResponse,
+  ) -> Result<(), ActorError> {
+    let should_unstash = should_unstash_after_snapshot_response(response);
+    self.actor.handle_snapshot_response(response, ctx);
+    self.update_recovery_timeout_after_snapshot_response(ctx, response)?;
+    if should_unstash && !self.is_recovery_running() && !self.actor.persistence_context().should_stash_commands() {
+      ctx.unstash_all()?;
+    }
+    Ok(())
+  }
+
+  fn receive_user_command(
+    &mut self,
+    ctx: &mut ActorContext<'_>,
+    message: AnyMessageView<'_>,
+  ) -> Result<(), ActorError> {
+    let recovery_running = self.is_recovery_running();
+    let should_stash = self.actor.persistence_context().should_stash_commands();
+    if recovery_running || should_stash {
+      return self.stash_current_message(ctx);
+    }
+    self.actor.handle_command(ctx, message)
+  }
+
   fn is_recovery_running(&mut self) -> bool {
     matches!(
       self.actor.persistence_context().state(),
       PersistentActorState::RecoveryStarted | PersistentActorState::Recovering
     )
   }
+}
+
+const fn should_unstash_after_snapshot_response(response: &SnapshotResponse) -> bool {
+  matches!(
+    response,
+    SnapshotResponse::SaveSnapshotSuccess { .. }
+      | SnapshotResponse::SaveSnapshotFailure { .. }
+      | SnapshotResponse::DeleteSnapshotSuccess { .. }
+      | SnapshotResponse::DeleteSnapshotFailure { .. }
+      | SnapshotResponse::DeleteSnapshotsSuccess { .. }
+      | SnapshotResponse::DeleteSnapshotsFailure { .. }
+  )
 }
 
 impl<A> Actor for PersistentActorAdapter<A>
@@ -247,61 +336,10 @@ where
 
   fn receive(&mut self, ctx: &mut ActorContext<'_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
     if let Some(response) = message.downcast_ref::<JournalResponse>() {
-      let current_instance_id = self.actor.persistence_context().instance_id();
-      let recovery_running = self.is_recovery_running();
-      self.actor.handle_journal_response(response);
-      self.update_recovery_timeout_after_journal_response(ctx, response)?;
-      if recovery_running {
-        match response {
-          | JournalResponse::ReplayMessagesFailure { cause } => {
-            return Err(ActorError::fatal(format!(
-              "persistent actor stopped after replay failure for persistence id {}: {:?}",
-              self.actor.persistence_id(),
-              cause
-            )));
-          },
-          | JournalResponse::HighestSequenceNrFailure { persistence_id, cause } => {
-            return Err(ActorError::fatal(format!(
-              "persistent actor stopped after highest sequence number lookup failure for persistence id {}: {:?}",
-              persistence_id, cause
-            )));
-          },
-          | _ => {},
-        }
-      }
-      if let JournalResponse::WriteMessageFailure { repr, cause, instance_id } = response
-        && *instance_id == current_instance_id
-      {
-        return Err(ActorError::fatal(format!(
-          "persistent actor stopped after write failure for persistence id {} sequence number {}: {:?}",
-          repr.persistence_id(),
-          repr.sequence_nr(),
-          cause
-        )));
-      }
-      if self.should_unstash_after_journal_response(response, current_instance_id) {
-        // unstash_all は Result<usize, ActorError>。`?` でエラーを伝播したうえで
-        // 件数 usize は分岐に不要なため捨てる (式文扱い)。
-        ctx.unstash_all()?;
-      }
-      return Ok(());
+      return self.receive_journal_response(ctx, response);
     }
     if let Some(response) = message.downcast_ref::<SnapshotResponse>() {
-      let should_unstash = matches!(
-        response,
-        SnapshotResponse::SaveSnapshotSuccess { .. }
-          | SnapshotResponse::SaveSnapshotFailure { .. }
-          | SnapshotResponse::DeleteSnapshotSuccess { .. }
-          | SnapshotResponse::DeleteSnapshotFailure { .. }
-          | SnapshotResponse::DeleteSnapshotsSuccess { .. }
-          | SnapshotResponse::DeleteSnapshotsFailure { .. }
-      );
-      self.actor.handle_snapshot_response(response, ctx);
-      self.update_recovery_timeout_after_snapshot_response(ctx, response)?;
-      if should_unstash && !self.is_recovery_running() && !self.actor.persistence_context().should_stash_commands() {
-        ctx.unstash_all()?;
-      }
-      return Ok(());
+      return self.receive_snapshot_response(ctx, response);
     }
     if let Some(tick) = message.downcast_ref::<RecoveryTick>() {
       self.handle_recovery_tick(ctx, *tick)?;
@@ -311,12 +349,7 @@ where
       self.actor.on_recovery_timed_out(signal);
       return Ok(());
     }
-    let recovery_running = self.is_recovery_running();
-    let should_stash = self.actor.persistence_context().should_stash_commands();
-    if recovery_running || should_stash {
-      return self.stash_current_message(ctx);
-    }
-    self.actor.handle_command(ctx, message)
+    self.receive_user_command(ctx, message)
   }
 
   fn post_stop(&mut self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_actor.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_actor.rs
@@ -27,29 +27,38 @@ use crate::snapshot::{
 
 struct SnapshotPoll;
 
+type SnapshotSaveFuture = Pin<Box<dyn Future<Output = Result<(), SnapshotError>> + Send>>;
+type SnapshotLoadFuture = Pin<Box<dyn Future<Output = Result<Option<Snapshot>, SnapshotError>> + Send>>;
+type SnapshotDeleteFuture = Pin<Box<dyn Future<Output = Result<(), SnapshotError>> + Send>>;
+
+struct SnapshotPollContext<'a, S: SnapshotStore> {
+  snapshot_store: &'a mut S,
+  retry_max:      u32,
+}
+
 enum SnapshotInFlight {
   Save {
-    future:      Pin<Box<dyn Future<Output = Result<(), SnapshotError>> + Send>>,
+    future:      SnapshotSaveFuture,
     metadata:    SnapshotMetadata,
     snapshot:    ArcShared<dyn Any + Send + Sync>,
     sender:      ActorRef,
     retry_count: u32,
   },
   Load {
-    future:         Pin<Box<dyn Future<Output = Result<Option<Snapshot>, SnapshotError>> + Send>>,
+    future:         SnapshotLoadFuture,
     persistence_id: String,
     criteria:       SnapshotSelectionCriteria,
     sender:         ActorRef,
     retry_count:    u32,
   },
   DeleteOne {
-    future:      Pin<Box<dyn Future<Output = Result<(), SnapshotError>> + Send>>,
+    future:      SnapshotDeleteFuture,
     metadata:    SnapshotMetadata,
     sender:      ActorRef,
     retry_count: u32,
   },
   DeleteMany {
-    future:         Pin<Box<dyn Future<Output = Result<(), SnapshotError>> + Send>>,
+    future:         SnapshotDeleteFuture,
     persistence_id: String,
     criteria:       SnapshotSelectionCriteria,
     sender:         ActorRef,
@@ -182,101 +191,217 @@ where
   for<'a> S::LoadFuture<'a>: Send + 'static,
   for<'a> S::DeleteOneFuture<'a>: Send + 'static,
   for<'a> S::DeleteManyFuture<'a>: Send + 'static, {
-  match &mut entry {
+  let mut poll_context = SnapshotPollContext { snapshot_store, retry_max };
+  let keep_pending = match &mut entry {
     | SnapshotInFlight::Save { future, metadata, snapshot, sender, retry_count } => {
-      match Future::poll(future.as_mut(), cx) {
-        | Poll::Ready(Ok(())) => {
-          sender
-            .try_tell(AnyMessage::new(SnapshotResponse::SaveSnapshotSuccess { metadata: metadata.clone() }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-          Ok(None)
-        },
-        | Poll::Ready(Err(error)) => {
-          if *retry_count < retry_max {
-            *retry_count = retry_count.saturating_add(1);
-            *future = Box::pin(snapshot_store.save_snapshot(metadata.clone(), snapshot.clone()));
-            Ok(Some(entry))
-          } else {
-            sender
-              .try_tell(AnyMessage::new(SnapshotResponse::SaveSnapshotFailure { metadata: metadata.clone(), error }))
-              .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            Ok(None)
-          }
-        },
-        | Poll::Pending => Ok(Some(entry)),
-      }
+      poll_save_entry(&mut poll_context, cx, future, metadata, snapshot, sender, retry_count)?
     },
     | SnapshotInFlight::Load { future, persistence_id, criteria, sender, retry_count } => {
-      match Future::poll(future.as_mut(), cx) {
-        | Poll::Ready(Ok(snapshot)) => {
-          sender
-            .try_tell(AnyMessage::new(SnapshotResponse::LoadSnapshotResult {
-              snapshot,
-              to_sequence_nr: criteria.max_sequence_nr(),
-            }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-          Ok(None)
-        },
-        | Poll::Ready(Err(error)) => {
-          if *retry_count < retry_max {
-            *retry_count = retry_count.saturating_add(1);
-            *future = Box::pin(snapshot_store.load_snapshot(persistence_id, criteria.clone()));
-            Ok(Some(entry))
-          } else {
-            sender
-              .try_tell(AnyMessage::new(SnapshotResponse::LoadSnapshotFailed { error }))
-              .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            Ok(None)
-          }
-        },
-        | Poll::Pending => Ok(Some(entry)),
-      }
+      poll_load_entry(&mut poll_context, cx, future, persistence_id, criteria, sender, retry_count)?
     },
     | SnapshotInFlight::DeleteOne { future, metadata, sender, retry_count } => {
-      match Future::poll(future.as_mut(), cx) {
-        | Poll::Ready(Ok(())) => {
-          sender
-            .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotSuccess { metadata: metadata.clone() }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-          Ok(None)
-        },
-        | Poll::Ready(Err(error)) => {
-          if *retry_count < retry_max {
-            *retry_count = retry_count.saturating_add(1);
-            *future = Box::pin(snapshot_store.delete_snapshot(metadata));
-            Ok(Some(entry))
-          } else {
-            sender
-              .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotFailure { metadata: metadata.clone(), error }))
-              .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            Ok(None)
-          }
-        },
-        | Poll::Pending => Ok(Some(entry)),
-      }
+      poll_delete_one_entry(&mut poll_context, cx, future, metadata, sender, retry_count)?
     },
     | SnapshotInFlight::DeleteMany { future, persistence_id, criteria, sender, retry_count } => {
-      match Future::poll(future.as_mut(), cx) {
-        | Poll::Ready(Ok(())) => {
-          sender
-            .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotsSuccess { criteria: criteria.clone() }))
-            .map_err(|error| ActorError::from_send_error(&error))?;
-          Ok(None)
-        },
-        | Poll::Ready(Err(error)) => {
-          if *retry_count < retry_max {
-            *retry_count = retry_count.saturating_add(1);
-            *future = Box::pin(snapshot_store.delete_snapshots(persistence_id, criteria.clone()));
-            Ok(Some(entry))
-          } else {
-            sender
-              .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotsFailure { criteria: criteria.clone(), error }))
-              .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-            Ok(None)
-          }
-        },
-        | Poll::Pending => Ok(Some(entry)),
-      }
+      poll_delete_many_entry(&mut poll_context, cx, future, persistence_id, criteria, sender, retry_count)?
     },
+  };
+
+  if keep_pending { Ok(Some(entry)) } else { Ok(None) }
+}
+
+fn poll_save_entry<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  cx: &mut Context<'_>,
+  future: &mut SnapshotSaveFuture,
+  metadata: &SnapshotMetadata,
+  snapshot: &ArcShared<dyn Any + Send + Sync>,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::SaveFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(())) => send_save_success(sender, metadata),
+    | Poll::Ready(Err(error)) => {
+      retry_or_fail_save(poll_context, future, metadata, snapshot, sender, retry_count, error)
+    },
+    | Poll::Pending => Ok(true),
   }
+}
+
+fn send_save_success(sender: &mut ActorRef, metadata: &SnapshotMetadata) -> Result<bool, ActorError> {
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::SaveSnapshotSuccess { metadata: metadata.clone() }))
+    .map_err(|error| ActorError::from_send_error(&error))?;
+  Ok(false)
+}
+
+fn retry_or_fail_save<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  future: &mut SnapshotSaveFuture,
+  metadata: &SnapshotMetadata,
+  snapshot: &ArcShared<dyn Any + Send + Sync>,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+  error: SnapshotError,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::SaveFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.snapshot_store.save_snapshot(metadata.clone(), snapshot.clone()));
+    return Ok(true);
+  }
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::SaveSnapshotFailure { metadata: metadata.clone(), error }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  Ok(false)
+}
+
+fn poll_load_entry<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  cx: &mut Context<'_>,
+  future: &mut SnapshotLoadFuture,
+  persistence_id: &str,
+  criteria: &SnapshotSelectionCriteria,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::LoadFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(snapshot)) => send_load_success(sender, snapshot, criteria.max_sequence_nr()),
+    | Poll::Ready(Err(error)) => {
+      retry_or_fail_load(poll_context, future, persistence_id, criteria, sender, retry_count, error)
+    },
+    | Poll::Pending => Ok(true),
+  }
+}
+
+fn send_load_success(
+  sender: &mut ActorRef,
+  snapshot: Option<Snapshot>,
+  to_sequence_nr: u64,
+) -> Result<bool, ActorError> {
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::LoadSnapshotResult { snapshot, to_sequence_nr }))
+    .map_err(|error| ActorError::from_send_error(&error))?;
+  Ok(false)
+}
+
+fn retry_or_fail_load<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  future: &mut SnapshotLoadFuture,
+  persistence_id: &str,
+  criteria: &SnapshotSelectionCriteria,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+  error: SnapshotError,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::LoadFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.snapshot_store.load_snapshot(persistence_id, criteria.clone()));
+    return Ok(true);
+  }
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::LoadSnapshotFailed { error }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  Ok(false)
+}
+
+fn poll_delete_one_entry<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  cx: &mut Context<'_>,
+  future: &mut SnapshotDeleteFuture,
+  metadata: &SnapshotMetadata,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::DeleteOneFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(())) => send_delete_one_success(sender, metadata),
+    | Poll::Ready(Err(error)) => retry_or_fail_delete_one(poll_context, future, metadata, sender, retry_count, error),
+    | Poll::Pending => Ok(true),
+  }
+}
+
+fn send_delete_one_success(sender: &mut ActorRef, metadata: &SnapshotMetadata) -> Result<bool, ActorError> {
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotSuccess { metadata: metadata.clone() }))
+    .map_err(|error| ActorError::from_send_error(&error))?;
+  Ok(false)
+}
+
+fn retry_or_fail_delete_one<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  future: &mut SnapshotDeleteFuture,
+  metadata: &SnapshotMetadata,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+  error: SnapshotError,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::DeleteOneFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.snapshot_store.delete_snapshot(metadata));
+    return Ok(true);
+  }
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotFailure { metadata: metadata.clone(), error }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  Ok(false)
+}
+
+fn poll_delete_many_entry<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  cx: &mut Context<'_>,
+  future: &mut SnapshotDeleteFuture,
+  persistence_id: &str,
+  criteria: &SnapshotSelectionCriteria,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::DeleteManyFuture<'a>: Send + 'static, {
+  match Future::poll(future.as_mut(), cx) {
+    | Poll::Ready(Ok(())) => send_delete_many_success(sender, criteria),
+    | Poll::Ready(Err(error)) => {
+      retry_or_fail_delete_many(poll_context, future, persistence_id, criteria, sender, retry_count, error)
+    },
+    | Poll::Pending => Ok(true),
+  }
+}
+
+fn send_delete_many_success(sender: &mut ActorRef, criteria: &SnapshotSelectionCriteria) -> Result<bool, ActorError> {
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotsSuccess { criteria: criteria.clone() }))
+    .map_err(|error| ActorError::from_send_error(&error))?;
+  Ok(false)
+}
+
+fn retry_or_fail_delete_many<S: SnapshotStore>(
+  poll_context: &mut SnapshotPollContext<'_, S>,
+  future: &mut SnapshotDeleteFuture,
+  persistence_id: &str,
+  criteria: &SnapshotSelectionCriteria,
+  sender: &mut ActorRef,
+  retry_count: &mut u32,
+  error: SnapshotError,
+) -> Result<bool, ActorError>
+where
+  for<'a> S::DeleteManyFuture<'a>: Send + 'static, {
+  if *retry_count < poll_context.retry_max {
+    *retry_count = retry_count.saturating_add(1);
+    *future = Box::pin(poll_context.snapshot_store.delete_snapshots(persistence_id, criteria.clone()));
+    return Ok(true);
+  }
+  sender
+    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotsFailure { criteria: criteria.clone(), error }))
+    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+  Ok(false)
 }

--- a/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer.rs
@@ -76,6 +76,23 @@ pub(super) struct RemotingRunState {
   termination_handle: Option<JoinHandle<()>>,
 }
 
+struct RemotingInstallChannels {
+  event_sender:        Sender<RemoteEvent>,
+  event_receiver:      Receiver<RemoteEvent>,
+  watcher_sender:      Sender<WatcherCommand>,
+  watcher_receiver:    Receiver<WatcherCommand>,
+  deployment_sender:   Sender<DeploymentDaemonCommand>,
+  deployment_receiver: Receiver<DeploymentDaemonCommand>,
+}
+
+struct RemotingInstallResources {
+  remote:                  RemoteShared,
+  local_address:           Address,
+  serialization_extension: ArcShared<SerializationExtensionShared>,
+  monotonic_epoch:         Instant,
+  channels:                RemotingInstallChannels,
+}
+
 /// Handles needed by the std remote actor-ref provider.
 pub(crate) struct RemoteProviderFlushHandles {
   /// Remote event sender.
@@ -215,31 +232,44 @@ impl RemotingExtensionInstaller {
 
 impl ExtensionInstaller for RemotingExtensionInstaller {
   fn install(&self, system: &ActorSystem) -> Result<(), ActorSystemBuildError> {
+    let transport = self.take_transport_for_install()?;
+    let serialization_extension = system.extended().register_extension(&default_serialization_extension_id());
+    let resources = self.build_remoting_install_resources(system, transport, serialization_extension);
+    resources.remote.start().map_err(remoting_build_error)?;
+    let rollback_remote = resources.remote.clone();
+    let rollback_event_sender = resources.channels.event_sender.clone();
+    let install_result = self.finish_remoting_install(system, resources);
+    if let Err(error) = install_result {
+      rollback_started_remote(&rollback_remote, &rollback_event_sender, &self.run_state);
+      return Err(error);
+    }
+    Ok(())
+  }
+}
+
+impl RemotingExtensionInstaller {
+  fn take_transport_for_install(&self) -> Result<TcpRemoteTransport, ActorSystemBuildError> {
     let mut transport_slot =
       self.transport.lock().map_err(|_| ActorSystemBuildError::Configuration(String::from(TRANSPORT_LOCK_POISONED)))?;
     if self.remote_shared.get().is_some() {
       return Err(ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)));
     }
-    let Some(transport) = transport_slot.take() else {
-      return Err(ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)));
-    };
-    let serialization_extension = system.extended().register_extension(&default_serialization_extension_id());
-    let (event_sender, event_receiver) = mpsc::channel(self.config.remote_event_queue_size());
-    let (watcher_sender, watcher_receiver) = mpsc::channel(self.config.remote_event_queue_size());
-    let (deployment_sender, deployment_receiver) = mpsc::channel(self.config.remote_event_queue_size());
+    transport_slot.take().ok_or_else(|| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))
+  }
+
+  fn build_remoting_install_resources(
+    &self,
+    system: &ActorSystem,
+    transport: TcpRemoteTransport,
+    serialization_extension: ArcShared<SerializationExtensionShared>,
+  ) -> RemotingInstallResources {
+    let channels = create_remoting_install_channels(self.config.remote_event_queue_size());
     let monotonic_epoch = Instant::now();
     let transport = transport
       .with_monotonic_epoch(monotonic_epoch)
-      .with_remote_event_sender(event_sender.clone())
+      .with_remote_event_sender(channels.event_sender.clone())
       .with_serialization_extension(serialization_extension.clone());
-    let local_address =
-      transport.default_address().or_else(|| transport.addresses().first()).cloned().unwrap_or_else(|| {
-        Address::new(
-          system.state().system_name(),
-          self.config.canonical_host(),
-          self.config.canonical_port().or_else(|| self.config.bind_port()).unwrap_or(0),
-        )
-      });
+    let local_address = remoting_local_address(&transport, system, &self.config);
     let event_publisher = EventPublisher::new(system.downgrade());
     let remote = RemoteShared::new(Remote::with_instrument(
       transport,
@@ -248,79 +278,117 @@ impl ExtensionInstaller for RemotingExtensionInstaller {
       serialization_extension.clone(),
       Box::new(RemotingFlightRecorder::new(self.config.flight_recorder_capacity())),
     ));
-    remote.start().map_err(remoting_build_error)?;
-    let install_result = (|| -> Result<(), ActorSystemBuildError> {
-      let mut run_state = self
-        .run_state
-        .lock()
-        .map_err(|_| ActorSystemBuildError::Configuration(String::from(RUN_STATE_LOCK_POISONED)))?;
-      run_state.receiver = Some(TokioMpscRemoteEventReceiver::new(event_receiver));
-      spawn_run_task_with_state(
-        &mut run_state,
-        remote.clone(),
-        system.clone(),
-        watcher_sender.clone(),
-        deployment_sender.clone(),
-        self.deployment_response_dispatcher.clone(),
-        event_sender.clone(),
-        self.flush_gate.clone(),
-      )
-      .map_err(remoting_build_error)?;
-      spawn_watcher_task_with_state(
-        &mut run_state,
-        watcher_receiver,
-        event_sender.clone(),
-        system.clone(),
-        local_address,
-        monotonic_epoch,
-        self.config.system_message_resend_interval(),
-      )
-      .map_err(remoting_build_error)?;
-      spawn_deployment_daemon_with_state(
-        &mut run_state,
-        deployment_receiver,
-        system.clone(),
-        serialization_extension.clone(),
-        event_sender.clone(),
-        monotonic_epoch,
-      )
-      .map_err(remoting_build_error)?;
-      let shutdown_flush_context =
-        ShutdownFlushContext { config: self.config.clone(), monotonic_epoch, flush_gate: self.flush_gate.clone() };
-      spawn_shutdown_on_system_termination(
-        system,
-        remote.clone(),
-        event_sender.clone(),
-        &mut run_state,
-        self.run_state.clone(),
-        shutdown_flush_context,
-      )
-      .map_err(remoting_build_error)?;
-      self
-        .event_sender
-        .set(event_sender.clone())
-        .map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))?;
-      self
-        .watcher_sender
-        .set(watcher_sender.clone())
-        .map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))?;
-      self
-        .monotonic_epoch
-        .set(monotonic_epoch)
-        .map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))?;
-      // ExtensionInstaller::install は &self 契約のため、一回限りの初期化に OnceLock を使う。
-      self
-        .remote_shared
-        .set(remote.clone())
-        .map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))?;
-      Ok(())
-    })();
-    if let Err(error) = install_result {
-      rollback_started_remote(&remote, &event_sender, &self.run_state);
-      return Err(error);
-    }
-    Ok(())
+    RemotingInstallResources { remote, local_address, serialization_extension, monotonic_epoch, channels }
   }
+
+  fn finish_remoting_install(
+    &self,
+    system: &ActorSystem,
+    resources: RemotingInstallResources,
+  ) -> Result<(), ActorSystemBuildError> {
+    let RemotingInstallResources { remote, local_address, serialization_extension, monotonic_epoch, channels } =
+      resources;
+    let RemotingInstallChannels {
+      event_sender,
+      event_receiver,
+      watcher_sender,
+      watcher_receiver,
+      deployment_sender,
+      deployment_receiver,
+    } = channels;
+    let mut run_state =
+      self.run_state.lock().map_err(|_| ActorSystemBuildError::Configuration(String::from(RUN_STATE_LOCK_POISONED)))?;
+    run_state.receiver = Some(TokioMpscRemoteEventReceiver::new(event_receiver));
+    spawn_run_task_with_state(
+      &mut run_state,
+      remote.clone(),
+      system.clone(),
+      watcher_sender.clone(),
+      deployment_sender,
+      self.deployment_response_dispatcher.clone(),
+      event_sender.clone(),
+      self.flush_gate.clone(),
+    )
+    .map_err(remoting_build_error)?;
+    spawn_watcher_task_with_state(
+      &mut run_state,
+      watcher_receiver,
+      event_sender.clone(),
+      system.clone(),
+      local_address,
+      monotonic_epoch,
+      self.config.system_message_resend_interval(),
+    )
+    .map_err(remoting_build_error)?;
+    spawn_deployment_daemon_with_state(
+      &mut run_state,
+      deployment_receiver,
+      system.clone(),
+      serialization_extension,
+      event_sender.clone(),
+      monotonic_epoch,
+    )
+    .map_err(remoting_build_error)?;
+    let shutdown_flush_context =
+      ShutdownFlushContext { config: self.config.clone(), monotonic_epoch, flush_gate: self.flush_gate.clone() };
+    spawn_shutdown_on_system_termination(
+      system,
+      remote.clone(),
+      event_sender.clone(),
+      &mut run_state,
+      self.run_state.clone(),
+      shutdown_flush_context,
+    )
+    .map_err(remoting_build_error)?;
+    self.store_remoting_install_handles(event_sender, watcher_sender, monotonic_epoch, remote)
+  }
+
+  fn store_remoting_install_handles(
+    &self,
+    event_sender: Sender<RemoteEvent>,
+    watcher_sender: Sender<WatcherCommand>,
+    monotonic_epoch: Instant,
+    remote: RemoteShared,
+  ) -> Result<(), ActorSystemBuildError> {
+    self
+      .event_sender
+      .set(event_sender)
+      .map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))?;
+    self
+      .watcher_sender
+      .set(watcher_sender)
+      .map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))?;
+    self
+      .monotonic_epoch
+      .set(monotonic_epoch)
+      .map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))?;
+    // ExtensionInstaller::install は &self 契約のため、一回限りの初期化に OnceLock を使う。
+    self.remote_shared.set(remote).map_err(|_| ActorSystemBuildError::Configuration(String::from(ALREADY_INSTALLED)))
+  }
+}
+
+fn create_remoting_install_channels(queue_size: usize) -> RemotingInstallChannels {
+  let (event_sender, event_receiver) = mpsc::channel(queue_size);
+  let (watcher_sender, watcher_receiver) = mpsc::channel(queue_size);
+  let (deployment_sender, deployment_receiver) = mpsc::channel(queue_size);
+  RemotingInstallChannels {
+    event_sender,
+    event_receiver,
+    watcher_sender,
+    watcher_receiver,
+    deployment_sender,
+    deployment_receiver,
+  }
+}
+
+fn remoting_local_address(transport: &TcpRemoteTransport, system: &ActorSystem, config: &RemoteConfig) -> Address {
+  transport.default_address().or_else(|| transport.addresses().first()).cloned().unwrap_or_else(|| {
+    Address::new(
+      system.state().system_name(),
+      config.canonical_host(),
+      config.canonical_port().or_else(|| config.bind_port()).unwrap_or(0),
+    )
+  })
 }
 
 fn remoting_build_error(error: RemotingError) -> ActorSystemBuildError {

--- a/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer_test.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer_test.rs
@@ -10,10 +10,12 @@ use fraktor_actor_core_kernel_rs::{
   actor::{
     Pid,
     actor_path::ActorPathParser,
+    extension::ExtensionInstaller,
     messaging::{AnyMessage, system_message::SystemMessage},
   },
   event::stream::CorrelationId,
   serialization::{SerializationExtensionShared, default_serialization_extension_id},
+  system::ActorSystemBuildError,
 };
 use fraktor_remote_core_rs::{
   address::{RemoteNodeId, UniqueAddress},
@@ -29,7 +31,7 @@ use tokio::{
 };
 
 use super::*;
-use crate::extension_installer::flush_gate::StdFlushNotification;
+use crate::{extension_installer::flush_gate::StdFlushNotification, transport::tcp::TcpRemoteTransport};
 
 struct TestRemoteTransport {
   addresses:    Vec<Address>,
@@ -319,6 +321,24 @@ async fn shutdown_remote_and_join_continues_when_shutdown_flush_is_not_started()
   .await
   .expect("shutdown should not hang")
   .expect("shutdown should continue after flush setup failure");
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = false)]
+async fn install_rolls_back_started_remote_when_handle_storage_fails() {
+  let installer = RemotingExtensionInstaller::new(
+    TcpRemoteTransport::new("127.0.0.1:0", vec![Address::new("local-sys", "127.0.0.1", 0)]),
+    RemoteConfig::new("127.0.0.1"),
+  );
+  let (event_sender, _event_receiver) = mpsc::channel(1);
+  installer.event_sender.set(event_sender).expect("preloaded event sender should be accepted");
+  let system = create_noop_actor_system();
+
+  let error = installer.install(&system).expect_err("handle storage failure should abort install");
+
+  match error {
+    | ActorSystemBuildError::Configuration(message) => assert_eq!(message, ALREADY_INSTALLED),
+    | other => panic!("expected configuration error, got {other:?}"),
+  }
 }
 
 #[test]

--- a/modules/remote-adaptor-std/src/transport/tcp/client.rs
+++ b/modules/remote-adaptor-std/src/transport/tcp/client.rs
@@ -15,7 +15,7 @@ use fraktor_remote_core_rs::{
   config::RemoteCompressionConfig,
   extension::RemoteEvent,
   transport::{TransportEndpoint, TransportError},
-  wire::CompressionTableKind,
+  wire::{CompressionTableKind, ControlPdu},
 };
 use futures::{SinkExt as _, StreamExt as _, future::poll_fn};
 use tokio::{
@@ -72,6 +72,11 @@ struct TcpClientRunOptions {
   compression_config:       RemoteCompressionConfig,
   local_authority:          String,
   connection_loss_reporter: Option<ConnectionLossReporter>,
+}
+
+enum TcpClientLoopDecision {
+  Continue,
+  Stop(Option<TransportError>),
 }
 
 impl TcpClientConnectOptions {
@@ -265,35 +270,17 @@ async fn run(
     tokio::select! {
       next = framed.next() => match next {
         | Some(Ok(decoded)) => {
-          let decoded = match compression_tables.handle_inbound_frame(decoded, &local_authority) {
-            | Ok(InboundCompressionAction::Forward(frame)) => frame,
-            | Ok(InboundCompressionAction::Reply { pdu, authority: frame_authority }) => {
-              authority = Some(frame_authority);
-              if framed.send(WireFrame::Control(pdu)).await.is_err() { break Some(TransportError::SendFailed); }
-              continue;
-            },
-            | Ok(InboundCompressionAction::Consumed { authority: frame_authority }) => {
-              authority = Some(frame_authority);
-              continue;
-            },
-            | Err(err) => {
-              tracing::warn!(?err, peer = %peer_addr, "tcp client compression frame error");
-              break Some(TransportError::SendFailed);
-            },
-          };
-          if let Some(frame_authority) = authority_for_frame(&decoded) {
-            authority = Some(frame_authority);
-          }
-          let lane_index = inbound_lane_index(&peer_addr, authority.as_ref(), &decoded, inbound_txs.len());
-          let Some(inbound_tx) = inbound_txs.get(lane_index) else {
-            break Some(TransportError::NotAvailable);
-          };
-          if inbound_tx.send(InboundFrameEvent {
-            peer: peer_addr.clone(),
-            authority: authority.clone(),
-            frame: decoded,
-          }).is_err() {
-            break None;
+          match handle_inbound_tcp_frame(
+            decoded,
+            &mut framed,
+            &mut compression_tables,
+            &local_authority,
+            &peer_addr,
+            &mut authority,
+            &inbound_txs,
+          ).await {
+            | TcpClientLoopDecision::Continue => continue,
+            | TcpClientLoopDecision::Stop(cause) => break cause,
           }
         }
         | Some(Err(err)) => {
@@ -304,27 +291,31 @@ async fn run(
       },
       next = next_writer_frame(&mut writer_rxs, &mut next_writer_lane) => match next {
         | Some(frame) => {
-          let frame = compression_tables.apply_outbound_frame(frame);
-          if let Err(err) = framed.send(frame).await {
-            tracing::warn!(?err, peer = %peer_addr, "tcp client write error");
-            break Some(TransportError::SendFailed);
+          if let Some(cause) = send_outbound_tcp_frame(frame, &mut framed, &mut compression_tables, &peer_addr).await {
+            break Some(cause);
           }
         }
         | None => break None,
       },
       _ = next_compression_advertisement_tick(&mut actor_ref_advertisement_interval) => {
-        let send_failed = match compression_tables.create_advertisement(CompressionTableKind::ActorRef, &local_authority) {
-          | Some(frame) => framed.send(frame).await.is_err(),
-          | None => false,
-        };
-        if send_failed { break Some(TransportError::SendFailed); }
+        if let Some(cause) = send_tcp_compression_advertisement(
+          &mut framed,
+          &mut compression_tables,
+          CompressionTableKind::ActorRef,
+          &local_authority,
+        ).await {
+          break Some(cause);
+        }
       },
       _ = next_compression_advertisement_tick(&mut manifest_advertisement_interval) => {
-        let send_failed = match compression_tables.create_advertisement(CompressionTableKind::Manifest, &local_authority) {
-          | Some(frame) => framed.send(frame).await.is_err(),
-          | None => false,
-        };
-        if send_failed { break Some(TransportError::SendFailed); }
+        if let Some(cause) = send_tcp_compression_advertisement(
+          &mut framed,
+          &mut compression_tables,
+          CompressionTableKind::Manifest,
+          &local_authority,
+        ).await {
+          break Some(cause);
+        }
       },
     }
   };
@@ -334,6 +325,94 @@ async fn run(
   if let Err(err) = framed.close().await {
     tracing::debug!(?err, "tcp client framed close failed during shutdown");
   }
+}
+
+async fn handle_inbound_tcp_frame(
+  decoded: WireFrame,
+  framed: &mut Framed<TcpStream, WireFrameCodec>,
+  compression_tables: &mut TcpCompressionTables,
+  local_authority: &str,
+  peer_addr: &str,
+  authority: &mut Option<TransportEndpoint>,
+  inbound_txs: &[UnboundedSender<InboundFrameEvent>],
+) -> TcpClientLoopDecision {
+  let decoded = match compression_tables.handle_inbound_frame(decoded, local_authority) {
+    | Ok(InboundCompressionAction::Forward(frame)) => frame,
+    | Ok(InboundCompressionAction::Reply { pdu, authority: frame_authority }) => {
+      *authority = Some(frame_authority);
+      return send_tcp_control_reply(framed, pdu).await;
+    },
+    | Ok(InboundCompressionAction::Consumed { authority: frame_authority }) => {
+      *authority = Some(frame_authority);
+      return TcpClientLoopDecision::Continue;
+    },
+    | Err(err) => {
+      tracing::warn!(?err, peer = %peer_addr, "tcp client compression frame error");
+      return TcpClientLoopDecision::Stop(Some(TransportError::SendFailed));
+    },
+  };
+  forward_inbound_tcp_frame(decoded, peer_addr, authority, inbound_txs)
+}
+
+async fn send_tcp_control_reply(
+  framed: &mut Framed<TcpStream, WireFrameCodec>,
+  pdu: ControlPdu,
+) -> TcpClientLoopDecision {
+  if framed.send(WireFrame::Control(pdu)).await.is_err() {
+    TcpClientLoopDecision::Stop(Some(TransportError::SendFailed))
+  } else {
+    TcpClientLoopDecision::Continue
+  }
+}
+
+fn forward_inbound_tcp_frame(
+  decoded: WireFrame,
+  peer_addr: &str,
+  authority: &mut Option<TransportEndpoint>,
+  inbound_txs: &[UnboundedSender<InboundFrameEvent>],
+) -> TcpClientLoopDecision {
+  if let Some(frame_authority) = authority_for_frame(&decoded) {
+    *authority = Some(frame_authority);
+  }
+  let lane_index = inbound_lane_index(peer_addr, authority.as_ref(), &decoded, inbound_txs.len());
+  let Some(inbound_tx) = inbound_txs.get(lane_index) else {
+    return TcpClientLoopDecision::Stop(Some(TransportError::NotAvailable));
+  };
+  if inbound_tx
+    .send(InboundFrameEvent { peer: peer_addr.into(), authority: authority.clone(), frame: decoded })
+    .is_err()
+  {
+    return TcpClientLoopDecision::Stop(None);
+  }
+  TcpClientLoopDecision::Continue
+}
+
+async fn send_outbound_tcp_frame(
+  frame: WireFrame,
+  framed: &mut Framed<TcpStream, WireFrameCodec>,
+  compression_tables: &mut TcpCompressionTables,
+  peer_addr: &str,
+) -> Option<TransportError> {
+  let frame = compression_tables.apply_outbound_frame(frame);
+  if let Err(err) = framed.send(frame).await {
+    tracing::warn!(?err, peer = %peer_addr, "tcp client write error");
+    return Some(TransportError::SendFailed);
+  }
+  None
+}
+
+async fn send_tcp_compression_advertisement(
+  framed: &mut Framed<TcpStream, WireFrameCodec>,
+  compression_tables: &mut TcpCompressionTables,
+  kind: CompressionTableKind,
+  local_authority: &str,
+) -> Option<TransportError> {
+  if let Some(frame) = compression_tables.create_advertisement(kind, local_authority)
+    && framed.send(frame).await.is_err()
+  {
+    return Some(TransportError::SendFailed);
+  }
+  None
 }
 
 async fn next_writer_frame(writer_rxs: &mut [Receiver<WireFrame>], next_writer_lane: &mut usize) -> Option<WireFrame> {

--- a/modules/remote-adaptor-std/src/transport/tcp/client_test.rs
+++ b/modules/remote-adaptor-std/src/transport/tcp/client_test.rs
@@ -1,12 +1,24 @@
 use alloc::{string::String, vec};
+use std::{
+  net::{TcpListener as StdTcpListener, TcpStream as StdTcpStream},
+  time::Duration,
+};
 
 use bytes::Bytes;
 use fraktor_remote_core_rs::{
   address::{Address, UniqueAddress},
+  config::RemoteCompressionConfig,
   transport::{TransportEndpoint, TransportError},
   wire::{AckPdu, ControlPdu, EnvelopePayload, EnvelopePdu, FlushScope, HandshakePdu, HandshakeReq},
 };
-use tokio::sync::mpsc;
+use futures::SinkExt as _;
+use tokio::{
+  io::AsyncWriteExt as _,
+  net::{TcpListener, TcpStream},
+  sync::mpsc,
+  time::timeout,
+};
+use tokio_util::codec::Framed;
 
 use super::*;
 
@@ -39,6 +51,48 @@ fn test_envelope_pdu(
     correlation_lo,
     priority,
     EnvelopePayload::new(5, None, payload),
+  )
+}
+
+fn test_manifest_envelope_pdu(manifest: String) -> EnvelopePdu {
+  EnvelopePdu::new(
+    String::from("fraktor.tcp://local-sys@127.0.0.1:2551/user/a"),
+    None,
+    1,
+    0,
+    1,
+    EnvelopePayload::new(5, Some(manifest), Bytes::from_static(b"payload")),
+  )
+}
+
+async fn tcp_stream_pair() -> (TcpStream, TcpStream) {
+  let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind listener");
+  let address = listener.local_addr().expect("listener address");
+  let client = TcpStream::connect(address);
+  let (accepted, connected) = tokio::join!(listener.accept(), client);
+  let (server, _) = accepted.expect("accept connection");
+  let client = connected.expect("connect client");
+  (client, server)
+}
+
+async fn tcp_framed_pair() -> (Framed<TcpStream, WireFrameCodec>, Framed<TcpStream, WireFrameCodec>) {
+  let (client, server) = tcp_stream_pair().await;
+  (Framed::new(client, WireFrameCodec::new()), Framed::new(server, WireFrameCodec::new()))
+}
+
+async fn tcp_stream_pair_with_client_control() -> (TcpStream, TcpStream, TcpStream) {
+  let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind std listener");
+  let address = listener.local_addr().expect("listener address");
+  let client = StdTcpStream::connect(address).expect("connect std client");
+  let (server, _) = listener.accept().expect("accept std connection");
+  client.set_nonblocking(true).expect("set client nonblocking");
+  let client_control = client.try_clone().expect("clone std client");
+  client_control.set_nonblocking(true).expect("set control nonblocking");
+  server.set_nonblocking(true).expect("set server nonblocking");
+  (
+    TcpStream::from_std(client).expect("convert client stream"),
+    TcpStream::from_std(client_control).expect("convert client control stream"),
+    TcpStream::from_std(server).expect("convert server stream"),
   )
 }
 
@@ -163,4 +217,141 @@ fn inbound_lane_index_can_use_frame_authority_before_state_is_known() {
   let expected = inbound_lane_index("peer-b", Some(&TransportEndpoint::new("remote-sys@10.0.0.1:2552")), &frame, 4);
 
   assert_eq!(selected, expected);
+}
+
+#[test]
+fn forward_inbound_tcp_frame_stops_without_inbound_lanes() {
+  let mut authority = None;
+
+  let decision = forward_inbound_tcp_frame(ack_frame(1), "peer-a", &mut authority, &[]);
+
+  assert!(matches!(decision, TcpClientLoopDecision::Stop(Some(TransportError::NotAvailable))));
+}
+
+#[test]
+fn forward_inbound_tcp_frame_stops_when_selected_lane_is_closed() {
+  let (inbound_tx, inbound_rx) = mpsc::unbounded_channel();
+  drop(inbound_rx);
+  let mut authority = None;
+
+  let decision = forward_inbound_tcp_frame(ack_frame(1), "peer-a", &mut authority, &[inbound_tx]);
+
+  assert!(matches!(decision, TcpClientLoopDecision::Stop(None)));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = false)]
+async fn send_tcp_control_reply_reports_send_failure_after_close() {
+  let (mut client, _server) = tcp_framed_pair().await;
+  client.close().await.expect("close framed client");
+
+  let decision =
+    send_tcp_control_reply(&mut client, ControlPdu::Heartbeat { authority: String::from("local@127.0.0.1:2551") })
+      .await;
+
+  assert!(matches!(decision, TcpClientLoopDecision::Stop(Some(TransportError::SendFailed))));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = false)]
+async fn send_outbound_tcp_frame_reports_send_failure_after_close() {
+  let (mut client, _server) = tcp_framed_pair().await;
+  let mut compression_tables = TcpCompressionTables::new(RemoteCompressionConfig::new());
+  client.close().await.expect("close framed client");
+
+  let error = send_outbound_tcp_frame(ack_frame(1), &mut client, &mut compression_tables, "peer-a").await;
+
+  assert_eq!(error, Some(TransportError::SendFailed));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = false)]
+async fn send_tcp_compression_advertisement_reports_send_failure_after_close() {
+  let (mut client, _server) = tcp_framed_pair().await;
+  let mut compression_tables = TcpCompressionTables::new(RemoteCompressionConfig::new());
+  let _ = compression_tables.apply_outbound_frame(WireFrame::Envelope(test_envelope_pdu(
+    String::from("fraktor.tcp://local-sys@127.0.0.1:2551/user/a"),
+    None,
+    1,
+    0,
+    1,
+    Bytes::from_static(b"payload"),
+  )));
+  client.close().await.expect("close framed client");
+
+  let error =
+    send_tcp_compression_advertisement(&mut client, &mut compression_tables, CompressionTableKind::ActorRef, "local")
+      .await;
+
+  assert_eq!(error, Some(TransportError::SendFailed));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = false)]
+async fn run_stops_when_writer_send_fails() {
+  let (mut client, _server) = tcp_stream_pair().await;
+  client.shutdown().await.expect("shutdown client writer");
+  let (writer_tx, writer_rx) = mpsc::channel(1);
+  writer_tx.send(ack_frame(1)).await.expect("writer lane accepts frame");
+  let options = TcpClientRunOptions {
+    frame_codec:              WireFrameCodec::new(),
+    compression_config:       RemoteCompressionConfig::new(),
+    local_authority:          String::from("local@127.0.0.1:2551"),
+    connection_loss_reporter: None,
+  };
+
+  timeout(Duration::from_secs(1), run(client, String::from("peer-a"), vec![writer_rx], Vec::new(), options))
+    .await
+    .expect("client run should stop after writer send failure");
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = false)]
+async fn run_stops_when_actor_ref_advertisement_send_fails() {
+  run_stops_when_compression_advertisement_send_fails(
+    RemoteCompressionConfig::new()
+      .with_actor_ref_advertisement_interval(Duration::from_millis(1))
+      .with_manifest_max(None),
+    WireFrame::Envelope(test_envelope_pdu(
+      String::from("fraktor.tcp://local-sys@127.0.0.1:2551/user/a"),
+      None,
+      1,
+      0,
+      1,
+      Bytes::from_static(b"payload"),
+    )),
+  )
+  .await;
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = false)]
+async fn run_stops_when_manifest_advertisement_send_fails() {
+  run_stops_when_compression_advertisement_send_fails(
+    RemoteCompressionConfig::new()
+      .with_actor_ref_max(None)
+      .with_manifest_advertisement_interval(Duration::from_millis(1)),
+    WireFrame::Envelope(test_manifest_envelope_pdu(String::from("example.Manifest"))),
+  )
+  .await;
+}
+
+async fn run_stops_when_compression_advertisement_send_fails(
+  compression_config: RemoteCompressionConfig,
+  frame: WireFrame,
+) {
+  let (client, mut client_control, server) = tcp_stream_pair_with_client_control().await;
+  let mut server = Framed::new(server, WireFrameCodec::new());
+  let (writer_tx, writer_rx) = mpsc::channel(1);
+  writer_tx.send(frame).await.expect("writer lane accepts frame");
+  let options = TcpClientRunOptions {
+    frame_codec: WireFrameCodec::new(),
+    compression_config,
+    local_authority: String::from("local@127.0.0.1:2551"),
+    connection_loss_reporter: None,
+  };
+  let task = tokio::spawn(run(client, String::from("peer-a"), vec![writer_rx], Vec::new(), options));
+
+  let first_frame = timeout(Duration::from_secs(1), server.next()).await.expect("first outbound frame should arrive");
+  assert!(matches!(first_frame, Some(Ok(WireFrame::Envelope(_)))));
+  client_control.shutdown().await.expect("shutdown client writer");
+
+  timeout(Duration::from_secs(1), task)
+    .await
+    .expect("client run should stop after advertisement send failure")
+    .unwrap();
 }

--- a/modules/remote-core/src/wire/control_codec.rs
+++ b/modules/remote-core/src/wire/control_codec.rs
@@ -4,7 +4,7 @@
 #[path = "control_codec_test.rs"]
 mod tests;
 
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::num::TryFromIntError;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -48,61 +48,7 @@ impl ControlCodec {
 impl Codec<ControlPdu> for ControlCodec {
   fn encode(&self, value: &ControlPdu, buf: &mut BytesMut) -> Result<(), WireError> {
     let len_pos = begin_frame(buf, KIND_CONTROL);
-    match value {
-      | ControlPdu::Heartbeat { authority } => {
-        buf.put_u8(SUBKIND_HEARTBEAT);
-        encode_string(authority, buf)?;
-        encode_option_string(None, buf)?;
-      },
-      | ControlPdu::HeartbeatResponse { authority, uid } => {
-        buf.put_u8(SUBKIND_HEARTBEAT_RESPONSE);
-        encode_string(authority, buf)?;
-        encode_option_string(None, buf)?;
-        buf.put_u64(*uid);
-      },
-      | ControlPdu::Quarantine { authority, reason } => {
-        buf.put_u8(SUBKIND_QUARANTINE);
-        encode_string(authority, buf)?;
-        encode_option_string(reason.as_deref(), buf)?;
-      },
-      | ControlPdu::Shutdown { authority } => {
-        buf.put_u8(SUBKIND_SHUTDOWN);
-        encode_string(authority, buf)?;
-        encode_option_string(None, buf)?;
-      },
-      | ControlPdu::FlushRequest { authority, flush_id, scope, lane_id, expected_acks } => {
-        buf.put_u8(SUBKIND_FLUSH_REQUEST);
-        encode_string(authority, buf)?;
-        encode_option_string(None, buf)?;
-        buf.put_u64(*flush_id);
-        buf.put_u8(scope.to_wire());
-        buf.put_u32(*lane_id);
-        buf.put_u32(*expected_acks);
-      },
-      | ControlPdu::FlushAck { authority, flush_id, lane_id, expected_acks } => {
-        buf.put_u8(SUBKIND_FLUSH_ACK);
-        encode_string(authority, buf)?;
-        encode_option_string(None, buf)?;
-        buf.put_u64(*flush_id);
-        buf.put_u32(*lane_id);
-        buf.put_u32(*expected_acks);
-      },
-      | ControlPdu::CompressionAdvertisement { authority, table_kind, generation, entries } => {
-        buf.put_u8(SUBKIND_COMPRESSION_ADVERTISEMENT);
-        encode_string(authority, buf)?;
-        encode_option_string(None, buf)?;
-        buf.put_u8(table_kind.to_wire());
-        buf.put_u64(*generation);
-        encode_compression_entries(entries, buf)?;
-      },
-      | ControlPdu::CompressionAck { authority, table_kind, generation } => {
-        buf.put_u8(SUBKIND_COMPRESSION_ACK);
-        encode_string(authority, buf)?;
-        encode_option_string(None, buf)?;
-        buf.put_u8(table_kind.to_wire());
-        buf.put_u64(*generation);
-      },
-    }
+    encode_control_body(value, buf)?;
     patch_frame_length(buf, len_pos)
   }
 
@@ -114,61 +60,147 @@ impl Codec<ControlPdu> for ControlCodec {
     let subkind = buf.get_u8();
     let authority = decode_string(buf)?;
     let reason = decode_option_string(buf)?;
-    match subkind {
-      | SUBKIND_HEARTBEAT => Ok(ControlPdu::Heartbeat { authority }),
-      | SUBKIND_HEARTBEAT_RESPONSE => {
-        if buf.remaining() < 8 {
-          return Err(WireError::Truncated);
-        }
-        Ok(ControlPdu::HeartbeatResponse { authority, uid: buf.get_u64() })
-      },
-      | SUBKIND_QUARANTINE => Ok(ControlPdu::Quarantine { authority, reason }),
-      | SUBKIND_SHUTDOWN => Ok(ControlPdu::Shutdown { authority }),
-      | SUBKIND_FLUSH_REQUEST => {
-        if buf.remaining() < 17 {
-          return Err(WireError::Truncated);
-        }
-        let flush_id = buf.get_u64();
-        let scope = FlushScope::from_wire(buf.get_u8()).ok_or(WireError::InvalidFormat)?;
-        let lane_id = buf.get_u32();
-        let expected_acks = buf.get_u32();
-        Ok(ControlPdu::FlushRequest { authority, flush_id, scope, lane_id, expected_acks })
-      },
-      | SUBKIND_FLUSH_ACK => {
-        if buf.remaining() < 16 {
-          return Err(WireError::Truncated);
-        }
-        let flush_id = buf.get_u64();
-        let lane_id = buf.get_u32();
-        let expected_acks = buf.get_u32();
-        Ok(ControlPdu::FlushAck { authority, flush_id, lane_id, expected_acks })
-      },
-      | SUBKIND_COMPRESSION_ADVERTISEMENT => {
-        if reason.is_some() {
-          return Err(WireError::InvalidFormat);
-        }
-        if buf.remaining() < 13 {
-          return Err(WireError::Truncated);
-        }
-        let table_kind = CompressionTableKind::from_wire(buf.get_u8()).ok_or(WireError::InvalidFormat)?;
-        let generation = buf.get_u64();
-        let entries = decode_compression_entries(buf)?;
-        Ok(ControlPdu::CompressionAdvertisement { authority, table_kind, generation, entries })
-      },
-      | SUBKIND_COMPRESSION_ACK => {
-        if reason.is_some() {
-          return Err(WireError::InvalidFormat);
-        }
-        if buf.remaining() < 9 {
-          return Err(WireError::Truncated);
-        }
-        let table_kind = CompressionTableKind::from_wire(buf.get_u8()).ok_or(WireError::InvalidFormat)?;
-        let generation = buf.get_u64();
-        Ok(ControlPdu::CompressionAck { authority, table_kind, generation })
-      },
-      | _ => Err(WireError::InvalidFormat),
-    }
+    decode_control_body(subkind, authority, reason, buf)
   }
+}
+
+fn encode_control_body(value: &ControlPdu, buf: &mut BytesMut) -> Result<(), WireError> {
+  match value {
+    | ControlPdu::Heartbeat { authority } => encode_authority_control(SUBKIND_HEARTBEAT, authority, None, buf),
+    | ControlPdu::HeartbeatResponse { authority, uid } => {
+      encode_authority_control(SUBKIND_HEARTBEAT_RESPONSE, authority, None, buf)?;
+      buf.put_u64(*uid);
+      Ok(())
+    },
+    | ControlPdu::Quarantine { authority, reason } => {
+      encode_authority_control(SUBKIND_QUARANTINE, authority, reason.as_deref(), buf)
+    },
+    | ControlPdu::Shutdown { authority } => encode_authority_control(SUBKIND_SHUTDOWN, authority, None, buf),
+    | ControlPdu::FlushRequest { authority, flush_id, scope, lane_id, expected_acks } => {
+      encode_authority_control(SUBKIND_FLUSH_REQUEST, authority, None, buf)?;
+      buf.put_u64(*flush_id);
+      buf.put_u8(scope.to_wire());
+      buf.put_u32(*lane_id);
+      buf.put_u32(*expected_acks);
+      Ok(())
+    },
+    | ControlPdu::FlushAck { authority, flush_id, lane_id, expected_acks } => {
+      encode_authority_control(SUBKIND_FLUSH_ACK, authority, None, buf)?;
+      buf.put_u64(*flush_id);
+      buf.put_u32(*lane_id);
+      buf.put_u32(*expected_acks);
+      Ok(())
+    },
+    | ControlPdu::CompressionAdvertisement { authority, table_kind, generation, entries } => {
+      encode_compression_advertisement(authority, *table_kind, *generation, entries, buf)
+    },
+    | ControlPdu::CompressionAck { authority, table_kind, generation } => {
+      encode_authority_control(SUBKIND_COMPRESSION_ACK, authority, None, buf)?;
+      buf.put_u8(table_kind.to_wire());
+      buf.put_u64(*generation);
+      Ok(())
+    },
+  }
+}
+
+fn encode_authority_control(
+  subkind: u8,
+  authority: &str,
+  reason: Option<&str>,
+  buf: &mut BytesMut,
+) -> Result<(), WireError> {
+  buf.put_u8(subkind);
+  encode_string(authority, buf)?;
+  encode_option_string(reason, buf)
+}
+
+fn encode_compression_advertisement(
+  authority: &str,
+  table_kind: CompressionTableKind,
+  generation: u64,
+  entries: &[CompressionTableEntry],
+  buf: &mut BytesMut,
+) -> Result<(), WireError> {
+  encode_authority_control(SUBKIND_COMPRESSION_ADVERTISEMENT, authority, None, buf)?;
+  buf.put_u8(table_kind.to_wire());
+  buf.put_u64(generation);
+  encode_compression_entries(entries, buf)
+}
+
+fn decode_control_body(
+  subkind: u8,
+  authority: String,
+  reason: Option<String>,
+  buf: &mut Bytes,
+) -> Result<ControlPdu, WireError> {
+  match subkind {
+    | SUBKIND_HEARTBEAT => Ok(ControlPdu::Heartbeat { authority }),
+    | SUBKIND_HEARTBEAT_RESPONSE => decode_heartbeat_response(authority, buf),
+    | SUBKIND_QUARANTINE => Ok(ControlPdu::Quarantine { authority, reason }),
+    | SUBKIND_SHUTDOWN => Ok(ControlPdu::Shutdown { authority }),
+    | SUBKIND_FLUSH_REQUEST => decode_flush_request(authority, buf),
+    | SUBKIND_FLUSH_ACK => decode_flush_ack(authority, buf),
+    | SUBKIND_COMPRESSION_ADVERTISEMENT => decode_compression_advertisement(authority, reason.as_deref(), buf),
+    | SUBKIND_COMPRESSION_ACK => decode_compression_ack(authority, reason.as_deref(), buf),
+    | _ => Err(WireError::InvalidFormat),
+  }
+}
+
+fn decode_heartbeat_response(authority: String, buf: &mut Bytes) -> Result<ControlPdu, WireError> {
+  ensure_remaining(buf, 8)?;
+  Ok(ControlPdu::HeartbeatResponse { authority, uid: buf.get_u64() })
+}
+
+fn decode_flush_request(authority: String, buf: &mut Bytes) -> Result<ControlPdu, WireError> {
+  ensure_remaining(buf, 17)?;
+  let flush_id = buf.get_u64();
+  let scope = FlushScope::from_wire(buf.get_u8()).ok_or(WireError::InvalidFormat)?;
+  let lane_id = buf.get_u32();
+  let expected_acks = buf.get_u32();
+  Ok(ControlPdu::FlushRequest { authority, flush_id, scope, lane_id, expected_acks })
+}
+
+fn decode_flush_ack(authority: String, buf: &mut Bytes) -> Result<ControlPdu, WireError> {
+  ensure_remaining(buf, 16)?;
+  let flush_id = buf.get_u64();
+  let lane_id = buf.get_u32();
+  let expected_acks = buf.get_u32();
+  Ok(ControlPdu::FlushAck { authority, flush_id, lane_id, expected_acks })
+}
+
+fn decode_compression_advertisement(
+  authority: String,
+  reason: Option<&str>,
+  buf: &mut Bytes,
+) -> Result<ControlPdu, WireError> {
+  ensure_no_reason(reason)?;
+  ensure_remaining(buf, 13)?;
+  let table_kind = CompressionTableKind::from_wire(buf.get_u8()).ok_or(WireError::InvalidFormat)?;
+  let generation = buf.get_u64();
+  let entries = decode_compression_entries(buf)?;
+  Ok(ControlPdu::CompressionAdvertisement { authority, table_kind, generation, entries })
+}
+
+fn decode_compression_ack(authority: String, reason: Option<&str>, buf: &mut Bytes) -> Result<ControlPdu, WireError> {
+  ensure_no_reason(reason)?;
+  ensure_remaining(buf, 9)?;
+  let table_kind = CompressionTableKind::from_wire(buf.get_u8()).ok_or(WireError::InvalidFormat)?;
+  let generation = buf.get_u64();
+  Ok(ControlPdu::CompressionAck { authority, table_kind, generation })
+}
+
+const fn ensure_no_reason(reason: Option<&str>) -> Result<(), WireError> {
+  if reason.is_some() {
+    return Err(WireError::InvalidFormat);
+  }
+  Ok(())
+}
+
+fn ensure_remaining(buf: &Bytes, len: usize) -> Result<(), WireError> {
+  if buf.remaining() < len {
+    return Err(WireError::Truncated);
+  }
+  Ok(())
 }
 
 fn encode_compression_entries(entries: &[CompressionTableEntry], buf: &mut BytesMut) -> Result<(), WireError> {

--- a/modules/stream-core-kernel/src/dsl/source.rs
+++ b/modules/stream-core-kernel/src/dsl/source.rs
@@ -35,7 +35,7 @@ use super::{
     take_while_definition, take_within_definition, throttle_definition, unzip_definition, unzip_with_definition,
     watch_termination_definition, zip_all_definition, zip_definition, zip_with_index_definition,
   },
-  shape::{Inlet, Outlet, StreamShape},
+  shape::{Inlet, Outlet, PortId, StreamShape},
   sink::Sink,
   source_group_by_sub_flow::SourceGroupBySubFlow,
   source_sub_flow::SourceSubFlow,
@@ -43,11 +43,11 @@ use super::{
   validate_positive_argument,
 };
 use crate::{
-  SubstreamCancelStrategy,
+  StreamPlan, SubstreamCancelStrategy,
   attributes::Attributes,
   r#impl::{
     fusing::{StreamBufferConfig, map_definition},
-    interpreter::{DEFAULT_BOUNDARY_CAPACITY, IslandBoundaryShared, IslandSplitter},
+    interpreter::{DEFAULT_BOUNDARY_CAPACITY, IslandBoundaryShared, IslandCrossing, IslandSplitter, SingleIslandPlan},
     materialization::Stream,
   },
   materialization::DriveOutcome,
@@ -3253,6 +3253,21 @@ fn drain_source_for_lazy_source<Out>(source: Source<Out, StreamNotUsed>) -> Resu
 where
   Out: Send + Sync + 'static, {
   let mut graph = source.graph;
+  let completion = attach_lazy_source_collect_sink::<Out>(&mut graph)?;
+  let plan = graph.into_plan()?;
+  let island_plan = IslandSplitter::split(plan);
+  if island_plan.islands().len() <= 1 {
+    drive_lazy_single_island(island_plan.into_single_plan())?;
+  } else {
+    let (mut islands, crossings) = island_plan.into_parts();
+    drive_lazy_multi_island(&mut islands, crossings)?;
+  }
+  completion.try_take().unwrap_or(Err(StreamError::Failed))
+}
+
+fn attach_lazy_source_collect_sink<Out>(graph: &mut StreamGraph) -> Result<StreamFuture<Vec<Out>>, StreamError>
+where
+  Out: Send + Sync + 'static, {
   let Some(tail_outlet_id) = graph.tail_outlet() else {
     return Err(StreamError::InvalidConnection);
   };
@@ -3262,78 +3277,128 @@ where
   let sink_inlet_id = sink_graph.head_inlet().ok_or(StreamError::InvalidConnection)?;
   graph.append(sink_graph);
   let sink_inlet = Inlet::<Out>::from_id(sink_inlet_id);
+  attach_lazy_source_fanout_branches(graph, tail_outlet_id, &tail_outlet, &sink_inlet);
+  Ok(completion)
+}
 
-  if let Some(expected_fan_out) = graph.expected_fan_out_for_outlet(tail_outlet_id) {
-    for _ in 1..expected_fan_out {
-      // lazy_source でも multi-outlet source の fan-out 契約どおりに各複製を収集する。
-      let branch = map_definition::<Out, Out, _>(|value| value);
-      let branch_inlet = Inlet::<Out>::from_id(branch.inlet);
-      let branch_outlet = Outlet::<Out>::from_id(branch.outlet);
-      graph.push_stage(StageDefinition::Flow(branch));
-      graph.connect_or_panic(&tail_outlet, &branch_inlet, MatCombine::Left);
-      graph.connect_or_panic(&branch_outlet, &sink_inlet, MatCombine::Right);
-    }
+fn attach_lazy_source_fanout_branches<Out>(
+  graph: &mut StreamGraph,
+  tail_outlet_id: PortId,
+  tail_outlet: &Outlet<Out>,
+  sink_inlet: &Inlet<Out>,
+) where
+  Out: Send + Sync + 'static, {
+  let Some(expected_fan_out) = graph.expected_fan_out_for_outlet(tail_outlet_id) else {
+    return;
+  };
+  for _ in 1..expected_fan_out {
+    // lazy_source でも multi-outlet source の fan-out 契約どおりに各複製を収集する。
+    let branch = map_definition::<Out, Out, _>(|value| value);
+    let branch_inlet = Inlet::<Out>::from_id(branch.inlet);
+    let branch_outlet = Outlet::<Out>::from_id(branch.outlet);
+    graph.push_stage(StageDefinition::Flow(branch));
+    graph.connect_or_panic(tail_outlet, &branch_inlet, MatCombine::Left);
+    graph.connect_or_panic(&branch_outlet, sink_inlet, MatCombine::Right);
   }
+}
 
-  let plan = graph.into_plan()?;
-  let island_plan = IslandSplitter::split(plan);
-  if island_plan.islands().len() <= 1 {
-    let mut stream = Stream::new(island_plan.into_single_plan(), StreamBufferConfig::default());
+fn drive_lazy_single_island(plan: StreamPlan) -> Result<(), StreamError> {
+  let mut stream = Stream::new(plan, StreamBufferConfig::default());
+  stream.start()?;
+  let mut idle_budget = 1024_usize;
+  while !stream.state().is_terminal() {
+    idle_budget = drive_lazy_single_stream_once(&mut stream, idle_budget)?;
+  }
+  Ok(())
+}
+
+fn drive_lazy_single_stream_once(stream: &mut Stream, idle_budget: usize) -> Result<usize, StreamError> {
+  match stream.drive() {
+    | DriveOutcome::Progressed => Ok(1024),
+    | DriveOutcome::Idle => decrement_lazy_idle_budget(idle_budget),
+  }
+}
+
+fn drive_lazy_multi_island(
+  islands: &mut Vec<SingleIslandPlan>,
+  crossings: Vec<IslandCrossing>,
+) -> Result<(), StreamError> {
+  let boundaries = wire_lazy_island_boundaries(islands, crossings);
+  let mut streams = start_lazy_island_streams(core::mem::take(islands))?;
+  drive_lazy_streams_until_terminal(&mut streams, &boundaries)
+}
+
+fn wire_lazy_island_boundaries(
+  islands: &mut [SingleIslandPlan],
+  crossings: Vec<IslandCrossing>,
+) -> Vec<(IslandBoundaryShared, usize)> {
+  let mut boundaries = Vec::with_capacity(crossings.len());
+  for crossing in crossings {
+    let upstream_idx = crossing.from_island().as_usize();
+    let downstream_idx = crossing.to_island().as_usize();
+    let boundary_capacity =
+      islands[downstream_idx].input_buffer_capacity_for_inlet(crossing.to_port()).unwrap_or(DEFAULT_BOUNDARY_CAPACITY);
+    let boundary = IslandBoundaryShared::new(boundary_capacity);
+    boundaries.push((boundary.clone(), downstream_idx));
+    islands[upstream_idx].add_boundary_sink(boundary.clone(), crossing.from_port(), crossing.element_type());
+    islands[downstream_idx].add_boundary_source(boundary, crossing.to_port(), crossing.element_type());
+  }
+  boundaries
+}
+
+fn start_lazy_island_streams(islands: Vec<SingleIslandPlan>) -> Result<Vec<Stream>, StreamError> {
+  let mut streams = Vec::with_capacity(islands.len());
+  for island in islands {
+    let mut stream = Stream::new(island.into_stream_plan(), StreamBufferConfig::default());
     stream.start()?;
-    let mut idle_budget = 1024_usize;
-    while !stream.state().is_terminal() {
-      match stream.drive() {
-        | DriveOutcome::Progressed => idle_budget = 1024,
-        | DriveOutcome::Idle => {
-          if idle_budget == 0 {
-            return Err(StreamError::WouldBlock);
-          }
-          idle_budget = idle_budget.saturating_sub(1);
-        },
-      }
-    }
-  } else {
-    let (mut islands, crossings) = island_plan.into_parts();
-    let mut boundaries = Vec::with_capacity(crossings.len());
-    for crossing in crossings {
-      let upstream_idx = crossing.from_island().as_usize();
-      let downstream_idx = crossing.to_island().as_usize();
-      let boundary_capacity = islands[downstream_idx]
-        .input_buffer_capacity_for_inlet(crossing.to_port())
-        .unwrap_or(DEFAULT_BOUNDARY_CAPACITY);
-      let boundary = IslandBoundaryShared::new(boundary_capacity);
-      boundaries.push((boundary.clone(), downstream_idx));
-      islands[upstream_idx].add_boundary_sink(boundary.clone(), crossing.from_port(), crossing.element_type());
-      islands[downstream_idx].add_boundary_source(boundary, crossing.to_port(), crossing.element_type());
-    }
-    let mut streams = Vec::with_capacity(islands.len());
-    for island in islands {
-      let mut stream = Stream::new(island.into_stream_plan(), StreamBufferConfig::default());
-      stream.start()?;
-      streams.push(stream);
-    }
-    let mut idle_budget = 4096_usize;
-    while streams.iter().any(|stream| !stream.state().is_terminal()) {
-      let mut progressed = false;
-      for stream in &mut streams {
-        if !stream.state().is_terminal() && matches!(stream.drive(), DriveOutcome::Progressed) {
-          progressed = true;
-        }
-      }
-      if progressed {
-        idle_budget = 4096;
-      } else if idle_budget == 0
-        || boundaries
-          .iter()
-          .any(|(boundary, downstream_idx)| boundary.is_full() && streams[*downstream_idx].state().is_terminal())
-      {
-        return Err(StreamError::WouldBlock);
-      } else {
-        idle_budget = idle_budget.saturating_sub(1);
-      }
+    streams.push(stream);
+  }
+  Ok(streams)
+}
+
+fn drive_lazy_streams_until_terminal(
+  streams: &mut [Stream],
+  boundaries: &[(IslandBoundaryShared, usize)],
+) -> Result<(), StreamError> {
+  let mut idle_budget = 4096_usize;
+  while streams.iter().any(|stream| !stream.state().is_terminal()) {
+    if drive_lazy_streams_once(streams) {
+      idle_budget = 4096;
+    } else if lazy_streams_would_block(idle_budget, boundaries, streams) {
+      return Err(StreamError::WouldBlock);
+    } else {
+      idle_budget = idle_budget.saturating_sub(1);
     }
   }
-  completion.try_take().unwrap_or(Err(StreamError::Failed))
+  Ok(())
+}
+
+fn drive_lazy_streams_once(streams: &mut [Stream]) -> bool {
+  let mut progressed = false;
+  for stream in streams {
+    if !stream.state().is_terminal() && matches!(stream.drive(), DriveOutcome::Progressed) {
+      progressed = true;
+    }
+  }
+  progressed
+}
+
+fn lazy_streams_would_block(
+  idle_budget: usize,
+  boundaries: &[(IslandBoundaryShared, usize)],
+  streams: &[Stream],
+) -> bool {
+  idle_budget == 0
+    || boundaries
+      .iter()
+      .any(|(boundary, downstream_idx)| boundary.is_full() && streams[*downstream_idx].state().is_terminal())
+}
+
+const fn decrement_lazy_idle_budget(idle_budget: usize) -> Result<usize, StreamError> {
+  if idle_budget == 0 {
+    return Err(StreamError::WouldBlock);
+  }
+  Ok(idle_budget.saturating_sub(1))
 }
 
 impl<Out> GraphStageLogic<StreamNotUsed, Out, StreamNotUsed> for SingleSourceLogic<Out>

--- a/modules/stream-core-kernel/src/dsl/source.rs
+++ b/modules/stream-core-kernel/src/dsl/source.rs
@@ -3259,8 +3259,8 @@ where
   if island_plan.islands().len() <= 1 {
     drive_lazy_single_island(island_plan.into_single_plan())?;
   } else {
-    let (mut islands, crossings) = island_plan.into_parts();
-    drive_lazy_multi_island(&mut islands, crossings)?;
+    let (islands, crossings) = island_plan.into_parts();
+    drive_lazy_multi_island(islands, crossings)?;
   }
   completion.try_take().unwrap_or(Err(StreamError::Failed))
 }
@@ -3320,11 +3320,11 @@ fn drive_lazy_single_stream_once(stream: &mut Stream, idle_budget: usize) -> Res
 }
 
 fn drive_lazy_multi_island(
-  islands: &mut Vec<SingleIslandPlan>,
+  mut islands: Vec<SingleIslandPlan>,
   crossings: Vec<IslandCrossing>,
 ) -> Result<(), StreamError> {
-  let boundaries = wire_lazy_island_boundaries(islands, crossings);
-  let mut streams = start_lazy_island_streams(core::mem::take(islands))?;
+  let boundaries = wire_lazy_island_boundaries(&mut islands, crossings);
+  let mut streams = start_lazy_island_streams(islands)?;
   drive_lazy_streams_until_terminal(&mut streams, &boundaries)
 }
 

--- a/modules/stream-core-kernel/src/impl/interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter.rs
@@ -13,4 +13,4 @@ mod island_splitter;
 mod outlet_dispatch_state;
 
 pub(crate) use island_boundary::{DEFAULT_BOUNDARY_CAPACITY, IslandBoundaryShared};
-pub(crate) use island_splitter::{IslandSplitter, SingleIslandPlan};
+pub(crate) use island_splitter::{IslandCrossing, IslandSplitter, SingleIslandPlan};

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
@@ -40,6 +40,16 @@ struct FlowStageStep {
   progressed:       bool,
 }
 
+struct SinkStagePorts {
+  inlet:      PortId,
+  input_type: TypeId,
+}
+
+enum SinkPushOutcome {
+  Decision(SinkDecision),
+  Progressed,
+}
+
 /// Executes a stream graph using a port-driven runtime.
 pub(crate) struct GraphInterpreter {
   stages:                 Vec<StageDefinition>,
@@ -215,134 +225,130 @@ impl GraphInterpreter {
       return DriveOutcome::Idle;
     }
 
-    self.tick_count = self.tick_count.saturating_add(1);
-
-    if let Err(error) = self.tick_restart_windows() {
-      self.fail(&error);
-      return DriveOutcome::Progressed;
-    }
-
-    let mut progressed = false;
-
-    match self.tick_flow_stages() {
-      | Ok(true) => progressed = true,
-      | Ok(false) => {},
+    match self.drive_running() {
+      | Ok(progressed) => Self::drive_outcome(progressed),
       | Err(error) => {
         self.fail(&error);
-        return DriveOutcome::Progressed;
+        DriveOutcome::Progressed
       },
     }
+  }
 
-    if !self.on_start_done {
-      match self.start_sinks() {
-        | Ok(()) => {
-          self.on_start_done = true;
-          progressed = true;
-        },
-        | Err(error) => {
-          self.fail(&error);
-          return DriveOutcome::Progressed;
-        },
-      }
-    }
+  fn drive_running(&mut self) -> Result<bool, StreamError> {
+    self.tick_count = self.tick_count.saturating_add(1);
+    self.tick_restart_windows()?;
+
+    let mut progressed = self.tick_flow_stages()?;
+    progressed |= self.start_sinks_if_needed()?;
 
     if self.state != StreamState::Running {
-      return DriveOutcome::Progressed;
+      return Ok(true);
     }
 
-    let pull_result = if self.demand.has_demand() {
-      self.pull_sources_if_needed()
-    } else if self.has_flow_requesting_upstream_drain() {
-      self.pull_sources_for_flows_requesting_drain()
-    } else {
-      Ok(false)
-    };
-    if self.demand.has_demand() || self.has_flow_requesting_upstream_drain() {
-      match pull_result {
-        | Ok(did_pull) => {
-          if did_pull {
-            progressed = true;
-          }
-        },
-        | Err(error) => {
-          self.fail(&error);
-          return DriveOutcome::Progressed;
-        },
-      }
+    progressed |= self.pull_and_drive_flows_if_needed()?;
+    progressed |= self.complete_if_runtime_work_done();
+    progressed |= self.drive_sinks_once()?;
+    progressed |= self.finish_sources_done_stream()?;
 
-      loop {
-        match self.drive_flow_stages_once() {
-          | Ok(true) => progressed = true,
-          | Ok(false) => break,
-          | Err(error) => {
-            self.fail(&error);
-            return DriveOutcome::Progressed;
-          },
-        }
-      }
+    Ok(progressed)
+  }
+
+  const fn drive_outcome(progressed: bool) -> DriveOutcome {
+    if progressed { DriveOutcome::Progressed } else { DriveOutcome::Idle }
+  }
+
+  fn start_sinks_if_needed(&mut self) -> Result<bool, StreamError> {
+    if self.on_start_done {
+      return Ok(false);
     }
+    self.start_sinks()?;
+    self.on_start_done = true;
+    Ok(true)
+  }
 
-    if self.state == StreamState::Running
-      && self.all_sinks_done()
-      && self.all_sources_done()
-      && !self.source_restart_waiting()
-      && !self.sink_restart_waiting()
-      && !self.flow_order.iter().any(|stage_index| self.flow_restart_waiting(*stage_index))
-      && !self.has_flow_requesting_upstream_drain()
-      && self.all_edge_buffers_empty()
-      && !self.flow_order.iter().any(|stage_index| self.flow_has_pending_output(*stage_index))
-    {
-      self.state = StreamState::Completed;
+  fn pull_and_drive_flows_if_needed(&mut self) -> Result<bool, StreamError> {
+    let pull_result = self.pull_sources_for_current_need();
+    if !self.flow_drive_requested() {
+      return Ok(false);
+    }
+    let did_pull = pull_result?;
+    let drove_flows = self.drive_flow_stages_until_idle()?;
+    Ok(did_pull || drove_flows)
+  }
+
+  fn pull_sources_for_current_need(&mut self) -> Result<bool, StreamError> {
+    if self.demand.has_demand() {
+      return self.pull_sources_if_needed();
+    }
+    if self.has_flow_requesting_upstream_drain() {
+      return self.pull_sources_for_flows_requesting_drain();
+    }
+    Ok(false)
+  }
+
+  fn flow_drive_requested(&self) -> bool {
+    self.demand.has_demand() || self.has_flow_requesting_upstream_drain()
+  }
+
+  fn drive_flow_stages_until_idle(&mut self) -> Result<bool, StreamError> {
+    let mut progressed = false;
+    while self.drive_flow_stages_once()? {
       progressed = true;
     }
+    Ok(progressed)
+  }
 
-    match self.drive_sinks_once() {
-      | Ok(true) => progressed = true,
-      | Ok(false) => {},
-      | Err(error) => {
-        self.fail(&error);
-        return DriveOutcome::Progressed;
-      },
+  fn complete_if_runtime_work_done(&mut self) -> bool {
+    if !self.runtime_work_done() {
+      return false;
+    }
+    self.state = StreamState::Completed;
+    true
+  }
+
+  fn runtime_work_done(&self) -> bool {
+    self.state == StreamState::Running
+      && self.all_sinks_done()
+      && self.all_sources_done()
+      && !self.restart_waiting()
+      && !self.has_flow_requesting_upstream_drain()
+      && self.all_edge_buffers_empty()
+      && !self.flow_has_any_pending_output()
+  }
+
+  fn restart_waiting(&self) -> bool {
+    self.source_restart_waiting() || self.sink_restart_waiting() || self.flow_restart_waiting_any()
+  }
+
+  fn flow_restart_waiting_any(&self) -> bool {
+    self.flow_order.iter().any(|stage_index| self.flow_restart_waiting(*stage_index))
+  }
+
+  fn flow_has_any_pending_output(&self) -> bool {
+    self.flow_order.iter().any(|stage_index| self.flow_has_pending_output(*stage_index))
+  }
+
+  fn finish_sources_done_stream(&mut self) -> Result<bool, StreamError> {
+    if !self.sources_done_stream_ready_to_finish() {
+      return Ok(false);
     }
 
-    if self.all_sources_done()
+    let mut progressed = self.drive_flow_stages_until_idle()?;
+    if self.all_edge_buffers_empty() {
+      progressed |= self.finish_sinks()?;
+      if self.all_sinks_done() {
+        self.state = StreamState::Completed;
+        progressed = true;
+      }
+    }
+    Ok(progressed)
+  }
+
+  fn sources_done_stream_ready_to_finish(&self) -> bool {
+    self.all_sources_done()
       && self.state == StreamState::Running
-      && !self.source_restart_waiting()
-      && !self.sink_restart_waiting()
-      && !self.flow_order.iter().any(|stage_index| self.flow_restart_waiting(*stage_index))
-      && !self.flow_order.iter().any(|stage_index| self.flow_has_pending_output(*stage_index))
-    {
-      loop {
-        match self.drive_flow_stages_once() {
-          | Ok(true) => progressed = true,
-          | Ok(false) => break,
-          | Err(error) => {
-            self.fail(&error);
-            return DriveOutcome::Progressed;
-          },
-        }
-      }
-
-      if self.all_edge_buffers_empty() {
-        match self.finish_sinks() {
-          | Ok(did_finish) => {
-            if did_finish {
-              progressed = true;
-            }
-            if self.all_sinks_done() {
-              self.state = StreamState::Completed;
-              progressed = true;
-            }
-          },
-          | Err(error) => {
-            self.fail(&error);
-            return DriveOutcome::Progressed;
-          },
-        }
-      }
-    }
-
-    if progressed { DriveOutcome::Progressed } else { DriveOutcome::Idle }
+      && !self.restart_waiting()
+      && !self.flow_has_any_pending_output()
   }
 
   fn tick_flow_stages(&mut self) -> Result<bool, StreamError> {
@@ -892,110 +898,131 @@ impl GraphInterpreter {
     }
 
     let sink_index = self.sink_indices[sink_position];
-    let (sink_inlet, sink_input_type) = match &self.stages[sink_index] {
-      | StageDefinition::Sink(sink) => (sink.inlet, sink.input_type),
-      | _ => return Err(StreamError::InvalidConnection),
-    };
+    let ports = self.sink_stage_ports(sink_index)?;
     if self.sink_restart_waiting_at(sink_index) {
       return Ok(false);
     }
-    let mut progressed = false;
+
+    let progressed = self.tick_sink_stage(sink_position, sink_index)?;
+    if !self.demand.has_demand() {
+      return Ok(progressed);
+    }
+
+    if !self.sink_can_accept_input(sink_index)? {
+      return self.finish_sink_if_input_exhausted(sink_position, sink_index, progressed);
+    }
+
+    let Some((_, value)) = self.poll_from_incoming_edges(ports.inlet, None)? else {
+      return self.finish_sink_if_input_exhausted(sink_position, sink_index, progressed);
+    };
+    if value.as_ref().type_id() != ports.input_type {
+      return Err(StreamError::TypeMismatch);
+    }
+    self.demand.consume(1)?;
+
+    match self.push_sink_input(sink_position, sink_index, value)? {
+      | SinkPushOutcome::Decision(decision) => self.apply_sink_decision(sink_position, sink_index, decision),
+      | SinkPushOutcome::Progressed => Ok(true),
+    }
+  }
+
+  fn sink_stage_ports(&self, sink_index: usize) -> Result<SinkStagePorts, StreamError> {
+    match &self.stages[sink_index] {
+      | StageDefinition::Sink(sink) => Ok(SinkStagePorts { inlet: sink.inlet, input_type: sink.input_type }),
+      | _ => Err(StreamError::InvalidConnection),
+    }
+  }
+
+  fn tick_sink_stage(&mut self, sink_position: usize, sink_index: usize) -> Result<bool, StreamError> {
     let on_tick_result = {
       let StageDefinition::Sink(sink) = &mut self.stages[sink_index] else {
         return Err(StreamError::InvalidConnection);
       };
       sink.logic.on_tick(&mut self.demand)
     };
-    let sink_tick_progressed = match on_tick_result {
-      | Ok(sink_tick_progressed) => sink_tick_progressed,
+    match on_tick_result {
+      | Ok(sink_tick_progressed) => Ok(sink_tick_progressed),
       | Err(StreamError::StreamDetached) => {
         self.detach_sink_position(sink_position)?;
-        return Ok(true);
+        Ok(true)
       },
-      | Err(error) => match self.handle_sink_failure(sink_index, error)? {
-        | FailureDisposition::Continue => return Ok(true),
-        | FailureDisposition::Complete => {
-          self.complete_sink_position(sink_position)?;
-          return Ok(true);
-        },
-        | FailureDisposition::Fail(error) => return Err(error),
+      | Err(error) => self.apply_sink_failure(sink_position, sink_index, error),
+    }
+  }
+
+  fn apply_sink_failure(
+    &mut self,
+    sink_position: usize,
+    sink_index: usize,
+    error: StreamError,
+  ) -> Result<bool, StreamError> {
+    match self.handle_sink_failure(sink_index, error)? {
+      | FailureDisposition::Continue => Ok(true),
+      | FailureDisposition::Complete => {
+        self.complete_sink_position(sink_position)?;
+        Ok(true)
       },
-    };
-    if sink_tick_progressed {
-      progressed = true;
+      | FailureDisposition::Fail(error) => Err(error),
     }
-    if !self.demand.has_demand() {
+  }
+
+  fn sink_can_accept_input(&self, sink_index: usize) -> Result<bool, StreamError> {
+    let StageDefinition::Sink(sink) = &self.stages[sink_index] else {
+      return Err(StreamError::InvalidConnection);
+    };
+    Ok(sink.logic.can_accept_input())
+  }
+
+  fn finish_sink_if_input_exhausted(
+    &mut self,
+    sink_position: usize,
+    sink_index: usize,
+    progressed: bool,
+  ) -> Result<bool, StreamError> {
+    if !self.stage_input_exhausted(sink_index) {
       return Ok(progressed);
     }
 
-    let sink_can_accept = {
-      let StageDefinition::Sink(sink) = &self.stages[sink_index] else {
-        return Err(StreamError::InvalidConnection);
-      };
-      sink.logic.can_accept_input()
-    };
-    if !sink_can_accept {
-      if self.stage_input_exhausted(sink_index) {
-        let upstream_progressed = self.notify_sink_upstream_finish(sink_position)?;
-        if self.sink_has_pending_work(sink_index)? {
-          return Ok(progressed || upstream_progressed);
-        }
-        self.complete_sink_position(sink_position)?;
-        return Ok(true);
-      }
-      return Ok(progressed);
+    let upstream_progressed = self.notify_sink_upstream_finish(sink_position)?;
+    if self.sink_has_pending_work(sink_index)? {
+      return Ok(progressed || upstream_progressed);
     }
+    self.complete_sink_position(sink_position)?;
+    Ok(true)
+  }
 
-    let Some((_, value)) = self.poll_from_incoming_edges(sink_inlet, None)? else {
-      if self.stage_input_exhausted(sink_index) {
-        let upstream_progressed = self.notify_sink_upstream_finish(sink_position)?;
-        if self.sink_has_pending_work(sink_index)? {
-          return Ok(progressed || upstream_progressed);
-        }
-        self.complete_sink_position(sink_position)?;
-        return Ok(true);
-      }
-      return Ok(progressed);
-    };
-    if value.as_ref().type_id() != sink_input_type {
-      return Err(StreamError::TypeMismatch);
-    }
-    self.demand.consume(1)?;
-
+  fn push_sink_input(
+    &mut self,
+    sink_position: usize,
+    sink_index: usize,
+    value: DynValue,
+  ) -> Result<SinkPushOutcome, StreamError> {
     let decision_result = {
       let StageDefinition::Sink(sink) = &mut self.stages[sink_index] else {
         return Err(StreamError::InvalidConnection);
       };
       sink.logic.on_push(value, &mut self.demand)
     };
-    let decision = match decision_result {
-      | Ok(decision) => decision,
+    match decision_result {
+      | Ok(decision) => Ok(SinkPushOutcome::Decision(decision)),
       | Err(StreamError::StreamDetached) => {
         self.detach_sink_position(sink_position)?;
-        return Ok(true);
+        Ok(SinkPushOutcome::Progressed)
       },
-      | Err(error) => match self.handle_sink_failure(sink_index, error)? {
-        | FailureDisposition::Continue => return Ok(true),
-        | FailureDisposition::Complete => {
-          self.complete_sink_position(sink_position)?;
-          return Ok(true);
-        },
-        | FailureDisposition::Fail(error) => return Err(error),
-      },
-    };
+      | Err(error) => self.apply_sink_failure(sink_position, sink_index, error).map(|_| SinkPushOutcome::Progressed),
+    }
+  }
+
+  fn apply_sink_decision(
+    &mut self,
+    sink_position: usize,
+    sink_index: usize,
+    decision: SinkDecision,
+  ) -> Result<bool, StreamError> {
     match decision {
       | SinkDecision::Continue => Ok(true),
       | SinkDecision::Complete => {
-        let (should_restart, complete_on_exhaustion) = {
-          let StageDefinition::Sink(sink) = &mut self.stages[sink_index] else {
-            return Err(StreamError::InvalidConnection);
-          };
-          if let Some(restart) = &mut sink.restart {
-            (restart.schedule(self.tick_count), restart.complete_on_max_restarts())
-          } else {
-            (false, true)
-          }
-        };
+        let (should_restart, complete_on_exhaustion) = self.schedule_sink_restart_or_complete(sink_index)?;
         if should_restart {
           return Ok(true);
         }
@@ -1006,6 +1033,19 @@ impl GraphInterpreter {
         Ok(true)
       },
     }
+  }
+
+  fn schedule_sink_restart_or_complete(&mut self, sink_index: usize) -> Result<(bool, bool), StreamError> {
+    let StageDefinition::Sink(sink) = &mut self.stages[sink_index] else {
+      return Err(StreamError::InvalidConnection);
+    };
+    Ok(
+      if let Some(restart) = &mut sink.restart {
+        (restart.schedule(self.tick_count), restart.complete_on_max_restarts())
+      } else {
+        (false, true)
+      },
+    )
   }
 
   fn finish_sinks(&mut self) -> Result<bool, StreamError> {

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
@@ -31,6 +31,12 @@ struct FlowStagePorts {
   output_type: TypeId,
 }
 
+#[derive(Clone, Copy)]
+struct SourceStagePorts {
+  outlet:      PortId,
+  output_type: TypeId,
+}
+
 #[derive(Default)]
 struct FlowStageStep {
   outputs:          Vec<DynValue>,
@@ -510,80 +516,93 @@ impl GraphInterpreter {
     let mut progressed = false;
 
     for &source_position in source_positions {
-      if self.source_done[source_position] {
-        continue;
-      }
-      if self.source_restart_waiting_at(source_position) {
-        continue;
-      }
-
-      let source_index = self.source_indices[source_position];
-      let (source_outlet, source_output_type) = match &self.stages[source_index] {
-        | StageDefinition::Source(source) => (source.outlet, source.output_type),
-        | _ => return Err(StreamError::InvalidConnection),
-      };
-
-      if self.has_buffered_outgoing(source_outlet) {
-        continue;
-      }
-
-      let pulled_result = {
-        let StageDefinition::Source(source) = &mut self.stages[source_index] else {
-          return Err(StreamError::InvalidConnection);
-        };
-        source.logic.pull()
-      };
-
-      let pulled = match pulled_result {
-        | Ok(pulled) => pulled,
-        | Err(StreamError::WouldBlock) => continue,
-        | Err(error) => match self.handle_source_failure(source_position, error)? {
-          | FailureDisposition::Continue => {
-            progressed = true;
-            continue;
-          },
-          | FailureDisposition::Complete => {
-            self.complete_source(source_position)?;
-            progressed = true;
-            continue;
-          },
-          | FailureDisposition::Fail(error) => return Err(error),
-        },
-      };
-
-      match pulled {
-        | Some(value) => {
-          if value.as_ref().type_id() != source_output_type {
-            return Err(StreamError::TypeMismatch);
-          }
-          self.offer_to_next_outgoing_edge(source_outlet, value)?;
-          progressed = true;
-        },
-        | None => {
-          let (should_restart, complete_on_exhaustion) = {
-            let StageDefinition::Source(source) = &mut self.stages[source_index] else {
-              return Err(StreamError::InvalidConnection);
-            };
-            if let Some(restart) = &mut source.restart {
-              (restart.schedule(self.tick_count), restart.complete_on_max_restarts())
-            } else {
-              (false, true)
-            }
-          };
-          if should_restart {
-            progressed = true;
-            continue;
-          }
-          if !complete_on_exhaustion {
-            return Err(StreamError::Failed);
-          }
-          self.complete_source(source_position)?;
-          progressed = true;
-        },
-      }
+      progressed |= self.pull_source_position_if_needed(source_position)?;
     }
 
     Ok(progressed)
+  }
+
+  fn pull_source_position_if_needed(&mut self, source_position: usize) -> Result<bool, StreamError> {
+    if !self.source_ready_to_pull(source_position) {
+      return Ok(false);
+    }
+
+    let source_index = self.source_indices[source_position];
+    let ports = self.source_stage_ports(source_index)?;
+    if self.has_buffered_outgoing(ports.outlet) {
+      return Ok(false);
+    }
+
+    match self.pull_source_value(source_index) {
+      | Ok(Some(value)) => self.emit_source_value(ports, value),
+      | Ok(None) => self.complete_or_restart_source(source_position, source_index),
+      | Err(StreamError::WouldBlock) => Ok(false),
+      | Err(error) => self.apply_source_failure(source_position, error),
+    }
+  }
+
+  fn source_ready_to_pull(&self, source_position: usize) -> bool {
+    !self.source_done[source_position] && !self.source_restart_waiting_at(source_position)
+  }
+
+  fn source_stage_ports(&self, source_index: usize) -> Result<SourceStagePorts, StreamError> {
+    match &self.stages[source_index] {
+      | StageDefinition::Source(source) => {
+        Ok(SourceStagePorts { outlet: source.outlet, output_type: source.output_type })
+      },
+      | _ => Err(StreamError::InvalidConnection),
+    }
+  }
+
+  fn pull_source_value(&mut self, source_index: usize) -> Result<Option<DynValue>, StreamError> {
+    let StageDefinition::Source(source) = &mut self.stages[source_index] else {
+      return Err(StreamError::InvalidConnection);
+    };
+    source.logic.pull()
+  }
+
+  fn emit_source_value(&mut self, ports: SourceStagePorts, value: DynValue) -> Result<bool, StreamError> {
+    if value.as_ref().type_id() != ports.output_type {
+      return Err(StreamError::TypeMismatch);
+    }
+    self.offer_to_next_outgoing_edge(ports.outlet, value)?;
+    Ok(true)
+  }
+
+  fn complete_or_restart_source(&mut self, source_position: usize, source_index: usize) -> Result<bool, StreamError> {
+    let (should_restart, complete_on_exhaustion) = self.schedule_source_restart_or_complete(source_index)?;
+    if should_restart {
+      return Ok(true);
+    }
+    if !complete_on_exhaustion {
+      return Err(StreamError::Failed);
+    }
+    self.complete_source(source_position)?;
+    Ok(true)
+  }
+
+  fn schedule_source_restart_or_complete(&mut self, source_index: usize) -> Result<(bool, bool), StreamError> {
+    let StageDefinition::Source(source) = &mut self.stages[source_index] else {
+      return Err(StreamError::InvalidConnection);
+    };
+    Ok(
+      if let Some(restart) = &mut source.restart {
+        (restart.schedule(self.tick_count), restart.complete_on_max_restarts())
+      } else {
+        (false, true)
+      },
+    )
+  }
+
+  fn apply_source_failure(&mut self, source_position: usize, error: StreamError) -> Result<bool, StreamError> {
+    match self.handle_source_failure(source_position, error)? {
+      | FailureDisposition::Continue => Ok(true),
+      | FailureDisposition::Complete => {
+        self.complete_source(source_position)?;
+        Ok(true)
+      },
+      | FailureDisposition::Fail(error) => Err(error),
+    }
   }
 
   fn drive_flow_stages_once(&mut self) -> Result<bool, StreamError> {

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
@@ -720,9 +720,7 @@ impl GraphInterpreter {
         Ok(())
       },
       | FailureDisposition::Complete => {
-        if !step.force_shutdown && !self.all_sources_done() {
-          self.set_all_sources_done()?;
-        }
+        self.set_all_sources_done()?;
         step.progressed = true;
         step.skip_stage_input = true;
         step.force_shutdown = true;
@@ -751,12 +749,7 @@ impl GraphInterpreter {
       return Err(StreamError::TypeMismatch);
     }
 
-    let apply_result = {
-      let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
-        return Err(StreamError::InvalidConnection);
-      };
-      flow.logic.apply_with_edge(edge_index, input)
-    };
+    let apply_result = self.apply_flow_logic_with_edge(stage_index, edge_index, input);
     match apply_result {
       | Ok(outputs) => {
         step.outputs.extend(outputs);
@@ -764,6 +757,18 @@ impl GraphInterpreter {
       },
       | Err(error) => self.apply_flow_failure_to_step(stage_index, &error, step),
     }
+  }
+
+  fn apply_flow_logic_with_edge(
+    &mut self,
+    stage_index: usize,
+    edge_index: usize,
+    input: DynValue,
+  ) -> Result<Vec<DynValue>, StreamError> {
+    let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
+      return Err(StreamError::InvalidConnection);
+    };
+    flow.logic.apply_with_edge(edge_index, input)
   }
 
   fn flow_can_accept_input(&self, stage_index: usize, skip_stage_input: bool) -> bool {
@@ -814,9 +819,7 @@ impl GraphInterpreter {
     match self.handle_flow_failure(stage_index, error)? {
       | FailureDisposition::Continue => Ok(true),
       | FailureDisposition::Complete => {
-        if !self.all_sources_done() {
-          self.set_all_sources_done()?;
-        }
+        self.set_all_sources_done()?;
         self.shutdown_flow_stage(stage_index)?;
         self.maybe_finish_flow_stage(stage_index);
         Ok(true)

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
@@ -632,6 +632,11 @@ impl GraphInterpreter {
   ) -> Result<bool, StreamError> {
     let mut step = FlowStageStep::default();
     self.append_flow_async_outputs(stage_index, &mut step)?;
+    if step.force_shutdown {
+      let shutdown_requested = self.take_flow_shutdown_request(stage_index)?;
+      let finished = self.finish_flow_stage_without_outputs(stage_index, shutdown_requested, true)?;
+      return Ok(step.progressed || finished);
+    }
     self.append_flow_timer_outputs(stage_index, &mut step)?;
     self.apply_flow_stage_input_if_ready(stage_index, ports, &mut step)?;
     if self.drain_flow_stage_pending_if_ready(stage_index, outgoing_buffered, &mut step)? {
@@ -906,6 +911,9 @@ impl GraphInterpreter {
     }
 
     let progressed = self.tick_sink_stage(sink_position, sink_index)?;
+    if self.sink_done[sink_position] {
+      return Ok(progressed);
+    }
     if !self.demand.has_demand() {
       return Ok(progressed);
     }

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
@@ -1,4 +1,5 @@
 use alloc::{vec, vec::Vec};
+use core::any::TypeId;
 
 mod failure_restart;
 #[cfg(test)]
@@ -22,6 +23,22 @@ use crate::{
   snapshot::RunningInterpreter,
   stream_ref::StreamRefSettings,
 };
+
+struct FlowStagePorts {
+  inlet:       PortId,
+  outlet:      PortId,
+  input_type:  TypeId,
+  output_type: TypeId,
+}
+
+#[derive(Default)]
+struct FlowStageStep {
+  outputs:          Vec<DynValue>,
+  consumed_input:   bool,
+  skip_stage_input: bool,
+  force_shutdown:   bool,
+  progressed:       bool,
+}
 
 /// Executes a stream graph using a port-driven runtime.
 pub(crate) struct GraphInterpreter {
@@ -568,216 +585,292 @@ impl GraphInterpreter {
 
     for flow_index in 0..self.flow_order.len() {
       let stage_index = self.flow_order[flow_index];
-      if self.flow_done_at(stage_index) {
-        continue;
-      }
-      if self.flow_restart_waiting(stage_index) {
-        continue;
-      }
-      if self.mark_flow_source_done(stage_index)? {
+      if self.drive_flow_stage_once(stage_index)? {
         progressed = true;
       }
-      let (flow_inlet, flow_outlet, flow_input_type, flow_output_type) = match &self.stages[stage_index] {
-        | StageDefinition::Flow(flow) => (flow.inlet, flow.outlet, flow.input_type, flow.output_type),
-        | _ => continue,
-      };
-      let outgoing_buffered = self.has_buffered_outgoing(flow_outlet);
-      let can_accept_input_while_output_buffered = match &self.stages[stage_index] {
-        | StageDefinition::Flow(flow) => flow.logic.can_accept_input_while_output_buffered(),
-        | _ => false,
-      };
-      if outgoing_buffered && !can_accept_input_while_output_buffered {
-        continue;
-      }
-
-      let mut consumed_input = false;
-      let mut outputs = Vec::new();
-      let mut skip_stage_input = false;
-      let mut force_shutdown = false;
-
-      let async_outputs = {
-        let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
-          return Err(StreamError::InvalidConnection);
-        };
-        flow.logic.on_async_callback()
-      };
-      outputs.extend(match async_outputs {
-        | Ok(outputs) => outputs,
-        | Err(error) => match self.handle_flow_failure(stage_index, &error)? {
-          | FailureDisposition::Continue => {
-            progressed = true;
-            skip_stage_input = true;
-            Vec::new()
-          },
-          | FailureDisposition::Complete => {
-            if !force_shutdown && !self.all_sources_done() {
-              self.set_all_sources_done()?;
-            }
-            progressed = true;
-            skip_stage_input = true;
-            force_shutdown = true;
-            Vec::new()
-          },
-          | FailureDisposition::Fail(error) => return Err(error),
-        },
-      });
-
-      let timer_outputs = {
-        let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
-          return Err(StreamError::InvalidConnection);
-        };
-        flow.logic.on_timer()
-      };
-      outputs.extend(match timer_outputs {
-        | Ok(outputs) => outputs,
-        | Err(error) => match self.handle_flow_failure(stage_index, &error)? {
-          | FailureDisposition::Continue => {
-            progressed = true;
-            skip_stage_input = true;
-            Vec::new()
-          },
-          | FailureDisposition::Complete => {
-            if !force_shutdown && !self.all_sources_done() {
-              self.set_all_sources_done()?;
-            }
-            progressed = true;
-            skip_stage_input = true;
-            force_shutdown = true;
-            Vec::new()
-          },
-          | FailureDisposition::Fail(error) => return Err(error),
-        },
-      });
-
-      let can_accept_input = if skip_stage_input {
-        false
-      } else {
-        match &self.stages[stage_index] {
-          | StageDefinition::Flow(flow) => !self.flow_source_done_at(stage_index) && flow.logic.can_accept_input(),
-          | _ => false,
-        }
-      };
-
-      let preferred_input_slot = match &self.stages[stage_index] {
-        | StageDefinition::Flow(flow) => flow.logic.preferred_input_edge_slot(),
-        | _ => None,
-      };
-      if can_accept_input
-        && let Some((edge_index, input)) = self.poll_from_incoming_edges(flow_inlet, preferred_input_slot)?
-      {
-        consumed_input = true;
-        if input.as_ref().type_id() != flow_input_type {
-          return Err(StreamError::TypeMismatch);
-        }
-
-        let apply_result = {
-          let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
-            return Err(StreamError::InvalidConnection);
-          };
-          flow.logic.apply_with_edge(edge_index, input)
-        };
-        let input_outputs = match apply_result {
-          | Ok(outputs) => outputs,
-          | Err(error) => match self.handle_flow_failure(stage_index, &error)? {
-            | FailureDisposition::Continue => {
-              progressed = true;
-              skip_stage_input = true;
-              Vec::new()
-            },
-            | FailureDisposition::Complete => {
-              if !force_shutdown && !self.all_sources_done() {
-                self.set_all_sources_done()?;
-              }
-              progressed = true;
-              skip_stage_input = true;
-              force_shutdown = true;
-              Vec::new()
-            },
-            | FailureDisposition::Fail(error) => return Err(error),
-          },
-        };
-        outputs.extend(input_outputs);
-      }
-
-      // apply で新しい出力が出ず、未送信バッファもなく、この tick で input apply を明示的に
-      // skip していないときだけ drain_pending に進める。
-      let can_drain_pending = outputs.is_empty() && !outgoing_buffered && !skip_stage_input;
-      if can_drain_pending {
-        let drain_result = {
-          let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
-            return Err(StreamError::InvalidConnection);
-          };
-          flow.logic.drain_pending()
-        };
-        outputs = match drain_result {
-          | Ok(outputs) => outputs,
-          | Err(error) => match self.handle_flow_failure(stage_index, &error)? {
-            | FailureDisposition::Continue => {
-              progressed = true;
-              continue;
-            },
-            | FailureDisposition::Complete => {
-              if !self.all_sources_done() {
-                self.set_all_sources_done()?;
-              }
-              self.shutdown_flow_stage(stage_index)?;
-              self.maybe_finish_flow_stage(stage_index);
-              progressed = true;
-              continue;
-            },
-            | FailureDisposition::Fail(error) => return Err(error),
-          },
-        };
-      }
-
-      if consumed_input {
-        progressed = true;
-      }
-
-      let shutdown_requested = {
-        let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
-          return Err(StreamError::InvalidConnection);
-        };
-        flow.logic.take_shutdown_request()
-      };
-      if outputs.is_empty() {
-        if shutdown_requested || force_shutdown {
-          self.shutdown_flow_stage(stage_index)?;
-          progressed = true;
-        }
-        if self.maybe_finish_flow_stage(stage_index) {
-          progressed = true;
-        }
-        continue;
-      }
-
-      let outgoing_edges = self.outgoing_edge_indices(flow_outlet)?;
-      for output in outputs {
-        if output.as_ref().type_id() != flow_output_type {
-          return Err(StreamError::TypeMismatch);
-        }
-        let selected_slot = {
-          let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
-            return Err(StreamError::InvalidConnection);
-          };
-          flow.logic.take_next_output_edge_slot()
-        };
-        match selected_slot {
-          | Some(slot) => {
-            let target = outgoing_edges[slot % outgoing_edges.len()];
-            self.offer_to_outgoing_edge(target, output)?;
-          },
-          | None => self.offer_to_next_outgoing_edge(flow_outlet, output)?,
-        }
-      }
-      if shutdown_requested || force_shutdown {
-        self.shutdown_flow_stage(stage_index)?;
-      }
-      self.maybe_finish_flow_stage(stage_index);
-      progressed = true;
     }
 
     Ok(progressed)
+  }
+
+  fn drive_flow_stage_once(&mut self, stage_index: usize) -> Result<bool, StreamError> {
+    if self.flow_stage_inactive(stage_index) {
+      return Ok(false);
+    }
+
+    let source_progressed = self.mark_flow_source_done(stage_index)?;
+    let Some(ports) = self.flow_stage_ports(stage_index) else {
+      return Ok(source_progressed);
+    };
+    let outgoing_buffered = self.has_buffered_outgoing(ports.outlet);
+    if self.flow_stage_output_backpressured(stage_index, outgoing_buffered) {
+      return Ok(source_progressed);
+    }
+
+    let stage_progressed = self.drive_ready_flow_stage_once(stage_index, &ports, outgoing_buffered)?;
+    Ok(source_progressed || stage_progressed)
+  }
+
+  fn flow_stage_inactive(&self, stage_index: usize) -> bool {
+    self.flow_done_at(stage_index) || self.flow_restart_waiting(stage_index)
+  }
+
+  fn flow_stage_output_backpressured(&self, stage_index: usize, outgoing_buffered: bool) -> bool {
+    outgoing_buffered && !self.flow_can_accept_input_while_output_buffered(stage_index)
+  }
+
+  fn drive_ready_flow_stage_once(
+    &mut self,
+    stage_index: usize,
+    ports: &FlowStagePorts,
+    outgoing_buffered: bool,
+  ) -> Result<bool, StreamError> {
+    let mut step = FlowStageStep::default();
+    self.append_flow_async_outputs(stage_index, &mut step)?;
+    self.append_flow_timer_outputs(stage_index, &mut step)?;
+    self.apply_flow_stage_input_if_ready(stage_index, ports, &mut step)?;
+    if self.drain_flow_stage_pending_if_ready(stage_index, outgoing_buffered, &mut step)? {
+      return Ok(true);
+    }
+
+    let progressed = step.consumed_input || step.progressed;
+    let shutdown_requested = self.take_flow_shutdown_request(stage_index)?;
+    if step.outputs.is_empty() {
+      let finished = self.finish_flow_stage_without_outputs(stage_index, shutdown_requested, step.force_shutdown)?;
+      return Ok(progressed || finished);
+    }
+
+    self.emit_flow_stage_outputs(stage_index, ports, step.outputs)?;
+    if shutdown_requested || step.force_shutdown {
+      self.shutdown_flow_stage(stage_index)?;
+    }
+    self.maybe_finish_flow_stage(stage_index);
+    Ok(true)
+  }
+
+  fn flow_stage_ports(&self, stage_index: usize) -> Option<FlowStagePorts> {
+    match &self.stages[stage_index] {
+      | StageDefinition::Flow(flow) => Some(FlowStagePorts {
+        inlet:       flow.inlet,
+        outlet:      flow.outlet,
+        input_type:  flow.input_type,
+        output_type: flow.output_type,
+      }),
+      | _ => None,
+    }
+  }
+
+  fn flow_can_accept_input_while_output_buffered(&self, stage_index: usize) -> bool {
+    match &self.stages[stage_index] {
+      | StageDefinition::Flow(flow) => flow.logic.can_accept_input_while_output_buffered(),
+      | _ => false,
+    }
+  }
+
+  fn append_flow_async_outputs(&mut self, stage_index: usize, step: &mut FlowStageStep) -> Result<(), StreamError> {
+    let async_outputs = {
+      let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
+        return Err(StreamError::InvalidConnection);
+      };
+      flow.logic.on_async_callback()
+    };
+    self.append_flow_hook_outputs(stage_index, async_outputs, step)
+  }
+
+  fn append_flow_timer_outputs(&mut self, stage_index: usize, step: &mut FlowStageStep) -> Result<(), StreamError> {
+    let timer_outputs = {
+      let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
+        return Err(StreamError::InvalidConnection);
+      };
+      flow.logic.on_timer()
+    };
+    self.append_flow_hook_outputs(stage_index, timer_outputs, step)
+  }
+
+  fn append_flow_hook_outputs(
+    &mut self,
+    stage_index: usize,
+    hook_outputs: Result<Vec<DynValue>, StreamError>,
+    step: &mut FlowStageStep,
+  ) -> Result<(), StreamError> {
+    match hook_outputs {
+      | Ok(outputs) => {
+        step.outputs.extend(outputs);
+        Ok(())
+      },
+      | Err(error) => self.apply_flow_failure_to_step(stage_index, &error, step),
+    }
+  }
+
+  fn apply_flow_failure_to_step(
+    &mut self,
+    stage_index: usize,
+    error: &StreamError,
+    step: &mut FlowStageStep,
+  ) -> Result<(), StreamError> {
+    match self.handle_flow_failure(stage_index, error)? {
+      | FailureDisposition::Continue => {
+        step.progressed = true;
+        step.skip_stage_input = true;
+        Ok(())
+      },
+      | FailureDisposition::Complete => {
+        if !step.force_shutdown && !self.all_sources_done() {
+          self.set_all_sources_done()?;
+        }
+        step.progressed = true;
+        step.skip_stage_input = true;
+        step.force_shutdown = true;
+        Ok(())
+      },
+      | FailureDisposition::Fail(error) => Err(error),
+    }
+  }
+
+  fn apply_flow_stage_input_if_ready(
+    &mut self,
+    stage_index: usize,
+    ports: &FlowStagePorts,
+    step: &mut FlowStageStep,
+  ) -> Result<(), StreamError> {
+    if !self.flow_can_accept_input(stage_index, step.skip_stage_input) {
+      return Ok(());
+    }
+
+    let preferred_input_slot = self.flow_preferred_input_edge_slot(stage_index);
+    let Some((edge_index, input)) = self.poll_from_incoming_edges(ports.inlet, preferred_input_slot)? else {
+      return Ok(());
+    };
+    step.consumed_input = true;
+    if input.as_ref().type_id() != ports.input_type {
+      return Err(StreamError::TypeMismatch);
+    }
+
+    let apply_result = {
+      let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
+        return Err(StreamError::InvalidConnection);
+      };
+      flow.logic.apply_with_edge(edge_index, input)
+    };
+    match apply_result {
+      | Ok(outputs) => {
+        step.outputs.extend(outputs);
+        Ok(())
+      },
+      | Err(error) => self.apply_flow_failure_to_step(stage_index, &error, step),
+    }
+  }
+
+  fn flow_can_accept_input(&self, stage_index: usize, skip_stage_input: bool) -> bool {
+    if skip_stage_input || self.flow_source_done_at(stage_index) {
+      return false;
+    }
+    match &self.stages[stage_index] {
+      | StageDefinition::Flow(flow) => flow.logic.can_accept_input(),
+      | _ => false,
+    }
+  }
+
+  fn flow_preferred_input_edge_slot(&self, stage_index: usize) -> Option<usize> {
+    match &self.stages[stage_index] {
+      | StageDefinition::Flow(flow) => flow.logic.preferred_input_edge_slot(),
+      | _ => None,
+    }
+  }
+
+  fn drain_flow_stage_pending_if_ready(
+    &mut self,
+    stage_index: usize,
+    outgoing_buffered: bool,
+    step: &mut FlowStageStep,
+  ) -> Result<bool, StreamError> {
+    // apply で新しい出力が出ず、未送信バッファもなく、この tick で input apply を明示的に
+    // skip していないときだけ drain_pending に進める。
+    if !step.outputs.is_empty() || outgoing_buffered || step.skip_stage_input {
+      return Ok(false);
+    }
+
+    let drain_result = {
+      let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
+        return Err(StreamError::InvalidConnection);
+      };
+      flow.logic.drain_pending()
+    };
+    match drain_result {
+      | Ok(outputs) => {
+        step.outputs = outputs;
+        Ok(false)
+      },
+      | Err(error) => self.handle_flow_drain_failure(stage_index, &error),
+    }
+  }
+
+  fn handle_flow_drain_failure(&mut self, stage_index: usize, error: &StreamError) -> Result<bool, StreamError> {
+    match self.handle_flow_failure(stage_index, error)? {
+      | FailureDisposition::Continue => Ok(true),
+      | FailureDisposition::Complete => {
+        if !self.all_sources_done() {
+          self.set_all_sources_done()?;
+        }
+        self.shutdown_flow_stage(stage_index)?;
+        self.maybe_finish_flow_stage(stage_index);
+        Ok(true)
+      },
+      | FailureDisposition::Fail(error) => Err(error),
+    }
+  }
+
+  fn take_flow_shutdown_request(&mut self, stage_index: usize) -> Result<bool, StreamError> {
+    let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
+      return Err(StreamError::InvalidConnection);
+    };
+    Ok(flow.logic.take_shutdown_request())
+  }
+
+  fn finish_flow_stage_without_outputs(
+    &mut self,
+    stage_index: usize,
+    shutdown_requested: bool,
+    force_shutdown: bool,
+  ) -> Result<bool, StreamError> {
+    let mut progressed = false;
+    if shutdown_requested || force_shutdown {
+      self.shutdown_flow_stage(stage_index)?;
+      progressed = true;
+    }
+    if self.maybe_finish_flow_stage(stage_index) {
+      progressed = true;
+    }
+    Ok(progressed)
+  }
+
+  fn emit_flow_stage_outputs(
+    &mut self,
+    stage_index: usize,
+    ports: &FlowStagePorts,
+    outputs: Vec<DynValue>,
+  ) -> Result<(), StreamError> {
+    let outgoing_edges = self.outgoing_edge_indices(ports.outlet)?;
+    for output in outputs {
+      if output.as_ref().type_id() != ports.output_type {
+        return Err(StreamError::TypeMismatch);
+      }
+      match self.take_flow_next_output_edge_slot(stage_index)? {
+        | Some(slot) => {
+          let target = outgoing_edges[slot % outgoing_edges.len()];
+          self.offer_to_outgoing_edge(target, output)?;
+        },
+        | None => self.offer_to_next_outgoing_edge(ports.outlet, output)?,
+      }
+    }
+    Ok(())
+  }
+
+  fn take_flow_next_output_edge_slot(&mut self, stage_index: usize) -> Result<Option<usize>, StreamError> {
+    let StageDefinition::Flow(flow) = &mut self.stages[stage_index] else {
+      return Err(StreamError::InvalidConnection);
+    };
+    Ok(flow.logic.take_next_output_edge_slot())
   }
 
   fn drive_sinks_once(&mut self) -> Result<bool, StreamError> {

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
@@ -46,6 +46,7 @@ struct FlowStageStep {
   progressed:       bool,
 }
 
+#[derive(Clone, Copy)]
 struct SinkStagePorts {
   inlet:      PortId,
   input_type: TypeId,
@@ -232,7 +233,8 @@ impl GraphInterpreter {
     }
 
     match self.drive_running() {
-      | Ok(progressed) => Self::drive_outcome(progressed),
+      | Ok(true) => DriveOutcome::Progressed,
+      | Ok(false) => DriveOutcome::Idle,
       | Err(error) => {
         self.fail(&error);
         DriveOutcome::Progressed
@@ -259,10 +261,6 @@ impl GraphInterpreter {
     Ok(progressed)
   }
 
-  const fn drive_outcome(progressed: bool) -> DriveOutcome {
-    if progressed { DriveOutcome::Progressed } else { DriveOutcome::Idle }
-  }
-
   fn start_sinks_if_needed(&mut self) -> Result<bool, StreamError> {
     if self.on_start_done {
       return Ok(false);
@@ -273,27 +271,15 @@ impl GraphInterpreter {
   }
 
   fn pull_and_drive_flows_if_needed(&mut self) -> Result<bool, StreamError> {
-    let pull_result = self.pull_sources_for_current_need();
-    if !self.flow_drive_requested() {
+    let did_pull = if self.demand.has_demand() {
+      self.pull_sources_if_needed()?
+    } else if self.has_flow_requesting_upstream_drain() {
+      self.pull_sources_for_flows_requesting_drain()?
+    } else {
       return Ok(false);
-    }
-    let did_pull = pull_result?;
+    };
     let drove_flows = self.drive_flow_stages_until_idle()?;
     Ok(did_pull || drove_flows)
-  }
-
-  fn pull_sources_for_current_need(&mut self) -> Result<bool, StreamError> {
-    if self.demand.has_demand() {
-      return self.pull_sources_if_needed();
-    }
-    if self.has_flow_requesting_upstream_drain() {
-      return self.pull_sources_for_flows_requesting_drain();
-    }
-    Ok(false)
-  }
-
-  fn flow_drive_requested(&self) -> bool {
-    self.demand.has_demand() || self.has_flow_requesting_upstream_drain()
   }
 
   fn drive_flow_stages_until_idle(&mut self) -> Result<bool, StreamError> {
@@ -319,19 +305,13 @@ impl GraphInterpreter {
       && !self.restart_waiting()
       && !self.has_flow_requesting_upstream_drain()
       && self.all_edge_buffers_empty()
-      && !self.flow_has_any_pending_output()
+      && !self.flow_order.iter().any(|stage_index| self.flow_has_pending_output(*stage_index))
   }
 
   fn restart_waiting(&self) -> bool {
-    self.source_restart_waiting() || self.sink_restart_waiting() || self.flow_restart_waiting_any()
-  }
-
-  fn flow_restart_waiting_any(&self) -> bool {
-    self.flow_order.iter().any(|stage_index| self.flow_restart_waiting(*stage_index))
-  }
-
-  fn flow_has_any_pending_output(&self) -> bool {
-    self.flow_order.iter().any(|stage_index| self.flow_has_pending_output(*stage_index))
+    self.source_restart_waiting()
+      || self.sink_restart_waiting()
+      || self.flow_order.iter().any(|stage_index| self.flow_restart_waiting(*stage_index))
   }
 
   fn finish_sources_done_stream(&mut self) -> Result<bool, StreamError> {
@@ -354,7 +334,7 @@ impl GraphInterpreter {
     self.all_sources_done()
       && self.state == StreamState::Running
       && !self.restart_waiting()
-      && !self.flow_has_any_pending_output()
+      && !self.flow_order.iter().any(|stage_index| self.flow_has_pending_output(*stage_index))
   }
 
   fn tick_flow_stages(&mut self) -> Result<bool, StreamError> {

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter_test.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter_test.rs
@@ -12,10 +12,13 @@ use fraktor_utils_core_rs::{
   sync::{ArcShared, SpinSyncMutex},
 };
 
-use super::super::{
-  buffered_edge::BufferedEdge, compiled_graph_plan::CompiledGraphPlan, failure_disposition::FailureDisposition,
-  graph_connections::GraphConnections, interpreter_snapshot_builder::InterpreterSnapshotBuilder,
-  outlet_dispatch_state::OutletDispatchState,
+use super::{
+  super::{
+    buffered_edge::BufferedEdge, compiled_graph_plan::CompiledGraphPlan, failure_disposition::FailureDisposition,
+    graph_connections::GraphConnections, interpreter_snapshot_builder::InterpreterSnapshotBuilder,
+    outlet_dispatch_state::OutletDispatchState,
+  },
+  FlowStageStep,
 };
 use crate::{
   Attributes, DynValue, FailureAction, FlowDefinition, FlowLogic, KillSwitchCommandTarget,
@@ -59,6 +62,458 @@ fn linear_plan(source: SourceDefinition, flows: Vec<FlowDefinition>, sink: SinkD
 
 fn stream_plan(stages: Vec<StageDefinition>, edges: Vec<(PortId, PortId, MatCombine)>) -> StreamPlan {
   StreamPlan::from_parts(stages, edges).expect("valid stream graph shape")
+}
+
+fn single_flow_interpreter_with_logic(
+  logic: Box<dyn FlowLogic>,
+  restart: Option<RestartBackoff>,
+) -> (GraphInterpreter, PortId, usize, usize) {
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let flow_inlet: Inlet<u32> = Inlet::new();
+  let flow_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let source = source_single_u32(source_outlet, 1);
+  let flow = FlowDefinition {
+    kind: StageKind::FlowMap,
+    inlet: flow_inlet.id(),
+    outlet: flow_outlet.id(),
+    input_type: TypeId::of::<u32>(),
+    output_type: TypeId::of::<u32>(),
+    mat_combine: MatCombine::Left,
+    logic,
+    supervision: SupervisionStrategy::Stop,
+    restart,
+    attributes: Attributes::new(),
+  };
+  let sink = collect_u32_sequence_sink(sink_inlet, StreamFuture::new());
+  let plan =
+    stream_plan(vec![StageDefinition::Source(source), StageDefinition::Flow(flow), StageDefinition::Sink(sink)], vec![
+      (source_outlet.id(), flow_inlet.id(), MatCombine::Left),
+      (flow_outlet.id(), sink_inlet.id(), MatCombine::Right),
+    ]);
+  (GraphInterpreter::new(plan, StreamBufferConfig::default()), source_outlet.id(), 1, 2)
+}
+
+fn single_flow_interpreter() -> (GraphInterpreter, PortId, usize, usize) {
+  single_flow_interpreter_with_logic(Box::new(IncrementFlowLogic), None)
+}
+
+#[test]
+fn stream_plan_rejects_duplicate_stage_ports() {
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let source_a = source_single_u32(source_outlet, 1);
+  let source_b = source_single_u32(Outlet::from_id(source_outlet.id()), 2);
+  let sink = collect_u32_sequence_sink(sink_inlet, StreamFuture::new());
+
+  let error = StreamPlan::from_parts(
+    vec![StageDefinition::Source(source_a), StageDefinition::Source(source_b), StageDefinition::Sink(sink)],
+    vec![(source_outlet.id(), sink_inlet.id(), MatCombine::Right)],
+  )
+  .err()
+  .expect("duplicate outlet should be rejected");
+
+  assert_eq!(error, StreamError::InvalidConnection);
+}
+
+#[test]
+fn stream_plan_rejects_missing_source_or_sink_stage() {
+  let flow_inlet: Inlet<u32> = Inlet::new();
+  let flow_outlet: Outlet<u32> = Outlet::new();
+  let flow = FlowDefinition {
+    kind:        StageKind::FlowMap,
+    inlet:       flow_inlet.id(),
+    outlet:      flow_outlet.id(),
+    input_type:  TypeId::of::<u32>(),
+    output_type: TypeId::of::<u32>(),
+    mat_combine: MatCombine::Right,
+    logic:       Box::new(IncrementFlowLogic),
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    attributes:  Attributes::new(),
+  };
+
+  let error = StreamPlan::from_parts(vec![StageDefinition::Flow(flow)], vec![(
+    flow_outlet.id(),
+    flow_inlet.id(),
+    MatCombine::Right,
+  )])
+  .err()
+  .expect("missing source and sink should be rejected");
+
+  assert_eq!(error, StreamError::InvalidConnection);
+}
+
+#[test]
+fn stream_plan_rejects_source_without_outgoing_edge() {
+  let connected_outlet: Outlet<u32> = Outlet::new();
+  let unconnected_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let connected_source = source_single_u32(connected_outlet, 1);
+  let unconnected_source = source_single_u32(unconnected_outlet, 2);
+  let sink = collect_u32_sequence_sink(sink_inlet, StreamFuture::new());
+
+  let error = StreamPlan::from_parts(
+    vec![
+      StageDefinition::Source(connected_source),
+      StageDefinition::Source(unconnected_source),
+      StageDefinition::Sink(sink),
+    ],
+    vec![(connected_outlet.id(), sink_inlet.id(), MatCombine::Right)],
+  )
+  .err()
+  .expect("source without outgoing edge should be rejected");
+
+  assert_eq!(error, StreamError::InvalidConnection);
+}
+
+#[test]
+fn stream_plan_rejects_flow_without_required_edges() {
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let flow_inlet: Inlet<u32> = Inlet::new();
+  let flow_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let source = source_single_u32(source_outlet, 1);
+  let flow = FlowDefinition {
+    kind:        StageKind::FlowMap,
+    inlet:       flow_inlet.id(),
+    outlet:      flow_outlet.id(),
+    input_type:  TypeId::of::<u32>(),
+    output_type: TypeId::of::<u32>(),
+    mat_combine: MatCombine::Right,
+    logic:       Box::new(IncrementFlowLogic),
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    attributes:  Attributes::new(),
+  };
+  let sink = collect_u32_sequence_sink(sink_inlet, StreamFuture::new());
+
+  let error = StreamPlan::from_parts(
+    vec![StageDefinition::Source(source), StageDefinition::Flow(flow), StageDefinition::Sink(sink)],
+    vec![(source_outlet.id(), sink_inlet.id(), MatCombine::Right)],
+  )
+  .err()
+  .expect("flow without incoming and outgoing edges should be rejected");
+
+  assert_eq!(error, StreamError::InvalidConnection);
+}
+
+#[test]
+fn stream_plan_rejects_sink_without_incoming_edge() {
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let connected_sink_inlet: Inlet<u32> = Inlet::new();
+  let unconnected_sink_inlet: Inlet<u32> = Inlet::new();
+  let source = source_single_u32(source_outlet, 1);
+  let connected_sink = collect_u32_sequence_sink(connected_sink_inlet, StreamFuture::new());
+  let unconnected_sink = collect_u32_sequence_sink(unconnected_sink_inlet, StreamFuture::new());
+
+  let error = StreamPlan::from_parts(
+    vec![
+      StageDefinition::Source(source),
+      StageDefinition::Sink(connected_sink),
+      StageDefinition::Sink(unconnected_sink),
+    ],
+    vec![(source_outlet.id(), connected_sink_inlet.id(), MatCombine::Right)],
+  )
+  .err()
+  .expect("sink without incoming edge should be rejected");
+
+  assert_eq!(error, StreamError::InvalidConnection);
+}
+
+#[test]
+fn drive_running_reports_progress_when_state_is_already_terminal() {
+  let (mut interpreter, _, _, _) = single_flow_interpreter();
+  interpreter.state = StreamState::Completed;
+
+  assert_eq!(interpreter.drive_running(), Ok(true));
+}
+
+#[test]
+fn source_helpers_reject_invalid_stage_and_type_mismatch() {
+  let (mut interpreter, _, flow_index, _) = single_flow_interpreter();
+
+  assert_eq!(interpreter.source_stage_ports(flow_index).err(), Some(StreamError::InvalidConnection));
+  assert_eq!(interpreter.pull_source_value(flow_index).err(), Some(StreamError::InvalidConnection));
+  assert_eq!(interpreter.schedule_source_restart_or_complete(flow_index).err(), Some(StreamError::InvalidConnection));
+  let ports = interpreter.source_stage_ports(0).expect("source ports");
+  assert_eq!(interpreter.emit_source_value(ports, Box::new("bad")), Err(StreamError::TypeMismatch));
+}
+
+#[test]
+fn source_completion_fails_when_restart_budget_exhaustion_is_configured_to_fail() {
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let source = SourceDefinition {
+    kind:        StageKind::SourceSingle,
+    outlet:      source_outlet.id(),
+    output_type: TypeId::of::<u32>(),
+    mat_combine: MatCombine::Right,
+    logic:       Box::new(EmptyTestSourceLogic),
+    supervision: SupervisionStrategy::Stop,
+    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 0).with_complete_on_max_restarts(false))),
+    attributes:  Attributes::new(),
+  };
+  let sink = collect_u32_sequence_sink(sink_inlet, StreamFuture::new());
+  let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
+    source_outlet.id(),
+    sink_inlet.id(),
+    MatCombine::Right,
+  )]);
+  let mut interpreter = GraphInterpreter::new(plan, StreamBufferConfig::default());
+
+  assert_eq!(interpreter.complete_or_restart_source(0, 0), Err(StreamError::Failed));
+}
+
+#[test]
+fn flow_helpers_reject_non_flow_stage_indices() {
+  let (mut interpreter, _, _, _) = single_flow_interpreter();
+  interpreter.flow_slots[0] = Some(0);
+
+  assert_eq!(interpreter.drive_flow_stage_once(0), Ok(false));
+  assert!(interpreter.flow_stage_ports(0).is_none());
+  assert!(!interpreter.flow_can_accept_input_while_output_buffered(0));
+  assert!(!interpreter.flow_can_accept_input(0, false));
+  assert_eq!(interpreter.flow_preferred_input_edge_slot(0), None);
+  assert_eq!(
+    interpreter.append_flow_async_outputs(0, &mut FlowStageStep::default()),
+    Err(StreamError::InvalidConnection)
+  );
+  assert_eq!(
+    interpreter.append_flow_timer_outputs(0, &mut FlowStageStep::default()),
+    Err(StreamError::InvalidConnection)
+  );
+  assert_eq!(
+    interpreter.drain_flow_stage_pending_if_ready(0, false, &mut FlowStageStep::default()),
+    Err(StreamError::InvalidConnection)
+  );
+  assert!(matches!(interpreter.apply_flow_logic_with_edge(0, 0, Box::new(1_u32)), Err(StreamError::InvalidConnection)));
+  assert_eq!(interpreter.take_flow_shutdown_request(0), Err(StreamError::InvalidConnection));
+  assert_eq!(interpreter.take_flow_next_output_edge_slot(0), Err(StreamError::InvalidConnection));
+}
+
+#[test]
+fn flow_logic_helper_applies_with_selected_edge() {
+  let (mut interpreter, _, flow_index, _) = single_flow_interpreter();
+
+  let mut outputs =
+    interpreter.apply_flow_logic_with_edge(flow_index, 0, Box::new(1_u32)).expect("flow logic should apply");
+
+  assert_eq!(outputs.len(), 1);
+  assert_eq!(*outputs.remove(0).downcast::<u32>().expect("u32 output"), 2_u32);
+}
+
+#[test]
+fn flow_input_rejects_type_mismatch_before_applying_logic() {
+  let (mut interpreter, source_outlet, flow_index, _) = single_flow_interpreter();
+  interpreter.offer_to_next_outgoing_edge(source_outlet, Box::new("bad")).expect("buffer bad input");
+  let ports = interpreter.flow_stage_ports(flow_index).expect("flow ports");
+
+  assert_eq!(
+    interpreter.apply_flow_stage_input_if_ready(flow_index, &ports, &mut FlowStageStep::default()),
+    Err(StreamError::TypeMismatch)
+  );
+}
+
+#[test]
+fn flow_failure_complete_updates_step_and_closes_sources() {
+  let restart = RestartBackoff::from_settings(RestartConfig::new(0, 0, 0));
+  let (mut interpreter, _, flow_index, _) =
+    single_flow_interpreter_with_logic(Box::new(DrainFailingFlowLogic), Some(restart));
+  let mut step = FlowStageStep::default();
+  assert!(!interpreter.all_sources_done());
+
+  assert_eq!(interpreter.apply_flow_failure_to_step(flow_index, &StreamError::Failed, &mut step), Ok(()));
+
+  assert!(step.progressed);
+  assert!(step.skip_stage_input);
+  assert!(step.force_shutdown);
+  assert!(interpreter.all_sources_done());
+}
+
+#[test]
+fn flow_drain_failure_complete_finishes_flow_without_failing_stream() {
+  let restart = RestartBackoff::from_settings(RestartConfig::new(0, 0, 0));
+  let (mut interpreter, _, flow_index, _) =
+    single_flow_interpreter_with_logic(Box::new(DrainFailingFlowLogic), Some(restart));
+  assert!(!interpreter.all_sources_done());
+
+  assert_eq!(interpreter.handle_flow_drain_failure(flow_index, &StreamError::Failed), Ok(true));
+  assert!(interpreter.all_sources_done());
+  assert!(interpreter.flow_done_at(flow_index));
+}
+
+#[test]
+fn sink_helpers_reject_non_sink_stage_indices() {
+  let (mut interpreter, _, _, _) = single_flow_interpreter();
+
+  assert_eq!(interpreter.sink_stage_ports(0).err(), Some(StreamError::InvalidConnection));
+  assert_eq!(interpreter.sink_can_accept_input(0), Err(StreamError::InvalidConnection));
+  assert_eq!(interpreter.schedule_sink_restart_or_complete(0).err(), Some(StreamError::InvalidConnection));
+}
+
+#[test]
+fn sink_drive_rejects_type_mismatch_before_pushing_logic() {
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let source = source_single_u32(source_outlet, 1);
+  let sink = collect_u32_sequence_sink(sink_inlet, StreamFuture::new());
+  let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
+    source_outlet.id(),
+    sink_inlet.id(),
+    MatCombine::Right,
+  )]);
+  let mut interpreter = GraphInterpreter::new(plan, StreamBufferConfig::default());
+  interpreter.start_sinks().expect("start sink demand");
+  interpreter.offer_to_next_outgoing_edge(source_outlet.id(), Box::new("bad")).expect("buffer bad input");
+
+  assert_eq!(interpreter.drive_sink_once(0), Err(StreamError::TypeMismatch));
+}
+
+#[test]
+fn sink_tick_failure_is_routed_through_sink_failure_policy() {
+  struct TickFailingSinkLogic;
+
+  impl SinkLogic for TickFailingSinkLogic {
+    fn on_start(&mut self, demand: &mut DemandTracker) -> Result<(), StreamError> {
+      demand.request(1)
+    }
+
+    fn on_push(&mut self, _input: DynValue, _demand: &mut DemandTracker) -> Result<SinkDecision, StreamError> {
+      Ok(SinkDecision::Continue)
+    }
+
+    fn on_complete(&mut self) -> Result<(), StreamError> {
+      Ok(())
+    }
+
+    fn on_error(&mut self, _error: StreamError) {}
+
+    fn on_tick(&mut self, _demand: &mut DemandTracker) -> Result<bool, StreamError> {
+      Err(StreamError::Failed)
+    }
+  }
+
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let source = source_single_u32(source_outlet, 1);
+  let sink = SinkDefinition {
+    kind:        StageKind::SinkFold,
+    inlet:       sink_inlet.id(),
+    input_type:  TypeId::of::<u32>(),
+    mat_combine: MatCombine::Right,
+    logic:       Box::new(TickFailingSinkLogic),
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    attributes:  Attributes::new(),
+  };
+  let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
+    source_outlet.id(),
+    sink_inlet.id(),
+    MatCombine::Right,
+  )]);
+  let mut interpreter = GraphInterpreter::new(plan, StreamBufferConfig::default());
+  let mut logic = TickFailingSinkLogic;
+  let mut demand = DemandTracker::new();
+
+  assert_eq!(logic.on_start(&mut demand), Ok(()));
+  assert_eq!(logic.on_push(Box::new(1_u32), &mut demand), Ok(SinkDecision::Continue));
+  assert_eq!(logic.on_complete(), Ok(()));
+  logic.on_error(StreamError::Failed);
+
+  assert_eq!(interpreter.tick_sink_stage(0, 1), Err(StreamError::Failed));
+}
+
+#[test]
+fn sink_failure_completes_when_restart_budget_is_exhausted() {
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let completion = StreamFuture::new();
+  let source = source_single_u32(source_outlet, 1);
+  let sink = SinkDefinition {
+    kind:        StageKind::SinkFold,
+    inlet:       sink_inlet.id(),
+    input_type:  TypeId::of::<u32>(),
+    mat_combine: MatCombine::Right,
+    logic:       Box::new(AlwaysFailCollectSinkLogic { completion }),
+    supervision: SupervisionStrategy::Stop,
+    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 0))),
+    attributes:  Attributes::new(),
+  };
+  let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
+    source_outlet.id(),
+    sink_inlet.id(),
+    MatCombine::Right,
+  )]);
+  let mut interpreter = GraphInterpreter::new(plan, StreamBufferConfig::default());
+
+  assert_eq!(interpreter.apply_sink_failure(0, 1, StreamError::Failed), Ok(true));
+  assert!(interpreter.sink_done[0]);
+}
+
+#[test]
+fn sink_finish_waits_when_sink_still_has_pending_work() {
+  struct PendingWorkSinkLogic;
+
+  impl SinkLogic for PendingWorkSinkLogic {
+    fn can_accept_input(&self) -> bool {
+      false
+    }
+
+    fn on_start(&mut self, demand: &mut DemandTracker) -> Result<(), StreamError> {
+      demand.request(1)
+    }
+
+    fn on_push(&mut self, _input: DynValue, _demand: &mut DemandTracker) -> Result<SinkDecision, StreamError> {
+      Ok(SinkDecision::Continue)
+    }
+
+    fn on_complete(&mut self) -> Result<(), StreamError> {
+      Ok(())
+    }
+
+    fn on_error(&mut self, _error: StreamError) {}
+
+    fn on_upstream_finish(&mut self) -> Result<bool, StreamError> {
+      Ok(true)
+    }
+
+    fn has_pending_work(&self) -> bool {
+      true
+    }
+  }
+
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let source = source_single_u32(source_outlet, 1);
+  let sink = SinkDefinition {
+    kind:        StageKind::SinkFold,
+    inlet:       sink_inlet.id(),
+    input_type:  TypeId::of::<u32>(),
+    mat_combine: MatCombine::Right,
+    logic:       Box::new(PendingWorkSinkLogic),
+    supervision: SupervisionStrategy::Stop,
+    restart:     None,
+    attributes:  Attributes::new(),
+  };
+  let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
+    source_outlet.id(),
+    sink_inlet.id(),
+    MatCombine::Right,
+  )]);
+  let mut interpreter = GraphInterpreter::new(plan, StreamBufferConfig::default());
+  let mut logic = PendingWorkSinkLogic;
+  let mut demand = DemandTracker::new();
+
+  assert!(!logic.can_accept_input());
+  assert_eq!(logic.on_push(Box::new(1_u32), &mut demand), Ok(SinkDecision::Continue));
+  assert_eq!(logic.on_complete(), Ok(()));
+  logic.on_error(StreamError::Failed);
+  interpreter.start_sinks().expect("start sink demand");
+  interpreter.complete_source(0).expect("source completion closes sink input");
+
+  assert_eq!(interpreter.finish_sink_if_input_exhausted(0, 1, false), Ok(true));
+  assert!(!interpreter.sink_done[0]);
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter_test.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter_test.rs
@@ -332,6 +332,49 @@ fn flow_failure_complete_updates_step_and_closes_sources() {
 }
 
 #[test]
+fn flow_async_restart_exhaustion_skips_timer_callback() {
+  struct AsyncRestartExhaustedFlowLogic {
+    timer_calls: ArcShared<SpinSyncMutex<u8>>,
+  }
+
+  impl FlowLogic for AsyncRestartExhaustedFlowLogic {
+    fn apply(&mut self, input: DynValue) -> Result<Vec<DynValue>, StreamError> {
+      Ok(vec![input])
+    }
+
+    fn on_async_callback(&mut self) -> Result<Vec<DynValue>, StreamError> {
+      Err(StreamError::Failed)
+    }
+
+    fn on_timer(&mut self) -> Result<Vec<DynValue>, StreamError> {
+      let mut timer_calls = self.timer_calls.lock();
+      *timer_calls = timer_calls.saturating_add(1);
+      Ok(vec![Box::new(10_u32)])
+    }
+  }
+
+  let timer_calls = ArcShared::new(SpinSyncMutex::new(0_u8));
+  let coverage_timer_calls = ArcShared::new(SpinSyncMutex::new(0_u8));
+  let mut coverage_logic = AsyncRestartExhaustedFlowLogic { timer_calls: coverage_timer_calls.clone() };
+  let mut outputs = coverage_logic.apply(Box::new(1_u32)).expect("apply outputs");
+  assert_eq!(outputs.len(), 1);
+  assert_eq!(*outputs.remove(0).downcast::<u32>().expect("u32 output"), 1);
+  assert_eq!(coverage_logic.on_timer().expect("timer output").len(), 1);
+  assert_eq!(*coverage_timer_calls.lock(), 1);
+
+  let restart = RestartBackoff::from_settings(RestartConfig::new(0, 0, 0));
+  let (mut interpreter, _, flow_index, _) = single_flow_interpreter_with_logic(
+    Box::new(AsyncRestartExhaustedFlowLogic { timer_calls: timer_calls.clone() }),
+    Some(restart),
+  );
+  let ports = interpreter.flow_stage_ports(flow_index).expect("flow ports");
+
+  assert_eq!(interpreter.drive_ready_flow_stage_once(flow_index, &ports, false), Ok(true));
+  assert_eq!(*timer_calls.lock(), 0);
+  assert!(interpreter.flow_done_at(flow_index));
+}
+
+#[test]
 fn flow_drain_failure_complete_finishes_flow_without_failing_stream() {
   let restart = RestartBackoff::from_settings(RestartConfig::new(0, 0, 0));
   let (mut interpreter, _, flow_index, _) =
@@ -449,6 +492,76 @@ fn sink_failure_completes_when_restart_budget_is_exhausted() {
 
   assert_eq!(interpreter.apply_sink_failure(0, 1, StreamError::Failed), Ok(true));
   assert!(interpreter.sink_done[0]);
+}
+
+#[test]
+fn sink_drive_returns_after_tick_completes_sink() {
+  struct CompletingTickSinkLogic {
+    can_accept_calls: ArcShared<SpinSyncMutex<u8>>,
+  }
+
+  impl SinkLogic for CompletingTickSinkLogic {
+    fn can_accept_input(&self) -> bool {
+      let mut can_accept_calls = self.can_accept_calls.lock();
+      *can_accept_calls = can_accept_calls.saturating_add(1);
+      true
+    }
+
+    fn on_start(&mut self, demand: &mut DemandTracker) -> Result<(), StreamError> {
+      demand.request(1)
+    }
+
+    fn on_push(&mut self, _input: DynValue, _demand: &mut DemandTracker) -> Result<SinkDecision, StreamError> {
+      Ok(SinkDecision::Continue)
+    }
+
+    fn on_complete(&mut self) -> Result<(), StreamError> {
+      Ok(())
+    }
+
+    fn on_error(&mut self, _error: StreamError) {}
+
+    fn on_tick(&mut self, _demand: &mut DemandTracker) -> Result<bool, StreamError> {
+      Err(StreamError::Failed)
+    }
+  }
+
+  let source_outlet: Outlet<u32> = Outlet::new();
+  let sink_inlet: Inlet<u32> = Inlet::new();
+  let can_accept_calls = ArcShared::new(SpinSyncMutex::new(0_u8));
+  let coverage_can_accept_calls = ArcShared::new(SpinSyncMutex::new(0_u8));
+  let mut coverage_logic = CompletingTickSinkLogic { can_accept_calls: coverage_can_accept_calls.clone() };
+  let mut coverage_demand = DemandTracker::new();
+  assert!(coverage_logic.can_accept_input());
+  assert_eq!(coverage_logic.on_start(&mut coverage_demand), Ok(()));
+  assert_eq!(coverage_logic.on_push(Box::new(1_u32), &mut coverage_demand), Ok(SinkDecision::Continue));
+  assert_eq!(coverage_logic.on_complete(), Ok(()));
+  coverage_logic.on_error(StreamError::Failed);
+  assert_eq!(coverage_logic.on_tick(&mut coverage_demand), Err(StreamError::Failed));
+  assert_eq!(*coverage_can_accept_calls.lock(), 1);
+
+  let source = source_single_u32(source_outlet, 1);
+  let sink = SinkDefinition {
+    kind:        StageKind::SinkFold,
+    inlet:       sink_inlet.id(),
+    input_type:  TypeId::of::<u32>(),
+    mat_combine: MatCombine::Right,
+    logic:       Box::new(CompletingTickSinkLogic { can_accept_calls: can_accept_calls.clone() }),
+    supervision: SupervisionStrategy::Stop,
+    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 0))),
+    attributes:  Attributes::new(),
+  };
+  let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
+    source_outlet.id(),
+    sink_inlet.id(),
+    MatCombine::Right,
+  )]);
+  let mut interpreter = GraphInterpreter::new(plan, StreamBufferConfig::default());
+  interpreter.start_sinks().expect("start sink demand");
+
+  assert_eq!(interpreter.drive_sink_once(0), Ok(true));
+  assert!(interpreter.sink_done[0]);
+  assert_eq!(*can_accept_calls.lock(), 0);
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/impl/io/compression.rs
+++ b/modules/stream-core-kernel/src/impl/io/compression.rs
@@ -57,60 +57,9 @@ impl Compression {
   /// Returns `StreamError::CompressionError` if the data is invalid or exceeds
   /// `max_bytes_per_chunk`.
   pub fn gunzip_bytes_with_options(bytes: &[u8], max_bytes_per_chunk: usize) -> Result<Vec<u8>, StreamError> {
-    if bytes.len() < 18 {
-      return Err(StreamError::CompressionError { kind: "gzip_too_short" });
-    }
-    if bytes[0] != 0x1f || bytes[1] != 0x8b || bytes[2] != 0x08 {
-      return Err(StreamError::CompressionError { kind: "gzip_header" });
-    }
-    let flags = bytes[3];
-    if flags & 0b1110_0000 != 0 {
-      return Err(StreamError::CompressionError { kind: "gzip_flags" });
-    }
-    let payload_end = bytes.len().saturating_sub(8);
-    let mut payload_start = 10_usize;
-
-    if flags & 0x04 != 0 {
-      if payload_start + 2 > payload_end {
-        return Err(StreamError::CompressionError { kind: "gzip_extra_len" });
-      }
-      let extra_len = u16::from_le_bytes([bytes[payload_start], bytes[payload_start + 1]]) as usize;
-      payload_start += 2;
-      if payload_start + extra_len > payload_end {
-        return Err(StreamError::CompressionError { kind: "gzip_extra" });
-      }
-      payload_start += extra_len;
-    }
-    if flags & 0x08 != 0 {
-      payload_start = consume_gzip_zero_terminated_field(bytes, payload_start, payload_end)?;
-    }
-    if flags & 0x10 != 0 {
-      payload_start = consume_gzip_zero_terminated_field(bytes, payload_start, payload_end)?;
-    }
-    if flags & 0x02 != 0 {
-      if payload_start + 2 > payload_end {
-        return Err(StreamError::CompressionError { kind: "gzip_header_crc" });
-      }
-      payload_start += 2;
-    }
-    if payload_start > payload_end {
-      return Err(StreamError::CompressionError { kind: "gzip_payload_bounds" });
-    }
-
-    let payload = &bytes[payload_start..payload_end];
-    let expected_crc =
-      u32::from_le_bytes([bytes[payload_end], bytes[payload_end + 1], bytes[payload_end + 2], bytes[payload_end + 3]]);
-    let expected_len = u32::from_le_bytes([
-      bytes[payload_end + 4],
-      bytes[payload_end + 5],
-      bytes[payload_end + 6],
-      bytes[payload_end + 7],
-    ]);
-    if usize::try_from(expected_len).ok().filter(|len| *len <= max_bytes_per_chunk).is_none() {
-      return Err(StreamError::CompressionError { kind: "gzip_too_large" });
-    }
-    let decompressed = Self::inflate_gzip_payload(payload, max_bytes_per_chunk)?;
-    if crc32(&decompressed) != expected_crc || (decompressed.len() as u32) != expected_len {
+    let gzip_parts = parse_gzip_member(bytes, max_bytes_per_chunk)?;
+    let decompressed = Self::inflate_gzip_payload(gzip_parts.payload, max_bytes_per_chunk)?;
+    if crc32(&decompressed) != gzip_parts.expected_crc || (decompressed.len() as u32) != gzip_parts.expected_len {
       return Err(StreamError::CompressionError { kind: "gzip_trailer" });
     }
     Ok(decompressed)
@@ -209,6 +158,89 @@ impl Compression {
     }
     Ok(decompressed)
   }
+}
+
+struct GzipMember<'a> {
+  payload:      &'a [u8],
+  expected_crc: u32,
+  expected_len: u32,
+}
+
+fn parse_gzip_member(bytes: &[u8], max_bytes_per_chunk: usize) -> Result<GzipMember<'_>, StreamError> {
+  let (flags, payload_end) = validate_gzip_header(bytes)?;
+  let payload_start = consume_gzip_optional_fields(bytes, flags, payload_end)?;
+  if payload_start > payload_end {
+    return Err(StreamError::CompressionError { kind: "gzip_payload_bounds" });
+  }
+
+  let expected_crc =
+    u32::from_le_bytes([bytes[payload_end], bytes[payload_end + 1], bytes[payload_end + 2], bytes[payload_end + 3]]);
+  let expected_len = u32::from_le_bytes([
+    bytes[payload_end + 4],
+    bytes[payload_end + 5],
+    bytes[payload_end + 6],
+    bytes[payload_end + 7],
+  ]);
+  validate_gzip_expected_len(expected_len, max_bytes_per_chunk)?;
+  Ok(GzipMember { payload: &bytes[payload_start..payload_end], expected_crc, expected_len })
+}
+
+fn validate_gzip_header(bytes: &[u8]) -> Result<(u8, usize), StreamError> {
+  if bytes.len() < 18 {
+    return Err(StreamError::CompressionError { kind: "gzip_too_short" });
+  }
+  if bytes[0] != 0x1f || bytes[1] != 0x8b || bytes[2] != 0x08 {
+    return Err(StreamError::CompressionError { kind: "gzip_header" });
+  }
+  let flags = bytes[3];
+  if flags & 0b1110_0000 != 0 {
+    return Err(StreamError::CompressionError { kind: "gzip_flags" });
+  }
+  Ok((flags, bytes.len().saturating_sub(8)))
+}
+
+fn consume_gzip_optional_fields(bytes: &[u8], flags: u8, payload_end: usize) -> Result<usize, StreamError> {
+  let mut payload_start = 10_usize;
+
+  if flags & 0x04 != 0 {
+    payload_start = consume_gzip_extra_field(bytes, payload_start, payload_end)?;
+  }
+  if flags & 0x08 != 0 {
+    payload_start = consume_gzip_zero_terminated_field(bytes, payload_start, payload_end)?;
+  }
+  if flags & 0x10 != 0 {
+    payload_start = consume_gzip_zero_terminated_field(bytes, payload_start, payload_end)?;
+  }
+  if flags & 0x02 != 0 {
+    payload_start = consume_gzip_header_crc(payload_start, payload_end)?;
+  }
+  Ok(payload_start)
+}
+
+fn consume_gzip_extra_field(bytes: &[u8], mut payload_start: usize, payload_end: usize) -> Result<usize, StreamError> {
+  if payload_start + 2 > payload_end {
+    return Err(StreamError::CompressionError { kind: "gzip_extra_len" });
+  }
+  let extra_len = u16::from_le_bytes([bytes[payload_start], bytes[payload_start + 1]]) as usize;
+  payload_start += 2;
+  if payload_start + extra_len > payload_end {
+    return Err(StreamError::CompressionError { kind: "gzip_extra" });
+  }
+  Ok(payload_start + extra_len)
+}
+
+fn consume_gzip_header_crc(payload_start: usize, payload_end: usize) -> Result<usize, StreamError> {
+  if payload_start + 2 > payload_end {
+    return Err(StreamError::CompressionError { kind: "gzip_header_crc" });
+  }
+  Ok(payload_start + 2)
+}
+
+fn validate_gzip_expected_len(expected_len: u32, max_bytes_per_chunk: usize) -> Result<(), StreamError> {
+  if usize::try_from(expected_len).ok().filter(|len| *len <= max_bytes_per_chunk).is_some() {
+    return Ok(());
+  }
+  Err(StreamError::CompressionError { kind: "gzip_too_large" })
 }
 
 fn consume_gzip_zero_terminated_field(

--- a/modules/stream-core-kernel/src/lib.rs
+++ b/modules/stream-core-kernel/src/lib.rs
@@ -373,25 +373,16 @@ fn collect_stream_plan_stage_ports(stages: &[StageDefinition]) -> Result<StreamP
   let mut output_ports = Vec::with_capacity(stages.len());
 
   for (stage_index, stage) in stages.iter().enumerate() {
-    collect_stream_plan_stage_index(stage, stage_index, &mut source_indices, &mut sink_indices);
+    match stage {
+      | StageDefinition::Source(_) => source_indices.push(stage_index),
+      | StageDefinition::Flow(_) => {},
+      | StageDefinition::Sink(_) => sink_indices.push(stage_index),
+    }
     collect_unique_stage_port(&mut input_ports, stage.inlet(), stage_index)?;
     collect_unique_stage_port(&mut output_ports, stage.outlet(), stage_index)?;
   }
 
   Ok(StreamPlanStagePorts { source_indices, sink_indices, input_ports, output_ports })
-}
-
-fn collect_stream_plan_stage_index(
-  stage: &StageDefinition,
-  stage_index: usize,
-  source_indices: &mut Vec<usize>,
-  sink_indices: &mut Vec<usize>,
-) {
-  match stage {
-    | StageDefinition::Source(_) => source_indices.push(stage_index),
-    | StageDefinition::Flow(_) => {},
-    | StageDefinition::Sink(_) => sink_indices.push(stage_index),
-  }
 }
 
 fn collect_unique_stage_port(
@@ -425,8 +416,8 @@ fn build_stream_plan_topology(
   for (from, to, mat) in edges {
     let from_stage = stage_index_for_port(&stage_ports.output_ports, from)?;
     let to_stage = stage_index_for_port(&stage_ports.input_ports, to)?;
-    topology.outgoing[from_stage] = topology.outgoing[from_stage].saturating_add(1);
-    topology.incoming[to_stage] = topology.incoming[to_stage].saturating_add(1);
+    topology.outgoing[from_stage] += 1;
+    topology.incoming[to_stage] += 1;
     topology.adjacency[from_stage].push(to_stage);
     topology.edges.push(StreamPlanEdge { from_port: from, to_port: to, mat });
   }
@@ -434,15 +425,12 @@ fn build_stream_plan_topology(
 }
 
 fn empty_stream_plan_topology(stage_count: usize, edge_count: usize) -> StreamPlanTopology {
-  let mut incoming = Vec::with_capacity(stage_count);
-  let mut outgoing = Vec::with_capacity(stage_count);
-  let mut adjacency = Vec::with_capacity(stage_count);
-  for _ in 0..stage_count {
-    incoming.push(0_usize);
-    outgoing.push(0_usize);
-    adjacency.push(Vec::new());
+  StreamPlanTopology {
+    edges:     Vec::with_capacity(edge_count),
+    incoming:  alloc::vec![0_usize; stage_count],
+    outgoing:  alloc::vec![0_usize; stage_count],
+    adjacency: alloc::vec![Vec::new(); stage_count],
   }
-  StreamPlanTopology { edges: Vec::with_capacity(edge_count), incoming, outgoing, adjacency }
 }
 
 fn stage_index_for_port(ports: &[(PortId, usize)], port: PortId) -> Result<usize, StreamError> {
@@ -505,16 +493,15 @@ const fn validate_sink_degree(incoming: usize) -> Result<(), StreamError> {
 
 fn topological_stream_plan_order(
   stage_count: usize,
-  incoming: Vec<usize>,
+  mut incoming: Vec<usize>,
   adjacency: &[Vec<usize>],
 ) -> Result<Vec<usize>, StreamError> {
   let mut ready = stream_plan_ready_stages(&incoming);
-  let mut processing_incoming = incoming;
   let mut ordered_indices = Vec::new();
 
   while let Some(stage_index) = ready.pop() {
     ordered_indices.push(stage_index);
-    collect_ready_downstream_stages(stage_index, adjacency, &mut processing_incoming, &mut ready);
+    collect_ready_downstream_stages(stage_index, adjacency, &mut incoming, &mut ready);
   }
 
   if ordered_indices.len() != stage_count {
@@ -540,7 +527,7 @@ fn collect_ready_downstream_stages(
   ready: &mut Vec<usize>,
 ) {
   for next_index in &adjacency[stage_index] {
-    processing_incoming[*next_index] = processing_incoming[*next_index].saturating_sub(1);
+    processing_incoming[*next_index] -= 1;
     if processing_incoming[*next_index] == 0 {
       ready.push(*next_index);
     }

--- a/modules/stream-core-kernel/src/lib.rs
+++ b/modules/stream-core-kernel/src/lib.rs
@@ -298,6 +298,20 @@ pub(crate) struct StreamPlan {
   kill_switch_states:        Vec<KillSwitchStateHandle>,
 }
 
+struct StreamPlanStagePorts {
+  source_indices: Vec<usize>,
+  sink_indices:   Vec<usize>,
+  input_ports:    Vec<(PortId, usize)>,
+  output_ports:   Vec<(PortId, usize)>,
+}
+
+struct StreamPlanTopology {
+  edges:     Vec<StreamPlanEdge>,
+  incoming:  Vec<usize>,
+  outgoing:  Vec<usize>,
+  adjacency: Vec<Vec<usize>>,
+}
+
 impl StreamPlan {
   pub(crate) fn from_parts(
     stages: Vec<StageDefinition>,
@@ -307,135 +321,21 @@ impl StreamPlan {
       return Err(StreamError::InvalidConnection);
     }
 
-    let mut source_indices = Vec::new();
-    let mut sink_indices = Vec::new();
+    let stage_ports = collect_stream_plan_stage_ports(&stages)?;
+    validate_stream_plan_stage_presence(&stage_ports)?;
+    let topology = build_stream_plan_topology(stages.len(), edges, &stage_ports)?;
+    validate_stream_plan_degrees(&stages, &topology)?;
+    let ordered_indices = topological_stream_plan_order(stages.len(), topology.incoming, &topology.adjacency)?;
+    let flow_order = stream_plan_flow_order(&stages, ordered_indices);
 
-    let mut input_ports = Vec::with_capacity(stages.len());
-    let mut output_ports = Vec::with_capacity(stages.len());
-
-    for (stage_index, stage) in stages.iter().enumerate() {
-      match stage {
-        | StageDefinition::Source(_) => {
-          source_indices.push(stage_index);
-        },
-        | StageDefinition::Flow(_) => {},
-        | StageDefinition::Sink(_) => {
-          sink_indices.push(stage_index);
-        },
-      }
-
-      if let Some(inlet) = stage.inlet() {
-        if input_ports.iter().any(|(port, _)| *port == inlet) {
-          return Err(StreamError::InvalidConnection);
-        }
-        input_ports.push((inlet, stage_index));
-      }
-      if let Some(outlet) = stage.outlet() {
-        if output_ports.iter().any(|(port, _)| *port == outlet) {
-          return Err(StreamError::InvalidConnection);
-        }
-        output_ports.push((outlet, stage_index));
-      }
-    }
-
-    if source_indices.is_empty() {
-      return Err(StreamError::InvalidConnection);
-    }
-    if sink_indices.is_empty() {
-      return Err(StreamError::InvalidConnection);
-    }
-
-    let mut incoming = Vec::with_capacity(stages.len());
-    let mut outgoing = Vec::with_capacity(stages.len());
-    let mut adjacency = Vec::with_capacity(stages.len());
-
-    for _ in 0..stages.len() {
-      incoming.push(0_usize);
-      outgoing.push(0_usize);
-      adjacency.push(Vec::new());
-    }
-
-    let mut plan_edges = Vec::with_capacity(edges.len());
-
-    for (from, to, mat) in edges {
-      let Some(from_stage) = output_ports.iter().find(|(port, _)| *port == from).map(|(_, stage_index)| *stage_index)
-      else {
-        return Err(StreamError::InvalidConnection);
-      };
-      let Some(to_stage) = input_ports.iter().find(|(port, _)| *port == to).map(|(_, stage_index)| *stage_index) else {
-        return Err(StreamError::InvalidConnection);
-      };
-      outgoing[from_stage] = outgoing[from_stage].saturating_add(1);
-      incoming[to_stage] = incoming[to_stage].saturating_add(1);
-      adjacency[from_stage].push(to_stage);
-      plan_edges.push(StreamPlanEdge { from_port: from, to_port: to, mat });
-    }
-
-    for stage_index in 0..stages.len() {
-      match &stages[stage_index] {
-        | StageDefinition::Source(_) => {
-          if outgoing[stage_index] == 0 {
-            return Err(StreamError::InvalidConnection);
-          }
-        },
-        | StageDefinition::Flow(definition) => {
-          if incoming[stage_index] == 0 {
-            return Err(StreamError::InvalidConnection);
-          }
-          if let Some(expected_fan_in) = definition.logic.expected_fan_in()
-            && incoming[stage_index] != expected_fan_in
-          {
-            return Err(StreamError::InvalidConnection);
-          }
-          if outgoing[stage_index] == 0 {
-            return Err(StreamError::InvalidConnection);
-          }
-          if let Some(expected_fan_out) = definition.logic.expected_fan_out()
-            && outgoing[stage_index] != expected_fan_out
-          {
-            return Err(StreamError::InvalidConnection);
-          }
-        },
-        | StageDefinition::Sink(_) => {
-          if incoming[stage_index] == 0 {
-            return Err(StreamError::InvalidConnection);
-          }
-        },
-      }
-    }
-
-    let mut ready = Vec::new();
-    for (stage_index, count) in incoming.iter().enumerate() {
-      if *count == 0 {
-        ready.push(stage_index);
-      }
-    }
-
-    let mut processing_incoming = incoming;
-    let mut ordered_indices = Vec::new();
-
-    while let Some(stage_index) = ready.pop() {
-      ordered_indices.push(stage_index);
-      for next_index in &adjacency[stage_index] {
-        processing_incoming[*next_index] = processing_incoming[*next_index].saturating_sub(1);
-        if processing_incoming[*next_index] == 0 {
-          ready.push(*next_index);
-        }
-      }
-    }
-
-    if ordered_indices.len() != stages.len() {
-      return Err(StreamError::InvalidConnection);
-    }
-
-    let mut flow_order = Vec::new();
-    for stage_index in ordered_indices {
-      if matches!(stages[stage_index], StageDefinition::Flow(_)) {
-        flow_order.push(stage_index);
-      }
-    }
-
-    Ok(Self { stages, edges: plan_edges, source_indices, sink_indices, flow_order, kill_switch_states: Vec::new() })
+    Ok(Self {
+      stages,
+      edges: topology.edges,
+      source_indices: stage_ports.source_indices,
+      sink_indices: stage_ports.sink_indices,
+      flow_order,
+      kill_switch_states: Vec::new(),
+    })
   }
 
   /// Creates a `StreamPlan` from pre-validated parts (used by island splitting).
@@ -464,6 +364,197 @@ impl StreamPlan {
   fn shared_kill_switch_states(&self) -> &[KillSwitchStateHandle] {
     &self.kill_switch_states
   }
+}
+
+fn collect_stream_plan_stage_ports(stages: &[StageDefinition]) -> Result<StreamPlanStagePorts, StreamError> {
+  let mut source_indices = Vec::new();
+  let mut sink_indices = Vec::new();
+  let mut input_ports = Vec::with_capacity(stages.len());
+  let mut output_ports = Vec::with_capacity(stages.len());
+
+  for (stage_index, stage) in stages.iter().enumerate() {
+    collect_stream_plan_stage_index(stage, stage_index, &mut source_indices, &mut sink_indices);
+    collect_unique_stage_port(&mut input_ports, stage.inlet(), stage_index)?;
+    collect_unique_stage_port(&mut output_ports, stage.outlet(), stage_index)?;
+  }
+
+  Ok(StreamPlanStagePorts { source_indices, sink_indices, input_ports, output_ports })
+}
+
+fn collect_stream_plan_stage_index(
+  stage: &StageDefinition,
+  stage_index: usize,
+  source_indices: &mut Vec<usize>,
+  sink_indices: &mut Vec<usize>,
+) {
+  match stage {
+    | StageDefinition::Source(_) => source_indices.push(stage_index),
+    | StageDefinition::Flow(_) => {},
+    | StageDefinition::Sink(_) => sink_indices.push(stage_index),
+  }
+}
+
+fn collect_unique_stage_port(
+  ports: &mut Vec<(PortId, usize)>,
+  port: Option<PortId>,
+  stage_index: usize,
+) -> Result<(), StreamError> {
+  let Some(port) = port else {
+    return Ok(());
+  };
+  if ports.iter().any(|(existing, _)| *existing == port) {
+    return Err(StreamError::InvalidConnection);
+  }
+  ports.push((port, stage_index));
+  Ok(())
+}
+
+const fn validate_stream_plan_stage_presence(stage_ports: &StreamPlanStagePorts) -> Result<(), StreamError> {
+  if stage_ports.source_indices.is_empty() || stage_ports.sink_indices.is_empty() {
+    return Err(StreamError::InvalidConnection);
+  }
+  Ok(())
+}
+
+fn build_stream_plan_topology(
+  stage_count: usize,
+  edges: Vec<(PortId, PortId, MatCombine)>,
+  stage_ports: &StreamPlanStagePorts,
+) -> Result<StreamPlanTopology, StreamError> {
+  let mut topology = empty_stream_plan_topology(stage_count, edges.len());
+  for (from, to, mat) in edges {
+    let from_stage = stage_index_for_port(&stage_ports.output_ports, from)?;
+    let to_stage = stage_index_for_port(&stage_ports.input_ports, to)?;
+    topology.outgoing[from_stage] = topology.outgoing[from_stage].saturating_add(1);
+    topology.incoming[to_stage] = topology.incoming[to_stage].saturating_add(1);
+    topology.adjacency[from_stage].push(to_stage);
+    topology.edges.push(StreamPlanEdge { from_port: from, to_port: to, mat });
+  }
+  Ok(topology)
+}
+
+fn empty_stream_plan_topology(stage_count: usize, edge_count: usize) -> StreamPlanTopology {
+  let mut incoming = Vec::with_capacity(stage_count);
+  let mut outgoing = Vec::with_capacity(stage_count);
+  let mut adjacency = Vec::with_capacity(stage_count);
+  for _ in 0..stage_count {
+    incoming.push(0_usize);
+    outgoing.push(0_usize);
+    adjacency.push(Vec::new());
+  }
+  StreamPlanTopology { edges: Vec::with_capacity(edge_count), incoming, outgoing, adjacency }
+}
+
+fn stage_index_for_port(ports: &[(PortId, usize)], port: PortId) -> Result<usize, StreamError> {
+  ports
+    .iter()
+    .find(|(existing, _)| *existing == port)
+    .map(|(_, stage_index)| *stage_index)
+    .ok_or(StreamError::InvalidConnection)
+}
+
+fn validate_stream_plan_degrees(stages: &[StageDefinition], topology: &StreamPlanTopology) -> Result<(), StreamError> {
+  for (stage_index, stage) in stages.iter().enumerate() {
+    validate_stream_plan_stage_degree(stage, topology.incoming[stage_index], topology.outgoing[stage_index])?;
+  }
+  Ok(())
+}
+
+fn validate_stream_plan_stage_degree(
+  stage: &StageDefinition,
+  incoming: usize,
+  outgoing: usize,
+) -> Result<(), StreamError> {
+  match stage {
+    | StageDefinition::Source(_) => validate_source_degree(outgoing),
+    | StageDefinition::Flow(definition) => validate_flow_degree(definition, incoming, outgoing),
+    | StageDefinition::Sink(_) => validate_sink_degree(incoming),
+  }
+}
+
+const fn validate_source_degree(outgoing: usize) -> Result<(), StreamError> {
+  if outgoing == 0 {
+    return Err(StreamError::InvalidConnection);
+  }
+  Ok(())
+}
+
+fn validate_flow_degree(definition: &FlowDefinition, incoming: usize, outgoing: usize) -> Result<(), StreamError> {
+  if incoming == 0 || outgoing == 0 {
+    return Err(StreamError::InvalidConnection);
+  }
+  if let Some(expected_fan_in) = definition.logic.expected_fan_in()
+    && incoming != expected_fan_in
+  {
+    return Err(StreamError::InvalidConnection);
+  }
+  if let Some(expected_fan_out) = definition.logic.expected_fan_out()
+    && outgoing != expected_fan_out
+  {
+    return Err(StreamError::InvalidConnection);
+  }
+  Ok(())
+}
+
+const fn validate_sink_degree(incoming: usize) -> Result<(), StreamError> {
+  if incoming == 0 {
+    return Err(StreamError::InvalidConnection);
+  }
+  Ok(())
+}
+
+fn topological_stream_plan_order(
+  stage_count: usize,
+  incoming: Vec<usize>,
+  adjacency: &[Vec<usize>],
+) -> Result<Vec<usize>, StreamError> {
+  let mut ready = stream_plan_ready_stages(&incoming);
+  let mut processing_incoming = incoming;
+  let mut ordered_indices = Vec::new();
+
+  while let Some(stage_index) = ready.pop() {
+    ordered_indices.push(stage_index);
+    collect_ready_downstream_stages(stage_index, adjacency, &mut processing_incoming, &mut ready);
+  }
+
+  if ordered_indices.len() != stage_count {
+    return Err(StreamError::InvalidConnection);
+  }
+  Ok(ordered_indices)
+}
+
+fn stream_plan_ready_stages(incoming: &[usize]) -> Vec<usize> {
+  let mut ready = Vec::new();
+  for (stage_index, count) in incoming.iter().enumerate() {
+    if *count == 0 {
+      ready.push(stage_index);
+    }
+  }
+  ready
+}
+
+fn collect_ready_downstream_stages(
+  stage_index: usize,
+  adjacency: &[Vec<usize>],
+  processing_incoming: &mut [usize],
+  ready: &mut Vec<usize>,
+) {
+  for next_index in &adjacency[stage_index] {
+    processing_incoming[*next_index] = processing_incoming[*next_index].saturating_sub(1);
+    if processing_incoming[*next_index] == 0 {
+      ready.push(*next_index);
+    }
+  }
+}
+
+fn stream_plan_flow_order(stages: &[StageDefinition], ordered_indices: Vec<usize>) -> Vec<usize> {
+  let mut flow_order = Vec::new();
+  for stage_index in ordered_indices {
+    if matches!(stages[stage_index], StageDefinition::Flow(_)) {
+      flow_order.push(stage_index);
+    }
+  }
+  flow_order
 }
 
 pub(crate) struct StreamPlanEdge {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Mostly mechanical refactors, but they touch persistence journaling/snapshot retry/polling, remoting TCP client loops, and stream lazy materialization; small logic regressions could affect message delivery, retries, or shutdown behavior.
> 
> **Overview**
> Tightens CI coverage enforcement by adding a dedicated `codecov-status` job that waits for external `codecov/project` (and `codecov/patch` on PRs) checks and makes `ci-success` depend on it; Codecov config is updated to require 100% patch coverage and fail if checks are missing.
> 
> Performs broad internal refactors to split large handlers into smaller helper functions across actor typed delivery controllers, routing (`PoolRouter`), receptionist command handling, serialization default registration, and stream lazy-source draining (including multi-island driving), with added/expanded tests for concurrency FIFO ordering, remoting installer rollback, and TCP client send/advertisement failure paths.
> 
> Refactors persistence journal and snapshot actors’ in-flight polling/retry code into shared helper functions/types, and similarly factors `PersistentActorAdapter` receive-path logic into dedicated methods without changing the public API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4a623bca22fed0ab072375e91bcdc2d7899005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 大規模な内部リファクタリングで多数のモジュールを整理し、可読性・保守性を向上。動作変更はありません。
* **Tests**
  * 並行テストやユニットテスト群を拡充・構造化し、エッジケースや失敗時の挙動検証を強化。
* **Chore (CI)**
  * CI とカバレッジ設定を更新し、外部カバレッジ結果の待機やパッチ閾値の扱いを調整。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1794)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->