### PR TITLE
fix(actor-core): restore blocking shared lock backends for actor and invoker

### DIFF
--- a/modules/actor-core-kernel/src/actor/actor_shared.rs
+++ b/modules/actor-core-kernel/src/actor/actor_shared.rs
@@ -2,7 +2,7 @@
 
 use alloc::boxed::Box;
 
-use fraktor_utils_core_rs::sync::{ArcShared, ExclusiveCell, SharedAccess};
+use fraktor_utils_core_rs::sync::{DefaultMutex, SharedAccess, SharedLock};
 
 use super::actor_lifecycle::Actor;
 
@@ -13,14 +13,14 @@ use super::actor_lifecycle::Actor;
 /// access from multiple owners.
 #[derive(Clone)]
 pub struct ActorShared {
-  inner: ArcShared<ExclusiveCell<Box<dyn Actor + Send>>>,
+  inner: SharedLock<Box<dyn Actor + Send>>,
 }
 
 impl ActorShared {
-  /// Creates a new shared wrapper using a CAS-backed exclusive cell.
+  /// Creates a new shared wrapper around the provided actor.
   #[must_use]
   pub fn new(actor: Box<dyn Actor + Send>) -> Self {
-    Self { inner: ArcShared::new(ExclusiveCell::new(actor)) }
+    Self { inner: SharedLock::new_with_driver::<DefaultMutex<_>>(actor) }
   }
 }
 

--- a/modules/actor-core-kernel/src/actor/messaging/message_invoker/invoker_shared.rs
+++ b/modules/actor-core-kernel/src/actor/messaging/message_invoker/invoker_shared.rs
@@ -2,7 +2,7 @@
 
 use alloc::boxed::Box;
 
-use fraktor_utils_core_rs::sync::{ArcShared, ExclusiveCell, SharedAccess};
+use fraktor_utils_core_rs::sync::{DefaultRwLock, SharedAccess, SharedRwLock};
 
 use super::invoker_trait::MessageInvoker;
 
@@ -13,14 +13,14 @@ use super::invoker_trait::MessageInvoker;
 /// access from multiple owners.
 #[derive(Clone)]
 pub struct MessageInvokerShared {
-  inner: ArcShared<ExclusiveCell<Box<dyn MessageInvoker>>>,
+  inner: SharedRwLock<Box<dyn MessageInvoker>>,
 }
 
 impl MessageInvokerShared {
-  /// Creates a new CAS-backed shared wrapper around the provided invoker.
+  /// Creates a shared wrapper around the provided invoker.
   #[must_use]
   pub fn new(invoker: Box<dyn MessageInvoker>) -> Self {
-    Self { inner: ArcShared::new(ExclusiveCell::new(invoker)) }
+    Self { inner: SharedRwLock::new_with_driver::<DefaultRwLock<_>>(invoker) }
   }
 }
 


### PR DESCRIPTION
### Motivation
- A CAS-backed `ExclusiveCell` was being used unconditionally for actor and invoker sharing, which busy-spins on contention and can cause CPU exhaustion when user code holds the lock for long-running operations.
- Restore configurable blocking lock backends so `std-locks` deployments use blocking `std::sync` locks and avoid tight-spin availability risks.

### Description
- Replace `ActorShared` internal storage from `ArcShared<ExclusiveCell<Box<dyn Actor + Send>>>` to `SharedLock<Box<dyn Actor + Send>>` and construct it with `SharedLock::new_with_driver::<DefaultMutex<_>>(...)` in `modules/actor-core-kernel/src/actor/actor_shared.rs`.
- Replace `MessageInvokerShared` internal storage from `ArcShared<ExclusiveCell<Box<dyn MessageInvoker>>>` to `SharedRwLock<Box<dyn MessageInvoker>>` and construct it with `SharedRwLock::new_with_driver::<DefaultRwLock<_>>(...)` in `modules/actor-core-kernel/src/actor/messaging/message_invoker/invoker_shared.rs`.
- The change is narrowly scoped to these two wrappers so feature-driven selection of synchronization backends (e.g., `std-locks`) is preserved.

### Testing
- Ran `cargo test -p fraktor-actor-core-kernel-rs actor_shared --quiet` which completed successfully (tests filtered but command returned OK).
- Ran `cargo test -p fraktor-actor-core-kernel-rs message_invoker_shared --quiet` which completed successfully (tests filtered but command returned OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbf346354832d981e82034d6f3489)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the synchronization primitives used to guard actor and message-invoker state; incorrect lock semantics or driver selection could impact concurrency, fairness, or performance under contention.
> 
> **Overview**
> Restores blocking, configurable synchronization for shared actor and message-invoker wrappers by replacing the CAS/busy-spin `ArcShared<ExclusiveCell<...>>` storage with `SharedLock`/`SharedRwLock` constructed via `new_with_driver::<DefaultMutex/_>` and `new_with_driver::<DefaultRwLock/_>`.
> 
> This keeps the external `SharedAccess` (`with_read`/`with_write`) API intact while avoiding CPU spin under contention (notably for long-running user code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8599613ef020700ad1476cb68c653ed67ecac9c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->