### PR TITLE
fix(remote-core): keep quarantined association on inbound shutdown

### DIFF
--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -733,6 +733,9 @@ impl Remote {
     self.associations[index].record_handshake_activity(now_ms);
     let gate_effects = self.associations[index].gate(None, now_ms);
     self.apply_association_effects(index, gate_effects, now_ms)?;
+    if self.associations[index].state().is_quarantined() {
+      return Ok(());
+    }
     let recover_effects = self.associations[index].recover(None, now_ms, self.instrument.as_mut());
     self.apply_association_effects(index, recover_effects, now_ms)
   }

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -1991,6 +1991,57 @@ fn inbound_shutdown_control_gates_and_restarts_matching_association() {
   assert!(timeout_calls.load(Ordering::Relaxed) >= 1);
 }
 
+
+#[test]
+fn inbound_shutdown_control_does_not_clear_quarantined_association() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport = RecordingTransport::new(vec![local_address.clone()]);
+  let handshake_calls = transport.handshake_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound control");
+  remote.insert_association(active_association(local_address, remote_address.clone(), &config));
+
+  remote
+    .handle_remote_event(RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(remote_address.to_string()),
+      frame:     WireFrame::Control(ControlPdu::Quarantine {
+        authority: remote_address.to_string(),
+        reason:    Some("test quarantine".to_string()),
+      }),
+      now_ms:    80,
+    })
+    .expect("quarantine control should be applied");
+
+  remote
+    .handle_remote_event(RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(remote_address.to_string()),
+      frame:     WireFrame::Control(ControlPdu::Shutdown { authority: remote_address.to_string() }),
+      now_ms:    81,
+    })
+    .expect("shutdown control should not clear quarantine");
+
+  let recipient = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.1:2552/user/worker").expect("recipient path");
+  let envelope = OutboundEnvelope::new(
+    recipient,
+    None,
+    AnyMessage::new(String::from("payload")),
+    OutboundPriority::User,
+    RemoteNodeId::new("remote-sys", "10.0.0.1", Some(2552), 1),
+    CorrelationId::nil(),
+  );
+  remote
+    .handle_remote_event(RemoteEvent::OutboundEnqueued {
+      authority: TransportEndpoint::new(remote_address.to_string()),
+      envelope:  Box::new(envelope),
+      now_ms:    82,
+    })
+    .expect("outbound for quarantined association should be discarded");
+
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 0);
+}
+
 #[test]
 fn inbound_shutdown_control_with_mismatched_peer_authority_is_ignored() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -1991,7 +1991,6 @@ fn inbound_shutdown_control_gates_and_restarts_matching_association() {
   assert!(timeout_calls.load(Ordering::Relaxed) >= 1);
 }
 
-
 #[test]
 fn inbound_shutdown_control_does_not_clear_quarantined_association() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);


### PR DESCRIPTION
### Motivation
- Prevent a quarantine bypass where an inbound `Shutdown` control could clear a quarantined association by triggering `recover(None)` and returning the association to `Idle`.
- Preserve quarantine semantics so that a quarantined authority cannot be returned to service by an untrusted inbound control frame.

### Description
- Added a guard in `Remote::handle_inbound_shutdown_control` to skip calling `recover(None)` when the association `state().is_quarantined()` after gating, leaving quarantined associations unchanged (`modules/remote-core/src/extension/remote.rs`).
- Added a focused regression test `inbound_shutdown_control_does_not_clear_quarantined_association` that applies a `Quarantine` control, then a `Shutdown` control, enqueues an outbound envelope, and asserts no handshake restart occurs (`modules/remote-core/src/extension_test.rs`).
- Kept the existing shutdown behavior test for non-quarantined associations to ensure intended gating/restart behavior remains covered.

### Testing
- Ran `cargo test -p fraktor-remote-core-rs inbound_shutdown_control_gates_and_restarts_matching_association` and it passed.
- Ran `cargo test -p fraktor-remote-core-rs inbound_shutdown_control_does_not_clear_quarantined_association` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc31b58ec832db4d6242e5ba584ca)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remoting lifecycle state transitions: a new early-return changes how `Shutdown` control PDUs affect association recovery, which could impact reconnection behavior if misapplied. Scope is small and covered by a targeted regression test.
> 
> **Overview**
> Prevents a quarantine bypass where an inbound `ControlPdu::Shutdown` could gate then immediately `recover(None)` a *quarantined* association, potentially returning it to service.
> 
> Adds a guard in `Remote::handle_inbound_shutdown_control` to skip recovery when `state().is_quarantined()` after gating, and adds a regression test ensuring a quarantined peer’s subsequent shutdown does not restart handshakes and that outbound is discarded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d7e99ffa427647f9bca605f8b9edb42292c46ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 隔離状態のリモート接続に対するシャットダウン制御が適切に処理されるように改善しました。

* **Tests**
  * 隔離されたリモート接続のシャットダウン処理検証テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1817?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->