### PR TITLE
fix(embassy): bound Embassy executor drain loop per driver turn

### DIFF
--- a/modules/actor-adaptor-embassy/src/dispatch/embassy_executor.rs
+++ b/modules/actor-adaptor-embassy/src/dispatch/embassy_executor.rs
@@ -31,6 +31,10 @@ impl<const N: usize> EmbassyExecutor<N> {
     self.signal.clone()
   }
 
+  pub(crate) fn signal_ready(&self) {
+    self.signal.signal(());
+  }
+
   pub(crate) fn pop_ready(&mut self) -> Option<EmbassyTask> {
     self.queue.try_receive().ok()
   }

--- a/modules/actor-adaptor-embassy/src/dispatch/embassy_executor_driver.rs
+++ b/modules/actor-adaptor-embassy/src/dispatch/embassy_executor_driver.rs
@@ -10,25 +10,39 @@ pub struct EmbassyExecutorDriver<const N: usize> {
 }
 
 impl<const N: usize> EmbassyExecutorDriver<N> {
+  const MAX_TASKS_PER_TURN: usize = 64;
+
   pub(crate) fn new(shared: EmbassyExecutorShared<N>) -> Self {
     Self { shared }
   }
 
   /// Drains currently queued tasks without waiting.
   pub fn drain_ready(&self) -> usize {
+    self.drain_ready_with_limit(usize::MAX)
+  }
+
+  pub(crate) fn drain_ready_with_limit(&self, limit: usize) -> usize {
     let mut drained = 0;
-    while let Some(task) = self.shared.with_write(|executor| executor.pop_ready()) {
+    while drained < limit {
+      let task = self.shared.with_write(|executor| executor.pop_ready());
+      let Some(task) = task else {
+        break;
+      };
       task();
       drained += 1;
     }
     drained
   }
 
-  /// Waits for a signal and drains all currently queued tasks.
+  /// Waits for a signal and drains a bounded batch of queued tasks.
   pub async fn run_once(&self) -> usize {
     let signal = self.shared.with_read(|executor| executor.ready_signal());
     signal.wait().await;
-    self.drain_ready()
+    let drained = self.drain_ready_with_limit(Self::MAX_TASKS_PER_TURN);
+    if drained == Self::MAX_TASKS_PER_TURN {
+      self.shared.with_read(|executor| executor.signal_ready());
+    }
+    drained
   }
 
   /// Runs the driver forever.

--- a/modules/actor-adaptor-embassy/src/dispatch/embassy_executor_test.rs
+++ b/modules/actor-adaptor-embassy/src/dispatch/embassy_executor_test.rs
@@ -73,3 +73,28 @@ fn executor_shutdown_does_not_stop_other_executor_from_same_factory() {
   assert_eq!(driver.drain_ready(), 1);
   assert_eq!(count.load(Ordering::SeqCst), 1);
 }
+
+#[test]
+fn driver_drain_ready_with_limit_stops_after_batch() {
+  let factory = EmbassyExecutorFactory::<8>::new();
+  let driver = factory.driver();
+  let executor = factory.create(DEFAULT_DISPATCHER_ID);
+  let count = Arc::new(AtomicUsize::new(0));
+
+  for _ in 0..3 {
+    let count_clone = count.clone();
+    executor
+      .execute(
+        Box::new(move || {
+          count_clone.fetch_add(1, Ordering::SeqCst);
+        }),
+        0,
+      )
+      .expect("execute should enqueue");
+  }
+
+  assert_eq!(driver.drain_ready_with_limit(2), 2);
+  assert_eq!(count.load(Ordering::SeqCst), 2);
+  assert_eq!(driver.drain_ready(), 1);
+  assert_eq!(count.load(Ordering::SeqCst), 3);
+}


### PR DESCRIPTION
### Motivation
- The Embassy executor driver previously drained the ready queue in a tight synchronous loop, allowing tasks that enqueue follow-up work to monopolize the cooperative executor and starve other Embassy tasks.
- A bounded per-turn drain or explicit yield point is required to ensure fairness between actor mailbox work and unrelated Embassy tasks.

### Description
- Add a per-turn batch limit `MAX_TASKS_PER_TURN = 64` and a new `drain_ready_with_limit(limit)` helper to bound synchronous execution per driver turn.
- Make `drain_ready()` delegate to `drain_ready_with_limit(usize::MAX)` to preserve existing manual-drain semantics.
- Add `signal_ready()` to `EmbassyExecutor` and re-signal when a full batch is consumed so remaining work is scheduled for a subsequent turn instead of being drained immediately.
- Add a unit test `driver_drain_ready_with_limit_stops_after_batch` to verify that bounded draining stops at the batch boundary and leaves remaining work for later processing.

### Testing
- Ran `cargo test -p fraktor-actor-adaptor-embassy-rs` and all tests passed.
- New test `driver_drain_ready_with_limit_stops_after_batch` exercised the batch-limited drain behavior and succeeded (6 tests passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4a929474832dadede1c3eafed327)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task scheduling behavior by limiting per-turn draining and re-signaling when more work remains, which can affect throughput/latency and has some risk of missed wakeups or altered fairness under load.
> 
> **Overview**
> **Prevents Embassy-task starvation** by bounding how many queued mailbox tasks the `EmbassyExecutorDriver` runs per `run_once` turn.
> 
> Adds `drain_ready_with_limit()` plus a `MAX_TASKS_PER_TURN` batch cap; `run_once()` now drains at most that many tasks and re-signals via a new `EmbassyExecutor::signal_ready()` when a full batch is consumed so remaining work is handled in a subsequent turn. Includes a unit test covering the batch-limited drain behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df981c0343aee9e9730d7dda078943f89d9d0b4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->