### PR TITLE
fix(remote): ignore inbound tables when compression is disabled

### DIFF
--- a/modules/remote-adaptor-std/src/transport/tcp/compression_test.rs
+++ b/modules/remote-adaptor-std/src/transport/tcp/compression_test.rs
@@ -95,13 +95,10 @@ fn inbound_advertisement_updates_table_and_replies_with_ack() {
     } if authority == "local@host:2"
   ));
 
-  let action =
-    tables.handle_inbound_frame(envelope_frame(CompressedText::table_ref(3), None, None), "local@host:2").unwrap();
+  let err =
+    tables.handle_inbound_frame(envelope_frame(CompressedText::table_ref(3), None, None), "local@host:2").unwrap_err();
 
-  assert!(matches!(
-    action,
-    InboundCompressionAction::Forward(WireFrame::Envelope(pdu)) if pdu.recipient_path() == "/user/a"
-  ));
+  assert_eq!(err, WireError::InvalidFormat);
 }
 
 #[test]
@@ -207,7 +204,7 @@ fn unknown_inbound_reference_is_rejected() {
 }
 
 #[test]
-fn disabled_config_keeps_local_outbound_literals_but_accepts_peer_advertisements() {
+fn disabled_config_acks_peer_advertisements_but_rejects_table_refs() {
   let config = RemoteCompressionConfig::new().with_actor_ref_max(None).with_manifest_max(max(1));
   let mut tables = TcpCompressionTables::new(config);
 
@@ -232,13 +229,10 @@ fn disabled_config_keeps_local_outbound_literals_but_accepts_peer_advertisements
     } if authority == "local@host:2"
   ));
 
-  let action =
-    tables.handle_inbound_frame(envelope_frame(CompressedText::table_ref(3), None, None), "local@host:2").unwrap();
+  let err =
+    tables.handle_inbound_frame(envelope_frame(CompressedText::table_ref(3), None, None), "local@host:2").unwrap_err();
 
-  assert!(matches!(
-    action,
-    InboundCompressionAction::Forward(WireFrame::Envelope(pdu)) if pdu.recipient_path() == "/user/a"
-  ));
+  assert_eq!(err, WireError::InvalidFormat);
 }
 
 #[test]

--- a/modules/remote-adaptor-std/src/transport/tcp/compression_test.rs
+++ b/modules/remote-adaptor-std/src/transport/tcp/compression_test.rs
@@ -95,10 +95,13 @@ fn inbound_advertisement_updates_table_and_replies_with_ack() {
     } if authority == "local@host:2"
   ));
 
-  let err =
-    tables.handle_inbound_frame(envelope_frame(CompressedText::table_ref(3), None, None), "local@host:2").unwrap_err();
+  let action =
+    tables.handle_inbound_frame(envelope_frame(CompressedText::table_ref(3), None, None), "local@host:2").unwrap();
 
-  assert_eq!(err, WireError::InvalidFormat);
+  assert!(matches!(
+    action,
+    InboundCompressionAction::Forward(WireFrame::Envelope(pdu)) if pdu.recipient_path() == "/user/a"
+  ));
 }
 
 #[test]

--- a/modules/remote-core/src/wire/compression_table.rs
+++ b/modules/remote-core/src/wire/compression_table.rs
@@ -189,7 +189,12 @@ impl CompressionTable {
   /// Returns [`WireError::InvalidFormat`] when the advertisement exceeds the configured max or
   /// contains duplicate entry ids.
   pub fn apply_advertisement(&mut self, generation: u64, entries: &[CompressionTableEntry]) -> Result<(), WireError> {
-    if self.max.is_some_and(|max| entries.len() > max.get()) {
+    let Some(max) = self.max else {
+      self.entries.clear();
+      self.latest_pending_generation = None;
+      return Ok(());
+    };
+    if entries.len() > max.get() {
       return Err(WireError::InvalidFormat);
     }
     if has_duplicate_entry_id(entries) {
@@ -205,6 +210,9 @@ impl CompressionTable {
   /// Resolves an inbound table reference id to a literal value.
   #[must_use]
   pub fn resolve(&self, entry_id: u32) -> Option<&str> {
+    if !self.is_enabled() {
+      return None;
+    }
     self.entries.iter().find(|entry| entry.id == entry_id).map(|entry| entry.literal.as_str())
   }
 }

--- a/modules/remote-core/src/wire/compression_table_test.rs
+++ b/modules/remote-core/src/wire/compression_table_test.rs
@@ -60,7 +60,7 @@ fn disabled_table_does_not_track_hits_or_advertise() {
 }
 
 #[test]
-fn disabled_table_still_applies_inbound_advertisements() {
+fn disabled_table_ignores_inbound_advertisements() {
   let mut table = CompressionTable::new(None);
   let entries = [CompressionTableEntry::new(9, "/user/a".to_string())];
 
@@ -68,7 +68,7 @@ fn disabled_table_still_applies_inbound_advertisements() {
 
   assert!(table.create_advertisement(CompressionTableKind::ActorRef).is_none());
   assert_eq!(table.encode("/user/a").as_literal(), Some("/user/a"));
-  assert_eq!(table.resolve(9), Some("/user/a"));
+  assert_eq!(table.resolve(9), None);
 }
 
 #[test]
@@ -157,7 +157,7 @@ fn inbound_advertisement_resolves_entry_ids() {
 
   assert_eq!(table.apply_advertisement(7, &entries), Ok(()));
 
-  assert_eq!(table.resolve(9), Some("/user/a"));
+  assert_eq!(table.resolve(9), None);
   assert_eq!(table.resolve(10), None);
 }
 

--- a/modules/remote-core/src/wire/compression_table_test.rs
+++ b/modules/remote-core/src/wire/compression_table_test.rs
@@ -157,7 +157,7 @@ fn inbound_advertisement_resolves_entry_ids() {
 
   assert_eq!(table.apply_advertisement(7, &entries), Ok(()));
 
-  assert_eq!(table.resolve(9), None);
+  assert_eq!(table.resolve(9), Some("/user/a"));
   assert_eq!(table.resolve(10), None);
 }
 


### PR DESCRIPTION
### Motivation
- A recent change caused inbound compression advertisements to be parsed, duplicate-scanned, and stored even when the local compression kind was configured as disabled, exposing a network-facing resource-exhaustion risk. 
- The intent is to preserve protocol liveness (still ACK advertisements) while preventing disabled kinds from accepting or resolving peer-provided table entries.

### Description
- In `CompressionTable::apply_advertisement` short-circuit when `max == None` to avoid parsing/storing inbound entries and to clear any transient state instead of performing duplicate scans. 
- In `CompressionTable::resolve` return `None` when the table is disabled so inbound table refs cannot be resolved for disabled kinds. 
- Updated unit tests in `modules/remote-core/src/wire/compression_table_test.rs` to assert that disabled tables ignore inbound advertisements. 
- Updated TCP adapter tests in `modules/remote-adaptor-std/src/transport/tcp/compression_test.rs` to preserve ACK behavior for liveness while asserting that subsequent table refs are rejected when the local kind is disabled.

### Testing
- Ran `cargo test -p fraktor-remote-core-rs disabled_table_ignores_inbound_advertisements` and it passed. 
- Ran `cargo test -p fraktor-remote-adaptor-std-rs disabled_config_acks_peer_advertisements_but_rejects_table_refs` and it passed. 
- Executed the affected package test runs for the changeset to verify the modified `compression_table` and TCP adapter tests complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc5437d44832da55583143aeedb01)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes network wire compression behavior when a table kind is disabled: advertisements are ACKed but ignored, and inbound `table_ref` lookups now fail, which could surface as new `InvalidFormat` errors for misconfigured peers.
> 
> **Overview**
> Prevents resource usage and accidental decoding when compression is configured as disabled by **ignoring inbound compression advertisements** (`CompressionTable::apply_advertisement` now short-circuits when `max == None`, clearing state and skipping bounds/duplicate checks).
> 
> Inbound `table_ref` resolution is also disabled (`CompressionTable::resolve` returns `None` when disabled), causing the TCP adapter to continue ACKing peer advertisements for liveness but **reject subsequent compressed envelope metadata**; unit tests were updated to assert this behavior in both `remote-core` and the TCP transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbec1ebb17506d5402d062b5faca694efd15fa6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->