### PR TITLE
fix(remote): preserve remote DeathWatch PID mappings across cache eviction

### DIFF
--- a/modules/remote-adaptor-std/src/provider/dispatch.rs
+++ b/modules/remote-adaptor-std/src/provider/dispatch.rs
@@ -196,7 +196,7 @@ impl StdRemoteActorRefProvider {
     let pid = Self::allocate_remote_pid(next_remote_pid)?;
     let path = remote_ref.path().clone();
     registry.with_lock(|registry| registry.record(pid, path.clone()));
-    let sender = RemoteActorRefSender::new(pid, remote_ref, event_sender, registry.clone(), monotonic_epoch);
+    let sender = RemoteActorRefSender::new(remote_ref, event_sender, monotonic_epoch);
     Ok(ActorRef::with_canonical_path(pid, sender, path))
   }
 

--- a/modules/remote-adaptor-std/src/provider/dispatch.rs
+++ b/modules/remote-adaptor-std/src/provider/dispatch.rs
@@ -193,9 +193,15 @@ impl StdRemoteActorRefProvider {
     registry: &SharedLock<RemoteActorPathRegistry>,
     monotonic_epoch: Instant,
   ) -> Result<ActorRef, StdRemoteActorRefProviderError> {
-    let pid = Self::allocate_remote_pid(next_remote_pid)?;
     let path = remote_ref.path().clone();
-    registry.with_lock(|registry| registry.record(pid, path.clone()));
+    let pid = registry.with_lock(|registry| -> Result<Pid, StdRemoteActorRefProviderError> {
+      if let Some(pid) = registry.pid_for_path(&path) {
+        return Ok(pid);
+      }
+      let pid = Self::allocate_remote_pid(next_remote_pid)?;
+      registry.record(pid, path.clone());
+      Ok(pid)
+    })?;
     let sender = RemoteActorRefSender::new(remote_ref, event_sender, monotonic_epoch);
     Ok(ActorRef::with_canonical_path(pid, sender, path))
   }

--- a/modules/remote-adaptor-std/src/provider/remote_actor_path_registry.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_actor_path_registry.rs
@@ -19,9 +19,6 @@ impl RemoteActorPathRegistry {
     self.paths.insert(pid, path);
   }
 
-  pub(crate) fn remove(&mut self, pid: &Pid) {
-    drop(self.paths.remove(pid));
-  }
 
   pub(crate) fn path_for_pid(&self, pid: &Pid) -> Option<ActorPath> {
     self.paths.get(pid).cloned()

--- a/modules/remote-adaptor-std/src/provider/remote_actor_path_registry.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_actor_path_registry.rs
@@ -8,6 +8,7 @@ use fraktor_utils_core_rs::sync::{DefaultMutex, SharedLock};
 #[derive(Default)]
 pub(crate) struct RemoteActorPathRegistry {
   paths: HashMap<Pid, ActorPath>,
+  pids:  HashMap<ActorPath, Pid>,
 }
 
 impl RemoteActorPathRegistry {
@@ -16,9 +17,23 @@ impl RemoteActorPathRegistry {
   }
 
   pub(crate) fn record(&mut self, pid: Pid, path: ActorPath) {
-    self.paths.insert(pid, path);
+    if let Some(previous_path) = self.paths.insert(pid, path.clone())
+      && previous_path != path
+    {
+      let removed_pid = self.pids.remove(&previous_path);
+      debug_assert_eq!(removed_pid, Some(pid));
+    }
+    if let Some(previous_pid) = self.pids.insert(path, pid)
+      && previous_pid != pid
+    {
+      let removed_path = self.paths.remove(&previous_pid);
+      debug_assert!(removed_path.is_some());
+    }
   }
 
+  pub(crate) fn pid_for_path(&self, path: &ActorPath) -> Option<Pid> {
+    self.pids.get(path).copied()
+  }
 
   pub(crate) fn path_for_pid(&self, pid: &Pid) -> Option<ActorPath> {
     self.paths.get(pid).cloned()

--- a/modules/remote-adaptor-std/src/provider/remote_actor_ref_sender.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_actor_ref_sender.rs
@@ -30,11 +30,7 @@ pub struct RemoteActorRefSender {
 impl RemoteActorRefSender {
   /// Creates a new sender for the given `remote_ref`.
   #[must_use]
-  pub(crate) fn new(
-    remote_ref: RemoteActorRef,
-    event_tx: Sender<RemoteEvent>,
-    monotonic_epoch: Instant,
-  ) -> Self {
+  pub(crate) fn new(remote_ref: RemoteActorRef, event_tx: Sender<RemoteEvent>, monotonic_epoch: Instant) -> Self {
     Self { remote_ref, event_tx, monotonic_epoch }
   }
 

--- a/modules/remote-adaptor-std/src/provider/remote_actor_ref_sender.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_actor_ref_sender.rs
@@ -4,7 +4,6 @@ use std::time::Instant;
 
 use fraktor_actor_core_kernel_rs::{
   actor::{
-    Pid,
     actor_ref::{ActorRefSender, SendOutcome},
     error::SendError,
     messaging::AnyMessage,
@@ -17,18 +16,14 @@ use fraktor_remote_core_rs::{
   provider::RemoteActorRef,
   transport::TransportEndpoint,
 };
-use fraktor_utils_core_rs::sync::SharedLock;
 use tokio::sync::mpsc::{Sender, error::TrySendError};
 
-use super::remote_actor_path_registry::RemoteActorPathRegistry;
 use crate::association::std_instant_elapsed_millis;
 
 /// Sender that wraps a [`RemoteActorRef`] and pushes outbound work to `Remote`.
 pub struct RemoteActorRefSender {
-  pid:             Pid,
   remote_ref:      RemoteActorRef,
   event_tx:        Sender<RemoteEvent>,
-  registry:        SharedLock<RemoteActorPathRegistry>,
   monotonic_epoch: Instant,
 }
 
@@ -36,13 +31,11 @@ impl RemoteActorRefSender {
   /// Creates a new sender for the given `remote_ref`.
   #[must_use]
   pub(crate) fn new(
-    pid: Pid,
     remote_ref: RemoteActorRef,
     event_tx: Sender<RemoteEvent>,
-    registry: SharedLock<RemoteActorPathRegistry>,
     monotonic_epoch: Instant,
   ) -> Self {
-    Self { pid, remote_ref, event_tx, registry, monotonic_epoch }
+    Self { remote_ref, event_tx, monotonic_epoch }
   }
 
   fn remote_authority(&self) -> Option<String> {
@@ -75,12 +68,6 @@ impl RemoteActorRefSender {
       },
       | _ => None,
     }
-  }
-}
-
-impl Drop for RemoteActorRefSender {
-  fn drop(&mut self) {
-    self.registry.with_lock(|registry| registry.remove(&self.pid));
   }
 }
 

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -754,6 +754,25 @@ fn remote_actor_path_registry_replaces_previous_pid_for_same_path() {
 }
 
 #[test]
+fn remote_actor_path_registry_replaces_previous_path_for_same_pid() {
+  let mut registry = RemoteActorPathRegistry::default();
+  let first_path = remote_actor_path();
+  let second_path =
+    ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.1:2552/user/remote-actor-replacement").expect("parse");
+  let pid = Pid::new(902, 0);
+
+  registry.record(pid, first_path.clone());
+  registry.record(pid, second_path.clone());
+
+  assert!(registry.pid_for_path(&first_path).is_none());
+  assert_eq!(registry.pid_for_path(&second_path), Some(pid));
+  assert_eq!(
+    registry.path_for_pid(&pid).as_ref().map(ActorPath::to_canonical_uri),
+    Some(second_path.to_canonical_uri())
+  );
+}
+
+#[test]
 fn remote_actor_ref_sender_drop_keeps_pid_path_mapping_for_remote_deathwatch() {
   let mut fixture = make_provider_fixture();
   let registry = fixture.registry.clone();

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -736,6 +736,24 @@ fn remote_actor_ref_resolution_records_pid_path_mapping() {
 }
 
 #[test]
+fn remote_actor_path_registry_replaces_previous_pid_for_same_path() {
+  let mut registry = RemoteActorPathRegistry::default();
+  let remote_path = remote_actor_path();
+  let first_pid = Pid::new(900, 0);
+  let second_pid = Pid::new(901, 0);
+
+  registry.record(first_pid, remote_path.clone());
+  registry.record(second_pid, remote_path.clone());
+
+  assert!(registry.path_for_pid(&first_pid).is_none());
+  assert_eq!(registry.pid_for_path(&remote_path), Some(second_pid));
+  assert_eq!(
+    registry.path_for_pid(&second_pid).as_ref().map(ActorPath::to_canonical_uri),
+    Some(remote_path.to_canonical_uri())
+  );
+}
+
+#[test]
 fn remote_actor_ref_sender_drop_keeps_pid_path_mapping_for_remote_deathwatch() {
   let mut fixture = make_provider_fixture();
   let registry = fixture.registry.clone();
@@ -748,6 +766,23 @@ fn remote_actor_ref_sender_drop_keeps_pid_path_mapping_for_remote_deathwatch() {
   assert!(registry.with_lock(|registry| registry.path_for_pid(&pid)).is_some());
   drop(actor_ref);
   assert!(registry.with_lock(|registry| registry.path_for_pid(&pid)).is_some());
+}
+
+#[test]
+fn remote_actor_ref_resolution_reuses_recorded_pid_after_cache_eviction() {
+  let mut fixture = make_provider_fixture();
+  let remote_path = remote_actor_path();
+
+  let first = fixture.provider.actor_ref(remote_path.clone()).expect("first remote actor ref should resolve");
+  for index in 0..1024 {
+    let eviction_path =
+      ActorPathParser::parse(&format!("fraktor.tcp://remote-sys@10.0.0.1:2552/user/evict-{index}")).expect("parse");
+    let _evicted = fixture.provider.actor_ref(eviction_path).expect("evicting remote actor ref should resolve");
+  }
+  let resolved_again = fixture.provider.actor_ref(remote_path).expect("remote actor ref should resolve after eviction");
+
+  assert_eq!(resolved_again.pid(), first.pid());
+  assert_eq!(fixture.actor_ref_call_count(), 1026);
 }
 
 #[test]

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -736,7 +736,7 @@ fn remote_actor_ref_resolution_records_pid_path_mapping() {
 }
 
 #[test]
-fn remote_actor_ref_sender_removes_pid_path_mapping_after_last_ref_is_dropped() {
+fn remote_actor_ref_sender_drop_keeps_pid_path_mapping_for_remote_deathwatch() {
   let mut fixture = make_provider_fixture();
   let registry = fixture.registry.clone();
   let remote_path = remote_actor_path();
@@ -747,7 +747,7 @@ fn remote_actor_ref_sender_removes_pid_path_mapping_after_last_ref_is_dropped() 
 
   assert!(registry.with_lock(|registry| registry.path_for_pid(&pid)).is_some());
   drop(actor_ref);
-  assert!(registry.with_lock(|registry| registry.path_for_pid(&pid)).is_none());
+  assert!(registry.with_lock(|registry| registry.path_for_pid(&pid)).is_some());
 }
 
 #[test]


### PR DESCRIPTION
### Motivation
- Remote PID→ActorPath registry entries were tied to the lifetime of cached `ActorRef` senders, so cache eviction could remove mappings required by remote DeathWatch notifications and cause missed outbound notifications.
- The change separates sender lifetime from registry lifetime so active DeathWatch routing is not lost when cached `ActorRef` instances are evicted.

### Description
- Removed the `Drop` impl and the `pid` + `registry` fields from `RemoteActorRefSender` so sender drop no longer removes the PID→path mapping.
- Updated `StdRemoteActorRefProvider::build_remote_actor_ref` to record the mapping in the registry and construct the simplified `RemoteActorRefSender` with the new signature (`remote_ref`, `event_sender`, `monotonic_epoch`).
- Deleted the now-unneeded `remove` helper from `RemoteActorPathRegistry` to align the API with the new lifetime policy.
- Adjusted a unit test in `provider_test.rs` to assert that the registry mapping remains present after the `ActorRef`/sender is dropped to prevent regressions.

### Testing
- Ran the targeted unit test: `cargo test -p fraktor-remote-adaptor-std-rs remote_actor_ref_sender_drop_keeps_pid_path_mapping_for_remote_deathwatch -- --nocapture`, and it passed.
- Compiled and ran the crate tests for `fraktor-remote-adaptor-std-rs`; the test run completed with the targeted test passing and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4a927974832db06d8e7505cf965a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote PID allocation and registry lifetime semantics used by DeathWatch routing; mistakes could cause PID/path mismatches or leaked mappings during long runtimes.
> 
> **Overview**
> Ensures remote DeathWatch can still resolve watcher paths even after `ActorRef` cache eviction by **making PID↔path registry entries persistent** rather than tied to `RemoteActorRefSender` drop.
> 
> `StdRemoteActorRefProvider::build_remote_actor_ref` now reuses an existing PID for a previously seen remote `ActorPath` (via a new reverse lookup), and `RemoteActorPathRegistry` becomes bidirectional with replacement logic to keep mappings consistent. Tests were updated/added to assert mappings are retained after sender drop and that PID reuse works after cache eviction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6db16bd39fb67f86af09da1787d7367d3e1679e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 改善されたリモートアクターリファレンス構築による、PID割り当てとリソース再利用の最適化
  * リモートアクターパスレジストリの双方向参照機能により、パスからPIDへの高速検索が可能に
  * リモートアクターリファレンス送信機の内部構造を簡素化

* **Tests**
  * リモートアクターパスレジストリの置き換え動作および再利用メカニズムの検証テストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1833?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->