### PR TITLE
[codex] Fix inbound handshake association leak

### DIFF
--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -1,5 +1,9 @@
 //! Default core implementation of the remoting lifecycle API.
 
+#[cfg(test)]
+#[path = "remote_test.rs"]
+mod tests;
+
 use alloc::{
   boxed::Box,
   format,
@@ -301,20 +305,11 @@ impl Remote {
     Ok(self.associations.len() - 1)
   }
 
-  fn ensure_association_for_handshake_request(&mut self, request: &HandshakeReq) -> Option<usize> {
+  fn association_index_for_handshake_request(&self, request: &HandshakeReq) -> Option<usize> {
     if !self.is_local_handshake_destination(request.to()) {
       return None;
     }
-    if let Some(index) = self.association_index_for_remote(request.from().address()) {
-      return Some(index);
-    }
-    let association = Association::from_config(
-      UniqueAddress::new(request.to().clone(), 0),
-      request.from().address().clone(),
-      &self.config,
-    );
-    self.insert_association(association);
-    Some(self.associations.len() - 1)
+    self.association_index_for_remote(request.from().address())
   }
 
   fn association_index_for_remote(&self, remote: &Address) -> Option<usize> {
@@ -419,7 +414,7 @@ impl Remote {
   }
 
   fn handle_inbound_handshake_request(&mut self, request: &HandshakeReq, now_ms: u64) -> Result<(), RemotingError> {
-    let Some(association_index) = self.ensure_association_for_handshake_request(request) else {
+    let Some(association_index) = self.association_index_for_handshake_request(request) else {
       return Ok(());
     };
     let accepted = {

--- a/modules/remote-core/src/extension/remote_test.rs
+++ b/modules/remote-core/src/extension/remote_test.rs
@@ -1,0 +1,7 @@
+use crate::extension::Remote;
+
+impl Remote {
+  pub(crate) const fn association_count_for_test(&self) -> usize {
+    self.associations.len()
+  }
+}

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -881,6 +881,36 @@ fn inbound_handshake_request_rejects_forged_local_destination() {
 }
 
 #[test]
+fn inbound_handshake_requests_from_unknown_sources_do_not_create_associations() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let transport = RecordingTransport::new(vec![local_address.clone()]);
+  let handshake_calls = transport.handshake_calls.clone();
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let mut remote = remote_new(transport, RemoteConfig::new("127.0.0.1"), event_publisher());
+  remote.start().expect("remote should be running before inbound handshakes");
+
+  for index in 0..64_u16 {
+    let remote_address = Address::new("remote-sys", "10.0.0.1", 30_000 + index);
+    let request = HandshakePdu::Req(HandshakeReq::new(
+      UniqueAddress::new(remote_address.clone(), u64::from(index) + 1),
+      local_address.clone(),
+    ));
+
+    remote
+      .handle_remote_event(RemoteEvent::InboundFrameReceived {
+        authority: TransportEndpoint::new(remote_address.to_string()),
+        frame:     WireFrame::Handshake(request),
+        now_ms:    u64::from(index) + 42,
+      })
+      .expect("unknown inbound handshake should be ignored without failing the event loop");
+  }
+
+  assert_eq!(remote.association_count_for_test(), 0);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 0);
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
 fn inbound_deployment_frame_without_adapter_routing_is_ignored() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);
   let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);


### PR DESCRIPTION
## Summary
- Stop inbound `HandshakeReq` lookup from creating a new `Association` for an unknown claimed remote address.
- Keep unknown inbound handshakes as no-ops while still routing known associations through the existing state-machine validation.
- Add a regression test that sends 64 distinct unknown inbound handshake requests and verifies no association, peer connection, or handshake response is created.

## Root Cause
Inbound handshake handling created an `Association` from untrusted `request.from().address()` data before the handshake was accepted. The fresh association was still `Idle`, so `accept_handshake_request` rejected it, and the handler returned `Ok(())` while leaving the idle entry in the in-memory association vector.

## Validation
- `cargo test -p fraktor-remote-core-rs inbound_handshake_requests_from_unknown_sources_do_not_create_associations -- --nocapture`
- `cargo test -p fraktor-remote-core-rs inbound_handshake -- --nocapture`
- `cargo test -p fraktor-remote-core-rs`
- `./scripts/ci-check.sh ai lint`
- `./scripts/ci-check.sh ai unit-test`
- `./scripts/ci-check.sh ai dylint tests-location-lint use-placement-lint redundant-fqcn-lint module-wiring-lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound handshake handling to stop creating new `Association` entries from untrusted `HandshakeReq` source data, which could affect connection establishment and handshake acceptance flows.
> 
> **Overview**
> Prevents inbound `HandshakeReq` processing from implicitly creating new `Association` entries; inbound handshakes now only proceed when an existing association for the claimed remote already exists (unknown sources become no-ops).
> 
> Adds a small test-only accessor (`association_count_for_test`) and a regression test that sends many unknown inbound handshakes and asserts no associations are created and no transport `connect_peer`/handshake sends occur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c30570bfb559bfd8c509ce41cad53988df284920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->