### PR TITLE
fix(remote): cap configurable frame size to 16 MiB

### DIFF
--- a/modules/remote-adaptor-std/src/transport/tcp/frame_codec.rs
+++ b/modules/remote-adaptor-std/src/transport/tcp/frame_codec.rs
@@ -21,6 +21,8 @@ const DEFAULT_MAXIMUM_FRAME_SIZE: usize = 256 * 1024;
 
 /// Minimum accepted maximum frame size.
 const MINIMUM_MAXIMUM_FRAME_SIZE: usize = 32 * 1024;
+/// Maximum accepted maximum frame size.
+const MAXIMUM_MAXIMUM_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
 fn declared_frame_length(frame: &[u8]) -> Result<usize, FrameCodecError> {
   if frame.len() < FRAME_HEADER_LEN {
@@ -52,10 +54,11 @@ impl WireFrameCodec {
   ///
   /// # Panics
   ///
-  /// Panics when `maximum_frame_size` is smaller than 32 KiB.
+  /// Panics when `maximum_frame_size` is outside 32 KiB..=16 MiB.
   #[must_use]
   pub const fn with_maximum_frame_size(maximum_frame_size: usize) -> Self {
     assert!(maximum_frame_size >= MINIMUM_MAXIMUM_FRAME_SIZE, "maximum frame size must be at least 32 KiB");
+    assert!(maximum_frame_size <= MAXIMUM_MAXIMUM_FRAME_SIZE, "maximum frame size must be at most 16 MiB");
     Self { maximum_frame_size }
   }
 }
@@ -105,7 +108,7 @@ impl Decoder for WireFrameCodec {
     if length > self.maximum_frame_size {
       return Err(FrameCodecError::from(WireError::FrameTooLarge));
     }
-    let total = 4 + length;
+    let total = 4usize.checked_add(length).ok_or(FrameCodecError::Wire(WireError::FrameTooLarge))?;
     if src.len() < total {
       // frame の残りが届くまで待つ。
       return Ok(None);

--- a/modules/remote-adaptor-std/src/transport/tcp_test.rs
+++ b/modules/remote-adaptor-std/src/transport/tcp_test.rs
@@ -40,6 +40,7 @@ use crate::transport::tcp::{
 
 const DEFAULT_MAXIMUM_FRAME_SIZE: usize = 256 * 1024;
 const MINIMUM_MAXIMUM_FRAME_SIZE: usize = 32 * 1024;
+const MAXIMUM_MAXIMUM_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
 fn append_declared_frame_header(buf: &mut BytesMut, length: usize) {
   let length = u32::try_from(length).expect("test frame length should fit in u32");
@@ -347,6 +348,12 @@ fn wire_frame_codec_rejects_frame_above_configured_maximum_frame_size() {
   let err = codec.decode(&mut buf).expect_err("oversized frame must be rejected");
   assert!(matches!(err, FrameCodecError::Wire(WireError::FrameTooLarge)));
   assert_eq!(buf.len(), 6, "oversized header must not partially consume the buffer");
+}
+
+#[test]
+fn wire_frame_codec_rejects_maximum_frame_size_above_upper_bound() {
+  let result = std::panic::catch_unwind(|| WireFrameCodec::with_maximum_frame_size(MAXIMUM_MAXIMUM_FRAME_SIZE + 1));
+  assert!(result.is_err(), "configured maximum frame size above 16 MiB must be rejected");
 }
 
 #[test]

--- a/modules/remote-core/src/config/remote_config.rs
+++ b/modules/remote-core/src/config/remote_config.rs
@@ -95,6 +95,8 @@ const DEFAULT_BUFFER_POOL_SIZE: usize = 128;
 
 /// Minimum accepted maximum wire frame size.
 const MINIMUM_MAXIMUM_FRAME_SIZE: usize = 32 * 1024;
+/// Maximum accepted maximum wire frame size.
+const MAXIMUM_MAXIMUM_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
 /// Typed remote subsystem configuration.
 ///
@@ -505,10 +507,11 @@ impl RemoteConfig {
   ///
   /// # Panics
   ///
-  /// Panics when `size` is smaller than 32 KiB.
+  /// Panics when `size` is outside 32 KiB..=16 MiB.
   #[must_use]
   pub const fn with_maximum_frame_size(mut self, size: usize) -> Self {
     assert!(size >= MINIMUM_MAXIMUM_FRAME_SIZE, "maximum frame size must be at least 32 KiB");
+    assert!(size <= MAXIMUM_MAXIMUM_FRAME_SIZE, "maximum frame size must be at most 16 MiB");
     self.maximum_frame_size = size;
     self
   }

--- a/modules/remote-core/src/config_test.rs
+++ b/modules/remote-core/src/config_test.rs
@@ -210,6 +210,15 @@ fn with_maximum_frame_size_rejects_values_below_minimum() {
 }
 
 #[test]
+fn with_maximum_frame_size_rejects_values_above_maximum() {
+  // When: 最大値超過の frame size を指定する
+  let result = std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_maximum_frame_size(16 * 1024 * 1024 + 1));
+
+  // Then: 不正な frame size として拒否する
+  assert!(result.is_err());
+}
+
+#[test]
 fn with_buffer_pool_size_rejects_zero() {
   // When: buffer pool size に 0 を指定する
   let result = std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_buffer_pool_size(0));

--- a/modules/remote-core/src/config_test.rs
+++ b/modules/remote-core/src/config_test.rs
@@ -212,7 +212,8 @@ fn with_maximum_frame_size_rejects_values_below_minimum() {
 #[test]
 fn with_maximum_frame_size_rejects_values_above_maximum() {
   // When: 最大値超過の frame size を指定する
-  let result = std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_maximum_frame_size(16 * 1024 * 1024 + 1));
+  let result =
+    std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_maximum_frame_size(16 * 1024 * 1024 + 1));
 
   // Then: 不正な frame size として拒否する
   assert!(result.is_err());


### PR DESCRIPTION
### Motivation

- The configurable `maximum_frame_size` removed the previous hard upper bound and allowed operators to set arbitrarily large frames, permitting unauthenticated peers to force large buffering and memory exhaustion (DoS) and enabling potential overflow on 32-bit targets. 

### Description

- Add a new upper bound constant `MAXIMUM_MAXIMUM_FRAME_SIZE = 16 * 1024 * 1024` and enforce it in `WireFrameCodec::with_maximum_frame_size` so configurable values must be in `32 KiB..=16 MiB`.
- Enforce the same `16 MiB` upper bound in `RemoteConfig::with_maximum_frame_size` to reject oversized configuration early.
- Harden decoder arithmetic by replacing `4 + length` with `4usize.checked_add(length).ok_or(...)` to avoid `usize` overflow on narrow pointer-width targets and map overflow to `FrameTooLarge`.
- Add focused unit tests that assert rejection of configuration values above `16 MiB` for both `RemoteConfig` and `WireFrameCodec` and adjust test helpers/constants accordingly.

### Testing

- Ran `cargo test -p fraktor-remote-core-rs config_test::with_maximum_frame_size_rejects_values_above_maximum -- --exact` which passed. 
- Ran `cargo test -p fraktor-remote-adaptor-std-rs wire_frame_codec_rejects_maximum_frame_size_above_upper_bound -- --exact` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bb5288e70832d96689dfbf683a012)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation of `maximum_frame_size` and frame decoding arithmetic, which can affect connectivity for deployments that previously relied on larger frames and touches inbound decode paths.
> 
> **Overview**
> **Caps configurable frame sizes** by introducing a `16 MiB` upper bound for `maximum_frame_size` in both `RemoteConfig::with_maximum_frame_size` and `WireFrameCodec::with_maximum_frame_size`, rejecting out-of-range values.
> 
> **Hardens inbound decoding** by using checked addition when computing total frame size to avoid `usize` overflow and treating it as `FrameTooLarge`, and adds unit tests ensuring configs/codecs reject values above the new limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf52f00d6b81acb5ad1c0cfc744e71b890bcb54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リモート通信のデフォルト最大フレームサイズを256KiBから16MiBに引き上げました。

* **バグ修正**
  * フレームサイズ判定の安全性を強化し、サイズ計算のオーバーフロー時に適切に扱うようにしました。
  * 受け入れ可能なフレームサイズ範囲を明確に32KiB〜16MiBに制限しました。

* **テスト**
  * 最大値を超えるフレームサイズが拒否されることを検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->