### PR TITLE
fix(actor-core-typed): cap guardian startup deferred buffer

### DIFF
--- a/modules/actor-core-typed/src/internal/guardian_startup_actor.rs
+++ b/modules/actor-core-typed/src/internal/guardian_startup_actor.rs
@@ -1,5 +1,9 @@
 //! Delays typed user guardian startup until actor-system bootstrap completes.
 
+#[cfg(test)]
+#[path = "guardian_startup_actor_test.rs"]
+mod tests;
+
 use alloc::{boxed::Box, vec::Vec};
 use core::mem;
 
@@ -20,6 +24,14 @@ use fraktor_utils_core_rs::sync::SharedAccess;
 use super::GuardianStartupStart;
 
 /// Pekko-compatible startup gate for the typed user guardian.
+const GUARDIAN_STARTUP_DEFERRED_LIMIT: usize = 1024;
+
+const GUARDIAN_STARTUP_DEFERRED_NO_ACTIVE_MESSAGE_REASON: &str =
+  "guardian startup deferral requires an active user message";
+const GUARDIAN_STARTUP_DEFERRED_OVERFLOW_REASON: &str = "guardian startup deferred buffer overflow";
+
+struct GuardianStartupDeferralError;
+
 pub(crate) struct GuardianStartupActor {
   inner:    Box<dyn Actor + Send>,
   started:  bool,
@@ -76,8 +88,15 @@ impl GuardianStartupActor {
 
   fn defer_current_message(&mut self, ctx: &ActorContext<'_>) -> Result<(), ActorError> {
     let Some(message) = ctx.clone_current_message() else {
-      return Err(ActorError::recoverable("guardian startup deferral requires an active user message"));
+      return Err(ActorError::recoverable_typed::<GuardianStartupDeferralError>(
+        GUARDIAN_STARTUP_DEFERRED_NO_ACTIVE_MESSAGE_REASON,
+      ));
     };
+    if self.deferred.len() >= GUARDIAN_STARTUP_DEFERRED_LIMIT {
+      return Err(ActorError::recoverable_typed::<GuardianStartupDeferralError>(
+        GUARDIAN_STARTUP_DEFERRED_OVERFLOW_REASON,
+      ));
+    }
     self.deferred.push(message);
     Ok(())
   }
@@ -144,6 +163,11 @@ impl Actor for GuardianStartupActor {
   }
 
   fn post_restart(&mut self, ctx: &mut ActorContext<'_>, reason: &ActorErrorReason) -> Result<(), ActorError> {
+    if reason.is_source_type::<GuardianStartupDeferralError>() {
+      self.started = false;
+      self.deferred.clear();
+      return Ok(());
+    }
     self.started = true;
     self.inner.post_restart(ctx, reason)?;
     self.deliver_deferred(ctx)

--- a/modules/actor-core-typed/src/internal/guardian_startup_actor_test.rs
+++ b/modules/actor-core-typed/src/internal/guardian_startup_actor_test.rs
@@ -1,0 +1,123 @@
+use std::sync::{
+  Arc,
+  atomic::{AtomicUsize, Ordering},
+};
+
+use fraktor_actor_core_kernel_rs::actor::{
+  Actor, ActorContext,
+  error::{ActorError, ActorErrorReason},
+  messaging::{AnyMessage, AnyMessageView},
+};
+
+use super::{
+  GUARDIAN_STARTUP_DEFERRED_LIMIT, GUARDIAN_STARTUP_DEFERRED_NO_ACTIVE_MESSAGE_REASON,
+  GUARDIAN_STARTUP_DEFERRED_OVERFLOW_REASON, GuardianStartupActor, GuardianStartupDeferralError, GuardianStartupStart,
+};
+
+struct SilentActor;
+
+impl Actor for SilentActor {
+  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}
+
+struct LifecycleProbeActor {
+  pre_start_calls:    Arc<AtomicUsize>,
+  post_restart_calls: Arc<AtomicUsize>,
+}
+
+impl Actor for LifecycleProbeActor {
+  fn pre_start(&mut self, _ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
+    self.pre_start_calls.fetch_add(1, Ordering::SeqCst);
+    Ok(())
+  }
+
+  fn post_restart(&mut self, _ctx: &mut ActorContext<'_>, _reason: &ActorErrorReason) -> Result<(), ActorError> {
+    self.post_restart_calls.fetch_add(1, Ordering::SeqCst);
+    Ok(())
+  }
+
+  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}
+
+fn build_context() -> ActorContext<'static> {
+  let system = fraktor_actor_adaptor_std_rs::system::create_noop_actor_system();
+  let pid = system.allocate_pid();
+  ActorContext::new(&system, pid)
+}
+
+fn receive_user_message(
+  actor: &mut GuardianStartupActor,
+  ctx: &mut ActorContext<'_>,
+  value: usize,
+) -> Result<(), ActorError> {
+  ctx.with_current_message(AnyMessage::new(value), |active_ctx, current_message| {
+    actor.receive(active_ctx, current_message.as_view())
+  })
+}
+
+#[test]
+fn deferral_requires_active_user_message_with_recoverable_error() {
+  let mut actor = GuardianStartupActor::new(Box::new(SilentActor));
+  let mut ctx = build_context();
+  let message = AnyMessage::new(0_usize);
+
+  let error = actor.receive(&mut ctx, message.as_view()).expect_err("deferral requires current message in context");
+
+  assert!(matches!(
+    error,
+    ActorError::Recoverable(reason)
+      if reason.as_str() == GUARDIAN_STARTUP_DEFERRED_NO_ACTIVE_MESSAGE_REASON
+        && reason.is_source_type::<GuardianStartupDeferralError>()
+  ));
+}
+
+#[test]
+fn deferred_overflow_is_recoverable_before_start() {
+  let mut actor = GuardianStartupActor::new(Box::new(SilentActor));
+  let mut ctx = build_context();
+
+  for value in 0..GUARDIAN_STARTUP_DEFERRED_LIMIT {
+    receive_user_message(&mut actor, &mut ctx, value).expect("message should fit deferred buffer");
+  }
+
+  let error = receive_user_message(&mut actor, &mut ctx, GUARDIAN_STARTUP_DEFERRED_LIMIT)
+    .expect_err("overflow must fail before guardian startup");
+  assert!(matches!(
+    error,
+    ActorError::Recoverable(reason)
+      if reason.as_str() == GUARDIAN_STARTUP_DEFERRED_OVERFLOW_REASON
+        && reason.is_source_type::<GuardianStartupDeferralError>()
+  ));
+}
+
+#[test]
+fn startup_deferral_restart_keeps_inner_unstarted_until_start_signal() {
+  let pre_start_calls = Arc::new(AtomicUsize::new(0));
+  let post_restart_calls = Arc::new(AtomicUsize::new(0));
+  let mut actor = GuardianStartupActor::new(Box::new(LifecycleProbeActor {
+    pre_start_calls:    pre_start_calls.clone(),
+    post_restart_calls: post_restart_calls.clone(),
+  }));
+  let mut ctx = build_context();
+  let error = ActorError::recoverable_typed::<GuardianStartupDeferralError>(GUARDIAN_STARTUP_DEFERRED_OVERFLOW_REASON);
+
+  actor.post_restart(&mut ctx, error.reason()).expect("startup deferral restart should not fail");
+
+  assert!(!actor.started);
+  assert_eq!(pre_start_calls.load(Ordering::SeqCst), 0);
+  assert_eq!(post_restart_calls.load(Ordering::SeqCst), 0);
+
+  ctx
+    .with_current_message(AnyMessage::new(GuardianStartupStart), |active_ctx, current_message| {
+      actor.receive(active_ctx, current_message.as_view())
+    })
+    .expect("guardian startup should start inner actor after deferral restart");
+
+  assert!(actor.started);
+  assert_eq!(pre_start_calls.load(Ordering::SeqCst), 1);
+  assert_eq!(post_restart_calls.load(Ordering::SeqCst), 0);
+}


### PR DESCRIPTION
### Motivation
- `GuardianStartupActor` が起動完了前メッセージを無制限に `Vec` へ蓄えるため、guardian startup が進まないケースでメモリを消費し続ける可能性があった。
- 起動前 deferral の失敗後に restart した場合、inner actor を起動済み扱いにしてしまうと、その後の `GuardianStartupStart` で inner startup が正しく実行されない。

### Description
- 起動前 deferred buffer に 1024 件の上限を追加。
- 上限到達時と active current message がない deferral 不変条件違反は、supervision policy が扱える `Recoverable` な typed error として返す。
- startup deferral 由来の restart では `started = false` を維持し、deferred queue を破棄して `GuardianStartupStart` まで inner actor の `pre_start` / `post_restart` を呼ばないようにした。
- overflow、active current message 不在、deferral restart 後の startup gate 維持を回帰テストで固定。

### Verification
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml cargo fmt --all --check`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml cargo test -p fraktor-actor-core-typed-rs guardian_startup`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml ./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup gating and restart behavior in `GuardianStartupActor`, which can affect message delivery ordering and supervision/restart semantics if edge cases are missed. Scope is contained and covered by new unit tests.
> 
> **Overview**
> **Typed guardian startup deferral is now bounded and restart-safe.** `GuardianStartupActor` caps the deferred pre-start message buffer at `1024` and returns *typed recoverable* errors when deferral invariants are violated (no active current message) or the buffer overflows.
> 
> On `post_restart`, deferral-originated errors now keep `started = false` and drop the deferred queue so the inner actor’s startup runs only after a subsequent `GuardianStartupStart`. Adds regression tests for missing active message, overflow behavior, and deferral-restart startup gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe63a3f49f2ad8d311f1708d591c2039f9386dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->