### PR TITLE
[codex] Add remote StreamRef transport change

### DIFF
--- a/openspec/changes/add-remote-stream-ref-transport/.openspec.yaml
+++ b/openspec/changes/add-remote-stream-ref-transport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/add-remote-stream-ref-transport/design.md
+++ b/openspec/changes/add-remote-stream-ref-transport/design.md
@@ -1,0 +1,82 @@
+## Context
+
+Pekko `SourceRef` / `SinkRef` は remote boundary を越えて渡すための actor-backed reference であり、`StreamRefResolver` はそれらを actor path の serialization format に変換して復元する。fraktor-rs の `StreamRefs` は `StreamRefHandoff` による local handoff、protocol enum、settings、exception variants を持つが、remote resolver / serializer / actor transport 連携は存在しない。
+
+remote 側は `StdRemoteActorRefProvider` による remote ActorRef materialization、`RemoteActorRefSender` による `RemoteEvent::OutboundEnqueued` 接続、serialization registry から envelope payload への変換、TCP transport、DeathWatch / `AddressTerminated` が揃っている。次の設計課題は、stream-core に remote 依存を入れずに StreamRef protocol を actor transport へ接続することである。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `SourceRef` / `SinkRef` を remote ActorRef として serialization format 化し、別 ActorSystem で復元できる契約を定義する。
+- local handoff と remote handoff を分離し、`stream-core-kernel` の no_std 境界を維持する。
+- StreamRef demand / element / completion / failure / cancellation を remote user payload として配送し、backpressure と terminal signal を失わない。
+- remote partner termination、address termination、invalid partner、sequence mismatch を stream failure として観測可能にする。
+- 既存 remote actor ref provider / transport / serialization 経路を利用し、StreamRef 専用の transport port を追加しない。
+
+**Non-Goals:**
+
+- TLS stream API、TLS option、TLS protocol message の実装。
+- 汎用 `Tcp`, `IncomingConnection`, `OutgoingConnection` stream DSL の実装。
+- Reactive Streams TCK / Java DSL / Scala implicit API の再現。
+- remote transport wire format の互換拡張や StreamRef 専用 frame の追加。
+- cluster sharding、pub-sub、persistence replay と StreamRef の統合。
+
+## Decisions
+
+### 決定 1: StreamRef remote endpoint は actor path で表現する
+
+`SourceRef` / `SinkRef` の remote serialization format は、Pekko と同様に endpoint actor の canonical actor path string とする。binary token や独自 id table ではなく actor path を使うことで、既存 `ActorRefResolver` / `StdRemoteActorRefProvider` / remote watch hook の契約に乗せられる。
+
+代替案として StreamRef 専用 registry id を remote wire に載せる方法があるが、remote actor ref 解決と DeathWatch を二重実装することになるため採用しない。
+
+### 決定 2: `stream-core-kernel` は protocol と local semantics だけを持つ
+
+`stream-core-kernel` は no_std のまま、StreamRef protocol、settings、sequence validation、local handoff、stream failure mapping を保持する。ActorSystem、remote ActorRef、tokio task、serialization registry、TCP transport は持たない。
+
+remote endpoint actor の起動、actor path の serialization format 化、serialized path の resolve、remote protocol message の送受信は std 側または stream / remote integration layer の責務にする。core から `remote-core` へ直接依存する案は crate 境界を逆転させるため採用しない。
+
+### 決定 3: StreamRef protocol は通常の remote user payload として配送する
+
+`SequencedOnNext`、`CumulativeDemand`、`OnSubscribeHandshake`、completion、failure、ack は StreamRef protocol payload として serializer に登録し、通常の remote actor envelope 経由で配送する。`RemoteTransport` に StreamRef 専用 method や wire frame を追加しない。
+
+これにより transport は既存の backpressure / retry / serialization failure / connection closed の観測経路を使える。専用 frame は高速化余地があるが、今は意味論を増やして検証面を広げるため採用しない。
+
+### 決定 4: remote endpoint actor は partner を固定し、one-shot を守る
+
+remote StreamRef は一度だけ partner と接続できる。最初の handshake で partner actor ref を固定し、以後は partner 以外からの protocol message を invalid partner failure として扱う。二重 materialization は成功させない。
+
+これは Pekko の StreamRef が 1:1 pair であることに対応する。broadcast や multicast は複数の新しい StreamRef を作ることで表現し、単一 StreamRef の共有を許可しない。
+
+### 決定 5: remote termination は stream failure へ写像する
+
+partner actor の DeathWatch notification、remote address termination、transport-level connection closed は StreamRef endpoint に観測可能な failure として伝播する。failure は `RemoteStreamRefActorTerminated` 相当、subscription timeout、invalid sequence、invalid partner のような stream error として分類する。
+
+remote node failure を silent completion に写像する案は、要素喪失を正常終了として隠すため採用しない。
+
+### 決定 6: TCP stream API は別 change に分離する
+
+remote-adaptor-std には TCP transport 実装があるが、これは actor remoting envelope 用であり、Pekko Stream の汎用 byte stream TCP API とは責務が異なる。この change は StreamRef remote handoff に限定し、`Tcp` stream DSL と TCP error marker 型の実装は別 change で扱う。
+
+## Risks / Trade-offs
+
+- StreamRef endpoint actor と stream materializer lifecycle が循環しやすい -> endpoint actor は stream graph の materialized resource として所有し、shutdown / cancellation の責務を tasks で明確化する。
+- protocol payload serializer が未登録だと remote delivery が失敗する -> std installer または integration setup が serializer registration を必須化し、未登録は materialization failure として観測する。
+- remote backpressure と transport backpressure の区別が曖昧になる -> StreamRef demand は stream-level credit、transport backpressure は envelope enqueue failure として別エラー経路にする。
+- DeathWatch / `AddressTerminated` と StreamRef completion が競合する -> failure は remote termination を優先し、正常 completion は protocol completion を sequence 通り受けた場合だけに限定する。
+- actor path string format が将来変わる可能性がある -> resolver は actor-core の canonical path API に委譲し、StreamRef 独自 parser を持たない。
+
+## Migration Plan
+
+1. StreamRef remote endpoint / resolver の spec と tests を追加し、local handoff の既存 tests をベースラインとして維持する。
+2. protocol payload serializer と remote endpoint actor の最小実装を std / integration layer に追加する。
+3. `SourceRef` / `SinkRef` の local conversion と remote resolver conversion を分離し、二重 materialization / invalid partner / sequence failure tests を追加する。
+4. two ActorSystem integration test で `SourceRef` と `SinkRef` を remote message payload として渡し、要素、demand、completion、failure が伝播することを検証する。
+5. 実装後に `docs/gap-analysis/stream-gap-analysis.md` を更新し、StreamRef remote gap の状態を反映する。
+
+rollback は active change を削除することで行う。pre-release のため legacy compatibility alias は追加しない。
+
+## Open Questions
+
+- endpoint actor を `stream-adaptor-std` に置くか、`stream-remote-adaptor-std` 相当の新 integration crate を作るかは実装時に Cargo 依存方向を確認して決める。
+- StreamRef protocol serializer id の割り当て範囲は既存 built-in serializer id と衝突しない値を実装時に確定する。

--- a/openspec/changes/add-remote-stream-ref-transport/design.md
+++ b/openspec/changes/add-remote-stream-ref-transport/design.md
@@ -8,7 +8,7 @@ remote 側は `StdRemoteActorRefProvider` による remote ActorRef materializat
 
 **Goals:**
 
-- `SourceRef` / `SinkRef` を remote ActorRef として serialization format 化し、別 ActorSystem で復元できる契約を定義する。
+- `SourceRef` / `SinkRef` を remote endpoint actor path として serialization format 化し、別 ActorSystem で remote-capable ref として復元できる契約を定義する。
 - local handoff と remote handoff を分離し、`stream-core-kernel` の no_std 境界を維持する。
 - StreamRef demand / element / completion / failure / cancellation を remote user payload として配送し、backpressure と terminal signal を失わない。
 - remote partner termination、address termination、invalid partner、sequence mismatch を stream failure として観測可能にする。
@@ -50,7 +50,7 @@ remote StreamRef は一度だけ partner と接続できる。最初の handshak
 
 ### 決定 5: remote termination は stream failure へ写像する
 
-partner actor の DeathWatch notification、remote address termination、transport-level connection closed は StreamRef endpoint に観測可能な failure として伝播する。failure は `RemoteStreamRefActorTerminated` 相当、subscription timeout、invalid sequence、invalid partner のような stream error として分類する。
+partner actor の DeathWatch notification、remote address termination、transport-level connection closed は StreamRef endpoint に観測可能な failure として伝播する。partner actor termination は `RemoteStreamRefActorTerminated` 相当へ、address termination / connection closed は remote address または transport context を含む stream failure へ写像し、subscription timeout、invalid sequence、invalid partner と混同しない。
 
 remote node failure を silent completion に写像する案は、要素喪失を正常終了として隠すため採用しない。
 

--- a/openspec/changes/add-remote-stream-ref-transport/proposal.md
+++ b/openspec/changes/add-remote-stream-ref-transport/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+stream の固定スコープで残る非 TLS ギャップは、`SourceRef` / `SinkRef` が local handoff に閉じており、Pekko `StreamRefResolver` 相当の remote serialization / actor transport 境界を持たない点に集中している。remote actor ref 解決、payload serialization、TCP transport、DeathWatch / `AddressTerminated` integration が揃ってきたため、StreamRef を remote boundary 越しに扱う change として切り出せる。
+
+## What Changes
+
+- `SourceRef` / `SinkRef` を serialization format へ変換し、remote actor ref として復元できる `StreamRefResolver` 相当の契約を追加する。
+- local handoff と remote transport handoff を分離し、`stream-core-kernel` が `remote-core` / `remote-adaptor-std` に依存しない境界を定義する。
+- StreamRef protocol message を remote user payload として配送できる serializer / manifest / dispatch contract を追加する。
+- remote 側 StreamRef partner actor の termination、subscription timeout、invalid partner、sequence mismatch を stream failure として観測できるようにする。
+- TLS stream API は対象外とし、汎用 `Tcp` stream DSL は別 change に分離する。
+
+## Capabilities
+
+### New Capabilities
+
+- `remote-stream-ref-transport`: `SourceRef` / `SinkRef` を remote ActorRef と serialization format 経由で共有し、remote boundary 越しに back-pressured stream handoff を成立させる契約。
+
+### Modified Capabilities
+
+- `streams-backpressure-integrity`: remote boundary 越しの StreamRef demand / element / terminal signal が local stream と同じ backpressure と failure visibility を維持する要件を追加する。
+- `remote-adaptor-std-provider-dispatch`: StreamRef resolver が remote actor ref provider surface を利用して remote StreamRef endpoint を materialize する要件を追加する。
+
+## Impact
+
+- `modules/stream-core-kernel/src/stream_ref/`
+- `modules/stream-core-kernel/src/impl/streamref/`
+- `modules/stream-core-kernel/src/dsl/stream_refs.rs`
+- `modules/stream-adaptor-std/src/`
+- `modules/remote-adaptor-std/src/provider/`
+- `modules/remote-adaptor-std/src/transport/`
+- `modules/actor-core-kernel/src/serialization/`
+- `docs/gap-analysis/stream-gap-analysis.md`
+
+`stream-core-kernel` は no_std を維持し、remote ActorSystem / TCP / task / serialization registry との接続は std adaptor または integration layer に閉じる。汎用 TCP stream API と TLS API はこの change では実装しない。

--- a/openspec/changes/add-remote-stream-ref-transport/proposal.md
+++ b/openspec/changes/add-remote-stream-ref-transport/proposal.md
@@ -4,8 +4,8 @@ stream の固定スコープで残る非 TLS ギャップは、`SourceRef` / `Si
 
 ## What Changes
 
-- `SourceRef` / `SinkRef` を serialization format へ変換し、remote actor ref として復元できる `StreamRefResolver` 相当の契約を追加する。
-- local handoff と remote transport handoff を分離し、`stream-core-kernel` が `remote-core` / `remote-adaptor-std` に依存しない境界を定義する。
+- `SourceRef` / `SinkRef` を serialization format へ変換し、remote endpoint ActorRef を介した ref として復元できる `StreamRefResolver` 相当の契約を追加する。
+- local handoff と remote actor handoff を分離し、`stream-core-kernel` が `remote-core` / `remote-adaptor-std` に依存しない境界を定義する。
 - StreamRef protocol message を remote user payload として配送できる serializer / manifest / dispatch contract を追加する。
 - remote 側 StreamRef partner actor の termination、subscription timeout、invalid partner、sequence mismatch を stream failure として観測できるようにする。
 - TLS stream API は対象外とし、汎用 `Tcp` stream DSL は別 change に分離する。
@@ -14,7 +14,7 @@ stream の固定スコープで残る非 TLS ギャップは、`SourceRef` / `Si
 
 ### New Capabilities
 
-- `remote-stream-ref-transport`: `SourceRef` / `SinkRef` を remote ActorRef と serialization format 経由で共有し、remote boundary 越しに back-pressured stream handoff を成立させる契約。
+- `remote-stream-ref-transport`: `SourceRef` / `SinkRef` を endpoint actor path と serialization format 経由で共有し、remote boundary 越しに back-pressured stream handoff を成立させる契約。
 
 ### Modified Capabilities
 
@@ -28,7 +28,6 @@ stream の固定スコープで残る非 TLS ギャップは、`SourceRef` / `Si
 - `modules/stream-core-kernel/src/dsl/stream_refs.rs`
 - `modules/stream-adaptor-std/src/`
 - `modules/remote-adaptor-std/src/provider/`
-- `modules/remote-adaptor-std/src/transport/`
 - `modules/actor-core-kernel/src/serialization/`
 - `docs/gap-analysis/stream-gap-analysis.md`
 

--- a/openspec/changes/add-remote-stream-ref-transport/specs/remote-adaptor-std-provider-dispatch/spec.md
+++ b/openspec/changes/add-remote-stream-ref-transport/specs/remote-adaptor-std-provider-dispatch/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: StreamRef resolver uses remote-aware actor-ref provider dispatch
+
+The std StreamRef resolver SHALL use the installed remote-aware actor-ref provider to resolve serialized StreamRef endpoint actor paths. It MUST NOT bypass provider dispatch by constructing `RemoteActorRefSender`, `RemoteEvent`, `TcpRemoteTransport`, or transport endpoints directly.
+
+#### Scenario: resolver uses ActorSystem provider surface
+
+- **GIVEN** a remote-aware actor-ref provider is installed in the ActorSystem
+- **WHEN** the StreamRef resolver resolves a serialized SourceRef or SinkRef actor path
+- **THEN** it calls the ActorSystem actor-ref resolution surface or an equivalent provider-dispatch API
+- **AND** the returned ActorRef is the endpoint used by the remote StreamRef wrapper
+
+#### Scenario: resolver does not construct transport directly
+
+- **WHEN** the StreamRef resolver implementation is inspected
+- **THEN** it does not instantiate `TcpRemoteTransport`
+- **AND** it does not enqueue `RemoteEvent::OutboundEnqueued` directly
+- **AND** it does not parse host and port into a transport connection outside provider dispatch
+
+#### Scenario: loopback serialized path stays local
+
+- **GIVEN** a serialized StreamRef endpoint path whose authority resolves to the local ActorSystem
+- **WHEN** the StreamRef resolver resolves that path
+- **THEN** provider dispatch applies the normal loopback rule
+- **AND** the resulting endpoint uses local actor delivery rather than remote TCP delivery
+
+#### Scenario: remote serialized path uses remote sender
+
+- **GIVEN** a serialized StreamRef endpoint path whose authority does not match the local ActorSystem
+- **WHEN** the StreamRef resolver resolves that path
+- **THEN** provider dispatch materializes a remote ActorRef
+- **AND** sending StreamRef protocol payloads to that ActorRef reaches the existing remote outbound envelope path
+
+### Requirement: remote watch integration covers StreamRef endpoint partners
+
+Remote StreamRef endpoint actors SHALL participate in the existing remote watch integration so partner termination can fail the materialized stream.
+
+#### Scenario: endpoint watches partner actor
+
+- **WHEN** a remote StreamRef endpoint accepts a partner handshake
+- **THEN** it registers a watch for the partner actor through the actor system watch path
+- **AND** remote watch hook dispatch handles remote partners using existing provider mapping
+
+#### Scenario: unpairing removes partner watch
+
+- **WHEN** a remote StreamRef endpoint reaches normal completion, cancellation, or failure
+- **THEN** it unregisters or otherwise releases the partner watch through the existing actor watch path
+- **AND** any failure to release the watch is observable rather than silently ignored
+
+#### Scenario: DeathWatch notification is routed to endpoint
+
+- **WHEN** the remote partner terminates before protocol completion
+- **THEN** the existing remote watch hook delivers a DeathWatch notification to the StreamRef endpoint actor
+- **AND** the endpoint fails the stream instead of completing it normally

--- a/openspec/changes/add-remote-stream-ref-transport/specs/remote-stream-ref-transport/spec.md
+++ b/openspec/changes/add-remote-stream-ref-transport/specs/remote-stream-ref-transport/spec.md
@@ -30,7 +30,7 @@ The system SHALL provide a StreamRef resolver contract that converts `SourceRef`
 
 ### Requirement: stream-core remains independent from remote and std
 
-The StreamRef remote transport implementation SHALL keep `stream-core-kernel` independent from `remote-core`, `remote-adaptor-std`, tokio, TCP, and std-only ActorSystem resources. Core SHALL own protocol semantics, settings, sequence validation, local handoff, and stream errors only.
+The remote StreamRef implementation SHALL keep `stream-core-kernel` independent from `remote-core`, `remote-adaptor-std`, tokio, TCP, and std-only ActorSystem resources. Core SHALL own protocol semantics, settings, sequence validation, local handoff, and stream errors only.
 
 #### Scenario: stream-core has no remote dependency
 
@@ -97,7 +97,14 @@ Remote partner actor termination, remote address termination, and transport conn
 #### Scenario: address termination fails the stream
 
 - **WHEN** the remote address that owns the paired endpoint is published as terminated before normal protocol completion
-- **THEN** the materialized stream fails with a remote StreamRef actor terminated error
+- **THEN** the materialized stream fails with a remote-address termination stream error
+- **AND** the failure context identifies the terminated remote address
+
+#### Scenario: transport connection loss fails the stream
+
+- **WHEN** the remote actor delivery path reports connection loss for the paired endpoint before normal protocol completion
+- **THEN** the materialized stream fails with a transport-related stream error
+- **AND** the failure is not reported as normal completion or as an invalid partner error
 
 #### Scenario: normal completion remains protocol-driven
 

--- a/openspec/changes/add-remote-stream-ref-transport/specs/remote-stream-ref-transport/spec.md
+++ b/openspec/changes/add-remote-stream-ref-transport/specs/remote-stream-ref-transport/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: StreamRef resolver serializes refs as canonical actor paths
+
+The system SHALL provide a StreamRef resolver contract that converts `SourceRef` and `SinkRef` backed by remote-capable endpoints to canonical actor path strings, and resolves those strings back into refs through the actor-ref provider surface.
+
+#### Scenario: SourceRef is converted to serialization format
+
+- **WHEN** a remote-capable `SourceRef` is passed to the StreamRef resolver
+- **THEN** the resolver returns the canonical actor path string of the SourceRef endpoint actor
+- **AND** the string includes the remote authority needed by another ActorSystem to resolve it
+
+#### Scenario: SinkRef is converted to serialization format
+
+- **WHEN** a remote-capable `SinkRef` is passed to the StreamRef resolver
+- **THEN** the resolver returns the canonical actor path string of the SinkRef endpoint actor
+- **AND** the string includes the remote authority needed by another ActorSystem to resolve it
+
+#### Scenario: Serialized SourceRef is resolved through provider dispatch
+
+- **WHEN** another ActorSystem resolves a serialized SourceRef string
+- **THEN** the resolver uses the actor-ref provider surface to materialize the remote endpoint ActorRef
+- **AND** it does not parse the path into a transport connection by itself
+
+#### Scenario: Serialized SinkRef is resolved through provider dispatch
+
+- **WHEN** another ActorSystem resolves a serialized SinkRef string
+- **THEN** the resolver uses the actor-ref provider surface to materialize the remote endpoint ActorRef
+- **AND** it does not parse the path into a transport connection by itself
+
+### Requirement: stream-core remains independent from remote and std
+
+The StreamRef remote transport implementation SHALL keep `stream-core-kernel` independent from `remote-core`, `remote-adaptor-std`, tokio, TCP, and std-only ActorSystem resources. Core SHALL own protocol semantics, settings, sequence validation, local handoff, and stream errors only.
+
+#### Scenario: stream-core has no remote dependency
+
+- **WHEN** `stream-core-kernel` Cargo dependencies are inspected
+- **THEN** they do not include `fraktor-remote-core-rs` or `fraktor-remote-adaptor-std-rs`
+- **AND** remote endpoint actor wiring is not implemented inside `stream-core-kernel`
+
+#### Scenario: std integration owns remote endpoint actor wiring
+
+- **WHEN** remote StreamRef endpoint actors, resolver installation, or serializer registration are implemented
+- **THEN** those implementations live in a std adaptor or integration layer
+- **AND** they may depend on actor / remote std runtime resources without leaking those dependencies into stream-core
+
+### Requirement: StreamRef protocol messages are delivered as remote actor payloads
+
+Remote StreamRef communication SHALL deliver StreamRef protocol messages through normal remote actor envelopes. The implementation MUST NOT add a StreamRef-specific `RemoteTransport` method or wire frame for this change.
+
+#### Scenario: demand is sent as a protocol payload
+
+- **WHEN** the receiving side requests more elements from a remote StreamRef partner
+- **THEN** cumulative demand is sent to the partner endpoint actor as a serialized StreamRef protocol payload
+
+#### Scenario: element is sent as a sequenced protocol payload
+
+- **WHEN** the producing side has demand and an element to deliver
+- **THEN** the element is sent as a sequenced StreamRef protocol payload through remote actor delivery
+
+#### Scenario: transport port is not extended for StreamRef
+
+- **WHEN** `RemoteTransport` is inspected after this change
+- **THEN** it does not contain StreamRef-specific methods
+- **AND** StreamRef delivery uses the existing outbound envelope path
+
+### Requirement: StreamRef endpoints enforce one-shot partner pairing
+
+A remote StreamRef endpoint SHALL pair with exactly one partner actor. After the first valid subscription handshake, messages from any different actor MUST fail the stream as an invalid partner condition.
+
+#### Scenario: first handshake fixes the partner
+
+- **WHEN** a remote StreamRef endpoint receives its first valid subscription handshake
+- **THEN** it records the sender actor as the only valid partner for the lifetime of that ref
+
+#### Scenario: second partner is rejected
+
+- **WHEN** a different actor sends demand, element, completion, failure, or handshake messages to an already paired StreamRef endpoint
+- **THEN** the endpoint fails the stream with an invalid partner error
+- **AND** it does not accept the second actor as a new partner
+
+#### Scenario: double materialization is rejected
+
+- **WHEN** the same serialized StreamRef is resolved and materialized more than once as an active remote connection
+- **THEN** only one partner pairing can succeed
+- **AND** the later materialization fails rather than sharing the same ref
+
+### Requirement: remote termination is visible as StreamRef failure
+
+Remote partner actor termination, remote address termination, and transport connection loss SHALL be observed as StreamRef failures. They MUST NOT be converted to normal stream completion.
+
+#### Scenario: partner DeathWatch fails the stream
+
+- **WHEN** the endpoint actor receives a DeathWatch notification for its paired partner before normal protocol completion
+- **THEN** the materialized stream fails with a remote StreamRef actor terminated error
+
+#### Scenario: address termination fails the stream
+
+- **WHEN** the remote address that owns the paired endpoint is published as terminated before normal protocol completion
+- **THEN** the materialized stream fails with a remote StreamRef actor terminated error
+
+#### Scenario: normal completion remains protocol-driven
+
+- **WHEN** the partner sends the sequenced remote stream completed message
+- **THEN** the stream completes normally only after sequence validation succeeds
+- **AND** no remote termination signal has already failed the stream
+
+### Requirement: sequence and failure validation is preserved across remote boundary
+
+Remote StreamRef endpoints SHALL validate sequence numbers, demand values, protocol failures, and partner identity with the same strictness as local StreamRef handoff.
+
+#### Scenario: out-of-order element fails the stream
+
+- **WHEN** a remote StreamRef endpoint receives `SequencedOnNext` with a sequence number different from the expected sequence number
+- **THEN** the endpoint fails the stream with an invalid sequence number error
+
+#### Scenario: invalid demand fails the stream
+
+- **WHEN** a remote StreamRef endpoint receives demand with a zero or otherwise invalid demand count
+- **THEN** the endpoint fails the stream with an invalid demand error
+
+#### Scenario: remote failure message fails the stream
+
+- **WHEN** a remote StreamRef endpoint receives a remote stream failure protocol message from its partner
+- **THEN** the local materialized stream fails with the received failure context

--- a/openspec/changes/add-remote-stream-ref-transport/specs/streams-backpressure-integrity/spec.md
+++ b/openspec/changes/add-remote-stream-ref-transport/specs/streams-backpressure-integrity/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: remote StreamRef preserves backpressure and terminal ordering
+
+Remote StreamRef handoff SHALL preserve stream-level backpressure, pending elements, completion, failure, and cancellation across the actor remoting boundary. Transport enqueue backpressure MUST be observable separately from stream-level demand and MUST NOT silently drop accepted stream elements.
+
+#### Scenario: elements are not sent without demand
+
+- **WHEN** a remote SourceRef endpoint has buffered elements but has not received cumulative demand from the partner
+- **THEN** it does not send those elements as accepted downstream delivery
+- **AND** the elements remain pending until demand or terminal failure changes the state
+
+#### Scenario: accepted element is not lost on transport backpressure
+
+- **WHEN** a remote StreamRef endpoint has an accepted element and remote actor delivery reports transport backpressure
+- **THEN** the endpoint keeps the element pending or fails the stream with an observable transport error
+- **AND** it does not silently discard the element
+
+#### Scenario: completion is delivered after pending elements
+
+- **WHEN** the producing side completes after sending one or more sequenced elements
+- **THEN** the remote partner observes all valid pending elements before normal completion
+- **AND** completion is not reordered ahead of elements that passed sequence validation
+
+#### Scenario: failure takes precedence over normal completion
+
+- **WHEN** a remote StreamRef endpoint observes remote failure, invalid sequence, invalid partner, or partner termination before protocol completion is accepted
+- **THEN** the materialized stream fails
+- **AND** it does not report normal completion for the same connection
+
+#### Scenario: cancellation propagates to the remote partner
+
+- **WHEN** the local materialized stream is cancelled before normal completion
+- **THEN** the remote StreamRef endpoint sends a cancellation or terminal failure signal to its partner
+- **AND** the partner stops publishing additional elements for that ref

--- a/openspec/changes/add-remote-stream-ref-transport/tasks.md
+++ b/openspec/changes/add-remote-stream-ref-transport/tasks.md
@@ -1,0 +1,46 @@
+## 1. Baseline and Contract Review
+
+- [ ] 1.1 Re-read Pekko `StreamRefs`, `StreamRefResolverImpl`, `StreamRefsMaster`, `SourceRefImpl`, `SinkRefImpl`, and stream ref protocol references; record only implementation-relevant notes in tests or code comments.
+- [ ] 1.2 Inspect current `stream-core-kernel` StreamRef local handoff, protocol, settings, and error mapping before editing.
+- [ ] 1.3 Inspect current remote provider dispatch, remote watch hook, serialization registry, and TCP outbound envelope path before editing.
+- [ ] 1.4 Run focused baseline tests for StreamRef, stream backpressure, remote provider dispatch, remote watch hook, and serialization paths.
+
+## 2. StreamRef Core Boundary
+
+- [ ] 2.1 Keep `stream-core-kernel` free of `remote-core`, `remote-adaptor-std`, tokio, and std-only dependencies while adding any protocol or error surface needed by remote StreamRef.
+- [ ] 2.2 Add or adjust StreamRef protocol tests for sequence validation, invalid demand, remote failure, and terminal ordering that are shared by local and remote handoff.
+- [ ] 2.3 Preserve existing local `SourceRef::into_source` and `SinkRef::into_sink` semantics while making remote-capable endpoint ownership explicit.
+- [ ] 2.4 Add tests proving local handoff still works without remote runtime installation.
+
+## 3. Resolver and Serialization Integration
+
+- [ ] 3.1 Implement StreamRef resolver installation in the std adaptor or integration layer without adding remote dependencies to stream-core.
+- [ ] 3.2 Convert remote-capable `SourceRef` and `SinkRef` to canonical endpoint actor path strings using actor-core path APIs.
+- [ ] 3.3 Resolve serialized SourceRef and SinkRef strings through ActorSystem actor-ref provider dispatch, including loopback and remote authority cases.
+- [ ] 3.4 Register StreamRef protocol payload serializers or equivalent manifest routes required for remote delivery.
+- [ ] 3.5 Add tests for missing serializer registration and unsupported ref implementation failures.
+
+## 4. Remote Endpoint Actor Wiring
+
+- [ ] 4.1 Materialize SourceRef and SinkRef endpoint actors as owned stream resources with deterministic shutdown on completion, cancellation, and failure.
+- [ ] 4.2 Route cumulative demand, sequenced elements, handshake, completion, failure, and cancellation through normal remote ActorRef delivery.
+- [ ] 4.3 Enforce one-shot partner pairing and reject double materialization or messages from a non-partner actor.
+- [ ] 4.4 Connect endpoint partner watches through the existing actor watch path and remote watch hook.
+- [ ] 4.5 Ensure watch release failures, send failures, and endpoint shutdown failures are observable and not silently ignored.
+
+## 5. Backpressure and Failure Semantics
+
+- [ ] 5.1 Verify elements are not delivered without remote cumulative demand.
+- [ ] 5.2 Preserve pending elements when transport enqueue reports backpressure, or fail the stream with an observable error.
+- [ ] 5.3 Verify completion is observed only after pending sequenced elements are delivered.
+- [ ] 5.4 Map partner DeathWatch notification, address termination, transport connection loss, invalid sequence, invalid demand, and invalid partner to stream failure.
+- [ ] 5.5 Verify cancellation propagates to the remote partner and prevents further element publication for that ref.
+
+## 6. Integration Tests and Documentation
+
+- [ ] 6.1 Add two-ActorSystem integration tests for passing a SourceRef as a remote message payload and streaming elements with backpressure.
+- [ ] 6.2 Add two-ActorSystem integration tests for passing a SinkRef as a remote message payload and streaming elements with backpressure.
+- [ ] 6.3 Add remote failure integration tests for partner termination and address termination before protocol completion.
+- [ ] 6.4 Update `docs/gap-analysis/stream-gap-analysis.md` to reflect the StreamRef remote gap status after implementation.
+- [ ] 6.5 Run targeted crate tests, `mise exec -- openspec validate add-remote-stream-ref-transport --strict`, and `git diff --check`.
+- [ ] 6.6 Unless a narrower verification scope is explicitly approved, run `./scripts/ci-check.sh ai all` before marking the change complete.

--- a/openspec/changes/add-remote-stream-ref-transport/tasks.md
+++ b/openspec/changes/add-remote-stream-ref-transport/tasks.md
@@ -33,7 +33,7 @@
 - [ ] 5.1 Verify elements are not delivered without remote cumulative demand.
 - [ ] 5.2 Preserve pending elements when transport enqueue reports backpressure, or fail the stream with an observable error.
 - [ ] 5.3 Verify completion is observed only after pending sequenced elements are delivered.
-- [ ] 5.4 Map partner DeathWatch notification, address termination, transport connection loss, invalid sequence, invalid demand, and invalid partner to stream failure.
+- [ ] 5.4 Map partner DeathWatch notification, address termination, transport connection loss, invalid sequence, invalid demand, and invalid partner to distinct observable stream failures.
 - [ ] 5.5 Verify cancellation propagates to the remote partner and prevents further element publication for that ref.
 
 ## 6. Integration Tests and Documentation


### PR DESCRIPTION
## Summary

- add an OpenSpec change for remote StreamRef transport integration
- define the new `remote-stream-ref-transport` capability
- add deltas for stream backpressure integrity and remote provider dispatch
- keep TLS and generic TCP stream APIs explicitly out of scope

## Why

The remaining non-TLS stream gap is concentrated around `SourceRef` / `SinkRef` being local handoff only. The recent remote work makes the StreamRef resolver, serializer, actor transport, DeathWatch, and AddressTerminated integration feasible to specify as a focused change.

## Validation

- `mise exec -- openspec validate add-remote-stream-ref-transport --strict`
- `git diff --cached --check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only addition that introduces new OpenSpec requirements and design notes; no runtime code is modified, so execution risk is minimal aside from downstream implementation alignment.
> 
> **Overview**
> Adds a new OpenSpec change, `add-remote-stream-ref-transport`, specifying how `SourceRef`/`SinkRef` are serialized as canonical actor paths and resolved via actor-ref provider dispatch for **remote** StreamRef handoff.
> 
> Defines requirements for delivering StreamRef protocol messages as standard remote actor payloads (no new transport frames/ports), enforcing one-shot partner pairing, and surfacing remote termination/sequence/demand issues as stream failures, plus related backpressure-integrity and remote provider-dispatch/watch integration deltas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31e1b1a262c2150150b0fcf5bd8ef0081252869. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->