### PR TITLE
fix(persistence): make typed effector signals unforgeable

### DIFF
--- a/modules/persistence-core-typed/src/internal/persistence_store_reply.rs
+++ b/modules/persistence-core-typed/src/internal/persistence_store_reply.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use fraktor_persistence_core_kernel_rs::error::PersistenceError;
 
-use crate::PersistenceEffectorSignal;
+use crate::{PersistenceEffectorSignal, persistence_effector_signal::PersistenceEffectorSignalAuth};
 
 #[derive(Clone, Debug)]
 pub(crate) enum PersistenceStoreReply<S, E> {
@@ -19,14 +19,18 @@ impl<S, E> From<PersistenceStoreReply<S, E>> for PersistenceEffectorSignal<S, E>
   fn from(reply: PersistenceStoreReply<S, E>) -> Self {
     match reply {
       | PersistenceStoreReply::RecoveryCompleted { state, sequence_nr } => {
-        Self::RecoveryCompleted { state, sequence_nr }
+        Self::RecoveryCompleted { auth: PersistenceEffectorSignalAuth::new(), state, sequence_nr }
       },
-      | PersistenceStoreReply::PersistedEvents { events, sequence_nr } => Self::PersistedEvents { events, sequence_nr },
+      | PersistenceStoreReply::PersistedEvents { events, sequence_nr } => {
+        Self::PersistedEvents { auth: PersistenceEffectorSignalAuth::new(), events, sequence_nr }
+      },
       | PersistenceStoreReply::PersistedSnapshot { snapshot, sequence_nr } => {
-        Self::PersistedSnapshot { snapshot, sequence_nr }
+        Self::PersistedSnapshot { auth: PersistenceEffectorSignalAuth::new(), snapshot, sequence_nr }
       },
-      | PersistenceStoreReply::DeletedSnapshots { to_sequence_nr } => Self::DeletedSnapshots { to_sequence_nr },
-      | PersistenceStoreReply::Failed { error } => Self::Failed { error },
+      | PersistenceStoreReply::DeletedSnapshots { to_sequence_nr } => {
+        Self::DeletedSnapshots { auth: PersistenceEffectorSignalAuth::new(), to_sequence_nr }
+      },
+      | PersistenceStoreReply::Failed { error } => Self::Failed { auth: PersistenceEffectorSignalAuth::new(), error },
     }
   }
 }

--- a/modules/persistence-core-typed/src/internal/persistence_store_reply.rs
+++ b/modules/persistence-core-typed/src/internal/persistence_store_reply.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use fraktor_persistence_core_kernel_rs::error::PersistenceError;
 
-use crate::{PersistenceEffectorSignal, persistence_effector_signal::PersistenceEffectorSignalAuth};
+use crate::{PersistenceEffectorSignal, persistence_effector_signal_auth::PersistenceEffectorSignalAuth};
 
 #[derive(Clone, Debug)]
 pub(crate) enum PersistenceStoreReply<S, E> {

--- a/modules/persistence-core-typed/src/lib.rs
+++ b/modules/persistence-core-typed/src/lib.rs
@@ -18,6 +18,7 @@ mod persistence_effector;
 mod persistence_effector_config;
 mod persistence_effector_message_adapter;
 mod persistence_effector_signal;
+mod persistence_effector_signal_auth;
 mod persistence_id;
 mod persistence_mode;
 mod retention_criteria;

--- a/modules/persistence-core-typed/src/persistence_effector.rs
+++ b/modules/persistence-core-typed/src/persistence_effector.rs
@@ -172,14 +172,14 @@ where
       Behaviors::receive_message(move |ctx, message| {
         if let Some(signal) = adapter.unwrap_signal(message) {
           return match signal {
-            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr } => {
+            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
               let effector =
                 Self::active(config.clone(), store_ref.clone(), reply_to.clone(), *sequence_nr, on_ready.clone());
               let next = on_ready(state.clone(), effector)?;
               stash.unstash_all(ctx)?;
               Ok(next)
             },
-            | PersistenceEffectorSignal::Failed { error } => Err(ActorError::fatal(error.to_string())),
+            | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
             | _ => Ok(Behaviors::unhandled()),
           };
         }
@@ -432,7 +432,7 @@ where
       Behaviors::receive_message(move |ctx, message| {
         if let Some(signal) = adapter.unwrap_signal(message) {
           return match signal {
-            | PersistenceEffectorSignal::PersistedEvents { events, sequence_nr } => {
+            | PersistenceEffectorSignal::PersistedEvents { events, sequence_nr, .. } => {
               sequence_nr_cell.with_lock(|stored_sequence_nr| {
                 *stored_sequence_nr = *sequence_nr;
               });
@@ -442,10 +442,10 @@ where
               stash.unstash_all(ctx)?;
               Ok(next)
             },
-            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr } => {
+            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
               effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
             },
-            | PersistenceEffectorSignal::Failed { error } => Err(ActorError::fatal(error.to_string())),
+            | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
             | _ => Ok(Behaviors::unhandled()),
           };
         }
@@ -479,7 +479,7 @@ where
       Behaviors::receive_message(move |ctx, message| {
         if let Some(signal) = adapter.unwrap_signal(message) {
           return match signal {
-            | PersistenceEffectorSignal::PersistedEvents { events, sequence_nr } => {
+            | PersistenceEffectorSignal::PersistedEvents { events, sequence_nr, .. } => {
               sequence_nr_cell.with_lock(|stored_sequence_nr| {
                 *stored_sequence_nr = *sequence_nr;
               });
@@ -507,10 +507,10 @@ where
               stash.unstash_all(ctx)?;
               Ok(next)
             },
-            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr } => {
+            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
               effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
             },
-            | PersistenceEffectorSignal::Failed { error } => Err(ActorError::fatal(error.to_string())),
+            | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
             | _ => Ok(Behaviors::unhandled()),
           };
         }
@@ -541,7 +541,7 @@ where
       Behaviors::receive_message(move |ctx, message| {
         if let Some(signal) = adapter.unwrap_signal(message) {
           return match signal {
-            | PersistenceEffectorSignal::PersistedSnapshot { snapshot, sequence_nr } => {
+            | PersistenceEffectorSignal::PersistedSnapshot { snapshot, sequence_nr, .. } => {
               sequence_nr_cell.with_lock(|stored_sequence_nr| {
                 *stored_sequence_nr = *sequence_nr;
               });
@@ -568,10 +568,10 @@ where
               stash.unstash_all(ctx)?;
               Ok(next)
             },
-            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr } => {
+            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
               effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
             },
-            | PersistenceEffectorSignal::Failed { error } => Err(ActorError::fatal(error.to_string())),
+            | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
             | _ => Ok(Behaviors::unhandled()),
           };
         }
@@ -593,7 +593,7 @@ where
     Behaviors::receive_message(move |ctx, message| {
       if let Some(signal) = adapter.unwrap_signal(message) {
         return match signal {
-          | PersistenceEffectorSignal::DeletedSnapshots { to_sequence_nr: deleted_to_sequence_nr }
+          | PersistenceEffectorSignal::DeletedSnapshots { to_sequence_nr: deleted_to_sequence_nr, .. }
             if *deleted_to_sequence_nr == to_sequence_nr =>
           {
             let next = snapshot.with_lock(|snapshot_slot| {
@@ -608,10 +608,10 @@ where
           | PersistenceEffectorSignal::DeletedSnapshots { .. } => {
             Err(ActorError::fatal("unexpected snapshot deletion acknowledgement"))
           },
-          | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr } => {
+          | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
             effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
           },
-          | PersistenceEffectorSignal::Failed { error } => Err(ActorError::fatal(error.to_string())),
+          | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
           | _ => Ok(Behaviors::unhandled()),
         };
       }

--- a/modules/persistence-core-typed/src/persistence_effector_signal.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_signal.rs
@@ -4,8 +4,7 @@ use alloc::vec::Vec;
 
 use fraktor_persistence_core_kernel_rs::error::PersistenceError;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct PersistenceEffectorSignalAuth(());
+use crate::persistence_effector_signal_auth::PersistenceEffectorSignalAuth;
 
 /// Stable signal delivered to the aggregate actor through its private message type.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -51,11 +50,4 @@ pub enum PersistenceEffectorSignal<S, E> {
     /// Persistence kernel error.
     error: PersistenceError,
   },
-}
-
-impl PersistenceEffectorSignalAuth {
-  #[must_use]
-  pub(crate) const fn new() -> Self {
-    Self(())
-  }
 }

--- a/modules/persistence-core-typed/src/persistence_effector_signal.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_signal.rs
@@ -10,6 +10,7 @@ use crate::persistence_effector_signal_auth::PersistenceEffectorSignalAuth;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PersistenceEffectorSignal<S, E> {
   /// Recovery completed with the recovered state and latest sequence number.
+  #[non_exhaustive]
   RecoveryCompleted {
     #[doc(hidden)]
     auth:        PersistenceEffectorSignalAuth,
@@ -19,6 +20,7 @@ pub enum PersistenceEffectorSignal<S, E> {
     sequence_nr: u64,
   },
   /// Events were persisted in order.
+  #[non_exhaustive]
   PersistedEvents {
     #[doc(hidden)]
     auth:        PersistenceEffectorSignalAuth,
@@ -28,6 +30,7 @@ pub enum PersistenceEffectorSignal<S, E> {
     sequence_nr: u64,
   },
   /// A snapshot was persisted.
+  #[non_exhaustive]
   PersistedSnapshot {
     #[doc(hidden)]
     auth:        PersistenceEffectorSignalAuth,
@@ -37,6 +40,7 @@ pub enum PersistenceEffectorSignal<S, E> {
     sequence_nr: u64,
   },
   /// Old snapshots were deleted.
+  #[non_exhaustive]
   DeletedSnapshots {
     #[doc(hidden)]
     auth:           PersistenceEffectorSignalAuth,
@@ -44,6 +48,7 @@ pub enum PersistenceEffectorSignal<S, E> {
     to_sequence_nr: u64,
   },
   /// Persistence failed.
+  #[non_exhaustive]
   Failed {
     #[doc(hidden)]
     auth:  PersistenceEffectorSignalAuth,

--- a/modules/persistence-core-typed/src/persistence_effector_signal.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_signal.rs
@@ -4,11 +4,16 @@ use alloc::vec::Vec;
 
 use fraktor_persistence_core_kernel_rs::error::PersistenceError;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PersistenceEffectorSignalAuth(());
+
 /// Stable signal delivered to the aggregate actor through its private message type.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PersistenceEffectorSignal<S, E> {
   /// Recovery completed with the recovered state and latest sequence number.
   RecoveryCompleted {
+    #[doc(hidden)]
+    auth:       PersistenceEffectorSignalAuth,
     /// Recovered state.
     state:       S,
     /// Latest recovered sequence number.
@@ -16,6 +21,8 @@ pub enum PersistenceEffectorSignal<S, E> {
   },
   /// Events were persisted in order.
   PersistedEvents {
+    #[doc(hidden)]
+    auth:       PersistenceEffectorSignalAuth,
     /// Persisted events.
     events:      Vec<E>,
     /// Latest sequence number after the batch.
@@ -23,6 +30,8 @@ pub enum PersistenceEffectorSignal<S, E> {
   },
   /// A snapshot was persisted.
   PersistedSnapshot {
+    #[doc(hidden)]
+    auth:       PersistenceEffectorSignalAuth,
     /// Persisted snapshot state.
     snapshot:    S,
     /// Snapshot sequence number.
@@ -30,12 +39,23 @@ pub enum PersistenceEffectorSignal<S, E> {
   },
   /// Old snapshots were deleted.
   DeletedSnapshots {
+    #[doc(hidden)]
+    auth:       PersistenceEffectorSignalAuth,
     /// Inclusive upper sequence number for deletion.
     to_sequence_nr: u64,
   },
   /// Persistence failed.
   Failed {
+    #[doc(hidden)]
+    auth:  PersistenceEffectorSignalAuth,
     /// Persistence kernel error.
     error: PersistenceError,
   },
+}
+
+impl PersistenceEffectorSignalAuth {
+  #[must_use]
+  pub(crate) const fn new() -> Self {
+    Self(())
+  }
 }

--- a/modules/persistence-core-typed/src/persistence_effector_signal.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_signal.rs
@@ -13,7 +13,7 @@ pub enum PersistenceEffectorSignal<S, E> {
   /// Recovery completed with the recovered state and latest sequence number.
   RecoveryCompleted {
     #[doc(hidden)]
-    auth:       PersistenceEffectorSignalAuth,
+    auth:        PersistenceEffectorSignalAuth,
     /// Recovered state.
     state:       S,
     /// Latest recovered sequence number.
@@ -22,7 +22,7 @@ pub enum PersistenceEffectorSignal<S, E> {
   /// Events were persisted in order.
   PersistedEvents {
     #[doc(hidden)]
-    auth:       PersistenceEffectorSignalAuth,
+    auth:        PersistenceEffectorSignalAuth,
     /// Persisted events.
     events:      Vec<E>,
     /// Latest sequence number after the batch.
@@ -31,7 +31,7 @@ pub enum PersistenceEffectorSignal<S, E> {
   /// A snapshot was persisted.
   PersistedSnapshot {
     #[doc(hidden)]
-    auth:       PersistenceEffectorSignalAuth,
+    auth:        PersistenceEffectorSignalAuth,
     /// Persisted snapshot state.
     snapshot:    S,
     /// Snapshot sequence number.
@@ -40,7 +40,7 @@ pub enum PersistenceEffectorSignal<S, E> {
   /// Old snapshots were deleted.
   DeletedSnapshots {
     #[doc(hidden)]
-    auth:       PersistenceEffectorSignalAuth,
+    auth:           PersistenceEffectorSignalAuth,
     /// Inclusive upper sequence number for deletion.
     to_sequence_nr: u64,
   },

--- a/modules/persistence-core-typed/src/persistence_effector_signal_auth.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_signal_auth.rs
@@ -1,6 +1,6 @@
 //! Authentication marker for persistence effector signals.
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PersistenceEffectorSignalAuth(());
 
 impl PersistenceEffectorSignalAuth {

--- a/modules/persistence-core-typed/src/persistence_effector_signal_auth.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_signal_auth.rs
@@ -1,0 +1,11 @@
+//! Authentication marker for persistence effector signals.
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PersistenceEffectorSignalAuth(());
+
+impl PersistenceEffectorSignalAuth {
+  #[must_use]
+  pub(crate) const fn new() -> Self {
+    Self(())
+  }
+}

--- a/modules/persistence-core-typed/tests/persistence_effector_flow.rs
+++ b/modules/persistence-core-typed/tests/persistence_effector_flow.rs
@@ -51,7 +51,6 @@ enum CounterEvent {
 #[derive(Clone, Debug)]
 enum CounterCommand {
   Add(i32),
-  AddThenRecovery(i32),
   AddBatch(Vec<i32>),
   AddWithSnapshot(i32),
   Reject { reply_to: TypedActorRef<String> },
@@ -152,23 +151,6 @@ fn counter_behavior(
       command_log.lock().push(*delta);
       let event = CounterEvent::Added(*delta);
       let next_state = apply_counter_event(&state, &event);
-      let next_effector = effector.clone();
-      let next_command_log = command_log.clone();
-      effector
-        .persist_event(ctx, event, move |_event| Ok(counter_behavior(next_state, next_effector, next_command_log)))
-    },
-    | CounterCommand::AddThenRecovery(delta) => {
-      command_log.lock().push(*delta);
-      let event = CounterEvent::Added(*delta);
-      let next_state = apply_counter_event(&state, &event);
-      let next_sequence_nr = effector.sequence_nr().saturating_add(1);
-      let mut self_ref = ctx.self_ref();
-      self_ref
-        .try_tell(CounterCommand::Persistence(PersistenceEffectorSignal::RecoveryCompleted {
-          state:       next_state.clone(),
-          sequence_nr: next_sequence_nr,
-        }))
-        .map_err(|error| ActorError::fatal(format!("recovery completion self-send failed: {error:?}")))?;
       let next_effector = effector.clone();
       let next_command_log = command_log.clone();
       effector
@@ -351,37 +333,6 @@ fn persisted_mode_runs_recovery_and_on_ready_during_startup() {
   assert!(wait_until(5000, || *ready_values.lock() == vec![3]));
   assert_eq!(ask_value(&mut actor), 3);
   assert_eq!(*command_log.lock(), Vec::<i32>::new());
-
-  terminate_system(system);
-}
-
-#[test]
-fn persisted_mode_resynchronizes_when_recovery_completes_during_persist_wait() {
-  const PERSISTENCE_ID: &str = "typed-persisted-restart-resync-counter";
-
-  let journal = InMemoryJournal::new();
-  let snapshot_store = InMemorySnapshotStore::new();
-  let command_log = ArcShared::new(SpinSyncMutex::new(Vec::new()));
-  let ready_values = ArcShared::new(SpinSyncMutex::new(Vec::new()));
-  let props = counter_props(
-    counter_config(PersistenceMode::Persisted, PERSISTENCE_ID),
-    command_log.clone(),
-    ready_values.clone(),
-  );
-  let system = TypedActorSystem::<CounterCommand>::create_from_props(
-    &props,
-    actor_system_config_with_persistence(journal, snapshot_store),
-  )
-  .expect("system");
-  let mut actor = system.user_guardian_ref();
-
-  assert_eq!(ask_value(&mut actor), 0);
-  actor.tell(CounterCommand::AddThenRecovery(1));
-
-  assert!(wait_until(5000, || *ready_values.lock() == vec![0, 1]));
-  assert_eq!(ask_value(&mut actor), 1);
-  assert_eq!(ask_sequence(&mut actor), 1);
-  assert_eq!(*command_log.lock(), vec![1]);
 
   terminate_system(system);
 }

--- a/modules/persistence-core-typed/tests/persistence_effector_signal_public_surface.rs
+++ b/modules/persistence-core-typed/tests/persistence_effector_signal_public_surface.rs
@@ -1,0 +1,97 @@
+#![cfg(not(target_os = "none"))]
+
+use std::{
+  env, fs,
+  path::{Path, PathBuf},
+  process::{Command, Output},
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+const FORGED_SIGNAL_SOURCE: &str = r#"
+use fraktor_persistence_core_typed_rs::PersistenceEffectorSignal;
+
+fn main() {
+  let _signal: PersistenceEffectorSignal<u64, u64> = PersistenceEffectorSignal::RecoveryCompleted {
+    auth: Default::default(),
+    state: 0,
+    sequence_nr: 0,
+  };
+}
+"#;
+
+#[test]
+fn persistence_effector_signal_auth_cannot_be_forged_from_external_crate() {
+  assert_fixture_build_failure_contains("persistence-effector-signal-auth-forged", FORGED_SIGNAL_SOURCE, "Default");
+}
+
+fn assert_fixture_build_failure_contains(name: &str, source: &str, expected: &str) {
+  let crate_dir = unique_crate_dir(name);
+  write_fixture_crate(&crate_dir, name, source);
+
+  let output = match Command::new("cargo")
+    .arg("check")
+    .arg("--quiet")
+    .env("CARGO_TARGET_DIR", crate_dir.join("target"))
+    .current_dir(&crate_dir)
+    .output()
+  {
+    | Ok(output) => output,
+    | Err(error) => panic!("fixture cargo check should start: {error}"),
+  };
+
+  let rendered = render_output(&output);
+  let cleanup_result = fs::remove_dir_all(&crate_dir);
+
+  assert!(!output.status.success(), "fixture should fail to compile:\n{rendered}");
+  assert!(rendered.contains(expected), "fixture should fail because of `{expected}`:\n{rendered}");
+
+  if let Err(error) = cleanup_result {
+    panic!("fixture directory cleanup should succeed: {error}");
+  }
+}
+
+fn write_fixture_crate(crate_dir: &Path, name: &str, source: &str) {
+  let src_dir = crate_dir.join("src");
+  if let Err(error) = fs::create_dir_all(&src_dir) {
+    panic!("fixture src directory should be created: {error}");
+  }
+  if let Err(error) = fs::write(crate_dir.join("Cargo.toml"), fixture_manifest(name)) {
+    panic!("fixture manifest should be written: {error}");
+  }
+  if let Err(error) = fs::write(src_dir.join("main.rs"), source) {
+    panic!("fixture main source should be written: {error}");
+  }
+}
+
+fn fixture_manifest(name: &str) -> String {
+  let manifest_dir = env!("CARGO_MANIFEST_DIR").replace('\\', "\\\\");
+  format!(
+    r#"[package]
+name = "{name}"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+fraktor-persistence-core-typed-rs = {{ path = "{manifest_dir}" }}
+"#
+  )
+}
+
+fn unique_crate_dir(name: &str) -> PathBuf {
+  let timestamp = match SystemTime::now().duration_since(UNIX_EPOCH) {
+    | Ok(duration) => duration.as_nanos(),
+    | Err(error) => panic!("system clock should be after unix epoch: {error}"),
+  };
+  let dir =
+    env::temp_dir().join(format!("fraktor-persistence-core-typed-rs-{name}-{}-{timestamp}", std::process::id()));
+  if let Err(error) = fs::create_dir_all(&dir) {
+    panic!("unique crate directory should be created: {error}");
+  }
+  dir
+}
+
+fn render_output(output: &Output) -> String {
+  let stdout = String::from_utf8_lossy(&output.stdout);
+  let stderr = String::from_utf8_lossy(&output.stderr);
+  format!("status={:?}\nstdout:\n{stdout}\nstderr:\n{stderr}", output.status.code())
+}

--- a/modules/persistence-core-typed/tests/persistence_effector_signal_public_surface.rs
+++ b/modules/persistence-core-typed/tests/persistence_effector_signal_public_surface.rs
@@ -19,9 +19,36 @@ fn main() {
 }
 "#;
 
+const REUSED_AUTH_SOURCE: &str = r#"
+use fraktor_persistence_core_typed_rs::PersistenceEffectorSignal;
+
+fn forge(signal: PersistenceEffectorSignal<u64, u64>) -> PersistenceEffectorSignal<u64, u64> {
+  let auth = match signal {
+    | PersistenceEffectorSignal::RecoveryCompleted { auth, .. }
+    | PersistenceEffectorSignal::PersistedEvents { auth, .. }
+    | PersistenceEffectorSignal::PersistedSnapshot { auth, .. }
+    | PersistenceEffectorSignal::DeletedSnapshots { auth, .. }
+    | PersistenceEffectorSignal::Failed { auth, .. } => auth,
+  };
+
+  PersistenceEffectorSignal::RecoveryCompleted {
+    auth,
+    state: 999,
+    sequence_nr: 999,
+  }
+}
+
+fn main() {}
+"#;
+
 #[test]
 fn persistence_effector_signal_auth_cannot_be_forged_from_external_crate() {
   assert_fixture_build_failure_contains("persistence-effector-signal-auth-forged", FORGED_SIGNAL_SOURCE, "Default");
+  assert_fixture_build_failure_contains(
+    "persistence-effector-signal-auth-reused",
+    REUSED_AUTH_SOURCE,
+    "non-exhaustive",
+  );
 }
 
 fn assert_fixture_build_failure_contains(name: &str, source: &str, expected: &str) {


### PR DESCRIPTION
### Motivation
- The public `PersistenceEffectorSignal` enum could be constructed by application code and used to forge internal persistence acknowledgements, allowing an attacker to advance sequence numbers, inject recovered state, or trigger snapshot/deletion flows.
- The intent is to restrict creation of effector signals to trusted internal storage replies while preserving the existing typed persistence API and behavior.

### Description
- Add a small authentication marker type `PersistenceEffectorSignalAuth` and a hidden `auth` field to every `PersistenceEffectorSignal` variant so external code cannot construct valid signals without crate-internal access to the marker.
- Populate the `auth` marker only when converting trusted `PersistenceStoreReply` values into `PersistenceEffectorSignal` in the `From<PersistenceStoreReply>` implementation.
- Update pattern matches in `persistence_effector.rs` to ignore the new `auth` field (`..`) so runtime behavior and state transitions remain unchanged.
- Remove the test path that intentionally injected forged `RecoveryCompleted` signals from application code and the associated `AddThenRecovery` test helper to reflect the new unforgeable signal invariant.

### Testing
- Ran `cargo test -p fraktor-persistence-core-typed-rs` and all package tests completed successfully (unit and flow tests passed).
- The crate builds and the persistence effector behavior tests verifying recovery, event persist, snapshot, and deletion flows pass under the updated signal authentication.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0491384118832da0e7bdd65dd6d86c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API surface of `PersistenceEffectorSignal` changes (new hidden fields + `#[non_exhaustive]` on variants), which may break downstream construction or exhaustive matches; behavior should be unchanged but needs consumer rebuild/adjustments.
> 
> **Overview**
> Hardens typed persistence by making `PersistenceEffectorSignal` effectively **unforgeable** from outside the crate.
> 
> Each signal variant now carries a hidden `PersistenceEffectorSignalAuth` marker (and is marked `#[non_exhaustive]`), and internal `PersistenceStoreReply -> PersistenceEffectorSignal` conversion is updated to populate this marker. Effector state machines update pattern matches to ignore the new field (`..`), and tests are adjusted by removing the previously-forged signal path and adding a compile-fail style test ensuring external crates cannot construct or reuse the auth marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dafd623ec632447eefe76fb04a711b59e2542314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 永続化エフェクタシグナルに認証マーカーフィールドを追加しました。
  * 永続化処理完了時のシグナル構造を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1805?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->