### PR TITLE
fix(remote-core): prevent panic on truncated compression entries

### DIFF
--- a/modules/remote-core/src/wire/control_codec.rs
+++ b/modules/remote-core/src/wire/control_codec.rs
@@ -217,12 +217,14 @@ fn compression_entry_count(entries_len: usize) -> Result<u32, WireError> {
 }
 
 fn decode_compression_entries(buf: &mut Bytes) -> Result<Vec<CompressionTableEntry>, WireError> {
+  ensure_remaining(buf, 4)?;
   let entry_count = buf.get_u32() as usize;
   if entry_count > buf.remaining() / MIN_COMPRESSION_ENTRY_BYTES {
     return Err(WireError::Truncated);
   }
   let mut entries = Vec::with_capacity(entry_count);
   for _ in 0..entry_count {
+    ensure_remaining(buf, 4)?;
     let id = buf.get_u32();
     let literal = decode_string(buf)?;
     entries.push(CompressionTableEntry::new(id, literal));

--- a/modules/remote-core/src/wire/control_codec_test.rs
+++ b/modules/remote-core/src/wire/control_codec_test.rs
@@ -1,4 +1,6 @@
-use super::compression_entry_count;
+use bytes::Bytes;
+
+use super::{compression_entry_count, decode_compression_entries};
 use crate::wire::WireError;
 
 #[test]
@@ -6,4 +8,18 @@ fn compression_entry_count_rejects_lengths_over_u32_max() {
   let err = compression_entry_count(u32::MAX as usize + 1).unwrap_err();
 
   assert_eq!(err, WireError::InvalidFormat);
+}
+
+#[test]
+fn decode_compression_entries_returns_truncated_when_later_entry_id_is_missing() {
+  let mut buf = Bytes::from_static(&[
+    0x00, 0x00, 0x00, 0x02, // entry_count = 2
+    0x00, 0x00, 0x00, 0x01, // first entry id
+    0x00, 0x00, 0x00, 0x08, // first entry literal length = 8
+    b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h',
+  ]);
+
+  let err = decode_compression_entries(&mut buf).unwrap_err();
+
+  assert_eq!(err, WireError::Truncated);
 }


### PR DESCRIPTION
### Motivation
- A malformed `CompressionAdvertisement` could cause `Bytes::get_u32()` to panic when a variable-length literal in an earlier entry consumed bytes needed for later entries. This exposed a remote DoS/availability risk. 

### Description
- Added an explicit `ensure_remaining(buf, 4)?` before reading the `entry_count` in `decode_compression_entries` to validate the count field is present. 
- Restored a per-entry `ensure_remaining(buf, 4)?` before reading each entry `id` so truncated/malformed advertisements return `WireError::Truncated` instead of panicking. 
- Added a regression test `decode_compression_entries_returns_truncated_when_later_entry_id_is_missing` in `modules/remote-core/src/wire/control_codec_test.rs` that models the 2-entry malformed advertisement and asserts the decoder returns `WireError::Truncated`.
- Changes are limited to `modules/remote-core/src/wire/control_codec.rs` and its tests to keep the fix minimal and surgical.

### Testing
- Ran `cargo test -p fraktor-remote-core-rs control_codec` and the focused unit tests passed. 
- The repository-level CI check `./scripts/ci-check.sh ai fmt dylint clippy` invoked by the environment hook failed due to the pinned `nightly-2025-12-01` toolchain requiring `rustup`, which is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bc54277c0832d91a1f19f91fe3f4f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wire decoding of `CompressionAdvertisement`; malformed/truncated input now returns `WireError::Truncated` instead of potentially panicking, but changes are small and localized to bounds checks and a regression test.
> 
> **Overview**
> Hardens `decode_compression_entries` against truncated `CompressionAdvertisement` payloads by adding explicit `ensure_remaining(buf, 4)` checks before reading the `entry_count` and each per-entry `id`, returning `WireError::Truncated` rather than panicking on `Bytes::get_u32()`.
> 
> Adds a regression unit test that constructs a malformed 2-entry buffer missing the second entry’s `id` and asserts the decoder reports `Truncated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3478c2f77eab2dee06c2dd059b4e7158fc3b448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->