### PR TITLE
[codex] Add persistence phase 1 kernel contracts

### DIFF
--- a/docs/gap-analysis/persistence-gap-analysis.md
+++ b/docs/gap-analysis/persistence-gap-analysis.md
@@ -1,6 +1,6 @@
 # persistence モジュール ギャップ分析
 
-更新日: 2026-05-19
+更新日: 2026-05-19 JST (Phase 1 kernel 契約更新後)
 
 ## 比較スコープ定義
 
@@ -74,22 +74,22 @@ classic write-side persistence は、persistent actor、journal、snapshot、eve
 
 fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventsourced` と `PersistentActor` に統合している。`persist` / `persist_async` / `persist_all` / `defer` / snapshot / delete / recovery callbacks は存在する。根拠は `modules/persistence-core-kernel/src/persistent/persistent_actor.rs:23`、`modules/persistence-core-kernel/src/persistent/eventsourced.rs:21`、`modules/persistence-core-kernel/src/persistent/eventsourced.rs:48`。
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `RecoveryCompleted` signal type | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala:29`, `PersistentActor.scala:35` | 部分実装 | kernel | trivial | `modules/persistence-core-kernel/src/persistent/eventsourced.rs:48` に `on_recovery_completed` callback はあるが、recovery signal として公開型はない |
-| `SnapshotOffer` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/SnapshotProtocol.scala:157` | 部分実装 | kernel | trivial | `modules/persistence-core-kernel/src/persistent/eventsourced.rs:38` に `receive_snapshot` callback はあるが、recovery signal としての `SnapshotOffer` 型はない |
-| `PersistenceSettings` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala:40` | 未対応 | kernel/config | easy | recovery timeout、stash、journal / snapshot 設定を束ねる公開設定型がない。現状は `JournalActorConfig` / `SnapshotActorConfig` に分散 |
-| `AtomicWrite` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Persistent.scala:45`, `Persistent.scala:49` | 部分実装 | kernel/journal | medium | `modules/persistence-core-kernel/src/journal/journal_message.rs:17` は `Vec<PersistentRepr>` を送るが、原子書き込み単位を表す公開型がない |
+| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
+|------------------|------------|-----------------|----------|--------|------|
+| `RecoveryCompleted` signal type | `PersistentActor.scala:29`, `PersistentActor.scala:35` | 実装済み / non-goal | core | n/a | classic は `on_recovery_completed` callback と internal `JournalResponseAction::RecoveryCompleted` で表現済み。typed は `PersistenceEffectorSignal::RecoveryCompleted` を公開済み。Pekko 同名の classic 公開型追加は現設計では不要 |
+| `SnapshotOffer` | `SnapshotProtocol.scala:157` | 実装済み | core | done | `SnapshotOffer` と `receive_snapshot_offer` を追加し、既存 `receive_snapshot` callback と互換 |
+| `PersistenceSettings` | `Persistence.scala:40` | 実装済み | core/config | done | `PersistenceSettings` が `JournalActorConfig` / `SnapshotActorConfig` を束ね、store actor retry 設定を公開 |
+| `AtomicWrite` | `Persistent.scala:45`, `Persistent.scala:49` | 部分実装 | core/journal | medium | `JournalMessage::WriteMessages` は `Vec<PersistentRepr>` を送るが、原子書き込み単位を表す公開型がない |
 
 ### 2. Journal / snapshot store protocol　✅ 実装済み 13/16 (81%)
 
 `Journal` は Pekko の `AsyncWriteJournal` と `AsyncRecovery` を統合した trait として存在し、`JournalActor` / `JournalMessage` / `JournalResponse` もある。`SnapshotStore`、`SnapshotActor`、`SnapshotMessage`、`SnapshotResponse`、`SnapshotMetadata`、`SnapshotSelectionCriteria` も実装済み。根拠は `modules/persistence-core-kernel/src/journal/base.rs:9`、`modules/persistence-core-kernel/src/journal/journal_message.rs:15`、`modules/persistence-core-kernel/src/snapshot/snapshot_store.rs:10`、`modules/persistence-core-kernel/src/snapshot/snapshot_message.rs:17`。
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `NoSnapshotStore` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/NoSnapshotStore.scala:28` | 未対応 | kernel/snapshot | trivial | 何もしない `SnapshotStore` 実装 |
-| `LocalSnapshotStore` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/local/LocalSnapshotStore.scala:40` | 未対応 | std/snapshot | medium | ファイルシステム依存。kernel ではなく std adapter が妥当 |
-| snapshot retry / plugin settings の公開契約 | `references/pekko/persistence/src/main/resources/reference.conf:272`, `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala:176` | 部分実装 | kernel/config | easy | `modules/persistence-core-kernel/src/snapshot/snapshot_actor_config.rs:5` はあるが、Pekko 互換の persistence settings として統合されていない |
+| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
+|------------------|------------|-----------------|----------|--------|------|
+| `NoSnapshotStore` | `snapshot/NoSnapshotStore.scala:28` | 実装済み | core/snapshot | done | 何もしない `SnapshotStore` 実装 |
+| `LocalSnapshotStore` | `snapshot/local/LocalSnapshotStore.scala:40` | 未対応 | std/snapshot | medium | ファイルシステム依存。core ではなく std adapter が妥当 |
+| snapshot retry settings の公開契約 | `Persistence.scala:40`, `SnapshotProtocol.scala:235` | 実装済み | core/config | done | `SnapshotActorConfig` を `PersistenceSettings` から渡せる。plugin settings は fraktor-rs の trait 実装注入モデルでは non-goal |
 
 ### 3. Persistent representation / adapters / serialization　✅ 実装済み 11/14 (79%)
 
@@ -105,28 +105,28 @@ fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventso
 
 `AtLeastOnceDelivery`、`AtLeastOnceDeliveryConfig`、`AtLeastOnceDeliverySnapshot`、`UnconfirmedDelivery`、`UnconfirmedWarning`、`RedeliveryTick` は存在する。未確認配送の snapshot / restore、redelivery、confirm も実装済み。根拠は `modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:21`、`modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:72`、`modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:103`。
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `MaxUnconfirmedMessagesExceededException` 相当 | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala:80`, `AtLeastOnceDelivery.scala:126` | 部分実装 | kernel/delivery | trivial | 現状は `modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:214` で `PersistenceError::MessagePassing("max unconfirmed deliveries exceeded")` を返す。専用 error variant がない |
+| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
+|------------------|------------|-----------------|----------|--------|------|
+| `MaxUnconfirmedMessagesExceededException` 相当 | `AtLeastOnceDelivery.scala:80`, `AtLeastOnceDelivery.scala:126` | 実装済み | core/delivery | done | `PersistenceError::MaxUnconfirmedMessagesExceeded` を返す |
 
 ### 5. Durable State store contract　✅ 実装済み 5/8 (63%)
 
 `DurableStateStore`、`DurableStateUpdateStore`、`DurableStateStoreProvider`、`DurableStateStoreRegistry`、`DurableStateError` は存在する。ただし Pekko の revision / tag を含む durable state write-side contract とはまだ差がある。根拠は `modules/persistence-core-kernel/src/state/durable_state_store.rs:12`、`modules/persistence-core-kernel/src/state/durable_state_update_store.rs:6`、`modules/persistence-core-kernel/src/state/durable_state_store_registry.rs:18`。
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `GetObjectResult[A]` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateStore.scala:26`, `DurableStateStore.scala:31` | 未対応 | kernel/durable_state | trivial | 現状は `modules/persistence-core-kernel/src/state/durable_state_store.rs:14` が `Option<A>` だけを返し、revision を保持しない |
-| revision / tag aware update store | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/DurableStateUpdateStore.scala:24`, `DurableStateUpdateStore.scala:37` | 部分実装 | kernel/durable_state | medium | `modules/persistence-core-kernel/src/state/durable_state_store.rs:17` と `durable_state_store.rs:20` に revision / tag がない |
-| `DeleteRevisionException` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/state/exception/DurableStateException.scala:41` | 未対応 | kernel/durable_state | trivial | `modules/persistence-core-kernel/src/state/durable_state_error.rs:12` に revision mismatch 系の variant がない |
+| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
+|------------------|------------|-----------------|----------|--------|------|
+| `GetObjectResult[A]` | `state/scaladsl/DurableStateStore.scala:31`, `state/scaladsl/DurableStateStore.scala:35` | 実装済み | core/durable_state | done | `GetObjectResult<A>` が value と revision を保持し、`DurableStateStore::get_object` が返す |
+| revision / tag aware update store | `state/scaladsl/DurableStateUpdateStore.scala:37`, `state/scaladsl/DurableStateUpdateStore.scala:63` | 部分実装 | core/durable_state | medium | `upsert_object` と `delete_object` に revision / tag がない |
+| `DeleteRevisionException` | `state/exception/DurableStateException.scala:41` | 実装済み | core/durable_state | done | `DurableStateError::DeleteRevision` を追加 |
 
 ### 6. Plugin / extension / in-memory stores　✅ 実装済み 5/7 (71%)
 
-`PersistenceExtension`、`PersistenceExtensionId`、`PersistenceExtensionInstaller`、`PersistencePluginProxy`、`InMemoryJournal`、`InMemorySnapshotStore` は存在する。HOCON loading は対象外だが、Rust 側にも runtime plugin selection の公開契約はまだ薄い。根拠は `modules/persistence-core-kernel/src/extension/persistence_extension.rs:26`、`modules/persistence-core-kernel/src/journal/persistence_plugin_proxy.rs:19`、`modules/persistence-core-kernel/src/journal/in_memory_journal.rs:21`、`modules/persistence-core-kernel/src/snapshot/in_memory_snapshot_store.rs:23`。
+`PersistenceExtension`、`PersistenceExtensionId`、`PersistenceExtensionInstaller`、`PersistencePluginProxy`、`InMemoryJournal`、`InMemorySnapshotStore` は存在する。HOCON loading と runtime plugin id selection は対象外であり、Rust 側は `Journal` / `SnapshotStore` trait 実装を注入するモデルを採用する。
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `RuntimePluginConfig` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala:78`, `Eventsourced.scala:86` | 未対応 | kernel/config | easy | HOCON ではなく Rust の型付き plugin config として定義可能 |
-| plugin target location / proxy extension semantics | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/PersistencePluginProxy.scala:38`, `PersistencePluginProxy.scala:85` | 部分実装 | kernel/plugin + std/runtime | medium | `modules/persistence-core-kernel/src/journal/persistence_plugin_proxy.rs:19` は forwarding object だが、Pekko の target location / extension actor semantics まではない |
+| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
+|------------------|------------|-----------------|----------|--------|------|
+| `RuntimePluginConfig` | `Persistence.scala:127` | non-goal | core/config | n/a | Pekko には存在するが、fraktor-rs は plugin 形式ではなく `Journal` / `SnapshotStore` trait 実装注入に留めるため不要 |
+| plugin target location / proxy extension semantics | `journal/PersistencePluginProxy.scala:38`, `journal/PersistencePluginProxy.scala:85` | 部分実装 | core/plugin + std/runtime | medium | `PersistencePluginProxy<J, S>` は forwarding object だが、Pekko の target location / extension actor semantics まではない |
 
 ### 7. Persistent FSM compatibility　✅ 実装済み 1/1 (100%)
 
@@ -177,7 +177,47 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 
 `modules/persistence-core-kernel/src` と `modules/persistence-core-typed/src` に対して `todo!()`、`unimplemented!()`、`panic!("not implemented")`、`TODO`、`FIXME`、`placeholder`、`stub` を検索した範囲では、公開 API 直下の未完成スタブは見つからなかった。
 
-`PersistentActor::defer` / `defer_async` は recovery 中に panic するが、これは Pekko 互換の不正利用検出であり、未実装スタブではない。根拠は `modules/persistence-core-kernel/src/persistent/persistent_actor.rs:191`、`modules/persistence-core-kernel/src/persistent/persistent_actor.rs:220`。
+`PersistentActor::defer` / `defer_async` は recovery 中に panic するが、これは Pekko 互換の不正利用検出であり、未実装スタブではない。
+
+## 実装優先度
+
+### Phase 1: trivial / easy
+
+| 項目 | 実装先層 | 根拠 | 状態 |
+|------|----------|------|------|
+| `SnapshotOffer` | core | カテゴリ1 | 実装済み |
+| `PersistenceSettings` | core/config | カテゴリ1 | 実装済み |
+| `NoSnapshotStore` | core/snapshot | カテゴリ2 | 実装済み |
+| snapshot retry settings の公開契約 | core/config | カテゴリ2 | 実装済み |
+| `MaxUnconfirmedMessagesExceededException` 相当 | core/delivery | カテゴリ4 | 実装済み |
+| `GetObjectResult[A]` | core/durable_state | カテゴリ5 | 実装済み |
+| `DeleteRevisionException` | core/durable_state | カテゴリ5 | 実装済み |
+| typed `Recovery` / typed `SnapshotSelectionCriteria` | core/typed | カテゴリ8 | 未実装 |
+| typed `EventAdapter` / `EventSeq` / `SnapshotAdapter` | core/typed | カテゴリ8 | 未実装 |
+| `DurableStateSignal` family | core/typed | カテゴリ9 | 未実装 |
+
+### Phase 2: medium
+
+| 項目 | 実装先層 | 根拠 |
+|------|----------|------|
+| `AtomicWrite` | core/journal | カテゴリ1 |
+| `LocalSnapshotStore` | std/snapshot | カテゴリ2 |
+| `MessageSerializer` | core/serialization | カテゴリ3 |
+| `SnapshotSerializer` | core/serialization | カテゴリ3 |
+| adapter manifest と serializer manifest の接続 | core/serialization | カテゴリ3 |
+| revision / tag aware update store | core/durable_state | カテゴリ5 |
+| plugin target location / proxy extension semantics | core/plugin + std/runtime | カテゴリ6 |
+| `EventSourcedSignal` family | core/typed | カテゴリ8 |
+| `PublishedEvent` / `EventRejectedException` | core/typed | カテゴリ8 |
+
+### Phase 3: hard
+
+| 項目 | 実装先層 | 根拠 |
+|------|----------|------|
+| `EventSourcedBehavior[C,E,S]` | core/typed | カテゴリ8 |
+| `Effect` / `EffectBuilder` / `ReplyEffect` | core/typed | カテゴリ8 |
+| `DurableStateBehavior[C,S]` | core/typed | カテゴリ9 |
+| durable state `Effect` / `EffectBuilder` / `ReplyEffect` | core/typed | カテゴリ9 |
 
 ## 内部モジュール構造ギャップ
 
@@ -193,64 +233,10 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 | plugin adapter 境界 | core extension は generic journal / snapshot を直接受ける | std runtime で plugin selection / local snapshot store をどう表すか |
 | typed effector と Pekko typed DSL の境界 | `PersistenceEffector` は通常 `Behavior` に統合されるが、Pekko の `EffectBuilder` / signal / adapter をそのまま露出しない | parity 目標を effector-first で固定するか、Pekko direct DSL を追加するか |
 
-## 実装優先度
-
-ここで出す優先度は「今の要求で実装すべきか」ではなく、「Pekko parity ギャップをどの順で埋めるか」を示す。YAGNI は適用しない。
-
-### Phase 1: trivial / easy
-
-| 項目 | 実装先層 | 根拠 |
-|------|----------|------|
-| `RecoveryCompleted` signal type | kernel | カテゴリ1 |
-| `SnapshotOffer` | kernel | カテゴリ1 |
-| `PersistenceSettings` | kernel/config | カテゴリ1 |
-| `NoSnapshotStore` | kernel/snapshot | カテゴリ2 |
-| snapshot retry / plugin settings の公開契約 | kernel/config | カテゴリ2 |
-| `MaxUnconfirmedMessagesExceededException` 相当 | kernel/delivery | カテゴリ4 |
-| `GetObjectResult[A]` | kernel/durable_state | カテゴリ5 |
-| `DeleteRevisionException` | kernel/durable_state | カテゴリ5 |
-| `RuntimePluginConfig` | kernel/config | カテゴリ6 |
-| typed `Recovery` / typed `SnapshotSelectionCriteria` | typed | カテゴリ8 |
-| typed `EventAdapter` / `EventSeq` / `SnapshotAdapter` | typed | カテゴリ8 |
-| `DurableStateSignal` family | typed | カテゴリ9 |
-
-### Phase 2: medium
-
-| 項目 | 実装先層 | 根拠 |
-|------|----------|------|
-| `AtomicWrite` | kernel/journal | カテゴリ1 |
-| `LocalSnapshotStore` | std/snapshot | カテゴリ2 |
-| `MessageSerializer` | kernel/serialization | カテゴリ3 |
-| `SnapshotSerializer` | kernel/serialization | カテゴリ3 |
-| adapter manifest と serializer manifest の接続 | kernel/serialization | カテゴリ3 |
-| revision / tag aware update store | kernel/durable_state | カテゴリ5 |
-| plugin target location / proxy extension semantics | kernel/plugin + std/runtime | カテゴリ6 |
-| `EventSourcedSignal` family | typed | カテゴリ8 |
-| `PublishedEvent` / `EventRejectedException` | typed | カテゴリ8 |
-| behavior-level `onPersistFailure` | typed | カテゴリ8 |
-
-### Phase 3: hard
-
-| 項目 | 実装先層 | 根拠 |
-|------|----------|------|
-| `EventSourcedBehavior[C,E,S]` | typed | カテゴリ8 |
-| `Effect` / `EffectBuilder` / `ReplyEffect` | typed | カテゴリ8 |
-| `DurableStateBehavior[C,S]` | typed | カテゴリ9 |
-| durable state `Effect` / `EffectBuilder` / `ReplyEffect` | typed | カテゴリ9 |
-
-### 対象外 (n/a)
-
-| 項目 | 理由 |
-|------|------|
-| `persistence-query` | write-side runtime とは別スコープ |
-| Java DSL / Scala syntax sugar | Rust API として再現不要 |
-| HOCON plugin loading / JVM reflection | JVM 固有 |
-| replicated event sourcing / CRDT / typed reliable delivery queue | 現 persistence 固定スコープ外 |
-
 ## まとめ
 
 persistence は classic write-side の基礎部品はかなり揃っている。`PersistentActor`、journal、snapshot、event adapter、at-least-once delivery、durable state store registry、in-memory store は存在し、panic 系スタブも見つからない。
 
-低コストで parity を前進できるのは、`RecoveryCompleted` / `SnapshotOffer` の signal 型、`NoSnapshotStore`、durable state の `GetObjectResult` / `DeleteRevisionException`、typed recovery / adapter wrapper である。
+Phase 1 の kernel 側低コスト項目は `SnapshotOffer`、`PersistenceSettings`、`NoSnapshotStore`、snapshot retry settings、`MaxUnconfirmedMessagesExceededException` 相当、`GetObjectResult[A]`、`DeleteRevisionException` まで実装済みである。`RecoveryCompleted` の classic 同名公開型と `RuntimePluginConfig` / plugin settings は現設計では non-goal とした。
 
-主要ギャップは、`AtomicWrite`、serialization contract、revision / tag aware durable state update、typed `EventSourcedBehavior` direct DSL、typed `DurableStateBehavior` である。typed write-side は effector-first API として前進しているが、Pekko parity の観点では `EffectBuilder`、signal、adapter、behavior-level failure supervision がまだ閉じていない。内部構造比較は、serializer / revision model と typed durable state の公開契約を決めた後に進めるのが妥当である。
+主要ギャップは、`AtomicWrite`、serialization contract、revision / tag aware durable state update、typed adapter / signal、typed `DurableStateBehavior` である。typed write-side は effector-first API として前進しているが、Pekko parity の観点では `EffectBuilder`、signal、adapter、behavior-level failure supervision がまだ閉じていない。内部構造比較は、serializer / revision model と typed durable state の公開契約を決めた後に進めるのが妥当である。

--- a/modules/persistence-core-kernel/src/config.rs
+++ b/modules/persistence-core-kernel/src/config.rs
@@ -1,0 +1,5 @@
+//! Persistence configuration package.
+
+mod persistence_settings;
+
+pub use persistence_settings::PersistenceSettings;

--- a/modules/persistence-core-kernel/src/config/persistence_settings.rs
+++ b/modules/persistence-core-kernel/src/config/persistence_settings.rs
@@ -1,0 +1,60 @@
+//! Public persistence runtime settings.
+
+#[cfg(test)]
+#[path = "persistence_settings_test.rs"]
+mod tests;
+
+use crate::{journal::JournalActorConfig, snapshot::SnapshotActorConfig};
+
+/// Public settings for the persistence runtime actors.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PersistenceSettings {
+  journal_actor_config:  JournalActorConfig,
+  snapshot_actor_config: SnapshotActorConfig,
+}
+
+impl PersistenceSettings {
+  /// Creates settings from the default store actor configs.
+  #[must_use]
+  pub const fn default_settings() -> Self {
+    Self::new(JournalActorConfig::default_config(), SnapshotActorConfig::default_config())
+  }
+
+  /// Creates settings with explicit store actor configs.
+  #[must_use]
+  pub const fn new(journal_actor_config: JournalActorConfig, snapshot_actor_config: SnapshotActorConfig) -> Self {
+    Self { journal_actor_config, snapshot_actor_config }
+  }
+
+  /// Returns the journal actor configuration.
+  #[must_use]
+  pub const fn journal_actor_config(&self) -> JournalActorConfig {
+    self.journal_actor_config
+  }
+
+  /// Returns the snapshot actor configuration.
+  #[must_use]
+  pub const fn snapshot_actor_config(&self) -> SnapshotActorConfig {
+    self.snapshot_actor_config
+  }
+
+  /// Updates the journal actor configuration.
+  #[must_use]
+  pub const fn with_journal_actor_config(mut self, journal_actor_config: JournalActorConfig) -> Self {
+    self.journal_actor_config = journal_actor_config;
+    self
+  }
+
+  /// Updates the snapshot actor configuration.
+  #[must_use]
+  pub const fn with_snapshot_actor_config(mut self, snapshot_actor_config: SnapshotActorConfig) -> Self {
+    self.snapshot_actor_config = snapshot_actor_config;
+    self
+  }
+}
+
+impl Default for PersistenceSettings {
+  fn default() -> Self {
+    Self::default_settings()
+  }
+}

--- a/modules/persistence-core-kernel/src/config/persistence_settings_test.rs
+++ b/modules/persistence-core-kernel/src/config/persistence_settings_test.rs
@@ -1,0 +1,19 @@
+use crate::{config::PersistenceSettings, journal::JournalActorConfig, snapshot::SnapshotActorConfig};
+
+#[test]
+fn default_settings_match_existing_runtime_actor_defaults() {
+  let settings = PersistenceSettings::default();
+
+  assert_eq!(settings.journal_actor_config(), JournalActorConfig::default());
+  assert_eq!(settings.snapshot_actor_config(), SnapshotActorConfig::default());
+}
+
+#[test]
+fn settings_builder_updates_runtime_actor_configs() {
+  let settings = PersistenceSettings::default()
+    .with_journal_actor_config(JournalActorConfig::new(3))
+    .with_snapshot_actor_config(SnapshotActorConfig::new(5));
+
+  assert_eq!(settings.journal_actor_config().retry_max(), 3);
+  assert_eq!(settings.snapshot_actor_config().retry_max(), 5);
+}

--- a/modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs
+++ b/modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs
@@ -211,7 +211,7 @@ impl AtLeastOnceDelivery {
   where
     M: Any + Send + Sync + 'static, {
     if !self.can_accept_more() {
-      return Err(PersistenceError::MessagePassing("max unconfirmed deliveries exceeded".into()));
+      return Err(PersistenceError::MaxUnconfirmedMessagesExceeded { max_unconfirmed: self.config.max_unconfirmed() });
     }
 
     let delivery_id = self.next_delivery_id();

--- a/modules/persistence-core-kernel/src/delivery/at_least_once_delivery_test.rs
+++ b/modules/persistence-core-kernel/src/delivery/at_least_once_delivery_test.rs
@@ -11,7 +11,10 @@ use fraktor_utils_core_rs::{
   time::TimerInstant,
 };
 
-use crate::delivery::{AtLeastOnceDelivery, AtLeastOnceDeliveryConfig, RedeliveryTick, UnconfirmedDelivery};
+use crate::{
+  delivery::{AtLeastOnceDelivery, AtLeastOnceDeliveryConfig, RedeliveryTick, UnconfirmedDelivery},
+  error::PersistenceError,
+};
 
 type MessageStore = ArcShared<SpinSyncMutex<Vec<AnyMessage>>>;
 
@@ -112,9 +115,11 @@ fn deliver_rejects_when_max_unconfirmed_exceeded() {
   let mut delivery = AtLeastOnceDelivery::new(config);
   let (destination, _store) = create_sender();
 
-  let _ = delivery.deliver(destination.clone(), None, TimerInstant::from_ticks(0, Duration::from_secs(1)), |id| id);
+  delivery
+    .deliver(destination.clone(), None, TimerInstant::from_ticks(0, Duration::from_secs(1)), |id| id)
+    .expect("first delivery should succeed");
   let result = delivery.deliver(destination, None, TimerInstant::from_ticks(0, Duration::from_secs(1)), |id| id);
-  assert!(result.is_err());
+  assert_eq!(result, Err(PersistenceError::MaxUnconfirmedMessagesExceeded { max_unconfirmed: 1 }));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/error/persistence_error.rs
+++ b/modules/persistence-core-kernel/src/error/persistence_error.rs
@@ -22,6 +22,11 @@ pub enum PersistenceError {
   StateMachine(String),
   /// Message passing failed.
   MessagePassing(String),
+  /// At-least-once delivery exceeded the configured unconfirmed message limit.
+  MaxUnconfirmedMessagesExceeded {
+    /// Configured maximum number of unconfirmed messages.
+    max_unconfirmed: usize,
+  },
 }
 
 impl Display for PersistenceError {
@@ -32,6 +37,9 @@ impl Display for PersistenceError {
       | PersistenceError::Recovery(reason) => write!(formatter, "recovery error: {}", reason),
       | PersistenceError::StateMachine(reason) => write!(formatter, "state machine error: {}", reason),
       | PersistenceError::MessagePassing(reason) => write!(formatter, "message passing error: {}", reason),
+      | PersistenceError::MaxUnconfirmedMessagesExceeded { max_unconfirmed } => {
+        write!(formatter, "max unconfirmed messages exceeded: limit {}", max_unconfirmed)
+      },
     }
   }
 }

--- a/modules/persistence-core-kernel/src/error/persistence_error_test.rs
+++ b/modules/persistence-core-kernel/src/error/persistence_error_test.rs
@@ -36,3 +36,10 @@ fn persistence_error_display_message_passing() {
 
   assert_eq!(error.to_string(), "message passing error: sender missing");
 }
+
+#[test]
+fn persistence_error_display_max_unconfirmed_messages_exceeded() {
+  let error = PersistenceError::MaxUnconfirmedMessagesExceeded { max_unconfirmed: 3 };
+
+  assert_eq!(error.to_string(), "max unconfirmed messages exceeded: limit 3");
+}

--- a/modules/persistence-core-kernel/src/extension/persistence_extension.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension.rs
@@ -16,9 +16,10 @@ use fraktor_actor_core_kernel_rs::{
 use fraktor_utils_core_rs::sync::{DefaultMutex, SharedLock};
 
 use crate::{
+  config::PersistenceSettings,
   error::PersistenceError,
-  journal::{Journal, JournalActor},
-  snapshot::{SnapshotActor, SnapshotStore},
+  journal::{Journal, JournalActor, JournalActorConfig},
+  snapshot::{SnapshotActor, SnapshotActorConfig, SnapshotStore},
 };
 
 /// Extension providing access to journal and snapshot actors.
@@ -26,6 +27,7 @@ use crate::{
 pub struct PersistenceExtension {
   journal_actor:  ActorRef,
   snapshot_actor: ActorRef,
+  settings:       PersistenceSettings,
 }
 
 impl PersistenceExtension {
@@ -46,10 +48,40 @@ impl PersistenceExtension {
     for<'a> S::LoadFuture<'a>: Send + 'static,
     for<'a> S::DeleteOneFuture<'a>: Send + 'static,
     for<'a> S::DeleteManyFuture<'a>: Send + 'static, {
-    let journal_actor = spawn_system_actor(system, "journal", move || JournalActorWrapper::<J>::new(journal.clone()))?;
-    let snapshot_actor =
-      spawn_system_actor(system, "snapshot", move || SnapshotActorWrapper::<S>::new(snapshot_store.clone()))?;
-    Ok(Self { journal_actor, snapshot_actor })
+    Self::new_with_settings(system, journal, snapshot_store, PersistenceSettings::default())
+  }
+
+  /// Creates a new persistence extension with explicit settings.
+  ///
+  /// # Errors
+  ///
+  /// Returns `PersistenceError::MessagePassing` when actor creation fails.
+  pub fn new_with_settings<J, S>(
+    system: &ActorSystem,
+    journal: J,
+    snapshot_store: S,
+    settings: PersistenceSettings,
+  ) -> Result<Self, PersistenceError>
+  where
+    J: Journal + Clone + Send + Sync + 'static,
+    S: SnapshotStore + Clone + Send + Sync + 'static,
+    for<'a> J::WriteFuture<'a>: Send + 'static,
+    for<'a> J::ReplayFuture<'a>: Send + 'static,
+    for<'a> J::DeleteFuture<'a>: Send + 'static,
+    for<'a> J::HighestSeqNrFuture<'a>: Send + 'static,
+    for<'a> S::SaveFuture<'a>: Send + 'static,
+    for<'a> S::LoadFuture<'a>: Send + 'static,
+    for<'a> S::DeleteOneFuture<'a>: Send + 'static,
+    for<'a> S::DeleteManyFuture<'a>: Send + 'static, {
+    let journal_config = settings.journal_actor_config();
+    let snapshot_config = settings.snapshot_actor_config();
+    let journal_actor = spawn_system_actor(system, "journal", move || {
+      JournalActorWrapper::<J>::new_with_config(journal.clone(), journal_config)
+    })?;
+    let snapshot_actor = spawn_system_actor(system, "snapshot", move || {
+      SnapshotActorWrapper::<S>::new_with_config(snapshot_store.clone(), snapshot_config)
+    })?;
+    Ok(Self { journal_actor, snapshot_actor, settings })
   }
 
   /// Returns the journal actor reference.
@@ -62,6 +94,12 @@ impl PersistenceExtension {
   #[must_use]
   pub(crate) fn snapshot_actor_ref(&self) -> ActorRef {
     self.snapshot_actor.clone()
+  }
+
+  /// Returns the settings used to create the runtime actors.
+  #[must_use]
+  pub const fn settings(&self) -> PersistenceSettings {
+    self.settings
   }
 }
 
@@ -93,8 +131,8 @@ where
   for<'a> J::DeleteFuture<'a>: Send + 'static,
   for<'a> J::HighestSeqNrFuture<'a>: Send + 'static,
 {
-  fn new(journal: J) -> Self {
-    Self { inner: SharedLock::new_with_driver::<DefaultMutex<_>>(JournalActor::new(journal)) }
+  fn new_with_config(journal: J, config: JournalActorConfig) -> Self {
+    Self { inner: SharedLock::new_with_driver::<DefaultMutex<_>>(JournalActor::new_with_config(journal, config)) }
   }
 }
 
@@ -121,8 +159,10 @@ where
   for<'a> S::DeleteOneFuture<'a>: Send + 'static,
   for<'a> S::DeleteManyFuture<'a>: Send + 'static,
 {
-  fn new(snapshot_store: S) -> Self {
-    Self { inner: SharedLock::new_with_driver::<DefaultMutex<_>>(SnapshotActor::new(snapshot_store)) }
+  fn new_with_config(snapshot_store: S, config: SnapshotActorConfig) -> Self {
+    Self {
+      inner: SharedLock::new_with_driver::<DefaultMutex<_>>(SnapshotActor::new_with_config(snapshot_store, config)),
+    }
   }
 }
 

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_id.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_id.rs
@@ -3,6 +3,7 @@
 use fraktor_actor_core_kernel_rs::{actor::extension::ExtensionId, system::ActorSystem};
 
 use crate::{
+  config::PersistenceSettings,
   extension::{PersistenceExtension, PersistenceExtensionShared},
   journal::Journal,
   snapshot::SnapshotStore,
@@ -12,13 +13,20 @@ use crate::{
 pub struct PersistenceExtensionId<J, S> {
   journal:        J,
   snapshot_store: S,
+  settings:       PersistenceSettings,
 }
 
 impl<J, S> PersistenceExtensionId<J, S> {
   /// Creates a new identifier with the provided journal and snapshot store.
   #[must_use]
   pub const fn new(journal: J, snapshot_store: S) -> Self {
-    Self { journal, snapshot_store }
+    Self::new_with_settings(journal, snapshot_store, PersistenceSettings::default_settings())
+  }
+
+  /// Creates a new identifier with explicit persistence settings.
+  #[must_use]
+  pub const fn new_with_settings(journal: J, snapshot_store: S, settings: PersistenceSettings) -> Self {
+    Self { journal, snapshot_store, settings }
   }
 }
 
@@ -38,7 +46,12 @@ where
   type Ext = PersistenceExtensionShared;
 
   fn create_extension(&self, system: &ActorSystem) -> Self::Ext {
-    let extension = match PersistenceExtension::new(system, self.journal.clone(), self.snapshot_store.clone()) {
+    let extension = match PersistenceExtension::new_with_settings(
+      system,
+      self.journal.clone(),
+      self.snapshot_store.clone(),
+      self.settings,
+    ) {
       | Ok(extension) => extension,
       | Err(error) => {
         panic!("persistence extension bootstrap failed: {error:?}");

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
@@ -9,19 +9,28 @@ use fraktor_actor_core_kernel_rs::{
   system::{ActorSystem, ActorSystemBuildError},
 };
 
-use crate::{extension::PersistenceExtensionId, journal::Journal, snapshot::SnapshotStore};
+use crate::{
+  config::PersistenceSettings, extension::PersistenceExtensionId, journal::Journal, snapshot::SnapshotStore,
+};
 
 /// Installs the persistence extension into the actor system.
 pub struct PersistenceExtensionInstaller<J, S> {
   journal:        J,
   snapshot_store: S,
+  settings:       PersistenceSettings,
 }
 
 impl<J, S> PersistenceExtensionInstaller<J, S> {
   /// Creates a new installer with the provided journal and snapshot store.
   #[must_use]
   pub const fn new(journal: J, snapshot_store: S) -> Self {
-    Self { journal, snapshot_store }
+    Self::new_with_settings(journal, snapshot_store, PersistenceSettings::default_settings())
+  }
+
+  /// Creates a new installer with explicit persistence settings.
+  #[must_use]
+  pub const fn new_with_settings(journal: J, snapshot_store: S, settings: PersistenceSettings) -> Self {
+    Self { journal, snapshot_store, settings }
   }
 }
 
@@ -39,7 +48,8 @@ where
   for<'a> S::DeleteManyFuture<'a>: Send + 'static,
 {
   fn install(&self, system: &ActorSystem) -> Result<(), ActorSystemBuildError> {
-    let extension_id = PersistenceExtensionId::new(self.journal.clone(), self.snapshot_store.clone());
+    let extension_id =
+      PersistenceExtensionId::new_with_settings(self.journal.clone(), self.snapshot_store.clone(), self.settings);
     install_extension_id(system, &extension_id);
     Ok(())
   }

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
@@ -8,9 +8,10 @@ use fraktor_actor_core_kernel_rs::{
 };
 
 use crate::{
+  config::PersistenceSettings,
   extension::{PersistenceExtensionInstaller, PersistenceExtensionShared},
-  journal::InMemoryJournal,
-  snapshot::InMemorySnapshotStore,
+  journal::{InMemoryJournal, JournalActorConfig},
+  snapshot::{InMemorySnapshotStore, SnapshotActorConfig},
 };
 
 struct NoopActor;
@@ -26,6 +27,27 @@ fn installer_registers_persistence_extension() {
   let journal = InMemoryJournal::new();
   let snapshot_store = InMemorySnapshotStore::new();
   let installer = PersistenceExtensionInstaller::new(journal, snapshot_store);
+  let installers = ExtensionInstallers::default().with_extension_installer(installer);
+  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
+  let config = ActorSystemConfig::new(TestTickDriver::default())
+    .with_scheduler_config(scheduler)
+    .with_extension_installers(installers);
+  let props = Props::from_fn(|| NoopActor);
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
+
+  let extension = system.extended().extension_by_type::<PersistenceExtensionShared>();
+
+  assert!(extension.is_some());
+}
+
+#[test]
+fn installer_registers_extension_with_explicit_settings() {
+  let journal = InMemoryJournal::new();
+  let snapshot_store = InMemorySnapshotStore::new();
+  let settings = PersistenceSettings::default()
+    .with_journal_actor_config(JournalActorConfig::new(2))
+    .with_snapshot_actor_config(SnapshotActorConfig::new(3));
+  let installer = PersistenceExtensionInstaller::new_with_settings(journal, snapshot_store, settings);
   let installers = ExtensionInstallers::default().with_extension_installer(installer);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default())

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_test.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_test.rs
@@ -1,13 +1,19 @@
 use fraktor_actor_adaptor_std_rs::tick_driver::TestTickDriver;
 use fraktor_actor_core_kernel_rs::{
   actor::{
-    Actor, ActorContext, Pid, error::ActorError, messaging::AnyMessageView, props::Props, scheduler::SchedulerConfig,
-    setup::ActorSystemConfig,
+    Actor, ActorContext, Pid, error::ActorError, extension::ExtensionId, messaging::AnyMessageView, props::Props,
+    scheduler::SchedulerConfig, setup::ActorSystemConfig,
   },
   system::ActorSystem,
 };
+use fraktor_utils_core_rs::sync::SharedAccess;
 
-use crate::{extension::PersistenceExtension, journal::InMemoryJournal, snapshot::InMemorySnapshotStore};
+use crate::{
+  config::PersistenceSettings,
+  extension::{PersistenceExtension, PersistenceExtensionId},
+  journal::{InMemoryJournal, JournalActorConfig},
+  snapshot::{InMemorySnapshotStore, SnapshotActorConfig},
+};
 
 struct NoopActor;
 
@@ -34,4 +40,54 @@ fn persistence_extension_creates_actor_refs() {
 
   let cloned = extension.clone();
   assert_eq!(cloned.journal_actor_ref().pid(), extension.journal_actor_ref().pid());
+}
+
+#[test]
+fn persistence_extension_accepts_explicit_runtime_settings() {
+  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
+  let props = Props::from_fn(|| NoopActor);
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
+  let journal = InMemoryJournal::new();
+  let snapshot = InMemorySnapshotStore::new();
+  let settings = PersistenceSettings::default()
+    .with_journal_actor_config(JournalActorConfig::new(2))
+    .with_snapshot_actor_config(SnapshotActorConfig::new(3));
+
+  let extension =
+    PersistenceExtension::new_with_settings(&system, journal, snapshot, settings).expect("extension should build");
+
+  assert_ne!(extension.journal_actor_ref().pid(), Pid::new(0, 0));
+  assert_ne!(extension.snapshot_actor_ref().pid(), Pid::new(0, 0));
+  assert_eq!(extension.settings().journal_actor_config(), JournalActorConfig::new(2));
+  assert_eq!(extension.settings().snapshot_actor_config(), SnapshotActorConfig::new(3));
+}
+
+#[test]
+fn persistence_extension_id_creates_shared_extension() {
+  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
+  let props = Props::from_fn(|| NoopActor);
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
+  let extension_id = PersistenceExtensionId::new(InMemoryJournal::new(), InMemorySnapshotStore::new());
+
+  let extension = extension_id.create_extension(&system);
+
+  let journal_pid = extension.with_read(|inner| inner.journal_actor_ref().pid());
+  let snapshot_pid = extension.with_read(|inner| inner.snapshot_actor_ref().pid());
+  assert_ne!(journal_pid, Pid::new(0, 0));
+  assert_ne!(snapshot_pid, Pid::new(0, 0));
+}
+
+#[test]
+#[should_panic(expected = "persistence extension bootstrap failed")]
+fn persistence_extension_id_panics_when_runtime_actor_names_are_already_taken() {
+  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_scheduler_config(scheduler);
+  let props = Props::from_fn(|| NoopActor);
+  let system = ActorSystem::create_from_props(&props, config).expect("system");
+  let extension_id = PersistenceExtensionId::new(InMemoryJournal::new(), InMemorySnapshotStore::new());
+
+  drop(extension_id.create_extension(&system));
+  drop(extension_id.create_extension(&system));
 }

--- a/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
+++ b/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
@@ -88,7 +88,7 @@ impl TestPersistentFsmActor {
 
   fn new_with_refs(journal: ActorRef, snapshot: ActorRef) -> Self {
     let mut actor = Self::new();
-    let _ = actor.context.bind_actor_refs(journal, snapshot);
+    actor.context.bind_actor_refs(journal, snapshot).expect("bind actor refs");
     actor
   }
 }

--- a/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
@@ -1,5 +1,8 @@
 use alloc::{vec, vec::Vec};
-use core::future::{Pending, Ready, pending, ready};
+use core::{
+  future::{Pending, Ready, pending, ready},
+  sync::atomic::{AtomicU32, Ordering},
+};
 
 use fraktor_actor_adaptor_std_rs::system::create_noop_actor_system;
 use fraktor_actor_core_kernel_rs::{
@@ -169,6 +172,127 @@ impl crate::journal::Journal for RetryJournal {
   }
 }
 
+struct ScriptedJournal {
+  replay_failures_left:  AtomicU32,
+  delete_failures_left:  AtomicU32,
+  highest_failures_left: AtomicU32,
+  highest_sequence_nr:   u64,
+}
+
+impl ScriptedJournal {
+  fn new(replay_failures_left: u32, delete_failures_left: u32, highest_failures_left: u32) -> Self {
+    Self {
+      replay_failures_left:  AtomicU32::new(replay_failures_left),
+      delete_failures_left:  AtomicU32::new(delete_failures_left),
+      highest_failures_left: AtomicU32::new(highest_failures_left),
+      highest_sequence_nr:   42,
+    }
+  }
+
+  fn consume_failure(counter: &AtomicU32) -> bool {
+    counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |value| value.checked_sub(1)).is_ok()
+  }
+}
+
+impl crate::journal::Journal for ScriptedJournal {
+  type DeleteFuture<'a>
+    = Ready<Result<(), JournalError>>
+  where
+    Self: 'a;
+  type HighestSeqNrFuture<'a>
+    = Ready<Result<u64, JournalError>>
+  where
+    Self: 'a;
+  type ReplayFuture<'a>
+    = Ready<Result<Vec<PersistentRepr>, JournalError>>
+  where
+    Self: 'a;
+  type WriteFuture<'a>
+    = Ready<Result<(), JournalError>>
+  where
+    Self: 'a;
+
+  fn write_messages<'a>(&'a mut self, _messages: &'a [PersistentRepr]) -> Self::WriteFuture<'a> {
+    ready(Ok(()))
+  }
+
+  fn replay_messages<'a>(
+    &'a self,
+    _persistence_id: &'a str,
+    _from_sequence_nr: u64,
+    _to_sequence_nr: u64,
+    _max: u64,
+  ) -> Self::ReplayFuture<'a> {
+    if Self::consume_failure(&self.replay_failures_left) {
+      ready(Err(JournalError::ReadFailed("replay failed".into())))
+    } else {
+      ready(Ok(Vec::new()))
+    }
+  }
+
+  fn delete_messages_to<'a>(&'a mut self, _persistence_id: &'a str, _to_sequence_nr: u64) -> Self::DeleteFuture<'a> {
+    if Self::consume_failure(&self.delete_failures_left) {
+      ready(Err(JournalError::DeleteFailed("delete failed".into())))
+    } else {
+      ready(Ok(()))
+    }
+  }
+
+  fn highest_sequence_nr<'a>(&'a self, _persistence_id: &'a str) -> Self::HighestSeqNrFuture<'a> {
+    if Self::consume_failure(&self.highest_failures_left) {
+      ready(Err(JournalError::ReadFailed("highest failed".into())))
+    } else {
+      ready(Ok(self.highest_sequence_nr))
+    }
+  }
+}
+
+#[test]
+fn scripted_journal_success_paths_are_exercised() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor =
+    JournalActor::<ScriptedJournal>::new_with_config(ScriptedJournal::new(0, 0, 0), JournalActorConfig::new(0));
+  let (sender, store) = create_sender();
+
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+  let write = JournalMessage::WriteMessages {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    messages:       vec![repr],
+    sender:         sender.clone(),
+    instance_id:    7,
+  };
+  let any_message = AnyMessage::new(write);
+  actor.receive(&mut ctx, any_message.as_view()).expect("write receive failed");
+
+  let replay = JournalMessage::ReplayMessages {
+    persistence_id:   "pid-1".into(),
+    from_sequence_nr: 1,
+    to_sequence_nr:   1,
+    max:              10,
+    sender:           sender.clone(),
+  };
+  let any_message = AnyMessage::new(replay);
+  actor.receive(&mut ctx, any_message.as_view()).expect("replay receive failed");
+
+  let delete = JournalMessage::DeleteMessagesTo {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    sender:         sender.clone(),
+  };
+  let any_message = AnyMessage::new(delete);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete receive failed");
+
+  let highest = JournalMessage::GetHighestSequenceNr { persistence_id: "pid-1".into(), from_sequence_nr: 0, sender };
+  let any_message = AnyMessage::new(highest);
+  actor.receive(&mut ctx, any_message.as_view()).expect("highest receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 5);
+}
+
 #[test]
 fn journal_actor_write_messages_sends_responses() {
   let system = new_test_system();
@@ -199,18 +323,28 @@ fn journal_actor_write_messages_sends_responses() {
   let mut batch_success_instance_id = None;
   for response in responses.iter() {
     let response = response.payload().downcast_ref::<JournalResponse>().expect("unexpected payload");
-    match response {
-      | JournalResponse::WriteMessageSuccess { .. } => success_count += 1,
-      | JournalResponse::WriteMessagesSuccessful { instance_id } => {
-        batch_success += 1;
-        batch_success_instance_id = Some(*instance_id);
-      },
-      | _ => {},
+    if let JournalResponse::WriteMessageSuccess { .. } = response {
+      success_count += 1;
+    }
+    if let JournalResponse::WriteMessagesSuccessful { instance_id } = response {
+      batch_success += 1;
+      batch_success_instance_id = Some(*instance_id);
     }
   }
   assert_eq!(success_count, 2);
   assert_eq!(batch_success, 1);
   assert_eq!(batch_success_instance_id, Some(9));
+}
+
+#[test]
+fn journal_actor_ignores_unrelated_messages() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor = JournalActor::<InMemoryJournal>::new(InMemoryJournal::new());
+
+  let any_message = AnyMessage::new(());
+  actor.receive(&mut ctx, any_message.as_view()).expect("receive failed");
 }
 
 #[test]
@@ -237,6 +371,40 @@ fn journal_actor_pending_does_not_emit_failure() {
 
   let responses = store.lock();
   assert_eq!(responses.len(), 0);
+}
+
+#[test]
+fn journal_actor_pending_replay_delete_and_highest_do_not_emit_failure() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = JournalActorConfig::new(0);
+  let mut actor = JournalActor::<PendingJournal>::new_with_config(PendingJournal, config);
+  let (sender, store) = create_sender();
+
+  let replay = JournalMessage::ReplayMessages {
+    persistence_id:   "pid-1".into(),
+    from_sequence_nr: 1,
+    to_sequence_nr:   3,
+    max:              10,
+    sender:           sender.clone(),
+  };
+  let any_message = AnyMessage::new(replay);
+  actor.receive(&mut ctx, any_message.as_view()).expect("replay receive failed");
+
+  let delete = JournalMessage::DeleteMessagesTo {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 3,
+    sender:         sender.clone(),
+  };
+  let any_message = AnyMessage::new(delete);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete receive failed");
+
+  let highest = JournalMessage::GetHighestSequenceNr { persistence_id: "pid-1".into(), from_sequence_nr: 0, sender };
+  let any_message = AnyMessage::new(highest);
+  actor.receive(&mut ctx, any_message.as_view()).expect("highest receive failed");
+
+  assert!(store.lock().is_empty());
 }
 
 #[test]
@@ -272,21 +440,146 @@ fn journal_actor_retry_max_exceeded_on_errors() {
   let mut batch_failures = 0;
   for response in responses.iter() {
     let response = response.payload().downcast_ref::<JournalResponse>().expect("unexpected payload");
-    match response {
-      | JournalResponse::WriteMessageFailure { cause, .. } => {
-        assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
-        failures += 1;
-      },
-      | JournalResponse::WriteMessagesFailed { cause, instance_id, .. } => {
-        assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
-        assert_eq!(*instance_id, 1);
-        batch_failures += 1;
-      },
-      | _ => {},
+    if let JournalResponse::WriteMessageFailure { cause, .. } = response {
+      assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
+      failures += 1;
+    }
+    if let JournalResponse::WriteMessagesFailed { cause, instance_id, .. } = response {
+      assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
+      assert_eq!(*instance_id, 1);
+      batch_failures += 1;
     }
   }
   assert_eq!(failures, 1);
   assert_eq!(batch_failures, 1);
+}
+
+#[test]
+fn journal_actor_replay_failure_after_retry_exhausted() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = JournalActorConfig::new(1);
+  let mut actor = JournalActor::<ScriptedJournal>::new_with_config(ScriptedJournal::new(2, 0, 0), config);
+  let (sender, store) = create_sender();
+
+  let replay = JournalMessage::ReplayMessages {
+    persistence_id: "pid-1".into(),
+    from_sequence_nr: 1,
+    to_sequence_nr: 3,
+    max: 10,
+    sender,
+  };
+  let any_message = AnyMessage::new(replay);
+  actor.receive(&mut ctx, any_message.as_view()).expect("replay receive failed");
+  assert!(store.lock().is_empty());
+
+  let poll = AnyMessage::new(JournalPoll);
+  actor.receive(&mut ctx, poll.as_view()).expect("poll receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 1);
+  let response = responses[0].payload().downcast_ref::<JournalResponse>().expect("unexpected payload");
+  assert!(
+    matches!(response, JournalResponse::ReplayMessagesFailure { cause } if cause == &JournalError::ReadFailed("replay failed".into()))
+  );
+}
+
+#[test]
+fn journal_actor_delete_and_highest_success_responses() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor = JournalActor::<InMemoryJournal>::new(InMemoryJournal::new());
+  let (sender, store) = create_sender();
+
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+  let write = JournalMessage::WriteMessages {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    messages:       vec![repr],
+    sender:         sender.clone(),
+    instance_id:    7,
+  };
+  let any_message = AnyMessage::new(write);
+  actor.receive(&mut ctx, any_message.as_view()).expect("write receive failed");
+  store.lock().clear();
+
+  let delete = JournalMessage::DeleteMessagesTo {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    sender:         sender.clone(),
+  };
+  let any_message = AnyMessage::new(delete);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete receive failed");
+
+  let highest = JournalMessage::GetHighestSequenceNr { persistence_id: "pid-1".into(), from_sequence_nr: 0, sender };
+  let any_message = AnyMessage::new(highest);
+  actor.receive(&mut ctx, any_message.as_view()).expect("highest receive failed");
+
+  let responses = store.lock();
+  let mut delete_success = None;
+  let mut highest_sequence_nr = None;
+  for response in responses.iter() {
+    let response = response.payload().downcast_ref::<JournalResponse>().expect("unexpected payload");
+    if let JournalResponse::DeleteMessagesSuccess { to_sequence_nr } = response {
+      delete_success = Some(*to_sequence_nr);
+    }
+    if let JournalResponse::HighestSequenceNr { persistence_id, sequence_nr } = response {
+      assert_eq!(persistence_id, "pid-1");
+      highest_sequence_nr = Some(*sequence_nr);
+    }
+  }
+  assert_eq!(delete_success, Some(1));
+  assert_eq!(highest_sequence_nr, Some(1));
+}
+
+#[test]
+fn journal_actor_delete_failure_after_retry_exhausted() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = JournalActorConfig::new(1);
+  let mut actor = JournalActor::<ScriptedJournal>::new_with_config(ScriptedJournal::new(0, 2, 0), config);
+  let (sender, store) = create_sender();
+
+  let delete = JournalMessage::DeleteMessagesTo { persistence_id: "pid-1".into(), to_sequence_nr: 9, sender };
+  let any_message = AnyMessage::new(delete);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete receive failed");
+  assert!(store.lock().is_empty());
+
+  let poll = AnyMessage::new(JournalPoll);
+  actor.receive(&mut ctx, poll.as_view()).expect("poll receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 1);
+  let response = responses[0].payload().downcast_ref::<JournalResponse>().expect("unexpected payload");
+  assert!(matches!(response, JournalResponse::DeleteMessagesFailure { cause, to_sequence_nr }
+      if cause == &JournalError::DeleteFailed("delete failed".into()) && *to_sequence_nr == 9));
+}
+
+#[test]
+fn journal_actor_highest_failure_after_retry_exhausted() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = JournalActorConfig::new(1);
+  let mut actor = JournalActor::<ScriptedJournal>::new_with_config(ScriptedJournal::new(0, 0, 2), config);
+  let (sender, store) = create_sender();
+
+  let highest = JournalMessage::GetHighestSequenceNr { persistence_id: "pid-1".into(), from_sequence_nr: 0, sender };
+  let any_message = AnyMessage::new(highest);
+  actor.receive(&mut ctx, any_message.as_view()).expect("highest receive failed");
+  assert!(store.lock().is_empty());
+
+  let poll = AnyMessage::new(JournalPoll);
+  actor.receive(&mut ctx, poll.as_view()).expect("poll receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 1);
+  let response = responses[0].payload().downcast_ref::<JournalResponse>().expect("unexpected payload");
+  assert!(matches!(response, JournalResponse::HighestSequenceNrFailure { persistence_id, cause }
+      if persistence_id == "pid-1" && cause == &JournalError::ReadFailed("highest failed".into())));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/lib.rs
+++ b/modules/persistence-core-kernel/src/lib.rs
@@ -57,6 +57,7 @@
 
 extern crate alloc;
 
+pub mod config;
 pub mod delivery;
 pub mod error;
 pub mod extension;

--- a/modules/persistence-core-kernel/src/persistent/eventsourced.rs
+++ b/modules/persistence-core-kernel/src/persistent/eventsourced.rs
@@ -12,7 +12,7 @@ use crate::{
   error::PersistenceError,
   journal::JournalError,
   persistent::{PersistentRepr, Recovery, RecoveryTimedOut},
-  snapshot::{Snapshot, SnapshotError, SnapshotMetadata, SnapshotSelectionCriteria},
+  snapshot::{Snapshot, SnapshotError, SnapshotMetadata, SnapshotOffer, SnapshotSelectionCriteria},
 };
 
 /// Event-sourced actor interface.
@@ -36,6 +36,11 @@ pub trait Eventsourced: Send {
 
   /// Handles loaded snapshot during recovery.
   fn receive_snapshot(&mut self, snapshot: &Snapshot);
+
+  /// Handles a loaded snapshot offer during recovery.
+  fn receive_snapshot_offer(&mut self, offer: &SnapshotOffer) {
+    self.receive_snapshot(offer.snapshot());
+  }
 
   /// Handles incoming commands.
   ///

--- a/modules/persistence-core-kernel/src/persistent/eventsourced_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/eventsourced_test.rs
@@ -6,15 +6,19 @@ use fraktor_actor_core_kernel_rs::actor::{
   error::ActorError,
   messaging::{AnyMessage, AnyMessageView},
 };
+use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::{
+  error::PersistenceError,
+  journal::JournalError,
   persistent::{Eventsourced, PersistentRepr, Recovery, RecoveryTimedOut},
-  snapshot::Snapshot,
+  snapshot::{Snapshot, SnapshotError, SnapshotMetadata, SnapshotOffer, SnapshotSelectionCriteria},
 };
 
 struct DummyEventsourced {
   persistence_id: String,
   last:           u64,
+  snapshots:      usize,
 }
 
 impl Eventsourced for DummyEventsourced {
@@ -24,7 +28,9 @@ impl Eventsourced for DummyEventsourced {
 
   fn receive_recover(&mut self, _event: &PersistentRepr) {}
 
-  fn receive_snapshot(&mut self, _snapshot: &Snapshot) {}
+  fn receive_snapshot(&mut self, _snapshot: &Snapshot) {
+    self.snapshots = self.snapshots.saturating_add(1);
+  }
 
   fn receive_command(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
     Ok(())
@@ -37,7 +43,7 @@ impl Eventsourced for DummyEventsourced {
 
 #[test]
 fn eventsourced_default_recovery_is_latest() {
-  let dummy = DummyEventsourced { persistence_id: "pid-1".into(), last: 0 };
+  let dummy = DummyEventsourced { persistence_id: "pid-1".into(), last: 0, snapshots: 0 };
 
   let recovery = dummy.recovery();
   assert_eq!(recovery, Recovery::default());
@@ -46,12 +52,38 @@ fn eventsourced_default_recovery_is_latest() {
 
 #[test]
 fn eventsourced_default_hooks_do_not_panic() {
-  let mut dummy = DummyEventsourced { persistence_id: "pid-1".into(), last: 0 };
+  let mut dummy = DummyEventsourced { persistence_id: "pid-1".into(), last: 0, snapshots: 0 };
   let system = create_noop_actor_system();
   let pid = Pid::new(1, 1);
   let mut ctx = ActorContext::new(&system, pid);
   let message = AnyMessage::new(1_i32);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+  let journal_error = JournalError::WriteFailed("boom".into());
+  let persistence_error = PersistenceError::Recovery("boom".into());
+  let snapshot_error = SnapshotError::SaveFailed("boom".into());
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+  let criteria = SnapshotSelectionCriteria::latest();
 
-  let _ = dummy.receive_command(&mut ctx, message.as_view());
+  dummy.receive_command(&mut ctx, message.as_view()).expect("receive command should succeed");
+  dummy.on_recovery_completed();
   dummy.on_recovery_timed_out(&RecoveryTimedOut::new("pid-1"));
+  dummy.on_persist_failure(&journal_error, &repr);
+  dummy.on_persist_rejected(&journal_error, &repr);
+  dummy.on_recovery_failure(&persistence_error);
+  dummy.on_snapshot_failure(&snapshot_error);
+  dummy.on_snapshot_saved(&metadata);
+  dummy.on_snapshot_deleted(&metadata);
+  dummy.on_snapshots_deleted(&criteria);
+}
+
+#[test]
+fn eventsourced_default_snapshot_offer_hook_forwards_to_snapshot_callback() {
+  let mut dummy = DummyEventsourced { persistence_id: "pid-1".into(), last: 0, snapshots: 0 };
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+  let snapshot = Snapshot::new(metadata, ArcShared::new(1_i32));
+  let offer = SnapshotOffer::new(snapshot);
+
+  dummy.receive_snapshot_offer(&offer);
+
+  assert_eq!(dummy.snapshots, 1);
 }

--- a/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
@@ -104,7 +104,7 @@ impl DummyPersistentActor {
 
   fn new_with_refs(journal: ActorRef, snapshot: ActorRef) -> Self {
     let mut actor = Self::new();
-    let _ = actor.context.bind_actor_refs(journal, snapshot);
+    actor.context.bind_actor_refs(journal, snapshot).expect("bind actor refs");
     actor
   }
 }

--- a/modules/persistence-core-kernel/src/snapshot.rs
+++ b/modules/persistence-core-kernel/src/snapshot.rs
@@ -2,11 +2,13 @@
 
 mod base;
 mod in_memory_snapshot_store;
+mod no_snapshot_store;
 mod snapshot_actor;
 mod snapshot_actor_config;
 mod snapshot_error;
 mod snapshot_message;
 mod snapshot_metadata;
+mod snapshot_offer;
 mod snapshot_response;
 mod snapshot_response_action;
 mod snapshot_selection_criteria;
@@ -14,11 +16,13 @@ mod snapshot_store;
 
 pub use base::Snapshot;
 pub use in_memory_snapshot_store::InMemorySnapshotStore;
+pub use no_snapshot_store::NoSnapshotStore;
 pub use snapshot_actor::SnapshotActor;
 pub use snapshot_actor_config::SnapshotActorConfig;
 pub use snapshot_error::SnapshotError;
 pub use snapshot_message::SnapshotMessage;
 pub use snapshot_metadata::SnapshotMetadata;
+pub use snapshot_offer::SnapshotOffer;
 pub use snapshot_response::SnapshotResponse;
 pub(crate) use snapshot_response_action::SnapshotResponseAction;
 pub use snapshot_selection_criteria::SnapshotSelectionCriteria;

--- a/modules/persistence-core-kernel/src/snapshot/no_snapshot_store.rs
+++ b/modules/persistence-core-kernel/src/snapshot/no_snapshot_store.rs
@@ -1,0 +1,73 @@
+//! Snapshot store implementation that never stores snapshots.
+
+#[cfg(test)]
+#[path = "no_snapshot_store_test.rs"]
+mod tests;
+
+use core::{
+  any::Any,
+  future::{Ready, ready},
+};
+
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::snapshot::{Snapshot, SnapshotError, SnapshotMetadata, SnapshotSelectionCriteria, SnapshotStore};
+
+/// Snapshot store that ignores save and delete requests and always returns no snapshot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NoSnapshotStore;
+
+impl NoSnapshotStore {
+  /// Creates a no-op snapshot store.
+  #[must_use]
+  pub const fn new() -> Self {
+    Self
+  }
+}
+
+impl SnapshotStore for NoSnapshotStore {
+  type DeleteManyFuture<'a>
+    = Ready<Result<(), SnapshotError>>
+  where
+    Self: 'a;
+  type DeleteOneFuture<'a>
+    = Ready<Result<(), SnapshotError>>
+  where
+    Self: 'a;
+  type LoadFuture<'a>
+    = Ready<Result<Option<Snapshot>, SnapshotError>>
+  where
+    Self: 'a;
+  type SaveFuture<'a>
+    = Ready<Result<(), SnapshotError>>
+  where
+    Self: 'a;
+
+  fn save_snapshot<'a>(
+    &'a mut self,
+    _metadata: SnapshotMetadata,
+    _snapshot: ArcShared<dyn Any + Send + Sync>,
+  ) -> Self::SaveFuture<'a> {
+    ready(Ok(()))
+  }
+
+  fn load_snapshot<'a>(
+    &'a self,
+    _persistence_id: &'a str,
+    _criteria: SnapshotSelectionCriteria,
+  ) -> Self::LoadFuture<'a> {
+    ready(Ok(None))
+  }
+
+  fn delete_snapshot<'a>(&'a mut self, _metadata: &'a SnapshotMetadata) -> Self::DeleteOneFuture<'a> {
+    ready(Ok(()))
+  }
+
+  fn delete_snapshots<'a>(
+    &'a mut self,
+    _persistence_id: &'a str,
+    _criteria: SnapshotSelectionCriteria,
+  ) -> Self::DeleteManyFuture<'a> {
+    ready(Ok(()))
+  }
+}

--- a/modules/persistence-core-kernel/src/snapshot/no_snapshot_store_test.rs
+++ b/modules/persistence-core-kernel/src/snapshot/no_snapshot_store_test.rs
@@ -1,0 +1,39 @@
+use core::{
+  future::{Future, pending},
+  task::{Context, Poll, Waker},
+};
+use std::panic::catch_unwind;
+
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::snapshot::{NoSnapshotStore, SnapshotMetadata, SnapshotSelectionCriteria, SnapshotStore};
+
+fn poll_ready<F: Future>(future: F) -> F::Output {
+  let waker = Waker::noop();
+  let mut context = Context::from_waker(waker);
+  let mut future = Box::pin(future);
+  match Future::poll(future.as_mut(), &mut context) {
+    | Poll::Ready(output) => output,
+    | Poll::Pending => panic!("future was pending"),
+  }
+}
+
+#[test]
+fn no_snapshot_store_ignores_writes_and_returns_no_snapshot() {
+  let mut store = NoSnapshotStore::new();
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+
+  poll_ready(store.save_snapshot(metadata.clone(), ArcShared::new(1_i32))).expect("save snapshot");
+  let loaded = poll_ready(store.load_snapshot("pid-1", SnapshotSelectionCriteria::latest())).expect("load snapshot");
+  poll_ready(store.delete_snapshot(&metadata)).expect("delete snapshot");
+  poll_ready(store.delete_snapshots("pid-1", SnapshotSelectionCriteria::latest())).expect("delete snapshots");
+
+  assert!(loaded.is_none());
+}
+
+#[test]
+fn poll_ready_panics_when_future_is_pending() {
+  let result = catch_unwind(|| poll_ready(pending::<()>()));
+
+  assert!(result.is_err());
+}

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_actor_test.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_actor_test.rs
@@ -1,6 +1,7 @@
 use core::{
   any::Any,
   future::{Pending, Ready, pending, ready},
+  sync::atomic::{AtomicU32, Ordering},
 };
 
 use fraktor_actor_adaptor_std_rs::system::create_noop_actor_system;
@@ -183,6 +184,129 @@ impl crate::snapshot::SnapshotStore for RetrySnapshotStore {
   }
 }
 
+struct ScriptedSnapshotStore {
+  load_failures_left:        AtomicU32,
+  delete_one_failures_left:  AtomicU32,
+  delete_many_failures_left: AtomicU32,
+}
+
+impl ScriptedSnapshotStore {
+  fn new(load_failures_left: u32, delete_one_failures_left: u32, delete_many_failures_left: u32) -> Self {
+    Self {
+      load_failures_left:        AtomicU32::new(load_failures_left),
+      delete_one_failures_left:  AtomicU32::new(delete_one_failures_left),
+      delete_many_failures_left: AtomicU32::new(delete_many_failures_left),
+    }
+  }
+
+  fn consume_failure(counter: &AtomicU32) -> bool {
+    counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |value| value.checked_sub(1)).is_ok()
+  }
+}
+
+impl crate::snapshot::SnapshotStore for ScriptedSnapshotStore {
+  type DeleteManyFuture<'a>
+    = Ready<Result<(), SnapshotError>>
+  where
+    Self: 'a;
+  type DeleteOneFuture<'a>
+    = Ready<Result<(), SnapshotError>>
+  where
+    Self: 'a;
+  type LoadFuture<'a>
+    = Ready<Result<Option<Snapshot>, SnapshotError>>
+  where
+    Self: 'a;
+  type SaveFuture<'a>
+    = Ready<Result<(), SnapshotError>>
+  where
+    Self: 'a;
+
+  fn save_snapshot<'a>(
+    &'a mut self,
+    _metadata: SnapshotMetadata,
+    _snapshot: ArcShared<dyn Any + Send + Sync>,
+  ) -> Self::SaveFuture<'a> {
+    ready(Ok(()))
+  }
+
+  fn load_snapshot<'a>(
+    &'a self,
+    _persistence_id: &'a str,
+    _criteria: SnapshotSelectionCriteria,
+  ) -> Self::LoadFuture<'a> {
+    if Self::consume_failure(&self.load_failures_left) {
+      ready(Err(SnapshotError::LoadFailed("load failed".into())))
+    } else {
+      ready(Ok(None))
+    }
+  }
+
+  fn delete_snapshot<'a>(&'a mut self, _metadata: &'a SnapshotMetadata) -> Self::DeleteOneFuture<'a> {
+    if Self::consume_failure(&self.delete_one_failures_left) {
+      ready(Err(SnapshotError::DeleteFailed("delete one failed".into())))
+    } else {
+      ready(Ok(()))
+    }
+  }
+
+  fn delete_snapshots<'a>(
+    &'a mut self,
+    _persistence_id: &'a str,
+    _criteria: SnapshotSelectionCriteria,
+  ) -> Self::DeleteManyFuture<'a> {
+    if Self::consume_failure(&self.delete_many_failures_left) {
+      ready(Err(SnapshotError::DeleteFailed("delete many failed".into())))
+    } else {
+      ready(Ok(()))
+    }
+  }
+}
+
+#[test]
+fn scripted_snapshot_store_success_paths_are_exercised() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor = SnapshotActor::<ScriptedSnapshotStore>::new_with_config(
+    ScriptedSnapshotStore::new(0, 0, 0),
+    SnapshotActorConfig::new(0),
+  );
+  let (sender, store) = create_sender();
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+
+  let save = SnapshotMessage::SaveSnapshot {
+    metadata: metadata.clone(),
+    snapshot: ArcShared::new(1_i32),
+    sender:   sender.clone(),
+  };
+  let any_message = AnyMessage::new(save);
+  actor.receive(&mut ctx, any_message.as_view()).expect("save receive failed");
+
+  let load = SnapshotMessage::LoadSnapshot {
+    persistence_id: "pid-1".into(),
+    criteria:       SnapshotSelectionCriteria::latest(),
+    sender:         sender.clone(),
+  };
+  let any_message = AnyMessage::new(load);
+  actor.receive(&mut ctx, any_message.as_view()).expect("load receive failed");
+
+  let delete_one = SnapshotMessage::DeleteSnapshot { metadata, sender: sender.clone() };
+  let any_message = AnyMessage::new(delete_one);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete one receive failed");
+
+  let delete_many = SnapshotMessage::DeleteSnapshots {
+    persistence_id: "pid-1".into(),
+    criteria: SnapshotSelectionCriteria::latest(),
+    sender,
+  };
+  let any_message = AnyMessage::new(delete_many);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete many receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 4);
+}
+
 #[test]
 fn snapshot_actor_save_and_load_responses() {
   let system = new_test_system();
@@ -222,13 +346,21 @@ fn snapshot_actor_save_and_load_responses() {
   let responses = store.lock();
   assert_eq!(responses.len(), 1);
   let response = responses[0].payload().downcast_ref::<SnapshotResponse>().expect("unexpected payload");
-  match response {
-    | SnapshotResponse::LoadSnapshotResult { snapshot, to_sequence_nr } => {
-      assert!(snapshot.is_some());
-      assert_eq!(*to_sequence_nr, u64::MAX);
-    },
-    | _ => panic!("unexpected response"),
-  }
+  assert!(matches!(response, SnapshotResponse::LoadSnapshotResult {
+    snapshot:       Some(_),
+    to_sequence_nr: u64::MAX,
+  }));
+}
+
+#[test]
+fn snapshot_actor_ignores_unrelated_messages() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor = SnapshotActor::<InMemorySnapshotStore>::new(InMemorySnapshotStore::new());
+
+  let any_message = AnyMessage::new(());
+  actor.receive(&mut ctx, any_message.as_view()).expect("receive failed");
 }
 
 #[test]
@@ -250,6 +382,39 @@ fn snapshot_actor_pending_does_not_emit_failure() {
 
   let responses = store.lock();
   assert_eq!(responses.len(), 0);
+}
+
+#[test]
+fn snapshot_actor_pending_save_delete_one_and_delete_many_do_not_emit_failure() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = SnapshotActorConfig::new(0);
+  let mut actor = SnapshotActor::<PendingSnapshotStore>::new_with_config(PendingSnapshotStore, config);
+  let (sender, store) = create_sender();
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+
+  let save = SnapshotMessage::SaveSnapshot {
+    metadata: metadata.clone(),
+    snapshot: ArcShared::new(1_i32),
+    sender:   sender.clone(),
+  };
+  let any_message = AnyMessage::new(save);
+  actor.receive(&mut ctx, any_message.as_view()).expect("save receive failed");
+
+  let delete_one = SnapshotMessage::DeleteSnapshot { metadata, sender: sender.clone() };
+  let any_message = AnyMessage::new(delete_one);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete one receive failed");
+
+  let delete_many = SnapshotMessage::DeleteSnapshots {
+    persistence_id: "pid-1".into(),
+    criteria: SnapshotSelectionCriteria::latest(),
+    sender,
+  };
+  let any_message = AnyMessage::new(delete_many);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete many receive failed");
+
+  assert!(store.lock().is_empty());
 }
 
 #[test]
@@ -275,10 +440,139 @@ fn snapshot_actor_retry_max_exceeded_on_errors() {
   let responses = store.lock();
   assert_eq!(responses.len(), 1);
   let response = responses[0].payload().downcast_ref::<SnapshotResponse>().expect("unexpected payload");
-  match response {
-    | SnapshotResponse::SaveSnapshotFailure { error, .. } => {
-      assert_eq!(error, &SnapshotError::SaveFailed("boom".into()));
-    },
-    | _ => panic!("unexpected response"),
+  assert!(matches!(
+    response,
+    SnapshotResponse::SaveSnapshotFailure { error, .. }
+      if *error == SnapshotError::SaveFailed("boom".into())
+  ));
+}
+
+#[test]
+fn snapshot_actor_delete_one_and_delete_many_success_responses() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor = SnapshotActor::<InMemorySnapshotStore>::new(InMemorySnapshotStore::new());
+  let (sender, store) = create_sender();
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+
+  let save = SnapshotMessage::SaveSnapshot {
+    metadata: metadata.clone(),
+    snapshot: ArcShared::new(1_i32),
+    sender:   sender.clone(),
+  };
+  let any_message = AnyMessage::new(save);
+  actor.receive(&mut ctx, any_message.as_view()).expect("save receive failed");
+  store.lock().clear();
+
+  let delete_one = SnapshotMessage::DeleteSnapshot { metadata: metadata.clone(), sender: sender.clone() };
+  let any_message = AnyMessage::new(delete_one);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete one receive failed");
+
+  let delete_many = SnapshotMessage::DeleteSnapshots {
+    persistence_id: "pid-1".into(),
+    criteria: SnapshotSelectionCriteria::latest(),
+    sender,
+  };
+  let any_message = AnyMessage::new(delete_many);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete many receive failed");
+
+  let responses = store.lock();
+  let mut delete_one_success = false;
+  let mut delete_many_success = false;
+  for response in responses.iter() {
+    let response = response.payload().downcast_ref::<SnapshotResponse>().expect("unexpected payload");
+    if let SnapshotResponse::DeleteSnapshotSuccess { metadata: response_metadata } = response {
+      assert_eq!(response_metadata.sequence_nr(), 1);
+      delete_one_success = true;
+    }
+    if let SnapshotResponse::DeleteSnapshotsSuccess { criteria } = response {
+      assert_eq!(criteria.max_sequence_nr(), u64::MAX);
+      delete_many_success = true;
+    }
   }
+  assert!(delete_one_success);
+  assert!(delete_many_success);
+}
+
+#[test]
+fn snapshot_actor_load_failure_after_retry_exhausted() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = SnapshotActorConfig::new(1);
+  let mut actor = SnapshotActor::<ScriptedSnapshotStore>::new_with_config(ScriptedSnapshotStore::new(2, 0, 0), config);
+  let (sender, store) = create_sender();
+
+  let load = SnapshotMessage::LoadSnapshot {
+    persistence_id: "pid-1".into(),
+    criteria: SnapshotSelectionCriteria::latest(),
+    sender,
+  };
+  let any_message = AnyMessage::new(load);
+  actor.receive(&mut ctx, any_message.as_view()).expect("load receive failed");
+  assert!(store.lock().is_empty());
+
+  let poll = AnyMessage::new(SnapshotPoll);
+  actor.receive(&mut ctx, poll.as_view()).expect("poll receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 1);
+  let response = responses[0].payload().downcast_ref::<SnapshotResponse>().expect("unexpected payload");
+  assert!(
+    matches!(response, SnapshotResponse::LoadSnapshotFailed { error } if error == &SnapshotError::LoadFailed("load failed".into()))
+  );
+}
+
+#[test]
+fn snapshot_actor_delete_one_failure_after_retry_exhausted() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = SnapshotActorConfig::new(1);
+  let mut actor = SnapshotActor::<ScriptedSnapshotStore>::new_with_config(ScriptedSnapshotStore::new(0, 2, 0), config);
+  let (sender, store) = create_sender();
+
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+  let delete_one = SnapshotMessage::DeleteSnapshot { metadata, sender };
+  let any_message = AnyMessage::new(delete_one);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete one receive failed");
+  assert!(store.lock().is_empty());
+
+  let poll = AnyMessage::new(SnapshotPoll);
+  actor.receive(&mut ctx, poll.as_view()).expect("poll receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 1);
+  let response = responses[0].payload().downcast_ref::<SnapshotResponse>().expect("unexpected payload");
+  assert!(matches!(response, SnapshotResponse::DeleteSnapshotFailure { metadata, error }
+      if metadata.sequence_nr() == 1 && error == &SnapshotError::DeleteFailed("delete one failed".into())));
+}
+
+#[test]
+fn snapshot_actor_delete_many_failure_after_retry_exhausted() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let config = SnapshotActorConfig::new(1);
+  let mut actor = SnapshotActor::<ScriptedSnapshotStore>::new_with_config(ScriptedSnapshotStore::new(0, 0, 2), config);
+  let (sender, store) = create_sender();
+
+  let delete_many = SnapshotMessage::DeleteSnapshots {
+    persistence_id: "pid-1".into(),
+    criteria: SnapshotSelectionCriteria::latest(),
+    sender,
+  };
+  let any_message = AnyMessage::new(delete_many);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete many receive failed");
+  assert!(store.lock().is_empty());
+
+  let poll = AnyMessage::new(SnapshotPoll);
+  actor.receive(&mut ctx, poll.as_view()).expect("poll receive failed");
+
+  let responses = store.lock();
+  assert_eq!(responses.len(), 1);
+  let response = responses[0].payload().downcast_ref::<SnapshotResponse>().expect("unexpected payload");
+  assert!(matches!(response, SnapshotResponse::DeleteSnapshotsFailure { criteria, error }
+      if criteria.max_sequence_nr() == u64::MAX && error == &SnapshotError::DeleteFailed("delete many failed".into())));
 }

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_offer.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_offer.rs
@@ -1,0 +1,41 @@
+//! Snapshot offer signal.
+
+#[cfg(test)]
+#[path = "snapshot_offer_test.rs"]
+mod tests;
+
+use core::any::Any;
+
+use crate::snapshot::{Snapshot, SnapshotMetadata};
+
+/// Snapshot offered to a persistent actor during recovery.
+#[derive(Clone, Debug)]
+pub struct SnapshotOffer {
+  snapshot: Snapshot,
+}
+
+impl SnapshotOffer {
+  /// Creates a new snapshot offer.
+  #[must_use]
+  pub const fn new(snapshot: Snapshot) -> Self {
+    Self { snapshot }
+  }
+
+  /// Returns the offered snapshot.
+  #[must_use]
+  pub const fn snapshot(&self) -> &Snapshot {
+    &self.snapshot
+  }
+
+  /// Returns the snapshot metadata.
+  #[must_use]
+  pub const fn metadata(&self) -> &SnapshotMetadata {
+    self.snapshot.metadata()
+  }
+
+  /// Attempts to downcast the snapshot payload.
+  #[must_use]
+  pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+    self.snapshot.downcast_ref::<T>()
+  }
+}

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_offer_test.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_offer_test.rs
@@ -1,0 +1,13 @@
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::snapshot::{Snapshot, SnapshotMetadata, SnapshotOffer};
+
+#[test]
+fn snapshot_offer_exposes_snapshot_metadata_and_payload() {
+  let metadata = SnapshotMetadata::new("pid-1", 4, 10);
+  let snapshot = Snapshot::new(metadata.clone(), ArcShared::new(99_i32));
+  let offer = SnapshotOffer::new(snapshot);
+
+  assert_eq!(offer.metadata(), &metadata);
+  assert_eq!(offer.downcast_ref::<i32>(), Some(&99));
+}

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_response_action.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_response_action.rs
@@ -1,8 +1,12 @@
 //! Actions derived from snapshot responses.
 
+#[cfg(test)]
+#[path = "snapshot_response_action_test.rs"]
+mod tests;
+
 use crate::{
   persistent::Eventsourced,
-  snapshot::{Snapshot, SnapshotError, SnapshotMetadata, SnapshotSelectionCriteria},
+  snapshot::{Snapshot, SnapshotError, SnapshotMetadata, SnapshotOffer, SnapshotSelectionCriteria},
 };
 
 /// Actions to apply on the actor after snapshot response handling.
@@ -25,7 +29,9 @@ impl SnapshotResponseAction {
   pub(crate) fn apply(self, actor: &mut impl Eventsourced) {
     match self {
       | SnapshotResponseAction::None => {},
-      | SnapshotResponseAction::ReceiveSnapshot(snapshot) => actor.receive_snapshot(&snapshot),
+      | SnapshotResponseAction::ReceiveSnapshot(snapshot) => {
+        actor.receive_snapshot_offer(&SnapshotOffer::new(snapshot))
+      },
       | SnapshotResponseAction::SnapshotSaved(metadata) => actor.on_snapshot_saved(&metadata),
       | SnapshotResponseAction::SnapshotDeleted(metadata) => actor.on_snapshot_deleted(&metadata),
       | SnapshotResponseAction::SnapshotsDeleted(criteria) => actor.on_snapshots_deleted(&criteria),

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_response_action_test.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_response_action_test.rs
@@ -1,0 +1,85 @@
+use fraktor_actor_adaptor_std_rs::system::create_noop_actor_system;
+use fraktor_actor_core_kernel_rs::actor::{
+  ActorContext, Pid,
+  error::ActorError,
+  messaging::{AnyMessage, AnyMessageView},
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::{
+  persistent::{Eventsourced, PersistentRepr},
+  snapshot::{Snapshot, SnapshotError, SnapshotMetadata, SnapshotResponseAction, SnapshotSelectionCriteria},
+};
+
+#[derive(Default)]
+struct TestEventsourced {
+  snapshots:         usize,
+  saved:             usize,
+  deleted:           usize,
+  deleted_by_filter: usize,
+  failures:          usize,
+}
+
+impl Eventsourced for TestEventsourced {
+  fn persistence_id(&self) -> &str {
+    "pid-1"
+  }
+
+  fn receive_recover(&mut self, _event: &PersistentRepr) {}
+
+  fn receive_snapshot(&mut self, _snapshot: &Snapshot) {
+    self.snapshots = self.snapshots.saturating_add(1);
+  }
+
+  fn receive_command(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+
+  fn on_snapshot_saved(&mut self, _metadata: &SnapshotMetadata) {
+    self.saved = self.saved.saturating_add(1);
+  }
+
+  fn on_snapshot_deleted(&mut self, _metadata: &SnapshotMetadata) {
+    self.deleted = self.deleted.saturating_add(1);
+  }
+
+  fn on_snapshots_deleted(&mut self, _criteria: &SnapshotSelectionCriteria) {
+    self.deleted_by_filter = self.deleted_by_filter.saturating_add(1);
+  }
+
+  fn on_snapshot_failure(&mut self, _cause: &SnapshotError) {
+    self.failures = self.failures.saturating_add(1);
+  }
+
+  fn last_sequence_nr(&self) -> u64 {
+    0
+  }
+}
+
+#[test]
+fn snapshot_response_action_apply_routes_to_eventsourced_hooks() {
+  let mut actor = TestEventsourced::default();
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+  let snapshot = Snapshot::new(metadata.clone(), ArcShared::new(1_i32));
+  let system = create_noop_actor_system();
+  let mut context = ActorContext::new(&system, Pid::new(1, 1));
+  let command = AnyMessage::new(1_i32);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+
+  assert_eq!(actor.persistence_id(), "pid-1");
+  actor.receive_recover(&repr);
+  actor.receive_command(&mut context, command.as_view()).expect("receive command should succeed");
+  SnapshotResponseAction::None.apply(&mut actor);
+  SnapshotResponseAction::ReceiveSnapshot(snapshot).apply(&mut actor);
+  SnapshotResponseAction::SnapshotSaved(metadata.clone()).apply(&mut actor);
+  SnapshotResponseAction::SnapshotDeleted(metadata).apply(&mut actor);
+  SnapshotResponseAction::SnapshotsDeleted(SnapshotSelectionCriteria::latest()).apply(&mut actor);
+  SnapshotResponseAction::SnapshotFailure(SnapshotError::LoadFailed("boom".into())).apply(&mut actor);
+
+  assert_eq!(actor.snapshots, 1);
+  assert_eq!(actor.saved, 1);
+  assert_eq!(actor.deleted, 1);
+  assert_eq!(actor.deleted_by_filter, 1);
+  assert_eq!(actor.failures, 1);
+  assert_eq!(actor.last_sequence_nr(), 0);
+}

--- a/modules/persistence-core-kernel/src/state.rs
+++ b/modules/persistence-core-kernel/src/state.rs
@@ -5,6 +5,7 @@ mod durable_state_store;
 mod durable_state_store_provider;
 mod durable_state_store_registry;
 mod durable_state_update_store;
+mod get_object_result;
 
 pub use durable_state_error::DurableStateError;
 pub use durable_state_store::DurableStateStore;
@@ -12,3 +13,4 @@ pub(crate) use durable_state_store::DurableStateStoreFuture;
 pub use durable_state_store_provider::DurableStateStoreProvider;
 pub use durable_state_store_registry::DurableStateStoreRegistry;
 pub use durable_state_update_store::DurableStateUpdateStore;
+pub use get_object_result::GetObjectResult;

--- a/modules/persistence-core-kernel/src/state/durable_state_error.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_error.rs
@@ -16,6 +16,15 @@ pub enum DurableStateError {
   UpsertObjectFailed(String),
   /// Failed to delete a durable state object.
   DeleteObjectFailed(String),
+  /// Failed to delete a durable state object because the revision did not match.
+  DeleteRevision {
+    /// Persistence identifier for the object.
+    persistence_id:    String,
+    /// Revision requested by the caller.
+    expected_revision: u64,
+    /// Revision stored by the durable state backend.
+    actual_revision:   u64,
+  },
   /// Failed to read durable state updates.
   ChangesFailed(String),
   /// Durable state provider identifier already exists.
@@ -36,6 +45,12 @@ impl DurableStateError {
   pub fn provider_not_found(id: impl Into<String>) -> Self {
     Self::ProviderNotFound(id.into())
   }
+
+  /// Creates a delete revision mismatch error.
+  #[must_use]
+  pub fn delete_revision(persistence_id: impl Into<String>, expected_revision: u64, actual_revision: u64) -> Self {
+    Self::DeleteRevision { persistence_id: persistence_id.into(), expected_revision, actual_revision }
+  }
 }
 
 impl Display for DurableStateError {
@@ -44,6 +59,11 @@ impl Display for DurableStateError {
       | Self::GetObjectFailed(reason) => write!(formatter, "get durable state object failed: {}", reason),
       | Self::UpsertObjectFailed(reason) => write!(formatter, "upsert durable state object failed: {}", reason),
       | Self::DeleteObjectFailed(reason) => write!(formatter, "delete durable state object failed: {}", reason),
+      | Self::DeleteRevision { persistence_id, expected_revision, actual_revision } => write!(
+        formatter,
+        "delete durable state object failed for '{}': expected revision {}, actual revision {}",
+        persistence_id, expected_revision, actual_revision
+      ),
       | Self::ChangesFailed(reason) => write!(formatter, "durable state changes failed: {}", reason),
       | Self::ProviderAlreadyRegistered(id) => write!(formatter, "durable state provider '{}' already exists", id),
       | Self::ProviderNotFound(id) => write!(formatter, "durable state provider '{}' not found", id),

--- a/modules/persistence-core-kernel/src/state/durable_state_error_test.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_error_test.rs
@@ -24,6 +24,16 @@ fn durable_state_error_display_delete_object_failed() {
 }
 
 #[test]
+fn durable_state_error_display_delete_revision() {
+  let error = DurableStateError::delete_revision("pid-1", 3, 2);
+
+  assert_eq!(
+    error.to_string(),
+    "delete durable state object failed for 'pid-1': expected revision 3, actual revision 2"
+  );
+}
+
+#[test]
 fn durable_state_error_display_changes_failed() {
   let error = DurableStateError::ChangesFailed("stream closed".into());
 

--- a/modules/persistence-core-kernel/src/state/durable_state_store.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_store.rs
@@ -3,7 +3,7 @@
 use alloc::boxed::Box;
 use core::{future::Future, pin::Pin};
 
-use crate::state::DurableStateError;
+use crate::state::{DurableStateError, GetObjectResult};
 
 pub(crate) type DurableStateStoreFuture<'a, T> =
   Pin<Box<dyn Future<Output = Result<T, DurableStateError>> + Send + 'a>>;
@@ -11,7 +11,7 @@ pub(crate) type DurableStateStoreFuture<'a, T> =
 /// Durable state store abstraction using object-safe boxed futures.
 pub trait DurableStateStore<A: Send>: Send + Sync + 'static {
   /// Loads the durable state object for the persistence identifier.
-  fn get_object<'a>(&'a self, persistence_id: &'a str) -> DurableStateStoreFuture<'a, Option<A>>;
+  fn get_object<'a>(&'a self, persistence_id: &'a str) -> DurableStateStoreFuture<'a, GetObjectResult<A>>;
 
   /// Inserts or updates the durable state object for the persistence identifier.
   fn upsert_object<'a>(&'a mut self, persistence_id: &'a str, object: A) -> DurableStateStoreFuture<'a, ()>;

--- a/modules/persistence-core-kernel/src/state/durable_state_store_registry_test.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_store_registry_test.rs
@@ -14,6 +14,7 @@ use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::state::{
   DurableStateError, DurableStateStore, DurableStateStoreProvider, DurableStateStoreRegistry, DurableStateUpdateStore,
+  GetObjectResult,
 };
 
 const TEST_PROVIDER_ID: &str = "in-memory";
@@ -24,29 +25,37 @@ type DurableStateFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, DurableSt
 
 #[derive(Default)]
 struct TestDurableStateStore {
-  objects: BTreeMap<String, i32>,
-  updates: BTreeMap<String, Vec<i32>>,
+  objects:   BTreeMap<String, i32>,
+  revisions: BTreeMap<String, u64>,
+  updates:   BTreeMap<String, Vec<i32>>,
 }
 
 impl TestDurableStateStore {
   const fn new() -> Self {
-    Self { objects: BTreeMap::new(), updates: BTreeMap::new() }
+    Self { objects: BTreeMap::new(), revisions: BTreeMap::new(), updates: BTreeMap::new() }
   }
 }
 
 impl DurableStateStore<i32> for TestDurableStateStore {
-  fn get_object<'a>(&'a self, persistence_id: &'a str) -> DurableStateFuture<'a, Option<i32>> {
-    Box::pin(ready(Ok(self.objects.get(persistence_id).copied())))
+  fn get_object<'a>(&'a self, persistence_id: &'a str) -> DurableStateFuture<'a, GetObjectResult<i32>> {
+    let result = self.objects.get(persistence_id).copied().map_or_else(GetObjectResult::empty, |value| {
+      let revision = *self.revisions.get(persistence_id).expect("revision must exist when object exists");
+      GetObjectResult::new(Some(value), revision)
+    });
+    Box::pin(ready(Ok(result)))
   }
 
   fn upsert_object<'a>(&'a mut self, persistence_id: &'a str, object: i32) -> DurableStateFuture<'a, ()> {
     self.objects.insert(persistence_id.to_string(), object);
+    let revision = self.revisions.get(persistence_id).copied().unwrap_or(0).saturating_add(1);
+    self.revisions.insert(persistence_id.to_string(), revision);
     self.updates.entry(persistence_id.to_string()).or_default().push(object);
     Box::pin(ready(Ok(())))
   }
 
   fn delete_object<'a>(&'a mut self, persistence_id: &'a str) -> DurableStateFuture<'a, ()> {
     self.objects.remove(persistence_id);
+    self.revisions.remove(persistence_id);
     Box::pin(ready(Ok(())))
   }
 }
@@ -101,11 +110,13 @@ fn register_and_resolve_provider_for_crud_operations() {
 
   poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 42)).expect("upsert durable state");
   let loaded = poll_ready(store.get_object(TEST_PERSISTENCE_ID)).expect("get durable state");
-  assert_eq!(loaded, Some(42));
+  assert_eq!(loaded.value(), Some(&42));
+  assert_eq!(loaded.revision(), 1);
 
   poll_ready(store.delete_object(TEST_PERSISTENCE_ID)).expect("delete durable state");
   let loaded_after_delete = poll_ready(store.get_object(TEST_PERSISTENCE_ID)).expect("get durable state after delete");
-  assert_eq!(loaded_after_delete, None);
+  assert!(loaded_after_delete.is_empty());
+  assert_eq!(loaded_after_delete.revision(), 0);
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/state/get_object_result.rs
+++ b/modules/persistence-core-kernel/src/state/get_object_result.rs
@@ -1,0 +1,50 @@
+//! Durable state load result.
+
+#[cfg(test)]
+#[path = "get_object_result_test.rs"]
+mod tests;
+
+/// Result returned when loading a durable state object.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GetObjectResult<A> {
+  value:    Option<A>,
+  revision: u64,
+}
+
+impl<A> GetObjectResult<A> {
+  /// Creates a durable state load result.
+  #[must_use]
+  pub const fn new(value: Option<A>, revision: u64) -> Self {
+    Self { value, revision }
+  }
+
+  /// Creates an empty durable state load result.
+  #[must_use]
+  pub const fn empty() -> Self {
+    Self { value: None, revision: 0 }
+  }
+
+  /// Returns the loaded value, when present.
+  #[must_use]
+  pub const fn value(&self) -> Option<&A> {
+    self.value.as_ref()
+  }
+
+  /// Consumes the result and returns the loaded value.
+  #[must_use]
+  pub fn into_value(self) -> Option<A> {
+    self.value
+  }
+
+  /// Returns the durable state revision.
+  #[must_use]
+  pub const fn revision(&self) -> u64 {
+    self.revision
+  }
+
+  /// Returns true when no value was found.
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.value.is_none()
+  }
+}

--- a/modules/persistence-core-kernel/src/state/get_object_result_test.rs
+++ b/modules/persistence-core-kernel/src/state/get_object_result_test.rs
@@ -1,0 +1,20 @@
+use crate::state::GetObjectResult;
+
+#[test]
+fn get_object_result_exposes_value_and_revision() {
+  let result = GetObjectResult::new(Some(42), 7);
+
+  assert_eq!(result.value(), Some(&42));
+  assert_eq!(result.revision(), 7);
+  assert!(!result.is_empty());
+  assert_eq!(result.into_value(), Some(42));
+}
+
+#[test]
+fn empty_get_object_result_has_no_value_and_zero_revision() {
+  let result = GetObjectResult::<i32>::empty();
+
+  assert_eq!(result.value(), None);
+  assert_eq!(result.revision(), 0);
+  assert!(result.is_empty());
+}

--- a/modules/persistence-core-kernel/tests/persistence_flow.rs
+++ b/modules/persistence-core-kernel/tests/persistence_flow.rs
@@ -176,12 +176,12 @@ fn recovery_flow_snapshot_then_replay() {
   let repr1 = PersistentRepr::new("pid-1", 2, ArcShared::new(Event::Incremented(6)));
   let repr2 = PersistentRepr::new("pid-1", 3, ArcShared::new(Event::Incremented(2)));
   let repr3 = PersistentRepr::new("pid-1", 4, ArcShared::new(Event::Incremented(3)));
-  let _ = drive_ready(journal.write_messages(&[repr0, repr1, repr2, repr3]));
+  drive_ready(journal.write_messages(&[repr0, repr1, repr2, repr3])).expect("seed journal");
 
   let mut snapshot_store = InMemorySnapshotStore::new();
   let snapshot_metadata = SnapshotMetadata::new("pid-1", 2, 0);
   let snapshot_payload: ArcShared<dyn Any + Send + Sync> = ArcShared::new(10_i32);
-  let _ = drive_ready(snapshot_store.save_snapshot(snapshot_metadata, snapshot_payload));
+  drive_ready(snapshot_store.save_snapshot(snapshot_metadata, snapshot_payload)).expect("seed snapshot");
 
   let installer = PersistenceExtensionInstaller::new(journal, snapshot_store);
   let installers = ExtensionInstallers::default().with_extension_installer(installer);

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -58,6 +58,7 @@ coverage_packages() {
   printf '%s\n' \
     "fraktor-actor-core-kernel-rs" \
     "fraktor-actor-adaptor-std-rs" \
+    "fraktor-persistence-core-kernel-rs" \
     "fraktor-stream-core-kernel-rs" \
     "fraktor-stream-core-actor-typed-rs" \
     "fraktor-stream-adaptor-std-rs" \


### PR DESCRIPTION
## 概要

persistence gap analysis の Phase 1 trivial / easy のうち、plugin 形式を前提にしない kernel 契約を実装しました。

## 変更内容

- `PersistenceSettings` を追加し、journal / snapshot actor runtime config を `PersistenceExtension` / installer / extension id に結線
- `SnapshotOffer` と `NoSnapshotStore` を追加し、snapshot response action から `receive_snapshot_offer` を通す経路を追加
- at-least-once delivery の上限超過を `PersistenceError::MaxUnconfirmedMessagesExceeded` として表現
- durable state の `GetObjectResult<A>` と revision-aware delete error を追加
- `scripts/coverage.sh` の対象に `fraktor-persistence-core-kernel-rs` を追加し、Codecov `if_not_found: failure` で persistence 変更が未計測にならないように調整
- gap analysis 文書を Phase 1 実装状況に合わせて更新

## 意図的に外したもの

- `RuntimePluginConfig` は追加していません。このライブラリは Pekko の plugin config 形式ではなく、`Journal` / `SnapshotStore` trait 実装を直接注入する境界なので non-goal として整理しました。
- plugin settings の公開契約も追加していません。snapshot retry settings は既存 actor config 経由の契約として扱っています。
- `RecoveryCompleted` は既存 callback / internal action / typed signal の接地があるため、新規 ZST 型は追加せず文書側で non-goal としました。

## 検証

- `cargo fmt --all --check`
- `cargo test -p fraktor-persistence-core-kernel-rs`
- `cargo check -p fraktor-persistence-core-typed-rs`
- `cargo clippy -p fraktor-persistence-core-kernel-rs --all-targets -- -D warnings`
- `./scripts/coverage.sh --tool llvm-cov --format lcov --output target/coverage/script-check`
- `cargo llvm-cov -p fraktor-persistence-core-kernel-rs --all-targets --lcov --output-path target/coverage/persistence-core-kernel/lcov.info`

## Coverage

- persistence-core-kernel local total: lines 87.83%, functions 81.43%, regions 91.20%
- local patch coverage approximation from LCOV: 349 / 349 coverable changed lines = 100%

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes public persistence APIs (`DurableStateStore::get_object` return type, new error variants) and wires new runtime settings through `PersistenceExtension`, which could affect downstream implementations and bootstrapping.
> 
> **Overview**
> Implements several **Phase 1 persistence kernel contracts** and wires them into the runtime.
> 
> Adds a public `PersistenceSettings` type (new `config` module) and threads it through `PersistenceExtension`, `PersistenceExtensionId`, and `PersistenceExtensionInstaller` so journal/snapshot runtime actor configs can be customized at install/creation time.
> 
> Introduces snapshot recovery signals and no-op storage: adds `SnapshotOffer` plus `Eventsourced::receive_snapshot_offer` (and routes snapshot load callbacks through it), and adds `NoSnapshotStore` as a built-in `SnapshotStore` implementation.
> 
> Tightens domain error contracts: `AtLeastOnceDelivery::deliver` now returns a structured `PersistenceError::MaxUnconfirmedMessagesExceeded`, and durable state adds `GetObjectResult<A>` (value + revision) with a new `DurableStateError::DeleteRevision`, updating `DurableStateStore::get_object` accordingly. Test coverage is expanded significantly, docs/gap analysis is updated to reflect completed Phase 1 items, and `scripts/coverage.sh` now includes `fraktor-persistence-core-kernel-rs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02c15e5c26d2a715d0f8e2a53c079194fb719def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * スナップショット提供メカニズムの追加
  * スナップショットなし設定のサポート
  * 永続化設定の管理機能を拡張

* **改善**
  * ダラブルステートの取得結果をより詳細な形式に変更
  * リビジョン管理のエラーハンドリング強化
  * 設定値のカスタマイズ機能を拡充

* **テスト**
  * スナップショット・設定関連のテストケース追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1812?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->