### PR TITLE
fix(remote-adaptor-std): avoid Tokio runtime panic in StdFlushGate deferred retry path

### DIFF
--- a/modules/remote-adaptor-std/src/extension_installer/flush_gate.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/flush_gate.rs
@@ -259,9 +259,9 @@ impl StdFlushGate {
     }
     let (retry_sender, mut retry_receiver) = mpsc::channel(RETRY_QUEUE_CAPACITY);
     let sender = event_sender.clone();
-    let _retry_task = tokio::spawn(async move {
-      while let Some(event) = retry_receiver.recv().await {
-        if sender.send(event).await.is_err() {
+    let _retry_task = std::thread::spawn(move || {
+      while let Some(event) = retry_receiver.blocking_recv() {
+        if sender.blocking_send(event).is_err() {
           tracing::warn!("remote watch notification event queue is closed");
           break;
         }

--- a/modules/remote-adaptor-std/src/extension_installer/flush_gate.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/flush_gate.rs
@@ -6,6 +6,7 @@ mod tests;
 
 use std::{
   sync::{Arc, Mutex},
+  thread::Builder,
   time::{Duration, Instant},
 };
 
@@ -259,14 +260,17 @@ impl StdFlushGate {
     }
     let (retry_sender, mut retry_receiver) = mpsc::channel(RETRY_QUEUE_CAPACITY);
     let sender = event_sender.clone();
-    let _retry_task = std::thread::spawn(move || {
-      while let Some(event) = retry_receiver.blocking_recv() {
-        if sender.blocking_send(event).is_err() {
-          tracing::warn!("remote watch notification event queue is closed");
-          break;
+    let _retry_task = Builder::new()
+      .name("flush_gate-retry".into())
+      .spawn(move || {
+        while let Some(event) = retry_receiver.blocking_recv() {
+          if sender.blocking_send(event).is_err() {
+            tracing::warn!("remote watch notification event queue is closed");
+            break;
+          }
         }
-      }
-    });
+      })
+      .expect("flush gate retry thread should start");
     state.retry_sender = Some(retry_sender.clone());
     retry_sender
   }

--- a/modules/remote-adaptor-std/src/extension_installer/flush_gate_test.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/flush_gate_test.rs
@@ -15,7 +15,10 @@ use fraktor_remote_core_rs::{
   transport::TransportEndpoint,
   wire::FlushScope,
 };
-use tokio::sync::mpsc::{self, Receiver};
+use tokio::{
+  sync::mpsc::{self, Receiver},
+  time::sleep,
+};
 
 use super::*;
 
@@ -291,19 +294,23 @@ async fn deferred_notification_retry_worker_observes_closed_event_queue() {
 
   gate.defer_outbound_event(&event_tx, test_outbound_event(authority.clone(), 42));
   drop(event_rx);
-  for _ in 0..10 {
-    let retry_closed = gate
-      .inner
-      .lock()
-      .expect(FLUSH_GATE_LOCK_POISONED)
-      .retry_sender
-      .as_ref()
-      .is_some_and(|retry_sender| retry_sender.is_closed());
-    if retry_closed {
-      break;
+  tokio::time::timeout(Duration::from_millis(100), async {
+    loop {
+      let retry_closed = gate
+        .inner
+        .lock()
+        .expect(FLUSH_GATE_LOCK_POISONED)
+        .retry_sender
+        .as_ref()
+        .is_some_and(|retry_sender| retry_sender.is_closed());
+      if retry_closed {
+        break;
+      }
+      sleep(Duration::from_millis(1)).await;
     }
-    tokio::task::yield_now().await;
-  }
+  })
+  .await
+  .expect("retry worker should observe closed event queue");
 
   assert!(
     gate

--- a/modules/remote-adaptor-std/src/extension_installer/flush_gate_test.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/flush_gate_test.rs
@@ -274,7 +274,13 @@ async fn deferred_notification_retry_queue_is_bounded() {
 
   let retry_sender = gate.retry_sender_for(&event_tx);
   retry_sender.try_send(test_outbound_event(authority.clone(), 41)).expect("retry queue should accept first event");
-  tokio::task::yield_now().await;
+  tokio::time::timeout(Duration::from_millis(100), async {
+    while retry_sender.capacity() != RETRY_QUEUE_CAPACITY {
+      sleep(Duration::from_millis(1)).await;
+    }
+  })
+  .await
+  .expect("retry worker should consume the first retry event");
   for index in 0..RETRY_QUEUE_CAPACITY {
     retry_sender
       .try_send(test_outbound_event(authority.clone(), index as u64))


### PR DESCRIPTION
### Motivation
- The deferred retry path in `StdFlushGate` used `tokio::spawn` from a synchronous call chain, which can panic when no Tokio runtime is entered and the bounded event queue is full. 
- The `TrySendError::Full` path is reachable under queue pressure, so this could cause a denial-of-service crash from non-Tokio threads handling remote-bound notifications. 

### Description
- Replace `tokio::spawn` with `std::thread::spawn` inside `StdFlushGate::retry_sender_for` to avoid requiring an entered Tokio runtime. 
- Switch the retry loop to use `blocking_recv` on the retry receiver and `blocking_send` on the event sender so the background thread can synchronously forward events. 
- Keep the retry queue semantics and capacity unchanged and limit the change to `modules/remote-adaptor-std/src/extension_installer/flush_gate.rs` to be minimal and surgical. 

### Testing
- Ran `cargo test -p fraktor-remote-adaptor-std-rs immediate_notification_full_event_queue_defers_delivery -- --nocapture`, which passed. 
- Ran the PoC regression test `cargo test -p fraktor-remote-adaptor-std-rs poc_immediate_notification_full_event_queue_panics_without_tokio_runtime -- --nocapture`, which now passes and no longer panics when executed outside a Tokio runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfa8a0d9c832d9b2894aa6c21c96b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the deferred retry path from a Tokio task to a dedicated std thread with blocking channel ops, which alters concurrency behavior and could impact shutdown/blocking characteristics under load. Scope is small and covered by targeted tests updated for the new timing model.
> 
> **Overview**
> Prevents deferred outbound notification retries from panicking when called outside an entered Tokio runtime by replacing the `tokio::spawn` retry worker with a named `std::thread` and switching to `blocking_recv`/`blocking_send` in `StdFlushGate::retry_sender_for`.
> 
> Updates retry-related tests to wait deterministically (via `timeout` + short `sleep` polling) for the background worker to consume events and to observe the event queue closing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1398266249a747e43599bd9efdd4e5d0106858ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * リトライキューのエラーハンドリング処理を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->