### PR TITLE
[codex] Keep inbound handshake send failures local

### DIFF
--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -21,7 +21,7 @@ use fraktor_utils_core_rs::sync::{ArcShared, SharedAccess};
 
 use crate::{
   address::{Address, UniqueAddress},
-  association::{Association, AssociationEffect, QuarantineReason},
+  association::{Association, AssociationEffect, AssociationState, QuarantineReason},
   config::RemoteConfig,
   envelope::{InboundEnvelope, OutboundEnvelope, OutboundPriority},
   extension::{
@@ -417,29 +417,16 @@ impl Remote {
     let Some(association_index) = self.association_index_for_handshake_request(request) else {
       return Ok(());
     };
-    let accepted = {
-      let association = &mut self.associations[association_index];
-      match association.accept_handshake_request(request, now_ms, self.instrument.as_mut()) {
-        | Ok(effects) => {
-          let remote = association.remote().clone();
-          let response = HandshakePdu::Rsp(HandshakeRsp::new(association.local().clone()));
-          Some((remote, response, effects))
-        },
-        | Err(error) => {
-          tracing::debug!(
-            ?error,
-            association_index,
-            remote = %association.remote(),
-            "accept handshake request failed"
-          );
-          None
-        },
+    let (remote, response) = {
+      let association = &self.associations[association_index];
+      if !matches!(association.state(), AssociationState::Handshaking { .. } | AssociationState::Active { .. }) {
+        tracing::debug!(association_index, remote = %association.remote(), "accept handshake request failed");
+        return Ok(());
       }
+      let remote = association.remote().clone();
+      let response = HandshakePdu::Rsp(HandshakeRsp::new(association.local().clone()));
+      (remote, response)
     };
-    let Some((remote, response, effects)) = accepted else {
-      return Ok(());
-    };
-    self.apply_association_effects(association_index, effects, now_ms)?;
     if let Err(error) = self.transport.connect_peer(&remote) {
       tracing::debug!(
         ?error,
@@ -456,6 +443,10 @@ impl Remote {
       );
       return Ok(());
     }
+    let effects = self.associations[association_index]
+      .accept_handshake_request(request, now_ms, self.instrument.as_mut())
+      .unwrap_or_default();
+    self.apply_association_effects(association_index, effects, now_ms)?;
     self.drain_outbound(association_index, now_ms)
   }
 

--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -71,6 +71,30 @@ fn accept_inbound_handshake_request(
   }
 }
 
+fn map_inbound_response_delivery_result(
+  remote: &Address,
+  operation: &'static str,
+  result: Result<(), TransportError>,
+) -> Result<bool, RemotingError> {
+  match result {
+    | Ok(()) => Ok(true),
+    | Err(error @ (TransportError::Backpressure | TransportError::ConnectionClosed)) => {
+      tracing::debug!(?error, remote = %remote, operation, "dropping inbound response because peer writer is unavailable");
+      Ok(false)
+    },
+    | Err(
+      error @ (TransportError::UnsupportedScheme
+      | TransportError::NotAvailable
+      | TransportError::AlreadyRunning
+      | TransportError::NotStarted
+      | TransportError::SendFailed),
+    ) => {
+      tracing::debug!(?error, remote = %remote, operation, "inbound response delivery failed");
+      Err(RemotingError::TransportUnavailable)
+    },
+  }
+}
+
 impl Remote {
   /// Creates a new remote lifecycle instance.
   #[must_use]
@@ -447,20 +471,14 @@ impl Remote {
       let response = HandshakePdu::Rsp(HandshakeRsp::new(association.local().clone()));
       (remote, response)
     };
-    if let Err(error) = self.transport.connect_peer(&remote) {
-      tracing::debug!(
-        ?error,
-        remote = %remote,
-        "dropping handshake response because peer writer is unavailable"
-      );
+    if !map_inbound_response_delivery_result(&remote, "connect_peer", self.transport.connect_peer(&remote))? {
       return Ok(());
     }
-    if let Err(error) = self.transport.send_handshake(&remote, response) {
-      tracing::debug!(
-        ?error,
-        remote = %remote,
-        "dropping handshake response because handshake channel is unavailable"
-      );
+    if !map_inbound_response_delivery_result(
+      &remote,
+      "send_handshake",
+      self.transport.send_handshake(&remote, response),
+    )? {
       return Ok(());
     }
     let effects = accept_inbound_handshake_request(

--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -55,6 +55,22 @@ pub struct Remote {
   flush_outcomes:       Vec<RemoteFlushOutcome>,
 }
 
+fn accept_inbound_handshake_request(
+  association: &mut Association,
+  request: &HandshakeReq,
+  now_ms: u64,
+  instrument: &mut dyn RemoteInstrument,
+  association_index: usize,
+) -> Vec<AssociationEffect> {
+  match association.accept_handshake_request(request, now_ms, instrument) {
+    | Ok(effects) => effects,
+    | Err(error) => {
+      tracing::debug!(?error, association_index, ?request, now_ms, "accept handshake request failed");
+      Default::default()
+    },
+  }
+}
+
 impl Remote {
   /// Creates a new remote lifecycle instance.
   #[must_use]
@@ -447,9 +463,13 @@ impl Remote {
       );
       return Ok(());
     }
-    let effects = self.associations[association_index]
-      .accept_handshake_request(request, now_ms, self.instrument.as_mut())
-      .unwrap_or_default();
+    let effects = accept_inbound_handshake_request(
+      &mut self.associations[association_index],
+      request,
+      now_ms,
+      self.instrument.as_mut(),
+      association_index,
+    );
     self.apply_association_effects(association_index, effects, now_ms)?;
     self.drain_outbound(association_index, now_ms)
   }

--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -440,8 +440,22 @@ impl Remote {
       return Ok(());
     };
     self.apply_association_effects(association_index, effects, now_ms)?;
-    self.transport.connect_peer(&remote).map_err(|_| RemotingError::TransportUnavailable)?;
-    map_wire_delivery_result(&remote, self.transport.send_handshake(&remote, response))?;
+    if let Err(error) = self.transport.connect_peer(&remote) {
+      tracing::debug!(
+        ?error,
+        remote = %remote,
+        "dropping handshake response because peer writer is unavailable"
+      );
+      return Ok(());
+    }
+    if let Err(error) = self.transport.send_handshake(&remote, response) {
+      tracing::debug!(
+        ?error,
+        remote = %remote,
+        "dropping handshake response because handshake channel is unavailable"
+      );
+      return Ok(());
+    }
     self.drain_outbound(association_index, now_ms)
   }
 

--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -423,6 +423,10 @@ impl Remote {
         tracing::debug!(association_index, remote = %association.remote(), "accept handshake request failed");
         return Ok(());
       }
+      if association.local().address() != request.to() {
+        tracing::debug!(association_index, remote = %association.remote(), "accept handshake request failed");
+        return Ok(());
+      }
       let remote = association.remote().clone();
       let response = HandshakePdu::Rsp(HandshakeRsp::new(association.local().clone()));
       (remote, response)

--- a/modules/remote-core/src/extension/remote_test.rs
+++ b/modules/remote-core/src/extension/remote_test.rs
@@ -1,4 +1,11 @@
-use crate::{address::Address, association::AssociationState, extension::Remote};
+use super::accept_inbound_handshake_request;
+use crate::{
+  address::{Address, UniqueAddress},
+  association::{Association, AssociationState},
+  extension::Remote,
+  instrument::NoopInstrument,
+  wire::HandshakeReq,
+};
 
 impl Remote {
   pub(crate) const fn association_count_for_test(&self) -> usize {
@@ -8,4 +15,17 @@ impl Remote {
   pub(crate) fn association_state_for_test(&self, remote: &Address) -> Option<&AssociationState> {
     self.associations.iter().find(|association| association.remote() == remote).map(|association| association.state())
   }
+}
+
+#[test]
+fn accept_inbound_handshake_request_defaults_when_association_rejects() {
+  let local = UniqueAddress::new(Address::new("local-sys", "127.0.0.1", 2551), 1);
+  let remote = Address::new("remote-sys", "10.0.0.1", 2552);
+  let mut association = Association::new(local.clone(), remote.clone());
+  let request = HandshakeReq::new(UniqueAddress::new(remote, 2), local.address().clone());
+
+  let effects = accept_inbound_handshake_request(&mut association, &request, 200, &mut NoopInstrument, 0);
+
+  assert!(effects.is_empty());
+  assert!(matches!(association.state(), AssociationState::Idle));
 }

--- a/modules/remote-core/src/extension/remote_test.rs
+++ b/modules/remote-core/src/extension/remote_test.rs
@@ -1,7 +1,11 @@
-use crate::extension::Remote;
+use crate::{address::Address, association::AssociationState, extension::Remote};
 
 impl Remote {
   pub(crate) const fn association_count_for_test(&self) -> usize {
     self.associations.len()
+  }
+
+  pub(crate) fn association_state_for_test(&self, remote: &Address) -> Option<&AssociationState> {
+    self.associations.iter().find(|association| association.remote() == remote).map(|association| association.state())
   }
 }

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -58,6 +58,7 @@ struct RecordingTransport {
   timeout_calls: ArcShared<AtomicUsize>,
   timeout_before_handshake_calls: ArcShared<AtomicUsize>,
   connect_peer_calls: ArcShared<AtomicUsize>,
+  connect_peer_result: Result<(), TransportError>,
 }
 
 struct VecRemoteEventReceiver {
@@ -209,6 +210,7 @@ impl RecordingTransport {
       timeout_calls: ArcShared::new(AtomicUsize::new(0)),
       timeout_before_handshake_calls: ArcShared::new(AtomicUsize::new(0)),
       connect_peer_calls: ArcShared::new(AtomicUsize::new(0)),
+      connect_peer_result: Ok(()),
     }
   }
 
@@ -230,6 +232,7 @@ impl RecordingTransport {
       timeout_calls: ArcShared::new(AtomicUsize::new(0)),
       timeout_before_handshake_calls: ArcShared::new(AtomicUsize::new(0)),
       connect_peer_calls: ArcShared::new(AtomicUsize::new(0)),
+      connect_peer_result: Ok(()),
     }
   }
 
@@ -255,6 +258,7 @@ impl RecordingTransport {
       timeout_calls: ArcShared::new(AtomicUsize::new(0)),
       timeout_before_handshake_calls: ArcShared::new(AtomicUsize::new(0)),
       connect_peer_calls: ArcShared::new(AtomicUsize::new(0)),
+      connect_peer_result: Ok(()),
     })
   }
 
@@ -276,6 +280,7 @@ impl RecordingTransport {
       timeout_calls: ArcShared::new(AtomicUsize::new(0)),
       timeout_before_handshake_calls: ArcShared::new(AtomicUsize::new(0)),
       connect_peer_calls: ArcShared::new(AtomicUsize::new(0)),
+      connect_peer_result: Ok(()),
     }
   }
 
@@ -297,6 +302,29 @@ impl RecordingTransport {
       timeout_calls: ArcShared::new(AtomicUsize::new(0)),
       timeout_before_handshake_calls: ArcShared::new(AtomicUsize::new(0)),
       connect_peer_calls: ArcShared::new(AtomicUsize::new(0)),
+      connect_peer_result: Ok(()),
+    }
+  }
+
+  fn with_connect_peer_result(addresses: Vec<Address>, connect_peer_result: Result<(), TransportError>) -> Self {
+    Self {
+      addresses,
+      start_result: Ok(()),
+      shutdown_result: Ok(()),
+      send_result: Ok(()),
+      control_result: Ok(()),
+      running: false,
+      shutdown_calls: ArcShared::new(AtomicUsize::new(0)),
+      send_calls: ArcShared::new(AtomicUsize::new(0)),
+      control_calls: ArcShared::new(AtomicUsize::new(0)),
+      control_frames: SharedLock::new_with_driver::<DefaultMutex<_>>(Vec::new()),
+      ack_calls: ArcShared::new(AtomicUsize::new(0)),
+      ack_frames: SharedLock::new_with_driver::<DefaultMutex<_>>(Vec::new()),
+      handshake_calls: ArcShared::new(AtomicUsize::new(0)),
+      timeout_calls: ArcShared::new(AtomicUsize::new(0)),
+      timeout_before_handshake_calls: ArcShared::new(AtomicUsize::new(0)),
+      connect_peer_calls: ArcShared::new(AtomicUsize::new(0)),
+      connect_peer_result,
     }
   }
 }
@@ -330,7 +358,10 @@ impl RemoteTransport for RecordingTransport {
 
   fn connect_peer(&mut self, _remote: &Address) -> Result<(), TransportError> {
     self.connect_peer_calls.fetch_add(1, Ordering::Relaxed);
-    if self.running { Ok(()) } else { Err(TransportError::NotStarted) }
+    if !self.running {
+      return Err(TransportError::NotStarted);
+    }
+    self.connect_peer_result.clone()
   }
 
   fn send_control(&mut self, remote: &Address, pdu: ControlPdu) -> Result<(), TransportError> {
@@ -971,6 +1002,71 @@ fn inbound_handshake_response_send_failure_keeps_event_loop_alive() {
   block_on_ready(remote.run(&mut receiver)).expect("handshake response send failure should not stop remote");
 
   assert_eq!(handshake_calls.load(Ordering::Relaxed), 1);
+  assert_eq!(control_calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn inbound_handshake_response_send_success_keeps_event_loop_alive() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport = RecordingTransport::new(vec![local_address.clone()]);
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let handshake_calls = transport.handshake_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound handshake");
+  remote.insert_association(active_association(local_address.clone(), remote_address.clone(), &config));
+  let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(remote_address.clone(), 7), local_address));
+  let mut receiver = VecRemoteEventReceiver::new([
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(remote_address.to_string()),
+      frame:     WireFrame::Handshake(handshake),
+      now_ms:    75,
+    },
+    RemoteEvent::TransportShutdown,
+  ]);
+
+  block_on_ready(remote.run(&mut receiver)).expect("successful handshake response should not stop remote");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 1);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn inbound_handshake_connect_peer_failure_keeps_event_loop_alive() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let first_remote = Address::new("first-sys", "10.0.0.1", 2552);
+  let second_remote = Address::new("second-sys", "10.0.0.2", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport =
+    RecordingTransport::with_connect_peer_result(vec![local_address.clone()], Err(TransportError::ConnectionClosed));
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let handshake_calls = transport.handshake_calls.clone();
+  let control_calls = transport.control_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound handshakes");
+  remote.insert_association(active_association(local_address.clone(), first_remote.clone(), &config));
+  remote.insert_association(active_association(local_address.clone(), second_remote.clone(), &config));
+  let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(first_remote.clone(), 7), local_address));
+  let heartbeat = ControlPdu::Heartbeat { authority: second_remote.to_string() };
+  let mut receiver = VecRemoteEventReceiver::new([
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(first_remote.to_string()),
+      frame:     WireFrame::Handshake(handshake),
+      now_ms:    75,
+    },
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(second_remote.to_string()),
+      frame:     WireFrame::Control(heartbeat),
+      now_ms:    76,
+    },
+    RemoteEvent::TransportShutdown,
+  ]);
+
+  block_on_ready(remote.run(&mut receiver)).expect("connect peer failure should not stop remote");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 1);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 0);
   assert_eq!(control_calls.load(Ordering::Relaxed), 1);
 }
 

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -25,7 +25,7 @@ use fraktor_utils_core_rs::sync::{ArcShared, DefaultMutex, SharedLock};
 
 use crate::{
   address::{Address, RemoteNodeId, UniqueAddress},
-  association::{Association, AssociationEffect, QuarantineReason},
+  association::{Association, AssociationEffect, AssociationState, QuarantineReason},
   config::RemoteConfig,
   envelope::{InboundEnvelope, OutboundEnvelope, OutboundPriority},
   extension::{
@@ -518,6 +518,14 @@ fn association_with_sent_system_envelope(local: Address, remote: Address, config
   association
 }
 
+fn handshaking_association(local: Address, remote: Address, config: &RemoteConfig) -> Association {
+  let mut association = Association::from_config(UniqueAddress::new(local, 1), remote.clone(), config);
+  let mut instrument = NoopInstrument;
+  let start_effects = association.associate(TransportEndpoint::new(remote.to_string()), 1, &mut instrument);
+  assert_eq!(start_effects.len(), 1);
+  association
+}
+
 fn active_association(local: Address, remote: Address, config: &RemoteConfig) -> Association {
   let mut association = Association::from_config(UniqueAddress::new(local, 1), remote.clone(), config);
   let mut instrument = NoopInstrument;
@@ -970,6 +978,36 @@ fn inbound_handshake_requests_from_unknown_sources_do_not_create_associations() 
 }
 
 #[test]
+fn inbound_handshake_request_rejects_idle_association_without_sending_response() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport = RecordingTransport::new(vec![local_address.clone()]);
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let handshake_calls = transport.handshake_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound handshakes");
+  remote.insert_association(Association::from_config(
+    UniqueAddress::new(local_address.clone(), 1),
+    remote_address.clone(),
+    &config,
+  ));
+  let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(remote_address.clone(), 7), local_address));
+
+  remote
+    .handle_remote_event(RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(remote_address.to_string()),
+      frame:     WireFrame::Handshake(handshake),
+      now_ms:    75,
+    })
+    .expect("idle association should reject inbound handshake without failing the event loop");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 0);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 0);
+  assert!(matches!(remote.association_state_for_test(&remote_address), Some(AssociationState::Idle)));
+}
+
+#[test]
 fn inbound_handshake_response_send_failure_keeps_event_loop_alive() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);
   let first_remote = Address::new("first-sys", "10.0.0.1", 2552);
@@ -981,7 +1019,7 @@ fn inbound_handshake_response_send_failure_keeps_event_loop_alive() {
   let control_calls = transport.control_calls.clone();
   let mut remote = remote_new(transport, config.clone(), event_publisher());
   remote.start().expect("remote should be running before inbound handshakes");
-  remote.insert_association(active_association(local_address.clone(), first_remote.clone(), &config));
+  remote.insert_association(handshaking_association(local_address.clone(), first_remote.clone(), &config));
   remote.insert_association(active_association(local_address.clone(), second_remote.clone(), &config));
   let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(first_remote.clone(), 7), local_address));
   let heartbeat = ControlPdu::Heartbeat { authority: second_remote.to_string() };
@@ -1003,6 +1041,7 @@ fn inbound_handshake_response_send_failure_keeps_event_loop_alive() {
 
   assert_eq!(handshake_calls.load(Ordering::Relaxed), 1);
   assert_eq!(control_calls.load(Ordering::Relaxed), 1);
+  assert!(matches!(remote.association_state_for_test(&first_remote), Some(AssociationState::Handshaking { .. })));
 }
 
 #[test]
@@ -1015,7 +1054,7 @@ fn inbound_handshake_response_send_success_keeps_event_loop_alive() {
   let handshake_calls = transport.handshake_calls.clone();
   let mut remote = remote_new(transport, config.clone(), event_publisher());
   remote.start().expect("remote should be running before inbound handshake");
-  remote.insert_association(active_association(local_address.clone(), remote_address.clone(), &config));
+  remote.insert_association(handshaking_association(local_address.clone(), remote_address.clone(), &config));
   let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(remote_address.clone(), 7), local_address));
   let mut receiver = VecRemoteEventReceiver::new([
     RemoteEvent::InboundFrameReceived {
@@ -1030,6 +1069,7 @@ fn inbound_handshake_response_send_success_keeps_event_loop_alive() {
 
   assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 1);
   assert_eq!(handshake_calls.load(Ordering::Relaxed), 1);
+  assert!(matches!(remote.association_state_for_test(&remote_address), Some(AssociationState::Active { .. })));
 }
 
 #[test]
@@ -1045,7 +1085,7 @@ fn inbound_handshake_connect_peer_failure_keeps_event_loop_alive() {
   let control_calls = transport.control_calls.clone();
   let mut remote = remote_new(transport, config.clone(), event_publisher());
   remote.start().expect("remote should be running before inbound handshakes");
-  remote.insert_association(active_association(local_address.clone(), first_remote.clone(), &config));
+  remote.insert_association(handshaking_association(local_address.clone(), first_remote.clone(), &config));
   remote.insert_association(active_association(local_address.clone(), second_remote.clone(), &config));
   let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(first_remote.clone(), 7), local_address));
   let heartbeat = ControlPdu::Heartbeat { authority: second_remote.to_string() };
@@ -1068,6 +1108,7 @@ fn inbound_handshake_connect_peer_failure_keeps_event_loop_alive() {
   assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 1);
   assert_eq!(handshake_calls.load(Ordering::Relaxed), 0);
   assert_eq!(control_calls.load(Ordering::Relaxed), 1);
+  assert!(matches!(remote.association_state_for_test(&first_remote), Some(AssociationState::Handshaking { .. })));
 }
 
 #[test]

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -1137,6 +1137,57 @@ fn inbound_handshake_connect_peer_failure_keeps_event_loop_alive() {
 }
 
 #[test]
+fn inbound_handshake_response_systemic_send_failure_returns_transport_unavailable() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport = RecordingTransport::with_send_result(vec![local_address.clone()], Err(TransportError::NotAvailable));
+  let handshake_calls = transport.handshake_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound handshake");
+  remote.insert_association(handshaking_association(local_address.clone(), remote_address.clone(), &config));
+  let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(remote_address.clone(), 7), local_address));
+  let mut receiver = VecRemoteEventReceiver::new([RemoteEvent::InboundFrameReceived {
+    authority: TransportEndpoint::new(remote_address.to_string()),
+    frame:     WireFrame::Handshake(handshake),
+    now_ms:    75,
+  }]);
+
+  let error = block_on_ready(remote.run(&mut receiver)).expect_err("systemic send failure should stop remote");
+
+  assert_eq!(error, RemotingError::TransportUnavailable);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 1);
+  assert!(matches!(remote.association_state_for_test(&remote_address), Some(AssociationState::Handshaking { .. })));
+}
+
+#[test]
+fn inbound_handshake_connect_peer_systemic_failure_returns_transport_unavailable() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport =
+    RecordingTransport::with_connect_peer_result(vec![local_address.clone()], Err(TransportError::NotAvailable));
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let handshake_calls = transport.handshake_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound handshake");
+  remote.insert_association(handshaking_association(local_address.clone(), remote_address.clone(), &config));
+  let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(remote_address.clone(), 7), local_address));
+  let mut receiver = VecRemoteEventReceiver::new([RemoteEvent::InboundFrameReceived {
+    authority: TransportEndpoint::new(remote_address.to_string()),
+    frame:     WireFrame::Handshake(handshake),
+    now_ms:    75,
+  }]);
+
+  let error = block_on_ready(remote.run(&mut receiver)).expect_err("systemic connect failure should stop remote");
+
+  assert_eq!(error, RemotingError::TransportUnavailable);
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 1);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 0);
+  assert!(matches!(remote.association_state_for_test(&remote_address), Some(AssociationState::Handshaking { .. })));
+}
+
+#[test]
 fn inbound_deployment_frame_without_adapter_routing_is_ignored() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);
   let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -939,6 +939,42 @@ fn inbound_handshake_requests_from_unknown_sources_do_not_create_associations() 
 }
 
 #[test]
+fn inbound_handshake_response_send_failure_keeps_event_loop_alive() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let first_remote = Address::new("first-sys", "10.0.0.1", 2552);
+  let second_remote = Address::new("second-sys", "10.0.0.2", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport =
+    RecordingTransport::with_send_result(vec![local_address.clone()], Err(TransportError::ConnectionClosed));
+  let handshake_calls = transport.handshake_calls.clone();
+  let control_calls = transport.control_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound handshakes");
+  remote.insert_association(active_association(local_address.clone(), first_remote.clone(), &config));
+  remote.insert_association(active_association(local_address.clone(), second_remote.clone(), &config));
+  let handshake = HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(first_remote.clone(), 7), local_address));
+  let heartbeat = ControlPdu::Heartbeat { authority: second_remote.to_string() };
+  let mut receiver = VecRemoteEventReceiver::new([
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(first_remote.to_string()),
+      frame:     WireFrame::Handshake(handshake),
+      now_ms:    75,
+    },
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(second_remote.to_string()),
+      frame:     WireFrame::Control(heartbeat),
+      now_ms:    76,
+    },
+    RemoteEvent::TransportShutdown,
+  ]);
+
+  block_on_ready(remote.run(&mut receiver)).expect("handshake response send failure should not stop remote");
+
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 1);
+  assert_eq!(control_calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
 fn inbound_deployment_frame_without_adapter_routing_is_ignored() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);
   let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -358,10 +358,7 @@ impl RemoteTransport for RecordingTransport {
 
   fn connect_peer(&mut self, _remote: &Address) -> Result<(), TransportError> {
     self.connect_peer_calls.fetch_add(1, Ordering::Relaxed);
-    if !self.running {
-      return Err(TransportError::NotStarted);
-    }
-    self.connect_peer_result.clone()
+    if self.running { self.connect_peer_result.clone() } else { Err(TransportError::NotStarted) }
   }
 
   fn send_control(&mut self, remote: &Address, pdu: ControlPdu) -> Result<(), TransportError> {

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -1005,6 +1005,34 @@ fn inbound_handshake_request_rejects_idle_association_without_sending_response()
 }
 
 #[test]
+fn inbound_handshake_request_rejects_other_advertised_local_destination_without_sending_response() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let other_local_address = Address::new("sys", "127.0.0.2", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport = RecordingTransport::new(vec![local_address.clone(), other_local_address.clone()]);
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let handshake_calls = transport.handshake_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound handshakes");
+  remote.insert_association(handshaking_association(local_address, remote_address.clone(), &config));
+  let handshake =
+    HandshakePdu::Req(HandshakeReq::new(UniqueAddress::new(remote_address.clone(), 7), other_local_address));
+
+  remote
+    .handle_remote_event(RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(remote_address.to_string()),
+      frame:     WireFrame::Handshake(handshake),
+      now_ms:    75,
+    })
+    .expect("wrong local destination should be ignored without failing the event loop");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 0);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 0);
+  assert!(matches!(remote.association_state_for_test(&remote_address), Some(AssociationState::Handshaking { .. })));
+}
+
+#[test]
 fn inbound_handshake_response_send_failure_keeps_event_loop_alive() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);
   let first_remote = Address::new("first-sys", "10.0.0.1", 2552);


### PR DESCRIPTION
## Summary
- isolate inbound handshake response connect/send failures to the current frame
- keep the remote event loop alive after stale or closed response paths
- add regression coverage proving a later peer heartbeat is still dispatched

## Root Cause
The current inbound adaptor no longer owns handshake/heartbeat replies, but `Remote::handle_inbound_handshake_request` still propagated `connect_peer` and `send_handshake` failures through `RemoteEvent` processing. That could terminate `Remote::run` or adaptor delivery before later inbound events from other peers were handled.

## Validation
- `cargo fmt --check`
- `cargo test -p fraktor-remote-core-rs inbound_handshake_response_send_failure_keeps_event_loop_alive -- --nocapture`
- `cargo test -p fraktor-remote-core-rs`
- `./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound handshake request handling to treat backpressure/closed-writer failures as drop-and-continue instead of propagating errors, which could alter association state progression and event-loop termination behavior. Risk is moderate because it affects core remoting handshake/transport error handling, but is covered by new regression tests.
> 
> **Overview**
> **Inbound handshake response delivery is now isolated to the current frame.** `Remote::handle_inbound_handshake_request` validates association state/local destination, attempts `connect_peer`/`send_handshake`, and *drops the response* on `Backpressure`/`ConnectionClosed` instead of failing the whole event loop; only systemic transport errors still return `RemotingError::TransportUnavailable`.
> 
> Adds helper functions (`accept_inbound_handshake_request`, `map_inbound_response_delivery_result`) and expands tests to cover: rejecting idle/wrong-destination requests without sending, continuing after response send/connect failures while still processing other peers’ heartbeats, and preserving failure-on-systemic transport errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65fbb4f8075ceb09db5c61614c7d37a8eff37323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 受信ハンドシェイクの応答送信挙動を改善：送信不能な場合は応答を破棄してエラー伝播を避け、応答送信に成功した場合のみハンドシェイク受理が反映されるように変更。
* **テスト**
  * 複数の受信ハンドシェイクシナリオ（送信失敗、別宛先、送信成功や接続失敗時の継続動作など）を検証するテストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->