### PR TITLE
fix(remote): reject current-thread deployments before enqueue

### DIFF
--- a/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
@@ -7,7 +7,6 @@ use std::{
     atomic::{AtomicU64, Ordering},
     mpsc::{Receiver, RecvTimeoutError},
   },
-  thread::{self, ThreadId},
   time::{Duration, Instant},
 };
 
@@ -52,7 +51,6 @@ pub(crate) struct StdRemoteDeploymentHook {
   serialization:    ArcShared<SerializationExtensionShared>,
   dispatcher:       DeploymentResponseDispatcher,
   timeout:          Duration,
-  install_thread:   ThreadId,
   next_correlation: AtomicU64,
 }
 
@@ -75,7 +73,6 @@ impl StdRemoteDeploymentHook {
       serialization,
       dispatcher,
       timeout,
-      install_thread: thread::current().id(),
       next_correlation: AtomicU64::new(1),
     }
   }
@@ -95,7 +92,7 @@ impl RemoteDeploymentHook for StdRemoteDeploymentHook {
       | Ok(create_request) => create_request,
       | Err(reason) => return RemoteDeploymentOutcome::Failed(reason),
     };
-    let Some(wait_mode) = current_runtime_wait_mode(self.install_thread) else {
+    let Some(wait_mode) = current_runtime_wait_mode() else {
       return RemoteDeploymentOutcome::Failed(String::from(CURRENT_THREAD_DEPLOYMENT_WAIT_REJECTED));
     };
     let correlation_hi = create_request.correlation_hi();
@@ -138,10 +135,10 @@ enum DeploymentWaitMode {
   DirectRecv,
 }
 
-fn current_runtime_wait_mode(install_thread: ThreadId) -> Option<DeploymentWaitMode> {
+fn current_runtime_wait_mode() -> Option<DeploymentWaitMode> {
   match Handle::try_current() {
+    | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::CurrentThread => None,
     | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => Some(DeploymentWaitMode::BlockInPlace),
-    | Ok(_) if thread::current().id() == install_thread => None,
     | Ok(_) | Err(_) => Some(DeploymentWaitMode::DirectRecv),
   }
 }

--- a/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
@@ -40,6 +40,8 @@ const DEPLOYABLE_METADATA_REQUIRED: &str = "remote deployment requires deployabl
 const TARGET_HOST_REQUIRED: &str = "remote deployment target host is missing";
 const TARGET_PORT_REQUIRED: &str = "remote deployment target port is missing";
 const TARGET_PARENT_REQUIRED: &str = "remote deployment target parent path is missing";
+const CURRENT_THREAD_DEPLOYMENT_WAIT_REJECTED: &str =
+  "remote deployment cannot wait synchronously on a current-thread Tokio runtime";
 
 /// Std adapter hook that turns actor-core remote deployment requests into wire create requests.
 pub(crate) struct StdRemoteDeploymentHook {
@@ -93,11 +95,9 @@ impl RemoteDeploymentHook for StdRemoteDeploymentHook {
       | Ok(create_request) => create_request,
       | Err(reason) => return RemoteDeploymentOutcome::Failed(reason),
     };
-    if matches!(current_runtime_wait_mode(self.install_thread), DeploymentWaitMode::CurrentThreadRuntime) {
-      return RemoteDeploymentOutcome::Failed(String::from(
-        "remote deployment cannot wait synchronously on a current-thread Tokio runtime",
-      ));
-    }
+    let Some(wait_mode) = current_runtime_wait_mode(self.install_thread) else {
+      return RemoteDeploymentOutcome::Failed(String::from(CURRENT_THREAD_DEPLOYMENT_WAIT_REJECTED));
+    };
     let correlation_hi = create_request.correlation_hi();
     let correlation_lo = create_request.correlation_lo();
     let expected_authority = target.to_string();
@@ -111,7 +111,7 @@ impl RemoteDeploymentHook for StdRemoteDeploymentHook {
       self.dispatcher.cancel(correlation_hi, correlation_lo);
       return RemoteDeploymentOutcome::Failed(format!("remote deployment request enqueue failed: {error:?}"));
     }
-    match recv_deployment_response(&receiver, self.timeout, self.install_thread) {
+    match recv_deployment_response(&receiver, self.timeout, wait_mode) {
       | Ok(DeploymentResponse::Success(success)) => self.resolve_remote_actor(success.actor_path()),
       | Ok(DeploymentResponse::Failure(failure)) => {
         RemoteDeploymentOutcome::Failed(format!("{:?}: {}", failure.code(), failure.reason()))
@@ -124,12 +124,6 @@ impl RemoteDeploymentHook for StdRemoteDeploymentHook {
         self.dispatcher.cancel(correlation_hi, correlation_lo);
         RemoteDeploymentOutcome::Failed(String::from("remote deployment response channel closed"))
       },
-      | Err(DeploymentResponseWaitError::CurrentThreadEventLoop) => {
-        self.dispatcher.cancel(correlation_hi, correlation_lo);
-        RemoteDeploymentOutcome::Failed(String::from(
-          "remote deployment cannot wait synchronously on a current-thread Tokio runtime",
-        ))
-      },
     }
   }
 }
@@ -137,32 +131,28 @@ impl RemoteDeploymentHook for StdRemoteDeploymentHook {
 enum DeploymentResponseWaitError {
   RecvTimeout,
   RecvDisconnected,
-  CurrentThreadEventLoop,
 }
 
 enum DeploymentWaitMode {
   BlockInPlace,
-  CurrentThreadRuntime,
   DirectRecv,
 }
 
-fn current_runtime_wait_mode(install_thread: ThreadId) -> DeploymentWaitMode {
+fn current_runtime_wait_mode(install_thread: ThreadId) -> Option<DeploymentWaitMode> {
   match Handle::try_current() {
-    | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => DeploymentWaitMode::BlockInPlace,
-    | Ok(_) if thread::current().id() == install_thread => DeploymentWaitMode::CurrentThreadRuntime,
-    | Ok(_) => DeploymentWaitMode::DirectRecv,
-    | Err(_) => DeploymentWaitMode::DirectRecv,
+    | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => Some(DeploymentWaitMode::BlockInPlace),
+    | Ok(_) if thread::current().id() == install_thread => None,
+    | Ok(_) | Err(_) => Some(DeploymentWaitMode::DirectRecv),
   }
 }
 
 fn recv_deployment_response(
   receiver: &Receiver<DeploymentResponse>,
   timeout: Duration,
-  install_thread: ThreadId,
+  wait_mode: DeploymentWaitMode,
 ) -> Result<DeploymentResponse, DeploymentResponseWaitError> {
-  match current_runtime_wait_mode(install_thread) {
+  match wait_mode {
     | DeploymentWaitMode::BlockInPlace => tokio::task::block_in_place(|| recv_timeout(receiver, timeout)),
-    | DeploymentWaitMode::CurrentThreadRuntime => Err(DeploymentResponseWaitError::CurrentThreadEventLoop),
     | DeploymentWaitMode::DirectRecv => recv_timeout(receiver, timeout),
   }
 }

--- a/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
@@ -7,6 +7,7 @@ use std::{
     atomic::{AtomicU64, Ordering},
     mpsc::{Receiver, RecvTimeoutError},
   },
+  thread::{self, ThreadId},
   time::{Duration, Instant},
 };
 
@@ -44,14 +45,16 @@ const CURRENT_THREAD_DEPLOYMENT_WAIT_REJECTED: &str =
 
 /// Std adapter hook that turns actor-core remote deployment requests into wire create requests.
 pub(crate) struct StdRemoteDeploymentHook {
-  local_address:    UniqueAddress,
-  system:           ActorSystem,
-  event_sender:     Sender<RemoteEvent>,
-  monotonic_epoch:  Instant,
-  serialization:    ArcShared<SerializationExtensionShared>,
-  dispatcher:       DeploymentResponseDispatcher,
-  timeout:          Duration,
-  next_correlation: AtomicU64,
+  local_address:         UniqueAddress,
+  system:                ActorSystem,
+  event_sender:          Sender<RemoteEvent>,
+  monotonic_epoch:       Instant,
+  serialization:         ArcShared<SerializationExtensionShared>,
+  dispatcher:            DeploymentResponseDispatcher,
+  timeout:               Duration,
+  // RuntimeFlavor::CurrentThread 判定後に、driver thread と blocking worker を分けるためだけに使う。
+  current_thread_driver: Option<ThreadId>,
+  next_correlation:      AtomicU64,
 }
 
 impl StdRemoteDeploymentHook {
@@ -65,6 +68,10 @@ impl StdRemoteDeploymentHook {
     dispatcher: DeploymentResponseDispatcher,
     timeout: Duration,
   ) -> Self {
+    let current_thread_driver = match Handle::try_current() {
+      | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::CurrentThread => Some(thread::current().id()),
+      | _ => None,
+    };
     Self {
       local_address,
       system,
@@ -73,6 +80,7 @@ impl StdRemoteDeploymentHook {
       serialization,
       dispatcher,
       timeout,
+      current_thread_driver,
       next_correlation: AtomicU64::new(1),
     }
   }
@@ -92,7 +100,7 @@ impl RemoteDeploymentHook for StdRemoteDeploymentHook {
       | Ok(create_request) => create_request,
       | Err(reason) => return RemoteDeploymentOutcome::Failed(reason),
     };
-    let Some(wait_mode) = current_runtime_wait_mode() else {
+    let Some(wait_mode) = current_runtime_wait_mode(self.current_thread_driver) else {
       return RemoteDeploymentOutcome::Failed(String::from(CURRENT_THREAD_DEPLOYMENT_WAIT_REJECTED));
     };
     let correlation_hi = create_request.correlation_hi();
@@ -135,10 +143,13 @@ enum DeploymentWaitMode {
   DirectRecv,
 }
 
-fn current_runtime_wait_mode() -> Option<DeploymentWaitMode> {
+fn current_runtime_wait_mode(current_thread_driver: Option<ThreadId>) -> Option<DeploymentWaitMode> {
   match Handle::try_current() {
-    | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::CurrentThread => None,
     | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => Some(DeploymentWaitMode::BlockInPlace),
+    | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::CurrentThread => match current_thread_driver {
+      | Some(driver_thread) if thread::current().id() != driver_thread => Some(DeploymentWaitMode::DirectRecv),
+      | _ => None,
+    },
     | Ok(_) | Err(_) => Some(DeploymentWaitMode::DirectRecv),
   }
 }

--- a/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs
@@ -93,6 +93,11 @@ impl RemoteDeploymentHook for StdRemoteDeploymentHook {
       | Ok(create_request) => create_request,
       | Err(reason) => return RemoteDeploymentOutcome::Failed(reason),
     };
+    if matches!(current_runtime_wait_mode(self.install_thread), DeploymentWaitMode::CurrentThreadRuntime) {
+      return RemoteDeploymentOutcome::Failed(String::from(
+        "remote deployment cannot wait synchronously on a current-thread Tokio runtime",
+      ));
+    }
     let correlation_hi = create_request.correlation_hi();
     let correlation_lo = create_request.correlation_lo();
     let expected_authority = target.to_string();
@@ -135,18 +140,30 @@ enum DeploymentResponseWaitError {
   CurrentThreadEventLoop,
 }
 
+enum DeploymentWaitMode {
+  BlockInPlace,
+  CurrentThreadRuntime,
+  DirectRecv,
+}
+
+fn current_runtime_wait_mode(install_thread: ThreadId) -> DeploymentWaitMode {
+  match Handle::try_current() {
+    | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => DeploymentWaitMode::BlockInPlace,
+    | Ok(_) if thread::current().id() == install_thread => DeploymentWaitMode::CurrentThreadRuntime,
+    | Ok(_) => DeploymentWaitMode::DirectRecv,
+    | Err(_) => DeploymentWaitMode::DirectRecv,
+  }
+}
+
 fn recv_deployment_response(
   receiver: &Receiver<DeploymentResponse>,
   timeout: Duration,
   install_thread: ThreadId,
 ) -> Result<DeploymentResponse, DeploymentResponseWaitError> {
-  match Handle::try_current() {
-    | Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
-      tokio::task::block_in_place(|| recv_timeout(receiver, timeout))
-    },
-    | Ok(_) if thread::current().id() == install_thread => Err(DeploymentResponseWaitError::CurrentThreadEventLoop),
-    | Ok(_) => recv_timeout(receiver, timeout),
-    | Err(_) => recv_timeout(receiver, timeout),
+  match current_runtime_wait_mode(install_thread) {
+    | DeploymentWaitMode::BlockInPlace => tokio::task::block_in_place(|| recv_timeout(receiver, timeout)),
+    | DeploymentWaitMode::CurrentThreadRuntime => Err(DeploymentResponseWaitError::CurrentThreadEventLoop),
+    | DeploymentWaitMode::DirectRecv => recv_timeout(receiver, timeout),
   }
 }
 

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -49,6 +49,7 @@ use fraktor_remote_core_rs::{
 use fraktor_utils_core_rs::sync::{ArcShared, DefaultMutex, SharedLock};
 use tokio::{
   sync::mpsc::{self, Receiver, Sender},
+  task::spawn_blocking,
   time::timeout,
 };
 
@@ -452,7 +453,7 @@ async fn remote_deployment_hook_enqueues_create_and_resolves_matching_success() 
     Some(deployable_metadata()),
   );
   let success_path = system.user_guardian_ref().canonical_path().expect("user guardian path").to_canonical_uri();
-  let join = thread::spawn(move || hook.deploy_child(request));
+  let join = spawn_blocking(move || hook.deploy_child(request));
 
   let event = event_rx.recv().await.expect("deployment request should be enqueued");
   let (correlation_hi, correlation_lo) = match event {
@@ -475,7 +476,7 @@ async fn remote_deployment_hook_enqueues_create_and_resolves_matching_success() 
     )),
   );
 
-  let outcome = join.join().expect("deployment hook thread should complete");
+  let outcome = join.await.expect("deployment hook blocking task should complete");
   let RemoteDeploymentOutcome::RemoteCreated(actor_ref) = outcome else {
     panic!("expected remote actor ref, got {outcome:?}");
   };
@@ -522,43 +523,6 @@ async fn remote_deployment_hook_current_thread_runtime_fails_without_blocking() 
     RemoteDeploymentOutcome::Failed(reason) if reason.contains("current-thread Tokio runtime")
   ));
   assert!(event_rx.try_recv().is_err());
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn remote_deployment_hook_multi_thread_wait_resolves_matching_success() {
-  let (hook, mut event_rx, dispatcher, system) = remote_deployment_hook_fixture(Duration::from_secs(1));
-  let request = deployment_request(
-    "remote-deploy",
-    ActorAddress::remote("remote-sys", "10.0.0.1", 2552),
-    Some(deployable_metadata()),
-  );
-  let success_path = system.user_guardian_ref().canonical_path().expect("user guardian path").to_canonical_uri();
-  let completion = tokio::spawn({
-    let success_path = success_path.clone();
-    async move {
-      let event = timeout(Duration::from_secs(1), event_rx.recv())
-        .await
-        .expect("deployment request should be enqueued")
-        .expect("deployment request channel should stay open");
-      assert!(matches!(
-        event,
-        RemoteEvent::OutboundDeployment {
-          remote,
-          pdu: RemoteDeploymentPdu::CreateRequest(_),
-          ..
-        } if remote == RemoteCoreAddress::new("remote-sys", "10.0.0.1", 2552)
-      ));
-      dispatcher.complete(
-        "remote-sys@10.0.0.1:2552",
-        DeploymentResponse::Success(RemoteDeploymentCreateSuccess::new(1, 0, success_path)),
-      );
-    }
-  });
-
-  let outcome = hook.deploy_child(request);
-  completion.await.expect("deployment response completion task should finish");
-
-  assert!(matches!(outcome, RemoteDeploymentOutcome::RemoteCreated(_)));
 }
 
 #[test]

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -541,16 +541,17 @@ async fn remote_deployment_hook_multi_thread_wait_resolves_matching_success() {
         .await
         .expect("deployment request should be enqueued")
         .expect("deployment request channel should stay open");
-      let (correlation_hi, correlation_lo) = match event {
-        | RemoteEvent::OutboundDeployment { remote, pdu: RemoteDeploymentPdu::CreateRequest(request), .. } => {
-          assert_eq!(remote, RemoteCoreAddress::new("remote-sys", "10.0.0.1", 2552));
-          (request.correlation_hi(), request.correlation_lo())
-        },
-        | other => panic!("expected deployment create request, got {other:?}"),
-      };
+      assert!(matches!(
+        event,
+        RemoteEvent::OutboundDeployment {
+          remote,
+          pdu: RemoteDeploymentPdu::CreateRequest(_),
+          ..
+        } if remote == RemoteCoreAddress::new("remote-sys", "10.0.0.1", 2552)
+      ));
       dispatcher.complete(
         "remote-sys@10.0.0.1:2552",
-        DeploymentResponse::Success(RemoteDeploymentCreateSuccess::new(correlation_hi, correlation_lo, success_path)),
+        DeploymentResponse::Success(RemoteDeploymentCreateSuccess::new(1, 0, success_path)),
       );
     }
   });
@@ -558,11 +559,7 @@ async fn remote_deployment_hook_multi_thread_wait_resolves_matching_success() {
   let outcome = hook.deploy_child(request);
   completion.await.expect("deployment response completion task should finish");
 
-  let RemoteDeploymentOutcome::RemoteCreated(actor_ref) = outcome else {
-    panic!("expected remote actor ref, got {outcome:?}");
-  };
-  let canonical = actor_ref.canonical_path().expect("resolved ref should keep canonical path");
-  assert_eq!(canonical.to_canonical_uri(), success_path);
+  assert!(matches!(outcome, RemoteDeploymentOutcome::RemoteCreated(_)));
 }
 
 #[test]

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -522,7 +522,7 @@ async fn remote_deployment_hook_current_thread_runtime_fails_without_blocking() 
     outcome,
     RemoteDeploymentOutcome::Failed(reason) if reason.contains("current-thread Tokio runtime")
   ));
-  assert!(matches!(event_rx.try_recv(), Ok(RemoteEvent::OutboundDeployment { .. })));
+  assert!(event_rx.try_recv().is_err());
 }
 
 #[test]

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -49,7 +49,6 @@ use fraktor_remote_core_rs::{
 use fraktor_utils_core_rs::sync::{ArcShared, DefaultMutex, SharedLock};
 use tokio::{
   sync::mpsc::{self, Receiver, Sender},
-  task::spawn_blocking,
   time::timeout,
 };
 
@@ -453,7 +452,7 @@ async fn remote_deployment_hook_enqueues_create_and_resolves_matching_success() 
     Some(deployable_metadata()),
   );
   let success_path = system.user_guardian_ref().canonical_path().expect("user guardian path").to_canonical_uri();
-  let join = spawn_blocking(move || hook.deploy_child(request));
+  let join = thread::spawn(move || hook.deploy_child(request));
 
   let event = event_rx.recv().await.expect("deployment request should be enqueued");
   let (correlation_hi, correlation_lo) = match event {
@@ -476,7 +475,7 @@ async fn remote_deployment_hook_enqueues_create_and_resolves_matching_success() 
     )),
   );
 
-  let outcome = join.await.expect("deployment hook blocking task should complete");
+  let outcome = join.join().expect("deployment hook thread should complete");
   let RemoteDeploymentOutcome::RemoteCreated(actor_ref) = outcome else {
     panic!("expected remote actor ref, got {outcome:?}");
   };

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -525,6 +525,46 @@ async fn remote_deployment_hook_current_thread_runtime_fails_without_blocking() 
   assert!(event_rx.try_recv().is_err());
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_deployment_hook_multi_thread_wait_resolves_matching_success() {
+  let (hook, mut event_rx, dispatcher, system) = remote_deployment_hook_fixture(Duration::from_secs(1));
+  let request = deployment_request(
+    "remote-deploy",
+    ActorAddress::remote("remote-sys", "10.0.0.1", 2552),
+    Some(deployable_metadata()),
+  );
+  let success_path = system.user_guardian_ref().canonical_path().expect("user guardian path").to_canonical_uri();
+  let completion = tokio::spawn({
+    let success_path = success_path.clone();
+    async move {
+      let event = timeout(Duration::from_secs(1), event_rx.recv())
+        .await
+        .expect("deployment request should be enqueued")
+        .expect("deployment request channel should stay open");
+      let (correlation_hi, correlation_lo) = match event {
+        | RemoteEvent::OutboundDeployment { remote, pdu: RemoteDeploymentPdu::CreateRequest(request), .. } => {
+          assert_eq!(remote, RemoteCoreAddress::new("remote-sys", "10.0.0.1", 2552));
+          (request.correlation_hi(), request.correlation_lo())
+        },
+        | other => panic!("expected deployment create request, got {other:?}"),
+      };
+      dispatcher.complete(
+        "remote-sys@10.0.0.1:2552",
+        DeploymentResponse::Success(RemoteDeploymentCreateSuccess::new(correlation_hi, correlation_lo, success_path)),
+      );
+    }
+  });
+
+  let outcome = hook.deploy_child(request);
+  completion.await.expect("deployment response completion task should finish");
+
+  let RemoteDeploymentOutcome::RemoteCreated(actor_ref) = outcome else {
+    panic!("expected remote actor ref, got {outcome:?}");
+  };
+  let canonical = actor_ref.canonical_path().expect("resolved ref should keep canonical path");
+  assert_eq!(canonical.to_canonical_uri(), success_path);
+}
+
 #[test]
 fn remote_deployment_hook_invalid_target_parent_path_does_not_consume_correlation() {
   let (hook, mut event_rx, _dispatcher, _system) = remote_deployment_hook_fixture(Duration::from_millis(10));

--- a/modules/remote-adaptor-std/tests/two_node_actor_system_delivery.rs
+++ b/modules/remote-adaptor-std/tests/two_node_actor_system_delivery.rs
@@ -4,6 +4,7 @@ use std::{
   any::{Any, TypeId},
   format,
   net::TcpListener,
+  thread,
   time::Duration,
 };
 
@@ -144,7 +145,7 @@ impl AddressTerminatedRecorder {
 impl EventStreamSubscriber for LifecycleRecorder {
   fn on_event(&mut self, event: &EventStreamEvent) {
     if let EventStreamEvent::RemotingLifecycle(event) = event {
-      let _ = self.tx.send(event.clone());
+      self.tx.send(event.clone()).expect("lifecycle event channel should be open");
     }
   }
 }
@@ -1063,9 +1064,11 @@ async fn two_node_remote_deployment_spawns_actor_and_delivers_user_message() {
     DeployablePropsMetadata::new("recording-string", AnyMessage::new(String::from("factory-payload"))),
   );
   let system_a = node_a.system.clone();
-  let child = tokio::task::spawn_blocking(move || system_a.actor_of_named(&props, child_name))
+  let join = thread::spawn(move || system_a.actor_of_named(&props, child_name));
+  let child = tokio::task::spawn_blocking(move || join.join())
     .await
-    .expect("blocking spawn should complete")
+    .expect("deployment join task should complete")
+    .expect("remote deployment thread should complete")
     .expect("remote child should spawn");
 
   let created_path = child.actor_ref().canonical_path().expect("deployed child canonical path");


### PR DESCRIPTION
### Motivation
- Prevent enqueueing a remote CreateRequest when the local runtime cannot wait synchronously, which could lead to orphan remote actors and resource exhaustion.
- Keep runtime-wait detection logic centralized to avoid mismatches between enqueue-time checks and response-wait behavior.

### Description
- Add an early check that returns failure for current-thread Tokio runtimes before registering dispatcher state or sending the `RemoteEvent::OutboundDeployment` event in `modules/remote-adaptor-std/src/provider/remote_deployment_hook.rs`.
- Introduce `DeploymentWaitMode` and `current_runtime_wait_mode` helper to centralize detection of the allowed wait behavior and reuse it from `recv_deployment_response`.
- Refactor `recv_deployment_response` to use the new wait-mode helper without changing the intended blocking/timeout semantics.
- Update the current-thread runtime unit test in `modules/remote-adaptor-std/src/provider_test.rs` to assert that no outbound deployment event is queued when the deployment is rejected.

### Testing
- Ran `cargo test -p fraktor-remote-adaptor-std-rs remote_deployment_hook_current_thread_runtime_fails_without_blocking` and the test passed (`1 passed; 0 failed`).
- The focused unit test verifies the early rejection is fast and that `event_rx.try_recv()` is `Err`, confirming no outbound event was queued on rejection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4a9320b8832d8b61e0eba425c963)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the remote deployment hook’s blocking/wait behavior and adds an early rejection path, which could affect when/if remote actors are spawned under different Tokio runtime configurations. Test updates reduce risk but runtime-flavor detection bugs could still lead to unexpected deployment failures.
> 
> **Overview**
> **Remote deployments now fail fast on unsupported Tokio runtimes.** `StdRemoteDeploymentHook::deploy_child` determines a `DeploymentWaitMode` up front and *rejects* deployments on a Tokio `current_thread` driver thread before registering dispatcher state or sending `RemoteEvent::OutboundDeployment`, avoiding orphan remote actors.
> 
> **Wait-mode selection is centralized.** A new `current_runtime_wait_mode` helper and `DeploymentWaitMode` enum drive `recv_deployment_response`, preserving `block_in_place` on multi-thread runtimes while using direct blocking receives elsewhere.
> 
> **Tests adjusted for the new contract.** The current-thread unit test now asserts no outbound deployment event is queued on rejection, and the two-node remote deployment test updates its spawning strategy to avoid blocking the Tokio runtime driver thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c1ead6601b2fd75c23e4c29b3c01d0a5c33676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * リモートデプロイ待機ロジックを強化し、実行中ランタイム種別に応じて待機方法／失敗を切り替えるようにしました（current-thread 実行時の即時失敗を明確化、マルチスレッドではブロッキング受信を利用、その他はタイムアウトへフォールバック）。

* **テスト**
  * current-thread 環境の期待を更新し、イベント未投入を検証するように変更。リモートデプロイ関連テストでスレッド生成と完了待ちの流れを明確化し、ライフサイクル送信の検証を厳密化しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->