### PR TITLE
fix(streams): map_async の pending キュー肥大化を防止

### DIFF
--- a/modules/stream-core-kernel/src/dsl/flow_test.rs
+++ b/modules/stream-core-kernel/src/dsl/flow_test.rs
@@ -1522,6 +1522,27 @@ fn map_async_logic_keeps_order_and_tracks_pending_output() {
 }
 
 #[test]
+fn map_async_logic_does_not_accept_input_when_completed_entries_are_queued() {
+  let mut logic = MapAsyncLogic::<u32, u32, _, MixedMapAsyncFuture<u32>> {
+    func:        |value: u32| {
+      if value == 0 { MixedMapAsyncFuture::Never } else { MixedMapAsyncFuture::Ready(Some(value.saturating_add(1))) }
+    },
+    parallelism: 2,
+    pending:     VecDeque::new(),
+    _pd:         PhantomData,
+  };
+
+  let _ = logic.apply(Box::new(0_u32)).expect("apply stalled");
+  let _ = logic.apply(Box::new(1_u32)).expect("apply ready");
+  assert!(!logic.can_accept_input());
+
+  let outputs = logic.drain_pending().expect("drain");
+  assert!(outputs.is_empty());
+  assert!(logic.has_pending_output());
+  assert!(!logic.can_accept_input());
+}
+
+#[test]
 fn conflate_with_seed_logic_defers_and_merges_pending_values() {
   let mut logic = ConflateWithSeedLogic::<u32, u32, _, _> {
     seed:         |value| value + 10,
@@ -1583,6 +1604,23 @@ impl<T: Unpin> Future for YieldThenOutputFuture<T> {
       Poll::Pending
     } else {
       Poll::Ready(this.value.take().expect("future value"))
+    }
+  }
+}
+
+enum MixedMapAsyncFuture<T> {
+  Never,
+  Ready(Option<T>),
+}
+
+impl<T: Unpin> Future for MixedMapAsyncFuture<T> {
+  type Output = T;
+
+  fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+    let this = self.get_mut();
+    match this {
+      | Self::Never => Poll::Pending,
+      | Self::Ready(value) => Poll::Ready(value.take().expect("future value")),
     }
   }
 }

--- a/modules/stream-core-kernel/src/impl/fusing/map_async_logic.rs
+++ b/modules/stream-core-kernel/src/impl/fusing/map_async_logic.rs
@@ -25,18 +25,6 @@ where
   Completed(Out),
 }
 
-impl<Out, Fut> MapAsyncEntry<Out, Fut>
-where
-  Fut: Future<Output = Out> + Send + 'static,
-{
-  const fn is_pending(&self) -> bool {
-    match self {
-      | Self::InFlight(_) => true,
-      | Self::Completed(_) => false,
-    }
-  }
-}
-
 impl<In, Out, F, Fut> FlowLogic for MapAsyncLogic<In, Out, F, Fut>
 where
   In: Send + Sync + 'static,
@@ -55,7 +43,7 @@ where
     if self.parallelism == 0 {
       return false;
     }
-    self.pending.iter().filter(|entry| entry.is_pending()).count() < self.parallelism
+    self.pending.len() < self.parallelism
   }
 
   fn drain_pending(&mut self) -> Result<Vec<DynValue>, StreamError> {


### PR DESCRIPTION
### Motivation
- `map_async` 実装は並列実行中の in-flight 件数のみをカウントしており、先頭の future が停滞すると後続の完了結果が前詰まりで溜まり `pending` が無限に増える可能性があったため、DoS に繋がる恐れがあった。
- 目的は最小かつ確実な修正で、`parallelism` を超えて入力を受け付けないようにして保護すること。

### Description
- `MapAsyncLogic::can_accept_input` の判定を「in-flight 件数を数える」方式から「`pending` キューの総長さ (`pending.len()`) を `parallelism` と比較する」方式に変更しました（`modules/streams/src/core/stage/flow/logic/map_async_logic.rs`）。
- 不要になった補助メソッド相当の `MapAsyncEntry::is_pending` 相当ロジックを削除してコードを簡素化しました。 
- 再発防止のための回帰テスト `map_async_logic_does_not_accept_input_when_completed_entries_are_queued` を追加し、テスト用の `MixedMapAsyncFuture` を導入しました（`modules/streams/src/core/stage/flow/tests.rs`）。

### Testing
- 単体テストを実行して対象テストは成功しました: `cargo test -p fraktor-streams-rs map_async_logic_does_not_accept_input_when_completed_entries_are_queued` — 成功（ok）。
- `./scripts/ci-check.sh dylint -m streams` は実行を試みましたが、環境依存で `rustc-dev` コンポーネントのダウンロードがトンネル接続エラーとなり実行不能でした（ネットワーク/環境要因）。
- `./scripts/ci-check.sh all` も同様に `rustc-dev` ダウンロード失敗により途中停止しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69afb04037fc832db187865404e8f10d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `map_async` backpressure behavior by rejecting new inputs when the internal `pending` queue (including completed-but-not-yet-drained entries) reaches `parallelism`, which could affect throughput/latency but is localized to this operator.
> 
> **Overview**
> **Fixes a potential unbounded growth/DoS vector in `map_async`.** `MapAsyncLogic::can_accept_input` now gates on total `pending.len()` rather than counting only in-flight futures, so completed-but-blocked entries also consume capacity and upstream is backpressured.
> 
> Adds a regression test (`map_async_logic_does_not_accept_input_when_completed_entries_are_queued`) with a mixed future (`MixedMapAsyncFuture`) to reproduce the “stalled head future + completed tail futures” scenario, and removes the now-unneeded `MapAsyncEntry::is_pending` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 178f7257b2abea47bc7bd9cfbd555049b0d673e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->