### PR TITLE
test(remote): validate max frame size constant in config tests

### DIFF
--- a/modules/remote-core/src/config_test.rs
+++ b/modules/remote-core/src/config_test.rs
@@ -1,3 +1,4 @@
+extern crate std;
 use core::{num::NonZeroUsize, time::Duration};
 
 use crate::config::{LargeMessageDestinationPattern, LargeMessageDestinations, RemoteCompressionConfig, RemoteConfig};
@@ -14,6 +15,7 @@ const DEFAULT_OUTBOUND_LOW_WATERMARK: usize = 512;
 const DEFAULT_REMOVE_QUARANTINED_ASSOCIATION_AFTER: Duration = Duration::from_secs(60 * 60);
 const DEFAULT_COMPRESSION_ADVERTISEMENT_INTERVAL: Duration = Duration::from_secs(60);
 const MINIMUM_MAXIMUM_FRAME_SIZE: usize = 32 * 1024;
+const MAXIMUM_MAXIMUM_FRAME_SIZE: usize = 16 * 1024 * 1024;
 
 fn non_zero(value: usize) -> NonZeroUsize {
   NonZeroUsize::new(value).expect("test value must be non-zero")
@@ -213,7 +215,7 @@ fn with_maximum_frame_size_rejects_values_below_minimum() {
 fn with_maximum_frame_size_rejects_values_above_maximum() {
   // When: 最大値超過の frame size を指定する
   let result =
-    std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_maximum_frame_size(16 * 1024 * 1024 + 1));
+    std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_maximum_frame_size(MAXIMUM_MAXIMUM_FRAME_SIZE + 1));
 
   // Then: 不正な frame size として拒否する
   assert!(result.is_err());


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only change that replaces an inline numeric limit with a named constant, with no production logic impact.
> 
> **Overview**
> **Refactors remote-core config tests** by introducing `MAXIMUM_MAXIMUM_FRAME_SIZE` and using it in the `with_maximum_frame_size_rejects_values_above_maximum` test instead of an inline `16 * 1024 * 1024` expression, keeping the boundary check intent explicit and consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 760814492047a85f790794cba105ace257a890bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * テスト内の標準ライブラリ参照を明示的に宣言し、テストの堅牢性を向上させました。
  * フレームサイズ検証テストを改善し、ハードコードされた値を共通定数に統一しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->