### PR TITLE
fix(actor): ActorContext::stash の既定容量を有界化

### DIFF
--- a/modules/actor-core-kernel/src/actor.rs
+++ b/modules/actor-core-kernel/src/actor.rs
@@ -45,7 +45,7 @@ pub use actor_cell::ActorCell;
 pub(crate) use actor_cell_state::ActorCellState;
 pub(crate) use actor_cell_state_shared::ActorCellStateShared;
 pub use actor_context::ActorContext;
-pub(crate) use actor_context::{STASH_OVERFLOW_REASON, STASH_REQUIRES_DEQUE_REASON};
+pub(crate) use actor_context::{DEFAULT_STASH_CAPACITY, STASH_OVERFLOW_REASON, STASH_REQUIRES_DEQUE_REASON};
 pub use actor_lifecycle::Actor;
 pub use actor_shared::ActorShared;
 pub use address::Address;

--- a/modules/actor-core-kernel/src/actor/actor_context.rs
+++ b/modules/actor-core-kernel/src/actor/actor_context.rs
@@ -26,6 +26,7 @@ use crate::{
 
 pub(crate) const STASH_OVERFLOW_REASON: &str = "stash buffer overflow";
 pub(crate) const STASH_REQUIRES_DEQUE_REASON: &str = "stash requires deque-capable mailbox";
+pub(crate) const DEFAULT_STASH_CAPACITY: usize = 1000;
 
 /// Provides contextual APIs while handling a message.
 pub struct ActorContext<'a> {
@@ -121,7 +122,7 @@ impl ActorContext<'_> {
   ///
   /// Returns an error when no current message is active or when the actor cell is unavailable.
   pub fn stash(&mut self) -> Result<(), ActorError> {
-    self.stash_with_limit(usize::MAX)
+    self.stash_with_limit(DEFAULT_STASH_CAPACITY)
   }
 
   /// Stashes the currently processed user message with an explicit stash limit.

--- a/modules/actor-core-kernel/src/actor/actor_context_test.rs
+++ b/modules/actor-core-kernel/src/actor/actor_context_test.rs
@@ -440,6 +440,26 @@ fn actor_context_stash_with_limit_detects_overflow() {
 }
 
 #[test]
+fn actor_context_stash_uses_default_capacity_limit() {
+  let system = ActorSystem::new_empty();
+  let pid = system.allocate_pid();
+  let props = Props::from_fn(|| ProbeActor::new(ArcShared::new(SpinSyncMutex::new(Vec::new())))).with_stash_mailbox();
+  let cell = register_cell(&system, pid, "self", &props);
+
+  let mut context = ActorContext::new(&system, pid);
+  for i in 0..1000_i32 {
+    context.set_current_message(Some(AnyMessage::new(i)));
+    context.stash().expect("stash within default limit");
+  }
+  context.set_current_message(Some(AnyMessage::new(1001_i32)));
+
+  let error = context.stash().expect_err("default stash limit overflow should fail");
+
+  assert!(ActorContext::is_stash_overflow_error(&error));
+  assert_eq!(cell.stashed_message_len(), 1000);
+}
+
+#[test]
 fn actor_context_stash_with_limit_requires_active_message() {
   let system = ActorSystem::new_empty();
   let pid = system.allocate_pid();

--- a/modules/actor-core-kernel/src/actor/supervision/backoff_supervisor_strategy.rs
+++ b/modules/actor-core-kernel/src/actor/supervision/backoff_supervisor_strategy.rs
@@ -3,13 +3,11 @@
 use core::time::Duration;
 
 use super::restart_limit::RestartLimit;
-use crate::event::logging::LogLevel;
+use crate::{actor::DEFAULT_STASH_CAPACITY, event::logging::LogLevel};
 
 #[cfg(test)]
 #[path = "backoff_supervisor_strategy_test.rs"]
 mod tests;
-
-const DEFAULT_STASH_CAPACITY: usize = 1000;
 
 /// Supervisor strategy providing exponential backoff for restart delays.
 ///

--- a/modules/actor-core-kernel/src/actor/supervision/base.rs
+++ b/modules/actor-core-kernel/src/actor/supervision/base.rs
@@ -12,7 +12,7 @@ use super::{
   supervisor_strategy_kind::SupervisorStrategyKind,
 };
 use crate::{
-  actor::{error::ActorError, supervision::restart_statistics::RestartStatistics},
+  actor::{DEFAULT_STASH_CAPACITY, error::ActorError, supervision::restart_statistics::RestartStatistics},
   event::logging::LogLevel,
 };
 
@@ -24,8 +24,6 @@ type SupervisorDecider = fn(&ActorError) -> SupervisorDirective;
 
 /// Boxed closure decider supporting type-discriminated supervision chains.
 type DynDecider = ArcShared<dyn Fn(&ActorError) -> SupervisorDirective + Send + Sync>;
-
-const DEFAULT_STASH_CAPACITY: usize = 1000;
 
 /// Supervisor configuration controlling restart policies.
 ///


### PR DESCRIPTION
### Motivation
- `ActorContext::stash()` がデフォルトで `usize::MAX` を使い、ActorCell の stash 用 `VecDeque` に事実上無制限でメッセージを積める経路がありました。
- リモート送信者などからのメッセージ洪水でメモリ枯渇 (DoS) につながる可能性があるため、untyped/kernel 側の既定経路にも有界な保護を入れます。

### Description
- 最新 `main` のモジュール分割に合わせ、変更先を `modules/actor-core-kernel/src/actor/actor_context.rs` に移しました。
- `DEFAULT_STASH_CAPACITY: usize = 1000` を追加し、`ActorContext::stash()` を `stash_with_limit(DEFAULT_STASH_CAPACITY)` に変更しました。
- Cursor Bugbot の指摘に対応し、supervision 側 (`backoff_supervisor_strategy.rs`, `base.rs`) の重複定数を削除して、`actor_context` の `DEFAULT_STASH_CAPACITY` を single source of truth として再利用するようにしました。
- `modules/actor-core-kernel/src/actor/actor_context_test.rs` に `actor_context_stash_uses_default_capacity_limit` を追加し、1000 件までは成功し、1001 件目で既存の stash overflow error になることを検証します。
- 旧 `modules/actor/src/core/actor/*` は最新 `main` で削除済みのため復活させず、kernel 側へ PR の意図だけを移植しました。

### Testing
- `cargo test -p fraktor-actor-core-kernel-rs actor_context_stash -- --nocapture`
- `cargo test -p fraktor-actor-core-kernel-rs default_stash_capacity_is_1000 -- --nocapture`
- `cargo fmt --check`
- `cargo clippy -p fraktor-actor-core-kernel-rs --lib -- -D warnings`
- `cargo clippy -p fraktor-actor-core-kernel-rs --all-targets -- -D warnings` は今回の差分外 `modules/actor-core-kernel/src/dispatch/mailbox/system_queue_test.rs` の既存 `needless_pass_by_value` で失敗しました。GitHub Actions の `Lint Check (Clippy, clippy)` は push 後に成功しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69afb31d6134832d9515f57a55eb1418)
