### PR TITLE
fix(persistence): preserve typed store backoff stashing

### DIFF
--- a/modules/actor-core-kernel/src/actor/supervision/backoff_supervisor.rs
+++ b/modules/actor-core-kernel/src/actor/supervision/backoff_supervisor.rs
@@ -68,7 +68,7 @@ impl BackoffSupervisor {
   #[allow(clippy::needless_pass_by_value)]
   pub fn props_on_stop(options: BackoffOnStopOptions) -> Props {
     let config = BackoffConfig::from_stop(options);
-    Props::from_fn(move || BackoffSupervisorActor::from_config(config.clone()))
+    Props::from_fn(move || BackoffSupervisorActor::from_config(config.clone())).with_stash_mailbox()
   }
 
   /// Creates [`Props`] for a backoff supervisor that restarts its child on failure.
@@ -78,7 +78,7 @@ impl BackoffSupervisor {
   #[allow(clippy::needless_pass_by_value)]
   pub fn props_on_failure(options: BackoffOnFailureOptions) -> Props {
     let config = BackoffConfig::from_failure(options);
-    Props::from_fn(move || BackoffSupervisorActor::from_config(config.clone()))
+    Props::from_fn(move || BackoffSupervisorActor::from_config(config.clone())).with_stash_mailbox()
   }
 }
 
@@ -131,6 +131,7 @@ struct BackoffSupervisorActor {
   max_retries: u32,
   initialized: bool,
   pending_restart: bool,
+  restart_scheduled: bool,
 }
 
 impl BackoffSupervisorActor {
@@ -169,6 +170,7 @@ impl BackoffSupervisorActor {
       max_retries: config.max_retries,
       initialized: false,
       pending_restart: false,
+      restart_scheduled: false,
     }
   }
 
@@ -187,6 +189,8 @@ impl BackoffSupervisorActor {
         }
         self.child = Some(child);
         self.initialized = true;
+        self.restart_scheduled = false;
+        ctx.unstash_all()?;
         Ok(())
       },
       | Err(error) => {
@@ -216,13 +220,15 @@ impl BackoffSupervisorActor {
     restart_count.saturating_sub(1)
   }
 
-  fn schedule_start_child(&self, ctx: &mut ActorContext<'_>, next_restart_count: u32) -> Result<(), ActorError> {
+  fn schedule_start_child(&mut self, ctx: &mut ActorContext<'_>, next_restart_count: u32) -> Result<(), ActorError> {
     // Pekko calculates the delay using the current restart counter before incrementing it.
     // We store the incremented restart count first, so map "restart attempt N" to
     // "backoff iteration N-1" explicitly here.
     let backoff_iteration = Self::backoff_iteration_for_restart_count(next_restart_count);
     let delay = self.strategy.compute_backoff(backoff_iteration);
-    Self::schedule_internal_command(ctx, delay, BackoffSupervisorInternalCommand::StartChild)
+    Self::schedule_internal_command(ctx, delay, BackoffSupervisorInternalCommand::StartChild)?;
+    self.restart_scheduled = true;
+    Ok(())
   }
 
   fn schedule_auto_reset(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
@@ -246,6 +252,7 @@ impl BackoffSupervisorActor {
   ) -> Result<(), ActorError> {
     match command {
       | BackoffSupervisorInternalCommand::StartChild => {
+        self.restart_scheduled = false;
         if self.child.is_none() {
           self.start_child(ctx)?;
           self.schedule_auto_reset(ctx)?;
@@ -320,6 +327,8 @@ impl Actor for BackoffSupervisorActor {
     {
       let mut child_ref = child.actor_ref().clone();
       ctx.forward(&mut child_ref, msg);
+    } else if self.restart_scheduled {
+      ctx.stash_with_limit(self.strategy.stash_capacity())?;
     }
     Ok(())
   }

--- a/modules/actor-core-kernel/src/actor/supervision/backoff_supervisor_test.rs
+++ b/modules/actor-core-kernel/src/actor/supervision/backoff_supervisor_test.rs
@@ -4,7 +4,7 @@ use std::thread::yield_now;
 
 use fraktor_utils_core_rs::sync::{ArcShared, SharedAccess, SpinSyncMutex};
 
-use super::{BackoffConfig, BackoffSupervisorActor};
+use super::{BackoffConfig, BackoffSupervisorActor, BackoffSupervisorInternalCommand};
 use crate::{
   actor::{
     Actor, ActorCell, ActorContext, Pid,
@@ -92,6 +92,28 @@ struct FailingOnMessageActor;
 impl Actor for FailingOnMessageActor {
   fn receive(&mut self, _context: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
     Err(ActorError::recoverable("boom"))
+  }
+}
+
+struct FailOnOneProbeActor {
+  received: ArcShared<SpinSyncMutex<Vec<i32>>>,
+}
+
+impl FailOnOneProbeActor {
+  fn new(received: ArcShared<SpinSyncMutex<Vec<i32>>>) -> Self {
+    Self { received }
+  }
+}
+
+impl Actor for FailOnOneProbeActor {
+  fn receive(&mut self, _context: &mut ActorContext<'_>, message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    match *message.downcast_ref::<i32>().expect("probe message") {
+      | 1 => Err(ActorError::recoverable("boom")),
+      | value => {
+        self.received.lock().push(value);
+        Ok(())
+      },
+    }
   }
 }
 
@@ -434,6 +456,52 @@ fn on_failure_forwarding_keeps_supervisor_responsive_until_backoff_restart() {
 
   let restarted_child = current_child_pid(&mut sup_ref).expect("restarted child after responsive failure path");
   assert_ne!(restarted_child, initial_child);
+}
+
+#[test]
+fn on_failure_stashes_user_messages_until_backoff_restart() {
+  let system = ActorSystem::new_empty();
+  let received = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let child_props = Props::from_fn({
+    let received = received.clone();
+    move || FailOnOneProbeActor::new(received.clone())
+  });
+  let options =
+    BackoffOnFailureOptions::new(child_props, String::from("child"), one_tick_strategy().with_stash_capacity(4));
+  let sup_props = BackoffSupervisor::props_on_failure(options);
+  let sup_pid = system.allocate_pid();
+  let sup_cell = register_cell(&system, sup_pid, "backoff-sup-stash-during-backoff", &sup_props);
+  let mut sup_ref = sup_cell.actor_ref();
+
+  let initial_child = current_child_pid(&mut sup_ref).expect("initial child");
+  sup_ref.tell(AnyMessage::new(1_i32));
+
+  assert_eq!(current_child_pid(&mut sup_ref), None, "failed child should stay stopped until backoff elapses");
+
+  sup_ref.tell(AnyMessage::new(2_i32));
+  assert!(received.lock().is_empty(), "message sent during backoff must wait for the restarted child");
+
+  system.scheduler().with_write(|scheduler| scheduler.run_for_test(1));
+
+  wait_until(|| *received.lock() == vec![2]);
+  let restarted_child = current_child_pid(&mut sup_ref).expect("restarted child after stashed message replay");
+  assert_ne!(restarted_child, initial_child);
+}
+
+#[test]
+fn start_child_command_clears_restart_scheduled_when_spawn_fails() {
+  let system = ActorSystem::new_empty();
+  let options = BackoffOnFailureOptions::new(noop_props(), String::from("child"), one_tick_strategy());
+  let config = BackoffConfig::from_failure(options);
+  let mut actor = BackoffSupervisorActor::from_config(config);
+  actor.initialized = true;
+  actor.restart_scheduled = true;
+  let mut ctx = ActorContext::new(&system, Pid::new(100, 0));
+
+  let result = actor.handle_internal_command(&mut ctx, &BackoffSupervisorInternalCommand::StartChild);
+
+  assert!(result.is_err(), "unregistered parent context should make child spawn fail");
+  assert!(!actor.restart_scheduled, "consumed restart command must not leave stale scheduled state");
 }
 
 #[test]

--- a/modules/persistence-core-typed/src/internal/persistence_store_actor.rs
+++ b/modules/persistence-core-typed/src/internal/persistence_store_actor.rs
@@ -2,12 +2,7 @@
 
 use alloc::{string::ToString, vec, vec::Vec};
 
-use fraktor_actor_core_kernel_rs::actor::{
-  ActorContext,
-  error::ActorError,
-  messaging::AnyMessageView,
-  supervision::{BackoffOnFailureOptions, BackoffSupervisor, BackoffSupervisorStrategy},
-};
+use fraktor_actor_core_kernel_rs::actor::{ActorContext, error::ActorError, messaging::AnyMessageView};
 use fraktor_actor_core_typed_rs::{TypedActorRef, TypedProps};
 use fraktor_persistence_core_kernel_rs::{
   error::PersistenceError,
@@ -50,16 +45,7 @@ where
   ) -> TypedProps<PersistenceStoreCommand<S, E>> {
     let child_config = config.clone();
     let child_reply_to = recovery_reply_to.clone();
-    let child_props = persistent_props(move || Self::new(child_config.clone(), child_reply_to.clone()));
-    let backoff_config = config.backoff_config();
-    let strategy = BackoffSupervisorStrategy::new(
-      backoff_config.min_backoff(),
-      backoff_config.max_backoff(),
-      backoff_config.random_factor(),
-    )
-    .with_stash_capacity(config.stash_capacity());
-    let options = BackoffOnFailureOptions::new(child_props, "store".to_string(), strategy);
-    TypedProps::from_props(BackoffSupervisor::props_on_failure(options))
+    TypedProps::from_props(persistent_props(move || Self::new(child_config.clone(), child_reply_to.clone())))
   }
 
   fn new(config: PersistenceEffectorConfig<S, E, M>, recovery_reply_to: ReplyRef<S, E>) -> Self {

--- a/modules/persistence-core-typed/src/internal/persistence_store_actor.rs
+++ b/modules/persistence-core-typed/src/internal/persistence_store_actor.rs
@@ -2,7 +2,12 @@
 
 use alloc::{string::ToString, vec, vec::Vec};
 
-use fraktor_actor_core_kernel_rs::actor::{ActorContext, error::ActorError, messaging::AnyMessageView};
+use fraktor_actor_core_kernel_rs::actor::{
+  ActorContext,
+  error::ActorError,
+  messaging::AnyMessageView,
+  supervision::{BackoffOnFailureOptions, BackoffSupervisor, BackoffSupervisorStrategy},
+};
 use fraktor_actor_core_typed_rs::{TypedActorRef, TypedProps};
 use fraktor_persistence_core_kernel_rs::{
   error::PersistenceError,
@@ -43,9 +48,17 @@ where
     config: PersistenceEffectorConfig<S, E, M>,
     recovery_reply_to: ReplyRef<S, E>,
   ) -> TypedProps<PersistenceStoreCommand<S, E>> {
-    let child_config = config.clone();
-    let child_reply_to = recovery_reply_to.clone();
-    TypedProps::from_props(persistent_props(move || Self::new(child_config.clone(), child_reply_to.clone())))
+    let backoff_config = config.backoff_config().clone();
+    let stash_capacity = config.stash_capacity();
+    let child_props = persistent_props(move || Self::new(config.clone(), recovery_reply_to.clone()));
+    let strategy = BackoffSupervisorStrategy::new(
+      backoff_config.min_backoff(),
+      backoff_config.max_backoff(),
+      backoff_config.random_factor(),
+    )
+    .with_stash_capacity(stash_capacity);
+    let options = BackoffOnFailureOptions::new(child_props, "store".to_string(), strategy);
+    TypedProps::from_props(BackoffSupervisor::props_on_failure(options))
   }
 
   fn new(config: PersistenceEffectorConfig<S, E, M>, recovery_reply_to: ReplyRef<S, E>) -> Self {


### PR DESCRIPTION
### Motivation
- The BackoffSupervisor wrapper around the typed persistence store caused an unsafe window where forwarded persistence protocol messages are accepted by the supervisor but dropped while its child is absent during backoff, leading to indefinite waits and actor-level DoS. 
- Keep the persistence protocol delivery deterministic so the effector always receives replies for its `PersistEvent`/`PersistEvents` requests.

### Description
- Replaced the `BackoffSupervisor`-wrapped props with a direct `persistent_props`-based `TypedProps::from_props(...)` for `PersistenceStoreActor::props` to ensure messages are delivered directly to the persistent store actor (file: `modules/persistence-core-typed/src/internal/persistence_store_actor.rs`).
- Removed now-unused supervision imports from the same file to keep the change surgical and limited to the affected area.
- The change preserves existing actor behavior while eliminating the supervisor drop-window for persistence protocol messages.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo test -p fraktor-persistence-core-typed-rs` where unit and flow tests passed; one test (`persistence_effector_signal_public_surface`) failed in this environment due to inability to fetch crates.io dependencies (network restriction), not because of the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4a926d70832da57bb3c6fbd99cf9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes backoff supervision message-handling to stash/unstash user messages while a restart is scheduled, which affects delivery ordering and mailbox behavior across restarts. Risk is moderate because it alters core actor supervision semantics used by persistence components.
> 
> **Overview**
> Prevents message loss during backoff restarts by giving `BackoffSupervisor` a stash-capable mailbox and stashing unrecognized/user messages while a child restart is scheduled, then `unstash_all()` once the child successfully respawns.
> 
> Adds explicit `restart_scheduled` tracking (set when scheduling `StartChild`, cleared when the command is handled or the child starts) plus new tests covering stashing during backoff and ensuring the scheduled state is cleared even if spawning the child fails. Updates `PersistenceStoreActor::props` to preserve stash capacity/backoff config when building the supervisor-wrapped persistent store props.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b77fde7a2bd6c2c36febbeefdf7b7181de59be4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 監督システムのバックオフ再起動中に、送信されたメッセージがスタッシュされるようになり、メッセージロスを防止しました。

* **Tests**
  * バックオフ中のメッセージスタッシング動作を検証する新しいテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1837?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->