### PR TITLE
Codex-generated pull request

### DIFF
--- a/modules/actor-core-typed/src/delivery/consumer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/consumer_controller.rs
@@ -71,6 +71,10 @@ where
     let window = u64::from(self.settings.flow_control_window());
     remaining <= window / 2
   }
+
+  const fn is_within_requested_window(&self, seq_nr: SeqNr) -> bool {
+    seq_nr <= self.requested_seq_nr
+  }
 }
 
 /// Factory for creating a `ConsumerController` behavior.
@@ -196,7 +200,8 @@ fn collect_on_sequenced_message<A>(
   deferred: &mut Vec<DeferredAction<A>>,
 ) where
   A: Clone + Send + Sync + 'static, {
-  if seq_msg.first() {
+  let is_first = seq_msg.first();
+  if is_first {
     state.producer_controller = Some(TypedActorRef::<ProducerControllerCommand<A>>::from_untyped(
       seq_msg.producer_controller().as_untyped().clone(),
     ));
@@ -214,6 +219,15 @@ fn collect_on_sequenced_message<A>(
     return;
   }
 
+  if !is_first && !state.is_within_requested_window(seq_nr) {
+    if !state.settings.only_flow_control()
+      && let Some(pc) = state.producer_controller.clone()
+    {
+      deferred.push(DeferredAction::SendToProducer(pc, ProducerControllerCommand::resend(state.received_seq_nr + 1)));
+    }
+    return;
+  }
+
   if state.is_next_expected(seq_nr) {
     state.received_seq_nr = seq_nr;
     if state.deliver_to.is_some() && !state.waiting_for_confirm {
@@ -228,7 +242,9 @@ fn collect_on_sequenced_message<A>(
     // ギャップ検出: 到着メッセージをスタッシュしてリセンドを要求する。
     // Pekko と同様に、既に受信したメッセージを破棄せず保持し、
     // ギャップが埋まった後に順序通り配信する。
-    state.stashed.push(seq_msg);
+    if !state.stashed.iter().any(|stashed| stashed.seq_nr() == seq_nr) {
+      state.stashed.push(seq_msg);
+    }
     if !state.settings.only_flow_control()
       && let Some(pc) = state.producer_controller.clone()
     {

--- a/modules/actor-core-typed/src/delivery/consumer_controller_test.rs
+++ b/modules/actor-core-typed/src/delivery/consumer_controller_test.rs
@@ -1,6 +1,30 @@
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 
-use crate::delivery::{ConsumerController, ConsumerControllerCommand};
+use fraktor_actor_core_kernel_rs::actor::{Pid, actor_ref::NullSender};
+
+use super::{ConsumerController, ConsumerControllerState, collect_on_sequenced_message};
+use crate::{
+  TypedActorRef,
+  delivery::{
+    ConsumerControllerCommand, ConsumerControllerConfig, ConsumerControllerConfirmed, ProducerControllerCommand, SeqNr,
+    SequencedMessage,
+  },
+};
+
+fn make_typed_ref<M: Send + Sync + 'static>() -> TypedActorRef<M> {
+  TypedActorRef::from_untyped(crate::test_support::actor_ref_with_sender(Pid::new(1, 0), NullSender))
+}
+
+fn make_sequenced_message(seq_nr: SeqNr) -> SequencedMessage<u32> {
+  SequencedMessage::new(
+    String::from("test-producer"),
+    seq_nr,
+    seq_nr as u32,
+    false,
+    false,
+    make_typed_ref::<ProducerControllerCommand<u32>>(),
+  )
+}
 
 #[test]
 fn consumer_controller_factory_methods_compile() {
@@ -9,4 +33,42 @@ fn consumer_controller_factory_methods_compile() {
 
   // 具体的な型でビヘイビアファクトリがコンパイルできることを確認する。
   let _behavior = ConsumerController::behavior::<u32>();
+}
+
+#[test]
+fn requested_window_accepts_messages_even_when_confirmation_lags() {
+  let settings = ConsumerControllerConfig::new().with_flow_control_window(3);
+  let mut state = ConsumerControllerState::<u32>::new(settings);
+  state.confirmed_seq_nr = 10;
+  state.received_seq_nr = 12;
+  state.requested_seq_nr = 15;
+  state.producer_controller = Some(make_typed_ref::<ProducerControllerCommand<u32>>());
+
+  let self_ref = make_typed_ref::<ConsumerControllerCommand<u32>>();
+  let confirm_adapter = make_typed_ref::<ConsumerControllerConfirmed>();
+  let mut deferred = Vec::new();
+
+  collect_on_sequenced_message(&mut state, make_sequenced_message(15), &self_ref, &confirm_adapter, &mut deferred);
+
+  assert_eq!(state.stashed.len(), 1);
+  assert_eq!(state.stashed[0].seq_nr(), 15);
+}
+
+#[test]
+fn requested_window_rejects_messages_above_requested_sequence() {
+  let settings = ConsumerControllerConfig::new().with_flow_control_window(3);
+  let mut state = ConsumerControllerState::<u32>::new(settings);
+  state.confirmed_seq_nr = 10;
+  state.received_seq_nr = 12;
+  state.requested_seq_nr = 15;
+  state.producer_controller = Some(make_typed_ref::<ProducerControllerCommand<u32>>());
+
+  let self_ref = make_typed_ref::<ConsumerControllerCommand<u32>>();
+  let confirm_adapter = make_typed_ref::<ConsumerControllerConfirmed>();
+  let mut deferred = Vec::new();
+
+  collect_on_sequenced_message(&mut state, make_sequenced_message(16), &self_ref, &confirm_adapter, &mut deferred);
+
+  assert!(state.stashed.is_empty());
+  assert_eq!(state.received_seq_nr, 12);
 }


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b9038e80bc832db05b1fb4b488edfb)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reliable-delivery sequencing/flow-control logic, which can affect message loss/duplication behavior under out-of-order or bursty traffic. Added tests reduce risk but edge cases may still exist around resend/first-message handling.
> 
> **Overview**
> **Consumer-side flow control is now enforced more strictly.** `ConsumerController` ignores non-first `SequencedMessage`s with a sequence number above `requested_seq_nr` (optionally triggering a `resend` request), preventing acceptance of messages outside the requested window.
> 
> **Gap handling is made more robust.** When detecting sequence gaps, the controller now deduplicates `stashed` messages by `seq_nr` to avoid storing the same out-of-order message multiple times.
> 
> Adds unit tests covering acceptance of messages at the top of the requested window even when confirmations lag, and rejection of messages beyond the requested sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2adcb76c93444b1312ef9ed0bdfa83bf1dac6d6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->