### PR TITLE
fix(persistence): ignore RecoveryCompleted in active wait states

### DIFF
--- a/modules/persistence-core-typed/src/persistence_effector.rs
+++ b/modules/persistence-core-typed/src/persistence_effector.rs
@@ -37,7 +37,6 @@ where
   store_ref:       Option<TypedActorRef<PersistenceStoreCommand<S, E>>>,
   reply_to:        Option<TypedActorRef<PersistenceStoreReply<S, E>>>,
   ephemeral_store: Option<ArcShared<EphemeralPersistenceStore>>,
-  on_ready:        Option<ArcShared<OnReady<S, E, M>>>,
   sequence_nr:     SharedLock<u64>,
   _message:        PhantomData<fn() -> M>,
 }
@@ -113,7 +112,6 @@ where
       store_ref: None,
       reply_to: None,
       ephemeral_store: None,
-      on_ready: None,
       sequence_nr: SharedLock::new_with_driver::<DefaultMutex<_>>(0),
       _message: PhantomData,
     }
@@ -129,7 +127,6 @@ where
       store_ref: None,
       reply_to: None,
       ephemeral_store: Some(store),
-      on_ready: None,
       sequence_nr: SharedLock::new_with_driver::<DefaultMutex<_>>(sequence_nr),
       _message: PhantomData,
     }
@@ -140,14 +137,12 @@ where
     store_ref: TypedActorRef<PersistenceStoreCommand<S, E>>,
     reply_to: TypedActorRef<PersistenceStoreReply<S, E>>,
     sequence_nr: u64,
-    on_ready: ArcShared<OnReady<S, E, M>>,
   ) -> Self {
     Self {
       config,
       store_ref: Some(store_ref),
       reply_to: Some(reply_to),
       ephemeral_store: None,
-      on_ready: Some(on_ready),
       sequence_nr: SharedLock::new_with_driver::<DefaultMutex<_>>(sequence_nr),
       _message: PhantomData,
     }
@@ -173,8 +168,7 @@ where
         if let Some(signal) = adapter.unwrap_signal(message) {
           return match signal {
             | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
-              let effector =
-                Self::active(config.clone(), store_ref.clone(), reply_to.clone(), *sequence_nr, on_ready.clone());
+              let effector = Self::active(config.clone(), store_ref.clone(), reply_to.clone(), *sequence_nr);
               let next = on_ready(state.clone(), effector)?;
               stash.unstash_all(ctx)?;
               Ok(next)
@@ -618,7 +612,6 @@ where
       store_ref:       self.store_ref.clone(),
       reply_to:        self.reply_to.clone(),
       ephemeral_store: self.ephemeral_store.clone(),
-      on_ready:        self.on_ready.clone(),
       sequence_nr:     self.sequence_nr.clone(),
       _message:        PhantomData,
     }

--- a/modules/persistence-core-typed/src/persistence_effector.rs
+++ b/modules/persistence-core-typed/src/persistence_effector.rs
@@ -390,22 +390,6 @@ where
     });
   }
 
-  fn recover_after_store_restart(
-    &self,
-    ctx: &mut TypedActorContext<'_, M>,
-    stash: &StashBuffer<M>,
-    state: &S,
-    sequence_nr: u64,
-  ) -> Result<Behavior<M>, ActorError> {
-    let on_ready =
-      self.on_ready.clone().ok_or_else(|| ActorError::fatal("persistence recovery callback is not available"))?;
-    let effector =
-      Self::active(self.config.clone(), self.store_ref()?, self.reply_to()?, sequence_nr, on_ready.clone());
-    let next = on_ready(state.clone(), effector)?;
-    stash.unstash_all(ctx)?;
-    Ok(next)
-  }
-
   fn wait_for_event(&self, callback: EventCallback<E, M>) -> Behavior<M> {
     let callback = SharedLock::new_with_driver::<DefaultMutex<_>>(Some(callback));
     self.wait_for_events(Box::new(move |events| match events.first() {
@@ -422,12 +406,10 @@ where
       | None => return fatal_behavior("persistence message adapter is not configured"),
     };
     let callback = SharedLock::new_with_driver::<DefaultMutex<_>>(Some(callback));
-    let effector = self.clone();
     let sequence_nr_cell = self.sequence_nr.clone();
     Behaviors::with_stash(self.config.stash_capacity(), move |stash| {
       let adapter = adapter.clone();
       let callback = callback.clone();
-      let effector = effector.clone();
       let sequence_nr_cell = sequence_nr_cell.clone();
       Behaviors::receive_message(move |ctx, message| {
         if let Some(signal) = adapter.unwrap_signal(message) {
@@ -441,9 +423,6 @@ where
               })?;
               stash.unstash_all(ctx)?;
               Ok(next)
-            },
-            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
-              effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
             },
             | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
             | _ => Ok(Behaviors::unhandled()),
@@ -507,9 +486,6 @@ where
               stash.unstash_all(ctx)?;
               Ok(next)
             },
-            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
-              effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
-            },
             | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
             | _ => Ok(Behaviors::unhandled()),
           };
@@ -530,14 +506,12 @@ where
     let store_ref = self.store_ref.clone();
     let reply_to = self.reply_to.clone();
     let retention_criteria = *self.config.retention_criteria();
-    let effector = self.clone();
     Behaviors::with_stash(self.config.stash_capacity(), move |stash| {
       let adapter = adapter.clone();
       let callback = callback.clone();
       let sequence_nr_cell = sequence_nr_cell.clone();
       let store_ref = store_ref.clone();
       let reply_to = reply_to.clone();
-      let effector = effector.clone();
       Behaviors::receive_message(move |ctx, message| {
         if let Some(signal) = adapter.unwrap_signal(message) {
           return match signal {
@@ -559,7 +533,6 @@ where
                   snapshot.clone(),
                   to_sequence_nr,
                   stash,
-                  effector.clone(),
                 ));
               }
               let next = callback.with_lock(|slot| {
@@ -567,9 +540,6 @@ where
               })?;
               stash.unstash_all(ctx)?;
               Ok(next)
-            },
-            | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
-              effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
             },
             | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
             | _ => Ok(Behaviors::unhandled()),
@@ -587,7 +557,6 @@ where
     snapshot: S,
     to_sequence_nr: u64,
     stash: StashBuffer<M>,
-    effector: PersistenceEffector<S, E, M>,
   ) -> Behavior<M> {
     let snapshot = SharedLock::new_with_driver::<DefaultMutex<_>>(Some(snapshot));
     Behaviors::receive_message(move |ctx, message| {
@@ -607,9 +576,6 @@ where
           },
           | PersistenceEffectorSignal::DeletedSnapshots { .. } => {
             Err(ActorError::fatal("unexpected snapshot deletion acknowledgement"))
-          },
-          | PersistenceEffectorSignal::RecoveryCompleted { state, sequence_nr, .. } => {
-            effector.recover_after_store_restart(ctx, &stash, state, *sequence_nr)
           },
           | PersistenceEffectorSignal::Failed { error, .. } => Err(ActorError::fatal(error.to_string())),
           | _ => Ok(Behaviors::unhandled()),


### PR DESCRIPTION
### Motivation
- Prevent forged `PersistenceEffectorSignal::RecoveryCompleted` messages from being accepted during active persist/snapshot flows, which could overwrite in-memory state and sequence number.
- Keep initial startup recovery (`await_recovery`) behavior intact so normal store-driven recovery still functions.

### Description
- Removed handling of `PersistenceEffectorSignal::RecoveryCompleted` from active wait states in `PersistenceEffector`: `wait_for_events`, `wait_for_events_then_snapshot`, `wait_for_snapshot`, and `wait_for_deleted_snapshots` so those paths only accept the expected store ack signals and failures.
- Kept `RecoveryCompleted` handling only in the initial `await_recovery` flow where it belongs.
- Removed now-unused locals/parameters introduced only to support the mid-flight recovery path to keep the change minimal and surgical.
- Files changed: `modules/persistence-core-typed/src/persistence_effector.rs`.

### Testing
- Ran `cargo test -p fraktor-persistence-core-typed-rs persistence_effector_flow -- --nocapture` and observed the test run completed successfully (no failures).
- Compiled and ran the typed persistence package tests as part of the above command and observed the test suite finished without failing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4a937a14832db06163fa8aa3620d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens signal handling during persist/snapshot waits to avoid accepting unexpected `RecoveryCompleted` messages, which could change in-flight behavior if anything relied on mid-flight recovery. Scope is small but touches persistence state/sequence updates.
> 
> **Overview**
> **Hardens persistence signal handling** by removing `PersistenceEffectorSignal::RecoveryCompleted` handling from the active wait behaviors used after sending persistence commands (event persist, event+snapshot flow, snapshot persist, and snapshot deletion ack). This keeps `RecoveryCompleted` processing only in the initial `await_recovery` path.
> 
> Cleans up related plumbing by removing the stored `on_ready` callback from `PersistenceEffector`, deleting the now-unused `recover_after_store_restart` helper, and simplifying wait-state closures/parameters accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d4d8ca57208f4d539aed39cfbe6ce74938f088b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * ストア再起動時の回復メカニズムの実装を簡潔化しました。初期化フローを整理し、回復処理の扱いをより一貫性のあるものに改善しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->