### PR TITLE
fix(stream): restore strict canonical sender validation for SinkRef control messages

### DIFF
--- a/modules/stream-core-kernel/src/stream_ref/sink_ref.rs
+++ b/modules/stream-core-kernel/src/stream_ref/sink_ref.rs
@@ -327,7 +327,7 @@ where
     };
     let endpoint_actor = StageActor::new(
       &system,
-      Box::new(ActorBackedSinkRefReceive::new(self.state.clone(), Self::actor_label(target_actor), target_actor.pid())),
+      Box::new(ActorBackedSinkRefReceive::new(self.state.clone(), Self::actor_label(target_actor))),
     );
     self.system = Some(system);
     self.endpoint_actor = Some(endpoint_actor);
@@ -437,12 +437,11 @@ impl ActorBackedSinkRefState {
 struct ActorBackedSinkRefReceive {
   state:            ActorBackedSinkRefStateShared,
   target_actor_ref: String,
-  target_actor_pid: Pid,
 }
 
 impl ActorBackedSinkRefReceive {
-  const fn new(state: ActorBackedSinkRefStateShared, target_actor_ref: String, target_actor_pid: Pid) -> Self {
-    Self { state, target_actor_ref, target_actor_pid }
+  const fn new(state: ActorBackedSinkRefStateShared, target_actor_ref: String) -> Self {
+    Self { state, target_actor_ref }
   }
 
   fn actor_label(actor_ref: &ActorRef) -> String {
@@ -451,8 +450,7 @@ impl ActorBackedSinkRefReceive {
 
   fn ensure_sender(&self, sender: &ActorRef) -> Result<(), StreamError> {
     let got_ref = Self::actor_label(sender);
-    // Remote senders are identified by canonical path; local loopback may only preserve the PID.
-    if got_ref == self.target_actor_ref || sender.pid() == self.target_actor_pid {
+    if got_ref == self.target_actor_ref {
       return Ok(());
     }
     Err(StreamError::InvalidPartnerActor {

--- a/modules/stream-core-kernel/src/stream_ref/sink_ref_test.rs
+++ b/modules/stream-core-kernel/src/stream_ref/sink_ref_test.rs
@@ -211,10 +211,7 @@ fn actor_backed_sink_ref_on_error_sends_failure_and_records_send_errors() {
 
   let endpoint_actor = StageActor::new(
     &system,
-    Box::new(ActorBackedSinkRefReceive::new(
-      ActorBackedSinkRefStateShared::new(),
-      String::from("missing"),
-    )),
+    Box::new(ActorBackedSinkRefReceive::new(ActorBackedSinkRefStateShared::new(), String::from("missing"))),
   );
   let mut release_failed = ActorBackedSinkRefLogic::<u32>::failed(StreamError::Failed);
   release_failed.endpoint_actor = Some(endpoint_actor);
@@ -389,8 +386,9 @@ fn actor_backed_sink_ref_receive_rejects_pid_forged_sender() {
   let pid_only_sender = ActorRef::new(target_pid, ActorRefSenderShared::new(Box::new(pid_sender)));
   let demand = NonZeroU64::new(1).expect("demand");
 
-  let ack_error =
-    receive.receive(StageActorEnvelope::new(pid_only_sender.clone(), AnyMessage::new(StreamRefAck))).expect_err("ack rejected");
+  let ack_error = receive
+    .receive(StageActorEnvelope::new(pid_only_sender.clone(), AnyMessage::new(StreamRefAck)))
+    .expect_err("ack rejected");
   let demand_error = receive
     .receive(StageActorEnvelope::new(pid_only_sender, AnyMessage::new(StreamRefCumulativeDemand::new(0, demand))))
     .expect_err("pid forged demand rejected");

--- a/modules/stream-core-kernel/src/stream_ref/sink_ref_test.rs
+++ b/modules/stream-core-kernel/src/stream_ref/sink_ref_test.rs
@@ -214,7 +214,6 @@ fn actor_backed_sink_ref_on_error_sends_failure_and_records_send_errors() {
     Box::new(ActorBackedSinkRefReceive::new(
       ActorBackedSinkRefStateShared::new(),
       String::from("missing"),
-      Pid::new(0, 0),
     )),
   );
   let mut release_failed = ActorBackedSinkRefLogic::<u32>::failed(StreamError::Failed);
@@ -309,11 +308,7 @@ fn actor_backed_sink_ref_on_complete_reports_send_and_release_failures() {
   let system = build_system();
   let endpoint_actor = StageActor::new(
     &system,
-    Box::new(ActorBackedSinkRefReceive::new(
-      ActorBackedSinkRefStateShared::new(),
-      String::from("missing"),
-      Pid::new(0, 0),
-    )),
+    Box::new(ActorBackedSinkRefReceive::new(ActorBackedSinkRefStateShared::new(), String::from("missing"))),
   );
   let mut release_failed = ActorBackedSinkRefLogic::<u32>::failed(StreamError::Failed);
   release_failed.endpoint_actor = Some(endpoint_actor);
@@ -366,7 +361,7 @@ fn actor_backed_sink_ref_receive_accepts_partner_protocols() {
   let (target, _system_messages, _user_messages) = temp_recording_actor(&system);
   let sender_key = target.canonical_path().expect("canonical path").to_canonical_uri();
   let state = ActorBackedSinkRefStateShared::new();
-  let mut receive = ActorBackedSinkRefReceive::new(state.clone(), sender_key, target.pid());
+  let mut receive = ActorBackedSinkRefReceive::new(state.clone(), sender_key);
   let demand = NonZeroU64::new(2).expect("demand");
 
   receive.receive(StageActorEnvelope::new(target.clone(), AnyMessage::new(StreamRefAck))).expect("ack accepted");
@@ -383,25 +378,26 @@ fn actor_backed_sink_ref_receive_accepts_partner_protocols() {
 }
 
 #[test]
-fn actor_backed_sink_ref_receive_accepts_pid_fallback_sender() {
+fn actor_backed_sink_ref_receive_rejects_pid_forged_sender() {
   let system = build_system();
   let (target, _system_messages, _user_messages) = temp_recording_actor(&system);
   let sender_key = target.canonical_path().expect("canonical path").to_canonical_uri();
   let target_pid = target.pid();
   let state = ActorBackedSinkRefStateShared::new();
-  let mut receive = ActorBackedSinkRefReceive::new(state.clone(), sender_key, target_pid);
+  let mut receive = ActorBackedSinkRefReceive::new(state.clone(), sender_key);
   let (_pid_system_messages, _pid_user_messages, pid_sender) = RecordingSender::new();
   let pid_only_sender = ActorRef::new(target_pid, ActorRefSenderShared::new(Box::new(pid_sender)));
   let demand = NonZeroU64::new(1).expect("demand");
 
-  receive
-    .receive(StageActorEnvelope::new(pid_only_sender.clone(), AnyMessage::new(StreamRefAck)))
-    .expect("ack accepted");
-  receive
+  let ack_error =
+    receive.receive(StageActorEnvelope::new(pid_only_sender.clone(), AnyMessage::new(StreamRefAck))).expect_err("ack rejected");
+  let demand_error = receive
     .receive(StageActorEnvelope::new(pid_only_sender, AnyMessage::new(StreamRefCumulativeDemand::new(0, demand))))
-    .expect("pid fallback demand accepted");
+    .expect_err("pid forged demand rejected");
 
-  assert!(state.can_accept_input());
+  assert!(matches!(ack_error, StreamError::InvalidPartnerActor { .. }));
+  assert!(matches!(demand_error, StreamError::InvalidPartnerActor { .. }));
+  assert!(!state.can_accept_input());
 }
 
 #[test]
@@ -410,7 +406,7 @@ fn actor_backed_sink_ref_receive_rejects_invalid_sender_unknown_message_and_deat
   let (target, _target_system_messages, _target_user_messages) = temp_recording_actor(&system);
   let (other, _other_system_messages, _other_user_messages) = temp_recording_actor(&system);
   let sender_key = target.canonical_path().expect("canonical path").to_canonical_uri();
-  let mut receive = ActorBackedSinkRefReceive::new(ActorBackedSinkRefStateShared::new(), sender_key, target.pid());
+  let mut receive = ActorBackedSinkRefReceive::new(ActorBackedSinkRefStateShared::new(), sender_key);
 
   let invalid_sender_error =
     receive.receive(StageActorEnvelope::new(other, AnyMessage::new(StreamRefAck))).expect_err("invalid sender");
@@ -431,7 +427,7 @@ fn actor_backed_sink_ref_receive_ignores_deathwatch_after_terminal_failure() {
   let (target, _system_messages, _user_messages) = temp_recording_actor(&system);
   let sender_key = target.canonical_path().expect("canonical path").to_canonical_uri();
   let state = ActorBackedSinkRefStateShared::new();
-  let mut receive = ActorBackedSinkRefReceive::new(state.clone(), sender_key, target.pid());
+  let mut receive = ActorBackedSinkRefReceive::new(state.clone(), sender_key);
 
   state.fail(StreamError::Failed);
 


### PR DESCRIPTION
### Motivation
- Restore strict partner authentication for SinkRef control messages to prevent forged PID-only senders from altering stream control state.
- The prior change accepted senders on PID equality, which is forgeable via public `ActorRef::new` and `AnyMessage::with_sender` APIs and thus widened the attacker surface.
- The intent is to preserve existing behavior for legitimate partners while removing the PID-only fallback that enabled spoofing.

### Description
- Reverted `ActorBackedSinkRefReceive::ensure_sender` to accept only canonical actor label equality and removed the PID-based acceptance branch.
- Removed the stored `target_actor_pid` field and simplified `ActorBackedSinkRefReceive::new` and all call sites accordingly, including endpoint wiring in `attach_actor_system`.
- Updated unit tests in `sink_ref_test.rs` to replace the PID-fallback acceptance test with a test that verifies a forged PID-only sender is rejected, and adjusted constructor usages.

### Testing
- Ran `cargo test -p fraktor-stream-core-kernel-rs actor_backed_sink_ref_receive_rejects_pid_forged_sender -- --nocapture`, which compiled and passed the targeted test.
- The modified crate built successfully during the test run and the updated unit test confirmed rejection of PID-forged senders (passes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc5424a80832dab351d0d6502e32e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes stream-ref control-plane authentication/validation; legitimate peers that relied on PID-only identity (e.g., missing canonical path) may now be rejected and stall demand/ack handling.
> 
> **Overview**
> Restores **strict partner validation** for actor-backed `SinkRef` control messages by requiring canonical actor label equality and removing the PID-equality fallback in `ActorBackedSinkRefReceive::ensure_sender`.
> 
> Simplifies endpoint receiver wiring by dropping stored `target_actor_pid` from `ActorBackedSinkRefReceive` and updating construction call sites (including `attach_actor_system`). Updates tests to assert that a forged PID-only sender is rejected and does not advance subscription/demand state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826cc109624da5efc4e94589dc5f6ec39cb438bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 送信者検証を PID フォールバックから正準パス（canonical path）ベースに移行し、受信時の認証を厳格化しました。

* **Tests**
  * テスト群を更新し、正準パス一致のみを許容する新しい検証基準を確認。なりすまし送信者の拒否を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1818?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->