### PR TITLE
fix(remote): stop forwarding raw ConnectionLost events to DeathWatch

### DIFF
--- a/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer.rs
@@ -745,13 +745,7 @@ pub(super) fn forward_watcher_command_for_event(event: &RemoteEvent, watcher_sen
       | WireFrame::Ack(_)
       | WireFrame::Deployment(_) => None,
     },
-    | RemoteEvent::ConnectionLost { authority, cause, now_ms } => {
-      parse_remote_authority(authority.authority()).map(|from| WatcherCommand::ConnectionLost {
-        from,
-        reason: format!("remote transport connection lost: {cause:?}"),
-        now: *now_ms,
-      })
-    },
+    | RemoteEvent::ConnectionLost { .. } => None,
     | RemoteEvent::TransportShutdown
     | RemoteEvent::OutboundEnqueued { .. }
     | RemoteEvent::OutboundControl { .. }

--- a/modules/remote-adaptor-std/src/extension_installer_test.rs
+++ b/modules/remote-adaptor-std/src/extension_installer_test.rs
@@ -446,7 +446,7 @@ async fn forward_watcher_command_logs_when_queue_is_full() {
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = false)]
-async fn forward_watcher_command_forwards_connection_lost() {
+async fn forward_watcher_command_does_not_forward_connection_lost() {
   let (watcher_tx, mut watcher_rx) = tokio_mpsc::channel(1);
   let event = RemoteEvent::ConnectionLost {
     authority: TransportEndpoint::new("remote-sys@10.0.0.1:2552"),
@@ -456,15 +456,7 @@ async fn forward_watcher_command_forwards_connection_lost() {
 
   forward_watcher_command_for_event(&event, &watcher_tx);
 
-  let command = watcher_rx.try_recv().expect("connection lost should enqueue watcher command");
-  assert!(matches!(
-    command,
-    WatcherCommand::ConnectionLost {
-      from,
-      reason,
-      now
-    } if from == Address::new("remote-sys", "10.0.0.1", 2552) && reason.contains("ConnectionClosed") && now == 77
-  ));
+  assert!(watcher_rx.try_recv().is_err(), "connection lost should not enqueue watcher command");
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = false)]


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated transport `ConnectionLost` authority from being trusted and causing false DeathWatch termination/quarantine effects. 
- The forwarding happened before association/Auth validation, so an attacker able to open/close a TCP connection with a spoofed handshake `from` could trigger watcher state transitions.

### Description

- Change `forward_watcher_command_for_event` to ignore `RemoteEvent::ConnectionLost` instead of converting it into `WatcherCommand::ConnectionLost` so unauthenticated transport close events are not forwarded to the watcher subsystem. 
- Update the existing unit test to `forward_watcher_command_does_not_forward_connection_lost` in `modules/remote-adaptor-std/src/extension_installer_test.rs` to assert that no watcher command is enqueued for a `ConnectionLost` event. 
- Modified files: `modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer.rs` and `modules/remote-adaptor-std/src/extension_installer_test.rs`.

### Testing

- Ran `cargo test -p fraktor-remote-adaptor-std-rs forward_watcher_command_does_not_forward_connection_lost -- --nocapture`, and the test passed. 
- The targeted unit test verifies that `ConnectionLost` is no longer forwarded to the watcher queue and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a9fc286f8832dabf5acfa642217a2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remoting failure signaling by dropping `RemoteEvent::ConnectionLost` before it reaches the watcher/DeathWatch subsystem, which could affect node liveness/termination behavior if something relied on these events. Scope is small and covered by an updated unit test, but it touches failure-handling paths.
> 
> **Overview**
> Stops converting unauthenticated transport-level `RemoteEvent::ConnectionLost` events into `WatcherCommand::ConnectionLost`, so raw connection closes no longer trigger watcher/DeathWatch state transitions.
> 
> Updates the corresponding unit test to assert that `ConnectionLost` does *not* enqueue any watcher command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e67380c43ad307ab22b26253898e8c9259033f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->