### PR TITLE
fix(remote): preserve watch hook fallback contract

### DIFF
--- a/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
@@ -82,7 +82,7 @@ impl StdRemoteWatchHook {
       | Ok(()) => true,
       | Err(TrySendError::Full(command)) => {
         tracing::warn!(?command, "remote watch command queue is full");
-        true
+        false
       },
       | Err(TrySendError::Closed(command)) => {
         tracing::warn!(?command, "remote watch command queue is closed");

--- a/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
@@ -82,7 +82,9 @@ impl StdRemoteWatchHook {
       | Ok(()) => true,
       | Err(TrySendError::Full(command)) => {
         tracing::warn!(?command, "remote watch command queue is full");
-        false
+        // `false` は actor-core 側の dead-actor fallback を起動するため、
+        // remote watcher queue が満杯でも消費済みとして扱う。
+        true
       },
       | Err(TrySendError::Closed(command)) => {
         tracing::warn!(?command, "remote watch command queue is closed");

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -952,7 +952,7 @@ fn remote_watch_hook_forwards_watch_command() {
 }
 
 #[test]
-fn remote_watch_hook_returns_false_when_watcher_queue_is_full() {
+fn remote_watch_hook_treats_full_watcher_queue_as_consumed() {
   let registry = RemoteActorPathRegistry::new_shared();
   let remote_pid = Pid::new(905, 0);
   let remote_path = remote_actor_path();
@@ -963,7 +963,7 @@ fn remote_watch_hook_returns_false_when_watcher_queue_is_full() {
   let _local_path = register_local_path(harness.system(), local_pid, "watcher-full");
 
   assert!(hook.handle_watch(remote_pid, local_pid));
-  assert!(!hook.handle_watch(remote_pid, local_pid));
+  assert!(hook.handle_watch(remote_pid, local_pid));
   assert!(matches!(watcher_rx.try_recv(), Ok(WatcherCommand::Watch { .. })));
   assert!(watcher_rx.try_recv().is_err());
 }

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -952,7 +952,7 @@ fn remote_watch_hook_forwards_watch_command() {
 }
 
 #[test]
-fn remote_watch_hook_treats_full_watcher_queue_as_handled() {
+fn remote_watch_hook_returns_false_when_watcher_queue_is_full() {
   let registry = RemoteActorPathRegistry::new_shared();
   let remote_pid = Pid::new(905, 0);
   let remote_path = remote_actor_path();
@@ -963,7 +963,7 @@ fn remote_watch_hook_treats_full_watcher_queue_as_handled() {
   let _local_path = register_local_path(harness.system(), local_pid, "watcher-full");
 
   assert!(hook.handle_watch(remote_pid, local_pid));
-  assert!(hook.handle_watch(remote_pid, local_pid));
+  assert!(!hook.handle_watch(remote_pid, local_pid));
   assert!(matches!(watcher_rx.try_recv(), Ok(WatcherCommand::Watch { .. })));
   assert!(watcher_rx.try_recv().is_err());
 }


### PR DESCRIPTION
### Motivation
- `RemoteWatchHook` の `false` は actor-core で未消費扱いになり、`DeathWatchNotification` fallback を送る契約です。
- watcher command queue 満杯時に `false` を返すと、live remote actor に誤った termination notification が届くため、満杯時も provider consumed として扱う必要があります。

### Description
- `TrySendError::Full` は warning を残しつつ `true` を返す契約へ戻しました。
- 同じ誤修正を避けるため、満杯時に `false` を返してはいけない理由を `StdRemoteWatchHook` にコメントとして固定しました。
- テスト名を `remote_watch_hook_treats_full_watcher_queue_as_consumed` に更新しました。
- 最新 `origin/main` を取り込みました。

### Testing
- `cargo test -p fraktor-remote-adaptor-std-rs remote_watch_hook`
- `cargo fmt --check -p fraktor-remote-adaptor-std-rs`
- `cargo test -p fraktor-actor-core-kernel-rs concurrent_push_pop_preserves_per_producer_fifo`
- `cargo clippy -p fraktor-remote-adaptor-std-rs --tests -- -D warnings`