### PR TITLE
[codex] persistence actor の返信 SendError DoS を修正

### DIFF
--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -117,7 +117,7 @@ where
     let retry_max = self.config.retry_max();
     let in_flight = core::mem::take(&mut self.in_flight);
     for entry in in_flight {
-      if let Some(entry) = poll_entry(&mut self.journal, entry, &mut cx, retry_max)? {
+      if let Some(entry) = poll_entry(&mut self.journal, entry, &mut cx, retry_max) {
         pending.push(entry);
       }
     }
@@ -195,7 +195,7 @@ fn poll_entry<J: Journal>(
   mut entry: JournalInFlight,
   cx: &mut Context<'_>,
   retry_max: u32,
-) -> Result<Option<JournalInFlight>, ActorError>
+) -> Option<JournalInFlight>
 where
   for<'a> J::WriteFuture<'a>: Send + 'static,
   for<'a> J::ReplayFuture<'a>: Send + 'static,
@@ -204,7 +204,7 @@ where
   let mut poll_context = JournalPollContext { journal, retry_max };
   let keep_pending = match &mut entry {
     | JournalInFlight::Write { future, messages, sender, instance_id, retry_count } => {
-      poll_write_entry(&mut poll_context, cx, future, messages, sender, *instance_id, retry_count)?
+      poll_write_entry(&mut poll_context, cx, future, messages, sender, *instance_id, retry_count)
     },
     | JournalInFlight::Replay {
       future,
@@ -220,17 +220,17 @@ where
         to_sequence_nr:   *to_sequence_nr,
         max:              *max,
       };
-      poll_replay_entry(&mut poll_context, cx, future, sender, persistence_id, request, retry_count)?
+      poll_replay_entry(&mut poll_context, cx, future, sender, persistence_id, request, retry_count)
     },
     | JournalInFlight::Delete { future, sender, persistence_id, to_sequence_nr, retry_count } => {
-      poll_delete_entry(&mut poll_context, cx, future, sender, persistence_id, *to_sequence_nr, retry_count)?
+      poll_delete_entry(&mut poll_context, cx, future, sender, persistence_id, *to_sequence_nr, retry_count)
     },
     | JournalInFlight::Highest { future, sender, persistence_id, retry_count } => {
-      poll_highest_entry(&mut poll_context, cx, future, sender, persistence_id, retry_count)?
+      poll_highest_entry(&mut poll_context, cx, future, sender, persistence_id, retry_count)
     },
   };
 
-  if keep_pending { Ok(Some(entry)) } else { Ok(None) }
+  if keep_pending { Some(entry) } else { None }
 }
 
 fn poll_write_entry<J: Journal>(
@@ -241,30 +241,26 @@ fn poll_write_entry<J: Journal>(
   sender: &mut ActorRef,
   instance_id: u32,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::WriteFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
     | Poll::Ready(Ok(())) => {
-      send_write_success(sender, messages, instance_id)?;
-      Ok(false)
+      send_write_success(sender, messages, instance_id);
+      false
     },
     | Poll::Ready(Err(error)) => {
       retry_or_fail_write(poll_context, future, messages, sender, instance_id, retry_count, error)
     },
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
-fn send_write_success(sender: &mut ActorRef, messages: &[PersistentRepr], instance_id: u32) -> Result<(), ActorError> {
+fn send_write_success(sender: &mut ActorRef, messages: &[PersistentRepr], instance_id: u32) {
   for repr in messages.iter().cloned() {
-    sender
-      .try_tell(AnyMessage::new(JournalResponse::WriteMessageSuccess { repr, instance_id }))
-      .map_err(|error| ActorError::from_send_error(&error))?;
+    tell_response(sender, JournalResponse::WriteMessageSuccess { repr, instance_id });
   }
-  sender
-    .try_tell(AnyMessage::new(JournalResponse::WriteMessagesSuccessful { instance_id }))
-    .map_err(|error| ActorError::from_send_error(&error))
+  tell_response(sender, JournalResponse::WriteMessagesSuccessful { instance_id });
 }
 
 fn retry_or_fail_write<J: Journal>(
@@ -275,36 +271,27 @@ fn retry_or_fail_write<J: Journal>(
   instance_id: u32,
   retry_count: &mut u32,
   error: JournalError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::WriteFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
     *retry_count = retry_count.saturating_add(1);
     *future = Box::pin(poll_context.journal.write_messages(messages));
-    return Ok(true);
+    return true;
   }
-  send_write_failure(sender, messages, instance_id, error)?;
-  Ok(false)
+  send_write_failure(sender, messages, instance_id, error);
+  false
 }
 
-fn send_write_failure(
-  sender: &mut ActorRef,
-  messages: &[PersistentRepr],
-  instance_id: u32,
-  error: JournalError,
-) -> Result<(), ActorError> {
+fn send_write_failure(sender: &mut ActorRef, messages: &[PersistentRepr], instance_id: u32, error: JournalError) {
   for repr in messages.iter().cloned() {
-    sender
-      .try_tell(AnyMessage::new(JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id }))
-      .map_err(|send_error| ActorError::from_send_error(&send_error))?;
+    tell_response(sender, JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id });
   }
-  sender
-    .try_tell(AnyMessage::new(JournalResponse::WriteMessagesFailed {
-      cause: error,
-      write_count: messages.len() as u64,
-      instance_id,
-    }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))
+  tell_response(sender, JournalResponse::WriteMessagesFailed {
+    cause: error,
+    write_count: messages.len() as u64,
+    instance_id,
+  });
 }
 
 fn poll_replay_entry<J: Journal>(
@@ -315,35 +302,31 @@ fn poll_replay_entry<J: Journal>(
   persistence_id: &str,
   request: JournalReplayRequest,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::ReplayFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
     | Poll::Ready(Ok(messages)) => {
-      send_replay_success(sender, &messages)?;
-      Ok(false)
+      send_replay_success(sender, &messages);
+      false
     },
     | Poll::Ready(Err(error)) => {
       retry_or_fail_replay(poll_context, future, sender, persistence_id, request, retry_count, error)
     },
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
-fn send_replay_success(sender: &mut ActorRef, messages: &[PersistentRepr]) -> Result<(), ActorError> {
+fn send_replay_success(sender: &mut ActorRef, messages: &[PersistentRepr]) {
   let mut highest = 0;
   for repr in messages.iter().cloned() {
     highest = repr.sequence_nr();
     if repr.deleted() {
       continue;
     }
-    sender
-      .try_tell(AnyMessage::new(JournalResponse::ReplayedMessage { persistent_repr: repr }))
-      .map_err(|error| ActorError::from_send_error(&error))?;
+    tell_response(sender, JournalResponse::ReplayedMessage { persistent_repr: repr });
   }
-  sender
-    .try_tell(AnyMessage::new(JournalResponse::RecoverySuccess { highest_sequence_nr: highest }))
-    .map_err(|error| ActorError::from_send_error(&error))
+  tell_response(sender, JournalResponse::RecoverySuccess { highest_sequence_nr: highest });
 }
 
 fn retry_or_fail_replay<J: Journal>(
@@ -354,7 +337,7 @@ fn retry_or_fail_replay<J: Journal>(
   request: JournalReplayRequest,
   retry_count: &mut u32,
   error: JournalError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::ReplayFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
@@ -365,12 +348,10 @@ where
       request.to_sequence_nr,
       request.max,
     ));
-    return Ok(true);
+    return true;
   }
-  sender
-    .try_tell(AnyMessage::new(JournalResponse::ReplayMessagesFailure { cause: error }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-  Ok(false)
+  tell_response(sender, JournalResponse::ReplayMessagesFailure { cause: error });
+  false
 }
 
 fn poll_delete_entry<J: Journal>(
@@ -381,20 +362,18 @@ fn poll_delete_entry<J: Journal>(
   persistence_id: &str,
   to_sequence_nr: u64,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::DeleteFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
     | Poll::Ready(Ok(())) => {
-      sender
-        .try_tell(AnyMessage::new(JournalResponse::DeleteMessagesSuccess { to_sequence_nr }))
-        .map_err(|error| ActorError::from_send_error(&error))?;
-      Ok(false)
+      tell_response(sender, JournalResponse::DeleteMessagesSuccess { to_sequence_nr });
+      false
     },
     | Poll::Ready(Err(error)) => {
       retry_or_fail_delete(poll_context, future, sender, persistence_id, to_sequence_nr, retry_count, error)
     },
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
@@ -406,18 +385,16 @@ fn retry_or_fail_delete<J: Journal>(
   to_sequence_nr: u64,
   retry_count: &mut u32,
   error: JournalError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::DeleteFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
     *retry_count = retry_count.saturating_add(1);
     *future = Box::pin(poll_context.journal.delete_messages_to(persistence_id, to_sequence_nr));
-    return Ok(true);
+    return true;
   }
-  sender
-    .try_tell(AnyMessage::new(JournalResponse::DeleteMessagesFailure { cause: error, to_sequence_nr }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-  Ok(false)
+  tell_response(sender, JournalResponse::DeleteMessagesFailure { cause: error, to_sequence_nr });
+  false
 }
 
 fn poll_highest_entry<J: Journal>(
@@ -427,23 +404,18 @@ fn poll_highest_entry<J: Journal>(
   sender: &mut ActorRef,
   persistence_id: &str,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::HighestSeqNrFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
     | Poll::Ready(Ok(sequence_nr)) => {
-      sender
-        .try_tell(AnyMessage::new(JournalResponse::HighestSequenceNr {
-          persistence_id: persistence_id.into(),
-          sequence_nr,
-        }))
-        .map_err(|error| ActorError::from_send_error(&error))?;
-      Ok(false)
+      tell_response(sender, JournalResponse::HighestSequenceNr { persistence_id: persistence_id.into(), sequence_nr });
+      false
     },
     | Poll::Ready(Err(error)) => {
       retry_or_fail_highest(poll_context, future, sender, persistence_id, retry_count, error)
     },
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
@@ -454,19 +426,22 @@ fn retry_or_fail_highest<J: Journal>(
   persistence_id: &str,
   retry_count: &mut u32,
   error: JournalError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> J::HighestSeqNrFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
     *retry_count = retry_count.saturating_add(1);
     *future = Box::pin(poll_context.journal.highest_sequence_nr(persistence_id));
-    return Ok(true);
+    return true;
   }
-  sender
-    .try_tell(AnyMessage::new(JournalResponse::HighestSequenceNrFailure {
-      persistence_id: persistence_id.into(),
-      cause:          error,
-    }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-  Ok(false)
+  tell_response(sender, JournalResponse::HighestSequenceNrFailure {
+    persistence_id: persistence_id.into(),
+    cause:          error,
+  });
+  false
+}
+
+fn tell_response(sender: &mut ActorRef, response: JournalResponse) {
+  // 返信先の閉鎖は要求元側の状態なので、journal actor 自身の失敗にはしない。
+  sender.tell(AnyMessage::new(response));
 }

--- a/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
@@ -629,3 +629,94 @@ fn journal_actor_replay_filters_deleted_messages() {
   assert_eq!(replayed, vec![1, 3]);
   assert_eq!(recovery_highest, Some(3));
 }
+
+#[test]
+fn journal_actor_success_responses_to_null_sender_do_not_fail() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor = JournalActor::<InMemoryJournal>::new(InMemoryJournal::new());
+
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+  let write = JournalMessage::WriteMessages {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    messages:       vec![repr],
+    sender:         ActorRef::null(),
+    instance_id:    7,
+  };
+  let any_message = AnyMessage::new(write);
+  actor.receive(&mut ctx, any_message.as_view()).expect("write receive failed");
+
+  let replay = JournalMessage::ReplayMessages {
+    persistence_id:   "pid-1".into(),
+    from_sequence_nr: 1,
+    to_sequence_nr:   1,
+    max:              10,
+    sender:           ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(replay);
+  actor.receive(&mut ctx, any_message.as_view()).expect("replay receive failed");
+
+  let delete = JournalMessage::DeleteMessagesTo {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    sender:         ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(delete);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete receive failed");
+
+  let highest = JournalMessage::GetHighestSequenceNr {
+    persistence_id:   "pid-1".into(),
+    from_sequence_nr: 0,
+    sender:           ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(highest);
+  actor.receive(&mut ctx, any_message.as_view()).expect("highest receive failed");
+}
+
+#[test]
+fn journal_actor_failure_responses_to_null_sender_do_not_fail() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+  let write = JournalMessage::WriteMessages {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    messages:       vec![repr],
+    sender:         ActorRef::null(),
+    instance_id:    7,
+  };
+  let mut write_actor = JournalActor::<RetryJournal>::new_with_config(RetryJournal::new(1), JournalActorConfig::new(0));
+  let any_message = AnyMessage::new(write);
+  write_actor.receive(&mut ctx, any_message.as_view()).expect("write receive failed");
+
+  let mut actor =
+    JournalActor::<ScriptedJournal>::new_with_config(ScriptedJournal::new(1, 1, 1), JournalActorConfig::new(0));
+  let replay = JournalMessage::ReplayMessages {
+    persistence_id:   "pid-1".into(),
+    from_sequence_nr: 1,
+    to_sequence_nr:   1,
+    max:              10,
+    sender:           ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(replay);
+  actor.receive(&mut ctx, any_message.as_view()).expect("replay receive failed");
+
+  let delete = JournalMessage::DeleteMessagesTo {
+    persistence_id: "pid-1".into(),
+    to_sequence_nr: 1,
+    sender:         ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(delete);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete receive failed");
+
+  let highest = JournalMessage::GetHighestSequenceNr {
+    persistence_id:   "pid-1".into(),
+    from_sequence_nr: 0,
+    sender:           ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(highest);
+  actor.receive(&mut ctx, any_message.as_view()).expect("highest receive failed");
+}

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_actor.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_actor.rs
@@ -109,7 +109,7 @@ where
     let retry_max = self.config.retry_max();
     let in_flight = core::mem::take(&mut self.in_flight);
     for entry in in_flight {
-      if let Some(entry) = poll_entry(&mut self.snapshot_store, entry, &mut cx, retry_max)? {
+      if let Some(entry) = poll_entry(&mut self.snapshot_store, entry, &mut cx, retry_max) {
         pending.push(entry);
       }
     }
@@ -185,7 +185,7 @@ fn poll_entry<S: SnapshotStore>(
   mut entry: SnapshotInFlight,
   cx: &mut Context<'_>,
   retry_max: u32,
-) -> Result<Option<SnapshotInFlight>, ActorError>
+) -> Option<SnapshotInFlight>
 where
   for<'a> S::SaveFuture<'a>: Send + 'static,
   for<'a> S::LoadFuture<'a>: Send + 'static,
@@ -194,20 +194,20 @@ where
   let mut poll_context = SnapshotPollContext { snapshot_store, retry_max };
   let keep_pending = match &mut entry {
     | SnapshotInFlight::Save { future, metadata, snapshot, sender, retry_count } => {
-      poll_save_entry(&mut poll_context, cx, future, metadata, snapshot, sender, retry_count)?
+      poll_save_entry(&mut poll_context, cx, future, metadata, snapshot, sender, retry_count)
     },
     | SnapshotInFlight::Load { future, persistence_id, criteria, sender, retry_count } => {
-      poll_load_entry(&mut poll_context, cx, future, persistence_id, criteria, sender, retry_count)?
+      poll_load_entry(&mut poll_context, cx, future, persistence_id, criteria, sender, retry_count)
     },
     | SnapshotInFlight::DeleteOne { future, metadata, sender, retry_count } => {
-      poll_delete_one_entry(&mut poll_context, cx, future, metadata, sender, retry_count)?
+      poll_delete_one_entry(&mut poll_context, cx, future, metadata, sender, retry_count)
     },
     | SnapshotInFlight::DeleteMany { future, persistence_id, criteria, sender, retry_count } => {
-      poll_delete_many_entry(&mut poll_context, cx, future, persistence_id, criteria, sender, retry_count)?
+      poll_delete_many_entry(&mut poll_context, cx, future, persistence_id, criteria, sender, retry_count)
     },
   };
 
-  if keep_pending { Ok(Some(entry)) } else { Ok(None) }
+  if keep_pending { Some(entry) } else { None }
 }
 
 fn poll_save_entry<S: SnapshotStore>(
@@ -218,23 +218,23 @@ fn poll_save_entry<S: SnapshotStore>(
   snapshot: &ArcShared<dyn Any + Send + Sync>,
   sender: &mut ActorRef,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::SaveFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
-    | Poll::Ready(Ok(())) => send_save_success(sender, metadata),
+    | Poll::Ready(Ok(())) => {
+      send_save_success(sender, metadata);
+      false
+    },
     | Poll::Ready(Err(error)) => {
       retry_or_fail_save(poll_context, future, metadata, snapshot, sender, retry_count, error)
     },
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
-fn send_save_success(sender: &mut ActorRef, metadata: &SnapshotMetadata) -> Result<bool, ActorError> {
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::SaveSnapshotSuccess { metadata: metadata.clone() }))
-    .map_err(|error| ActorError::from_send_error(&error))?;
-  Ok(false)
+fn send_save_success(sender: &mut ActorRef, metadata: &SnapshotMetadata) {
+  tell_response(sender, SnapshotResponse::SaveSnapshotSuccess { metadata: metadata.clone() });
 }
 
 fn retry_or_fail_save<S: SnapshotStore>(
@@ -245,18 +245,16 @@ fn retry_or_fail_save<S: SnapshotStore>(
   sender: &mut ActorRef,
   retry_count: &mut u32,
   error: SnapshotError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::SaveFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
     *retry_count = retry_count.saturating_add(1);
     *future = Box::pin(poll_context.snapshot_store.save_snapshot(metadata.clone(), snapshot.clone()));
-    return Ok(true);
+    return true;
   }
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::SaveSnapshotFailure { metadata: metadata.clone(), error }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-  Ok(false)
+  tell_response(sender, SnapshotResponse::SaveSnapshotFailure { metadata: metadata.clone(), error });
+  false
 }
 
 fn poll_load_entry<S: SnapshotStore>(
@@ -267,27 +265,23 @@ fn poll_load_entry<S: SnapshotStore>(
   criteria: &SnapshotSelectionCriteria,
   sender: &mut ActorRef,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::LoadFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
-    | Poll::Ready(Ok(snapshot)) => send_load_success(sender, snapshot, criteria.max_sequence_nr()),
+    | Poll::Ready(Ok(snapshot)) => {
+      send_load_success(sender, snapshot, criteria.max_sequence_nr());
+      false
+    },
     | Poll::Ready(Err(error)) => {
       retry_or_fail_load(poll_context, future, persistence_id, criteria, sender, retry_count, error)
     },
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
-fn send_load_success(
-  sender: &mut ActorRef,
-  snapshot: Option<Snapshot>,
-  to_sequence_nr: u64,
-) -> Result<bool, ActorError> {
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::LoadSnapshotResult { snapshot, to_sequence_nr }))
-    .map_err(|error| ActorError::from_send_error(&error))?;
-  Ok(false)
+fn send_load_success(sender: &mut ActorRef, snapshot: Option<Snapshot>, to_sequence_nr: u64) {
+  tell_response(sender, SnapshotResponse::LoadSnapshotResult { snapshot, to_sequence_nr });
 }
 
 fn retry_or_fail_load<S: SnapshotStore>(
@@ -298,18 +292,16 @@ fn retry_or_fail_load<S: SnapshotStore>(
   sender: &mut ActorRef,
   retry_count: &mut u32,
   error: SnapshotError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::LoadFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
     *retry_count = retry_count.saturating_add(1);
     *future = Box::pin(poll_context.snapshot_store.load_snapshot(persistence_id, criteria.clone()));
-    return Ok(true);
+    return true;
   }
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::LoadSnapshotFailed { error }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-  Ok(false)
+  tell_response(sender, SnapshotResponse::LoadSnapshotFailed { error });
+  false
 }
 
 fn poll_delete_one_entry<S: SnapshotStore>(
@@ -319,21 +311,21 @@ fn poll_delete_one_entry<S: SnapshotStore>(
   metadata: &SnapshotMetadata,
   sender: &mut ActorRef,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::DeleteOneFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
-    | Poll::Ready(Ok(())) => send_delete_one_success(sender, metadata),
+    | Poll::Ready(Ok(())) => {
+      send_delete_one_success(sender, metadata);
+      false
+    },
     | Poll::Ready(Err(error)) => retry_or_fail_delete_one(poll_context, future, metadata, sender, retry_count, error),
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
-fn send_delete_one_success(sender: &mut ActorRef, metadata: &SnapshotMetadata) -> Result<bool, ActorError> {
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotSuccess { metadata: metadata.clone() }))
-    .map_err(|error| ActorError::from_send_error(&error))?;
-  Ok(false)
+fn send_delete_one_success(sender: &mut ActorRef, metadata: &SnapshotMetadata) {
+  tell_response(sender, SnapshotResponse::DeleteSnapshotSuccess { metadata: metadata.clone() });
 }
 
 fn retry_or_fail_delete_one<S: SnapshotStore>(
@@ -343,18 +335,16 @@ fn retry_or_fail_delete_one<S: SnapshotStore>(
   sender: &mut ActorRef,
   retry_count: &mut u32,
   error: SnapshotError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::DeleteOneFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
     *retry_count = retry_count.saturating_add(1);
     *future = Box::pin(poll_context.snapshot_store.delete_snapshot(metadata));
-    return Ok(true);
+    return true;
   }
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotFailure { metadata: metadata.clone(), error }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-  Ok(false)
+  tell_response(sender, SnapshotResponse::DeleteSnapshotFailure { metadata: metadata.clone(), error });
+  false
 }
 
 fn poll_delete_many_entry<S: SnapshotStore>(
@@ -365,23 +355,23 @@ fn poll_delete_many_entry<S: SnapshotStore>(
   criteria: &SnapshotSelectionCriteria,
   sender: &mut ActorRef,
   retry_count: &mut u32,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::DeleteManyFuture<'a>: Send + 'static, {
   match Future::poll(future.as_mut(), cx) {
-    | Poll::Ready(Ok(())) => send_delete_many_success(sender, criteria),
+    | Poll::Ready(Ok(())) => {
+      send_delete_many_success(sender, criteria);
+      false
+    },
     | Poll::Ready(Err(error)) => {
       retry_or_fail_delete_many(poll_context, future, persistence_id, criteria, sender, retry_count, error)
     },
-    | Poll::Pending => Ok(true),
+    | Poll::Pending => true,
   }
 }
 
-fn send_delete_many_success(sender: &mut ActorRef, criteria: &SnapshotSelectionCriteria) -> Result<bool, ActorError> {
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotsSuccess { criteria: criteria.clone() }))
-    .map_err(|error| ActorError::from_send_error(&error))?;
-  Ok(false)
+fn send_delete_many_success(sender: &mut ActorRef, criteria: &SnapshotSelectionCriteria) {
+  tell_response(sender, SnapshotResponse::DeleteSnapshotsSuccess { criteria: criteria.clone() });
 }
 
 fn retry_or_fail_delete_many<S: SnapshotStore>(
@@ -392,16 +382,19 @@ fn retry_or_fail_delete_many<S: SnapshotStore>(
   sender: &mut ActorRef,
   retry_count: &mut u32,
   error: SnapshotError,
-) -> Result<bool, ActorError>
+) -> bool
 where
   for<'a> S::DeleteManyFuture<'a>: Send + 'static, {
   if *retry_count < poll_context.retry_max {
     *retry_count = retry_count.saturating_add(1);
     *future = Box::pin(poll_context.snapshot_store.delete_snapshots(persistence_id, criteria.clone()));
-    return Ok(true);
+    return true;
   }
-  sender
-    .try_tell(AnyMessage::new(SnapshotResponse::DeleteSnapshotsFailure { criteria: criteria.clone(), error }))
-    .map_err(|send_error| ActorError::from_send_error(&send_error))?;
-  Ok(false)
+  tell_response(sender, SnapshotResponse::DeleteSnapshotsFailure { criteria: criteria.clone(), error });
+  false
+}
+
+fn tell_response(sender: &mut ActorRef, response: SnapshotResponse) {
+  // 返信先の閉鎖は要求元側の状態なので、snapshot actor 自身の失敗にはしない。
+  sender.tell(AnyMessage::new(response));
 }

--- a/modules/persistence-core-kernel/src/snapshot/snapshot_actor_test.rs
+++ b/modules/persistence-core-kernel/src/snapshot/snapshot_actor_test.rs
@@ -576,3 +576,81 @@ fn snapshot_actor_delete_many_failure_after_retry_exhausted() {
   assert!(matches!(response, SnapshotResponse::DeleteSnapshotsFailure { criteria, error }
       if criteria.max_sequence_nr() == u64::MAX && error == &SnapshotError::DeleteFailed("delete many failed".into())));
 }
+
+#[test]
+fn snapshot_actor_success_responses_to_null_sender_do_not_fail() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let mut actor = SnapshotActor::<InMemorySnapshotStore>::new(InMemorySnapshotStore::new());
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+
+  let save = SnapshotMessage::SaveSnapshot {
+    metadata: metadata.clone(),
+    snapshot: ArcShared::new(1_i32),
+    sender:   ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(save);
+  actor.receive(&mut ctx, any_message.as_view()).expect("save receive failed");
+
+  let load = SnapshotMessage::LoadSnapshot {
+    persistence_id: "pid-1".into(),
+    criteria:       SnapshotSelectionCriteria::latest(),
+    sender:         ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(load);
+  actor.receive(&mut ctx, any_message.as_view()).expect("load receive failed");
+
+  let delete_one = SnapshotMessage::DeleteSnapshot { metadata, sender: ActorRef::null() };
+  let any_message = AnyMessage::new(delete_one);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete one receive failed");
+
+  let delete_many = SnapshotMessage::DeleteSnapshots {
+    persistence_id: "pid-1".into(),
+    criteria:       SnapshotSelectionCriteria::latest(),
+    sender:         ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(delete_many);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete many receive failed");
+}
+
+#[test]
+fn snapshot_actor_failure_responses_to_null_sender_do_not_fail() {
+  let system = new_test_system();
+  let pid = test_actor_pid();
+  let mut ctx = ActorContext::new(&system, pid);
+  let metadata = SnapshotMetadata::new("pid-1", 1, 10);
+  let save = SnapshotMessage::SaveSnapshot {
+    metadata: metadata.clone(),
+    snapshot: ArcShared::new(1_i32),
+    sender:   ActorRef::null(),
+  };
+  let mut save_actor =
+    SnapshotActor::<RetrySnapshotStore>::new_with_config(RetrySnapshotStore::new(1), SnapshotActorConfig::new(0));
+  let any_message = AnyMessage::new(save);
+  save_actor.receive(&mut ctx, any_message.as_view()).expect("save receive failed");
+
+  let mut actor = SnapshotActor::<ScriptedSnapshotStore>::new_with_config(
+    ScriptedSnapshotStore::new(1, 1, 1),
+    SnapshotActorConfig::new(0),
+  );
+  let load = SnapshotMessage::LoadSnapshot {
+    persistence_id: "pid-1".into(),
+    criteria:       SnapshotSelectionCriteria::latest(),
+    sender:         ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(load);
+  actor.receive(&mut ctx, any_message.as_view()).expect("load receive failed");
+
+  let delete_one = SnapshotMessage::DeleteSnapshot { metadata, sender: ActorRef::null() };
+  let any_message = AnyMessage::new(delete_one);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete one receive failed");
+
+  let delete_many = SnapshotMessage::DeleteSnapshots {
+    persistence_id: "pid-1".into(),
+    criteria:       SnapshotSelectionCriteria::latest(),
+    sender:         ActorRef::null(),
+  };
+  let any_message = AnyMessage::new(delete_many);
+  actor.receive(&mut ctx, any_message.as_view()).expect("delete many receive failed");
+}


### PR DESCRIPTION
## 概要

persistence の journal / snapshot actor がリクエスト元へ返信する経路で、返信先 mailbox の閉鎖を actor 自身の失敗として扱わないようにしました。

## 背景 / 原因

`JournalResponse` / `SnapshotResponse` の配送に `try_tell()` を使い、`SendError` を `ActorError` に変換していたため、`ActorRef::null()` や停止済み actor など返信不能な sender を指定されると、永続化 actor の処理失敗として伝播していました。

返信配送は要求元側の状態に依存する best-effort な通知なので、ここでは戻り値なしの `tell()` を使うのが actor の fire-and-forget 契約に合っています。一方で、actor 自身の poll スケジュールのような内部進行制御は引き続き `try_tell()` のままにしています。

## 変更内容

- journal actor の `JournalResponse` 配送を `tell()` に統一
- snapshot actor の `SnapshotResponse` 配送を `tell()` に統一
- response 配送が `ActorError` を返さなくなったため、poll helper の戻り値を in-flight 継続可否だけに整理
- `ActorRef::null()` sender に対して成功 / 失敗レスポンスを送っても actor が失敗しない回帰テストを追加

## 検証

- `cargo clippy -p fraktor-persistence-core-kernel-rs --lib --tests -- -D warnings`
- `cargo test -p fraktor-persistence-core-kernel-rs --lib`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `JournalActor`/`SnapshotActor` to stop treating reply delivery failures as actor errors, which alters error propagation semantics in persistence flow. While scoped and covered by tests, it touches core persistence actors and could mask issues if callers relied on synchronous send failure reporting.
> 
> **Overview**
> Prevents persistence `JournalActor` and `SnapshotActor` from failing when a reply cannot be delivered (e.g., `ActorRef::null()` or stopped senders) by switching response delivery from `try_tell()` (error-returning) to fire-and-forget `tell()` via a new `tell_response` helper.
> 
> Refactors the polling helpers (`poll_entry` and per-operation poll/retry functions) to return only *pending vs completed* booleans/options instead of `Result`, since response sending no longer produces `ActorError`. Adds regression tests ensuring both success and failure responses to a null sender do not fail the actors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cecd01435d77517d913afe5c9576d4b1d8fb4652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * ジャーナルおよびスナップショット操作のエラー処理ロジックを改善し、異常な条件下でも処理が安全に継続されるよう強化しました。

* **テスト**
  * ジャーナルとスナップショットの各処理が、予期しない送信者情報を受け取った場合でも正常に動作することを検証するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->