### PR TITLE
[codex] Add inbound heartbeat failure regression

### DIFF
--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -1573,6 +1573,45 @@ fn inbound_heartbeat_control_send_failure_does_not_stop_remote() {
 }
 
 #[test]
+fn repeated_inbound_heartbeat_response_failures_keep_event_loop_alive() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let first_remote = Address::new("first-sys", "10.0.0.1", 2552);
+  let second_remote = Address::new("second-sys", "10.0.0.2", 2552);
+  let config = RemoteConfig::new("127.0.0.1");
+  let transport =
+    RecordingTransport::with_control_result(vec![local_address.clone()], Err(TransportError::ConnectionClosed));
+  let control_calls = transport.control_calls.clone();
+  let mut remote = remote_new(transport, config.clone(), event_publisher());
+  remote.start().expect("remote should be running before inbound control");
+  remote.insert_association(active_association(local_address.clone(), first_remote.clone(), &config));
+  remote.insert_association(active_association(local_address, second_remote.clone(), &config));
+  let first_heartbeat = ControlPdu::Heartbeat { authority: first_remote.to_string() };
+  let second_heartbeat = ControlPdu::Heartbeat { authority: second_remote.to_string() };
+  let mut receiver = VecRemoteEventReceiver::new([
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(first_remote.to_string()),
+      frame:     WireFrame::Control(first_heartbeat.clone()),
+      now_ms:    76,
+    },
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(first_remote.to_string()),
+      frame:     WireFrame::Control(first_heartbeat),
+      now_ms:    77,
+    },
+    RemoteEvent::InboundFrameReceived {
+      authority: TransportEndpoint::new(second_remote.to_string()),
+      frame:     WireFrame::Control(second_heartbeat),
+      now_ms:    78,
+    },
+    RemoteEvent::TransportShutdown,
+  ]);
+
+  block_on_ready(remote.run(&mut receiver)).expect("heartbeat response failures should not stop remote");
+
+  assert_eq!(control_calls.load(Ordering::Relaxed), 3);
+}
+
+#[test]
 fn inbound_heartbeat_control_with_mismatched_peer_authority_is_ignored() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);
   let first_remote = Address::new("first-sys", "10.0.0.1", 2552);


### PR DESCRIPTION
## Summary
- Add a regression test for repeated inbound heartbeat response send failures.
- Assert the remote event loop keeps processing a later peer frame after earlier heartbeat response sends return `ConnectionClosed`.

## Context
- The runtime fix for the reported inbound dispatch availability issue is already on `main` via PR #1839.
- This PR adds a focused regression guard for the heartbeat side of the same failure class.

## Validation
- `cargo test -p fraktor-remote-core-rs repeated_inbound_heartbeat_response_failures_keep_event_loop_alive`
- `cargo test -p fraktor-remote-core-rs inbound_heartbeat`
- `cargo fmt --check --all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a unit regression test only, with no production code changes. Risk is limited to potential test flakiness or incorrect assumptions about heartbeat/control send semantics.
> 
> **Overview**
> Adds a regression test (`repeated_inbound_heartbeat_response_failures_keep_event_loop_alive`) to ensure the remote event loop continues processing subsequent inbound heartbeat frames even when multiple heartbeat response `send_control` attempts fail with `TransportError::ConnectionClosed`.
> 
> The test drives `Remote::run` with a sequence of inbound heartbeats from two peers and asserts the loop completes on `TransportShutdown` while still attempting all expected control sends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54b461044f90a48eb2a1d1c203a0871e3e7ef3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * イベントループの堅牢性に関するテストケースを追加しました。複数のハートビート応答が同時に失敗する状況下でも、システムが正常に動作し続けることを検証するようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->