### PR TITLE
[codex] Bound remote authority deferred queues

### DIFF
--- a/modules/actor-core-kernel/src/actor/actor_path/path_resolution_error.rs
+++ b/modules/actor-core-kernel/src/actor/actor_path/path_resolution_error.rs
@@ -13,6 +13,8 @@ pub enum PathResolutionError {
   AuthorityUnresolved,
   /// Authority is currently quarantined.
   AuthorityQuarantined,
+  /// Authority is unresolved and its deferred queue cannot accept more messages.
+  AuthorityDeferredQueueFull,
   /// UID is reserved and cannot be reused yet.
   UidReserved {
     /// The reserved UID.
@@ -26,6 +28,7 @@ impl Display for PathResolutionError {
       | PathResolutionError::PidUnknown => write!(f, "PID not found in registry"),
       | PathResolutionError::AuthorityUnresolved => write!(f, "authority is not resolved"),
       | PathResolutionError::AuthorityQuarantined => write!(f, "authority is quarantined"),
+      | PathResolutionError::AuthorityDeferredQueueFull => write!(f, "authority deferred queue is full"),
       | PathResolutionError::UidReserved { uid } => {
         write!(f, "UID {} is reserved and cannot be reused", uid.value())
       },

--- a/modules/actor-core-kernel/src/actor/actor_path_test.rs
+++ b/modules/actor-core-kernel/src/actor/actor_path_test.rs
@@ -130,6 +130,7 @@ fn path_resolution_error_display_matches_public_contract() {
     (PathResolutionError::PidUnknown, "PID not found in registry"),
     (PathResolutionError::AuthorityUnresolved, "authority is not resolved"),
     (PathResolutionError::AuthorityQuarantined, "authority is quarantined"),
+    (PathResolutionError::AuthorityDeferredQueueFull, "authority deferred queue is full"),
     (PathResolutionError::UidReserved { uid: ActorUid::new(42) }, "UID 42 is reserved and cannot be reused"),
   ];
 

--- a/modules/actor-core-kernel/src/actor/actor_selection.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection.rs
@@ -1,5 +1,7 @@
 //! Actor selection expression and relative path resolution.
 
+use crate::{actor::actor_path::PathResolutionError, system::remote::RemoteAuthorityError};
+
 mod actor_selection_error;
 mod actor_selection_message;
 mod resolver;
@@ -15,3 +17,10 @@ pub use actor_selection_message::ActorSelectionMessage;
 pub use resolver::ActorSelectionResolver;
 pub use selection::ActorSelection;
 pub use selection_path_element::SelectionPathElement;
+
+const fn remote_authority_error_to_path_resolution(error: RemoteAuthorityError) -> PathResolutionError {
+  match error {
+    | RemoteAuthorityError::Quarantined => PathResolutionError::AuthorityQuarantined,
+    | RemoteAuthorityError::DeferredQueueFull => PathResolutionError::AuthorityDeferredQueueFull,
+  }
+}

--- a/modules/actor-core-kernel/src/actor/actor_selection/actor_selection_error.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection/actor_selection_error.rs
@@ -11,7 +11,7 @@ use crate::actor::{
 pub enum ActorSelectionError {
   /// The relative path itself was invalid.
   InvalidPath(ActorPathError),
-  /// Authority resolution failed (unresolved/quarantine).
+  /// Authority resolution failed (unresolved/quarantine/deferred queue full).
   Authority(PathResolutionError),
   /// Actor reference lookup failed.
   Resolve(ActorRefResolveError),

--- a/modules/actor-core-kernel/src/actor/actor_selection/resolver.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection/resolver.rs
@@ -8,7 +8,10 @@ use crate::{
     actor_path::{ActorPath, ActorPathError, PathResolutionError, PathSegment},
     messaging::AnyMessage,
   },
-  system::{remote::RemoteAuthorityRegistry, state::AuthorityState},
+  system::{
+    remote::{RemoteAuthorityError, RemoteAuthorityRegistry},
+    state::AuthorityState,
+  },
 };
 
 /// Resolves relative actor selection expressions against a base path.
@@ -58,9 +61,10 @@ impl ActorSelectionResolver {
   ///
   /// # Errors
   ///
-  /// If the authority is unresolved, the provided `message` is deferred (when present) and
-  /// [`PathResolutionError::AuthorityUnresolved`] is returned. When the authority is quarantined,
-  /// [`PathResolutionError::AuthorityQuarantined`] is returned immediately.
+  /// If the authority is unresolved, the provided `message` is deferred when capacity allows and
+  /// [`PathResolutionError::AuthorityUnresolved`] is returned. If the deferred queue is full,
+  /// [`PathResolutionError::AuthorityDeferredQueueFull`] is returned. When the authority is
+  /// quarantined, [`PathResolutionError::AuthorityQuarantined`] is returned immediately.
   pub fn ensure_authority_state(
     path: &ActorPath,
     authority_registry: &mut RemoteAuthorityRegistry,
@@ -76,7 +80,7 @@ impl ActorSelectionResolver {
         if let Some(envelope) = message {
           authority_registry
             .defer_send(endpoint.clone(), envelope)
-            .map_err(|_| PathResolutionError::AuthorityQuarantined)?;
+            .map_err(Self::remote_authority_error_to_path_resolution)?;
         }
         Err(PathResolutionError::AuthorityUnresolved)
       },
@@ -99,5 +103,12 @@ impl ActorSelectionResolver {
     let resolved = Self::resolve_relative(base, selection)?;
     Self::ensure_authority_state(&resolved, authority_registry, message).map_err(ActorSelectionError::from)?;
     Ok(resolved)
+  }
+
+  const fn remote_authority_error_to_path_resolution(error: RemoteAuthorityError) -> PathResolutionError {
+    match error {
+      | RemoteAuthorityError::Quarantined => PathResolutionError::AuthorityQuarantined,
+      | RemoteAuthorityError::DeferredQueueFull => PathResolutionError::AuthorityDeferredQueueFull,
+    }
   }
 }

--- a/modules/actor-core-kernel/src/actor/actor_selection/resolver.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection/resolver.rs
@@ -2,16 +2,13 @@
 
 use alloc::{string::ToString, vec::Vec};
 
-use super::actor_selection_error::ActorSelectionError;
+use super::{actor_selection_error::ActorSelectionError, remote_authority_error_to_path_resolution};
 use crate::{
   actor::{
     actor_path::{ActorPath, ActorPathError, PathResolutionError, PathSegment},
     messaging::AnyMessage,
   },
-  system::{
-    remote::{RemoteAuthorityError, RemoteAuthorityRegistry},
-    state::AuthorityState,
-  },
+  system::{remote::RemoteAuthorityRegistry, state::AuthorityState},
 };
 
 /// Resolves relative actor selection expressions against a base path.
@@ -80,7 +77,7 @@ impl ActorSelectionResolver {
         if let Some(envelope) = message {
           authority_registry
             .defer_send(endpoint.clone(), envelope)
-            .map_err(Self::remote_authority_error_to_path_resolution)?;
+            .map_err(remote_authority_error_to_path_resolution)?;
         }
         Err(PathResolutionError::AuthorityUnresolved)
       },
@@ -103,12 +100,5 @@ impl ActorSelectionResolver {
     let resolved = Self::resolve_relative(base, selection)?;
     Self::ensure_authority_state(&resolved, authority_registry, message).map_err(ActorSelectionError::from)?;
     Ok(resolved)
-  }
-
-  const fn remote_authority_error_to_path_resolution(error: RemoteAuthorityError) -> PathResolutionError {
-    match error {
-      | RemoteAuthorityError::Quarantined => PathResolutionError::AuthorityQuarantined,
-      | RemoteAuthorityError::DeferredQueueFull => PathResolutionError::AuthorityDeferredQueueFull,
-    }
   }
 }

--- a/modules/actor-core-kernel/src/actor/actor_selection/selection.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection/selection.rs
@@ -22,6 +22,7 @@ use crate::{
   },
   system::{
     ActorSystem,
+    remote::RemoteAuthorityError,
     state::{AuthorityState, SystemStateShared},
   },
 };
@@ -136,11 +137,18 @@ impl ActorSelection {
           self
             .system
             .remote_authority_defer(authority, message.clone())
-            .map_err(|_| ActorSelectionError::from(PathResolutionError::AuthorityQuarantined))?;
+            .map_err(|error| ActorSelectionError::from(Self::remote_authority_error_to_path_resolution(error)))?;
         }
         Err(ActorSelectionError::from(PathResolutionError::AuthorityUnresolved))
       },
       | AuthorityState::Quarantine { .. } => Err(ActorSelectionError::from(PathResolutionError::AuthorityQuarantined)),
+    }
+  }
+
+  const fn remote_authority_error_to_path_resolution(error: RemoteAuthorityError) -> PathResolutionError {
+    match error {
+      | RemoteAuthorityError::Quarantined => PathResolutionError::AuthorityQuarantined,
+      | RemoteAuthorityError::DeferredQueueFull => PathResolutionError::AuthorityDeferredQueueFull,
     }
   }
 

--- a/modules/actor-core-kernel/src/actor/actor_selection/selection.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection/selection.rs
@@ -9,7 +9,7 @@ use core::{
   time::Duration,
 };
 
-use super::{ActorSelectionError, ActorSelectionResolver};
+use super::{ActorSelectionError, ActorSelectionResolver, remote_authority_error_to_path_resolution};
 use crate::{
   actor::{
     actor_path::{
@@ -22,7 +22,6 @@ use crate::{
   },
   system::{
     ActorSystem,
-    remote::RemoteAuthorityError,
     state::{AuthorityState, SystemStateShared},
   },
 };
@@ -137,18 +136,11 @@ impl ActorSelection {
           self
             .system
             .remote_authority_defer(authority, message.clone())
-            .map_err(|error| ActorSelectionError::from(Self::remote_authority_error_to_path_resolution(error)))?;
+            .map_err(|error| ActorSelectionError::from(remote_authority_error_to_path_resolution(error)))?;
         }
         Err(ActorSelectionError::from(PathResolutionError::AuthorityUnresolved))
       },
       | AuthorityState::Quarantine { .. } => Err(ActorSelectionError::from(PathResolutionError::AuthorityQuarantined)),
-    }
-  }
-
-  const fn remote_authority_error_to_path_resolution(error: RemoteAuthorityError) -> PathResolutionError {
-    match error {
-      | RemoteAuthorityError::Quarantined => PathResolutionError::AuthorityQuarantined,
-      | RemoteAuthorityError::DeferredQueueFull => PathResolutionError::AuthorityDeferredQueueFull,
     }
   }
 

--- a/modules/actor-core-kernel/src/actor/actor_selection_test.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection_test.rs
@@ -209,6 +209,31 @@ fn test_ensure_authority_state_defers_and_errors_when_unresolved() {
 }
 
 #[test]
+fn test_ensure_authority_state_reports_queue_full_when_deferred_queue_is_full() {
+  let parts = ActorPathParts::with_authority("remote-sys", Some(("host.example.com", 2552)));
+  let path = ActorPath::from_parts(parts).child("worker");
+  let mut registry = RemoteAuthorityRegistry::new();
+  let mut accepted = 0;
+
+  loop {
+    match registry.defer_send("host.example.com:2552", AnyMessage::new(accepted)) {
+      | Ok(()) => {
+        accepted += 1;
+        assert!(accepted <= 10_000, "deferred queue must be bounded");
+      },
+      | Err(RemoteAuthorityError::DeferredQueueFull) => break,
+      | Err(error) => panic!("unexpected remote authority error: {error:?}"),
+    }
+  }
+
+  let err =
+    ActorSelectionResolver::ensure_authority_state(&path, &mut registry, Some(AnyMessage::new(accepted))).unwrap_err();
+
+  assert!(matches!(err, PathResolutionError::AuthorityDeferredQueueFull));
+  assert_eq!(registry.deferred_count("host.example.com:2552"), accepted);
+}
+
+#[test]
 fn test_ensure_authority_state_rejects_quarantine() {
   let parts = ActorPathParts::with_authority("remote-sys", Some(("blocked-host", 2553)));
   let path = ActorPath::from_parts(parts).child("logger");

--- a/modules/actor-core-kernel/src/actor/actor_selection_test.rs
+++ b/modules/actor-core-kernel/src/actor/actor_selection_test.rs
@@ -215,15 +215,9 @@ fn test_ensure_authority_state_reports_queue_full_when_deferred_queue_is_full() 
   let mut registry = RemoteAuthorityRegistry::new();
   let mut accepted = 0;
 
-  loop {
-    match registry.defer_send("host.example.com:2552", AnyMessage::new(accepted)) {
-      | Ok(()) => {
-        accepted += 1;
-        assert!(accepted <= 10_000, "deferred queue must be bounded");
-      },
-      | Err(RemoteAuthorityError::DeferredQueueFull) => break,
-      | Err(error) => panic!("unexpected remote authority error: {error:?}"),
-    }
+  while registry.defer_send("host.example.com:2552", AnyMessage::new(accepted)).is_ok() {
+    accepted += 1;
+    assert!(accepted <= 10_000, "deferred queue must be bounded");
   }
 
   let err =
@@ -231,6 +225,18 @@ fn test_ensure_authority_state_reports_queue_full_when_deferred_queue_is_full() 
 
   assert!(matches!(err, PathResolutionError::AuthorityDeferredQueueFull));
   assert_eq!(registry.deferred_count("host.example.com:2552"), accepted);
+}
+
+#[test]
+fn remote_authority_errors_map_to_path_resolution_errors() {
+  assert_eq!(
+    super::remote_authority_error_to_path_resolution(RemoteAuthorityError::Quarantined),
+    PathResolutionError::AuthorityQuarantined
+  );
+  assert_eq!(
+    super::remote_authority_error_to_path_resolution(RemoteAuthorityError::DeferredQueueFull),
+    PathResolutionError::AuthorityDeferredQueueFull
+  );
 }
 
 #[test]
@@ -443,6 +449,27 @@ fn actor_selection_tell_defers_when_remote_authority_is_unresolved() {
 
   assert!(matches!(error, ActorSelectionError::Authority(PathResolutionError::AuthorityUnresolved)));
   assert_eq!(system.state().remote_authority_deferred_count("peer.example.com:2552"), 1);
+}
+
+#[test]
+fn actor_selection_tell_reports_queue_full_when_remote_deferred_queue_is_full() {
+  let system = build_selection_system();
+  let authority = "full-peer.example.com:2552";
+  let mut accepted = 0;
+  while system.state().remote_authority_defer(authority, AnyMessage::new(accepted)).is_ok() {
+    accepted += 1;
+    assert!(accepted <= 10_000, "deferred queue must be bounded");
+  }
+
+  let path =
+    ActorPath::from_parts(ActorPathParts::with_authority("selection-spec", Some(("full-peer.example.com", 2552))))
+      .child("worker");
+  let selection = ActorSelection::from_path(system.state(), &path);
+
+  let error = selection.tell(AnyMessage::new(String::from("remote")), None).expect_err("deferred queue full");
+
+  assert!(matches!(error, ActorSelectionError::Authority(PathResolutionError::AuthorityDeferredQueueFull)));
+  assert_eq!(system.state().remote_authority_deferred_count(authority), accepted);
 }
 
 #[test]

--- a/modules/actor-core-kernel/src/system/remote/remote_authority_error.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_authority_error.rs
@@ -1,8 +1,10 @@
 //! Remote authority error types.
 
 /// Error type for remote authority operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoteAuthorityError {
   /// Authority is quarantined and cannot accept messages.
   Quarantined,
+  /// Deferred message queue is full and cannot accept more messages.
+  DeferredQueueFull,
 }

--- a/modules/actor-core-kernel/src/system/remote/remote_authority_registry.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_authority_registry.rs
@@ -19,6 +19,9 @@ use crate::{
   system::{remote::RemoteAuthorityError, state::AuthorityState},
 };
 
+const MAX_DEFERRED_MESSAGES_PER_AUTHORITY: usize = 1024;
+const MAX_DEFERRED_MESSAGES_TOTAL: usize = 8192;
+
 /// Entry tracking authority state and deferred messages.
 #[derive(Debug)]
 struct AuthorityEntry {
@@ -34,15 +37,16 @@ impl AuthorityEntry {
 
 /// Tracks remote authority state transitions and deferred message queues.
 pub struct RemoteAuthorityRegistry {
-  entries: HashMap<String, AuthorityEntry, RandomState>,
-  _marker: PhantomData<()>,
+  entries:        HashMap<String, AuthorityEntry, RandomState>,
+  total_deferred: usize,
+  _marker:        PhantomData<()>,
 }
 
 impl RemoteAuthorityRegistry {
   /// Creates a new registry with no authorities.
   #[must_use]
   pub fn new() -> Self {
-    Self { entries: HashMap::with_hasher(RandomState::new()), _marker: PhantomData }
+    Self { entries: HashMap::with_hasher(RandomState::new()), total_deferred: 0, _marker: PhantomData }
   }
 
   /// Returns the current state of an authority.
@@ -55,7 +59,8 @@ impl RemoteAuthorityRegistry {
   ///
   /// # Errors
   ///
-  /// Returns [`RemoteAuthorityError::Quarantined`] if the authority is quarantined.
+  /// Returns [`RemoteAuthorityError::Quarantined`] if the authority is quarantined, or
+  /// [`RemoteAuthorityError::DeferredQueueFull`] if the deferred queue reached its limit.
   pub fn defer_send(&mut self, authority: impl Into<String>, message: AnyMessage) -> Result<(), RemoteAuthorityError> {
     self.defer_or_reject(authority.into(), message)
   }
@@ -64,7 +69,8 @@ impl RemoteAuthorityRegistry {
   ///
   /// # Errors
   ///
-  /// Returns [`RemoteAuthorityError::Quarantined`] if the authority is quarantined.
+  /// Returns [`RemoteAuthorityError::Quarantined`] if the authority is quarantined, or
+  /// [`RemoteAuthorityError::DeferredQueueFull`] if the deferred queue reached its limit.
   pub fn try_defer_send(
     &mut self,
     authority: impl Into<String>,
@@ -74,14 +80,32 @@ impl RemoteAuthorityRegistry {
   }
 
   fn defer_or_reject(&mut self, authority: String, message: AnyMessage) -> Result<(), RemoteAuthorityError> {
-    let entry = self.entries.entry(authority).or_insert_with(|| AuthorityEntry::new(AuthorityState::Unresolved));
+    if let Some(entry) = self.entries.get_mut(&authority) {
+      return Self::defer_into_entry(entry, &mut self.total_deferred, message);
+    }
 
+    let mut entry = AuthorityEntry::new(AuthorityState::Unresolved);
+    Self::defer_into_entry(&mut entry, &mut self.total_deferred, message)?;
+    self.entries.insert(authority, entry);
+    Ok(())
+  }
+
+  fn defer_into_entry(
+    entry: &mut AuthorityEntry,
+    total_deferred: &mut usize,
+    message: AnyMessage,
+  ) -> Result<(), RemoteAuthorityError> {
     // Quarantine中は拒否
     if matches!(entry.state, AuthorityState::Quarantine { .. }) {
       return Err(RemoteAuthorityError::Quarantined);
     }
 
+    if entry.deferred.len() >= MAX_DEFERRED_MESSAGES_PER_AUTHORITY || *total_deferred >= MAX_DEFERRED_MESSAGES_TOTAL {
+      return Err(RemoteAuthorityError::DeferredQueueFull);
+    }
+
     entry.deferred.push_back(message);
+    *total_deferred += 1;
     Ok(())
   }
 
@@ -90,6 +114,7 @@ impl RemoteAuthorityRegistry {
     let entry =
       self.entries.entry(authority.to_string()).or_insert_with(|| AuthorityEntry::new(AuthorityState::Unresolved));
     entry.state = AuthorityState::Connected;
+    self.total_deferred = self.total_deferred.saturating_sub(entry.deferred.len());
     Some(core::mem::take(&mut entry.deferred))
   }
 
@@ -99,6 +124,7 @@ impl RemoteAuthorityRegistry {
     let deadline = duration.map(|d| now + d.as_secs());
     let entry = self.entries.entry(authority).or_insert_with(|| AuthorityEntry::new(AuthorityState::Unresolved));
     entry.state = AuthorityState::Quarantine { deadline };
+    self.total_deferred = self.total_deferred.saturating_sub(entry.deferred.len());
     entry.deferred.clear();
   }
 
@@ -148,6 +174,11 @@ impl RemoteAuthorityRegistry {
   #[must_use]
   pub fn deferred_count(&self, authority: &str) -> usize {
     self.entries.get(authority).map(|e| e.deferred.len()).unwrap_or(0)
+  }
+
+  #[cfg(test)]
+  const fn total_deferred_count(&self) -> usize {
+    self.total_deferred
   }
 }
 

--- a/modules/actor-core-kernel/src/system/remote/remote_authority_registry.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_authority_registry.rs
@@ -137,6 +137,8 @@ impl RemoteAuthorityRegistry {
   pub fn manual_override_to_connected(&mut self, authority: &str) {
     if let Some(entry) = self.entries.get_mut(authority) {
       entry.state = AuthorityState::Connected;
+      self.total_deferred = self.total_deferred.saturating_sub(entry.deferred.len());
+      entry.deferred.clear();
     }
   }
 

--- a/modules/actor-core-kernel/src/system/remote/remote_authority_registry.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_authority_registry.rs
@@ -175,11 +175,6 @@ impl RemoteAuthorityRegistry {
   pub fn deferred_count(&self, authority: &str) -> usize {
     self.entries.get(authority).map(|e| e.deferred.len()).unwrap_or(0)
   }
-
-  #[cfg(test)]
-  const fn total_deferred_count(&self) -> usize {
-    self.total_deferred
-  }
 }
 
 impl Default for RemoteAuthorityRegistry {

--- a/modules/actor-core-kernel/src/system/remote/remote_authority_registry_test.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_authority_registry_test.rs
@@ -1,5 +1,7 @@
+use alloc::format;
 use core::time::Duration;
 
+use super::{MAX_DEFERRED_MESSAGES_PER_AUTHORITY, MAX_DEFERRED_MESSAGES_TOTAL};
 use crate::{
   actor::messaging::AnyMessage,
   system::{
@@ -235,4 +237,65 @@ fn test_multiple_authorities_independent_states() {
   registry.set_quarantine("host2", 0, Some(Duration::from_secs(300)));
   assert_eq!(registry.state("host1"), AuthorityState::Connected);
   assert!(matches!(registry.state("host2"), AuthorityState::Quarantine { .. }));
+}
+
+#[test]
+fn test_defer_send_rejects_when_per_authority_queue_is_full() {
+  let mut registry = RemoteAuthorityRegistry::new();
+
+  for index in 0..MAX_DEFERRED_MESSAGES_PER_AUTHORITY {
+    registry.defer_send("remote1", AnyMessage::new(index)).expect("defer");
+  }
+
+  let result = registry.defer_send("remote1", AnyMessage::new(MAX_DEFERRED_MESSAGES_PER_AUTHORITY));
+
+  assert!(matches!(result, Err(RemoteAuthorityError::DeferredQueueFull)));
+  assert_eq!(registry.deferred_count("remote1"), MAX_DEFERRED_MESSAGES_PER_AUTHORITY);
+  assert_eq!(registry.total_deferred_count(), MAX_DEFERRED_MESSAGES_PER_AUTHORITY);
+}
+
+#[test]
+fn test_defer_send_rejects_when_global_deferred_queue_is_full() {
+  let mut registry = RemoteAuthorityRegistry::new();
+
+  for index in 0..MAX_DEFERRED_MESSAGES_TOTAL {
+    let authority = format!("remote-{index}:2552");
+    registry.defer_send(authority, AnyMessage::new(index)).expect("defer");
+  }
+
+  let result = registry.defer_send("overflow:2552", AnyMessage::new(MAX_DEFERRED_MESSAGES_TOTAL));
+
+  assert!(matches!(result, Err(RemoteAuthorityError::DeferredQueueFull)));
+  assert_eq!(registry.deferred_count("overflow:2552"), 0);
+  assert_eq!(registry.total_deferred_count(), MAX_DEFERRED_MESSAGES_TOTAL);
+}
+
+#[test]
+fn test_set_connected_decrements_total_deferred_count() {
+  let mut registry = RemoteAuthorityRegistry::new();
+
+  registry.defer_send("remote1", AnyMessage::new(1i32)).expect("defer");
+  registry.defer_send("remote1", AnyMessage::new(2i32)).expect("defer");
+  registry.defer_send("remote2", AnyMessage::new(3i32)).expect("defer");
+
+  let deferred = registry.set_connected("remote1").expect("deferred");
+
+  assert_eq!(deferred.len(), 2);
+  assert_eq!(registry.deferred_count("remote1"), 0);
+  assert_eq!(registry.deferred_count("remote2"), 1);
+  assert_eq!(registry.total_deferred_count(), 1);
+}
+
+#[test]
+fn test_set_quarantine_decrements_total_deferred_count() {
+  let mut registry = RemoteAuthorityRegistry::new();
+
+  registry.defer_send("remote1", AnyMessage::new(1i32)).expect("defer");
+  registry.defer_send("remote2", AnyMessage::new(2i32)).expect("defer");
+
+  registry.set_quarantine("remote1", 0, Some(Duration::from_secs(300)));
+
+  assert_eq!(registry.deferred_count("remote1"), 0);
+  assert_eq!(registry.deferred_count("remote2"), 1);
+  assert_eq!(registry.total_deferred_count(), 1);
 }

--- a/modules/actor-core-kernel/src/system/remote/remote_authority_registry_test.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_authority_registry_test.rs
@@ -10,6 +10,12 @@ use crate::{
   },
 };
 
+impl RemoteAuthorityRegistry {
+  const fn total_deferred_count(&self) -> usize {
+    self.total_deferred
+  }
+}
+
 #[test]
 fn test_initial_state_is_unresolved() {
   let registry = RemoteAuthorityRegistry::new();

--- a/modules/actor-core-kernel/src/system/remote/remote_authority_registry_test.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_authority_registry_test.rs
@@ -305,3 +305,19 @@ fn test_set_quarantine_decrements_total_deferred_count() {
   assert_eq!(registry.deferred_count("remote2"), 1);
   assert_eq!(registry.total_deferred_count(), 1);
 }
+
+#[test]
+fn test_manual_override_to_connected_decrements_total_deferred_count() {
+  let mut registry = RemoteAuthorityRegistry::new();
+
+  registry.defer_send("remote1", AnyMessage::new(1i32)).expect("defer");
+  registry.defer_send("remote1", AnyMessage::new(2i32)).expect("defer");
+  registry.defer_send("remote2", AnyMessage::new(3i32)).expect("defer");
+
+  registry.manual_override_to_connected("remote1");
+
+  assert_eq!(registry.state("remote1"), AuthorityState::Connected);
+  assert_eq!(registry.deferred_count("remote1"), 0);
+  assert_eq!(registry.deferred_count("remote2"), 1);
+  assert_eq!(registry.total_deferred_count(), 1);
+}

--- a/modules/actor-core-kernel/src/system/state/system_state.rs
+++ b/modules/actor-core-kernel/src/system/state/system_state.rs
@@ -1092,7 +1092,7 @@ impl SystemState {
   /// # Errors
   ///
   /// Returns [`RemoteAuthorityError::Quarantined`] if the target authority is currently
-  /// quarantined.
+  /// quarantined, or [`RemoteAuthorityError::DeferredQueueFull`] if the deferred queue is full.
   pub fn remote_authority_defer(
     &mut self,
     authority: impl Into<String>,
@@ -1105,7 +1105,8 @@ impl SystemState {
   ///
   /// # Errors
   ///
-  /// Returns [`RemoteAuthorityError::Quarantined`] when the authority remains quarantined.
+  /// Returns [`RemoteAuthorityError::Quarantined`] when the authority remains quarantined, or
+  /// [`RemoteAuthorityError::DeferredQueueFull`] if the deferred queue is full.
   pub fn remote_authority_try_defer(
     &mut self,
     authority: impl Into<String>,

--- a/modules/actor-core-kernel/src/system/state/system_state_shared.rs
+++ b/modules/actor-core-kernel/src/system/state/system_state_shared.rs
@@ -1046,7 +1046,8 @@ impl SystemStateShared {
   ///
   /// # Errors
   ///
-  /// Returns [`RemoteAuthorityError`] if the authority is quarantined.
+  /// Returns [`RemoteAuthorityError`] if the authority is quarantined or the deferred queue is
+  /// full.
   pub fn remote_authority_defer(
     &self,
     authority: impl Into<String>,
@@ -1059,7 +1060,8 @@ impl SystemStateShared {
   ///
   /// # Errors
   ///
-  /// Returns [`RemoteAuthorityError`] if the authority is quarantined.
+  /// Returns [`RemoteAuthorityError`] if the authority is quarantined or the deferred queue is
+  /// full.
   pub fn remote_authority_try_defer(
     &self,
     authority: impl Into<String>,


### PR DESCRIPTION
## 概要
- 未解決 remote authority への deferred message queue に per-authority 上限と registry 全体上限を追加
- 上限到達時に `RemoteAuthorityError::DeferredQueueFull` / `PathResolutionError::AuthorityDeferredQueueFull` として拒否を明示
- connected/quarantine 遷移時に deferred 総数カウンタを補正するテストを追加

## 背景
ActorSelection が未解決 authority への message を `RemoteAuthorityRegistry` に defer する一方、既存実装では `VecDeque` と authority entry が無制限に増え、任意の未解決 authority を繰り返し指定されるとメモリ増加による DoS につながる可能性がありました。

## 検証
- `cargo test -p fraktor-actor-core-kernel-rs remote_authority_registry --lib`
- `cargo test -p fraktor-actor-core-kernel-rs actor_selection --lib`
- `cargo test -p fraktor-actor-core-kernel-rs --lib`
- `cargo test -p fraktor-actor-core-kernel-rs --test actor_path_e2e`
- `cargo test -p fraktor-actor-core-kernel-rs --test actor_selection_e2e`
- `cargo clippy -p fraktor-actor-core-kernel-rs --lib -- -D warnings`
- `git diff --check`

## 補足
`cargo clippy -p fraktor-actor-core-kernel-rs --lib --tests -- -D warnings` は既存の `system_queue_test.rs` の `needless_pass_by_value` で失敗します。この PR の変更範囲外です。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds hard limits and new error paths to remote deferred-message handling; behavior changes under load and could affect message delivery/retry semantics for unresolved authorities.
> 
> **Overview**
> Prevents unbounded memory growth when sending to *unresolved* remote authorities by bounding deferred-message queues (per-authority and global) in `RemoteAuthorityRegistry`, tracking `total_deferred`, and rejecting additional defers once limits are hit.
> 
> Surfaces this condition end-to-end by introducing `RemoteAuthorityError::DeferredQueueFull` and `PathResolutionError::AuthorityDeferredQueueFull`, mapping remote errors into actor-selection path resolution (`ActorSelectionResolver`/`ActorSelection::tell`) instead of treating all defer failures as quarantine.
> 
> Adds/updates unit tests to lock in the new display contract and to cover queue-full behavior plus correct `total_deferred` accounting when transitioning authorities to connected/quarantine or manual override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f8a25eb615134e7eb8d5b757d49c2ca6e023603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * リモート権限のディファーキューが満杯の場合のエラー処理を強化しました。キュー上限に達すると、適切なエラーが返されるようになり、システムの安定性が向上しました。

* **Documentation**
  * 権限解決に関するエラードキュメントを更新し、キュー満杯時のエラーが発生し得ることを明記しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1814?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->