### PR TITLE
[codex] Fix automatic remote peer dialing SSRF

### DIFF
--- a/modules/cluster-adaptor-std/tests/remote_delivery_via_cluster_api.rs
+++ b/modules/cluster-adaptor-std/tests/remote_delivery_via_cluster_api.rs
@@ -132,7 +132,8 @@ fn remote_extension_parts(
 ) -> (ArcShared<RemotingExtensionInstaller>, Address, StdRemoteActorRefProviderInstaller) {
   let address = Address::new(SYSTEM_NAME, "127.0.0.1", port);
   let transport = TcpRemoteTransport::new(format!("127.0.0.1:{port}"), vec![address.clone()]);
-  let installer = ArcShared::new(RemotingExtensionInstaller::new(transport, RemoteConfig::new("127.0.0.1")));
+  let config = RemoteConfig::new("127.0.0.1").with_allowed_remote_host("127.0.0.1");
+  let installer = ArcShared::new(RemotingExtensionInstaller::new(transport, config));
   let provider_installer = StdRemoteActorRefProviderInstaller::from_remoting_extension_installer(
     UniqueAddress::new(address.clone(), uid),
     installer.clone(),

--- a/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer.rs
@@ -189,6 +189,10 @@ impl RemotingExtensionInstaller {
     Ok((sender, monotonic_epoch))
   }
 
+  pub(crate) const fn config(&self) -> &RemoteConfig {
+    &self.config
+  }
+
   pub(crate) fn remote_event_sender_epoch_and_watcher(
     &self,
   ) -> Result<(Sender<RemoteEvent>, Instant, Sender<WatcherCommand>), RemotingError> {

--- a/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer_test.rs
+++ b/modules/remote-adaptor-std/src/extension_installer/remoting_extension_installer_test.rs
@@ -127,6 +127,7 @@ fn serialization_extension() -> ArcShared<SerializationExtensionShared> {
 
 fn remote_shared(config: RemoteConfig, transport: TestRemoteTransport) -> RemoteShared {
   let system = create_noop_actor_system();
+  let config = config.with_allowed_remote_host("10.0.0.1");
   let remote = Remote::new(transport, config, EventPublisher::new(system.downgrade()), serialization_extension());
   let shared = RemoteShared::new(remote);
   shared.start().expect("remote should start");
@@ -135,6 +136,7 @@ fn remote_shared(config: RemoteConfig, transport: TestRemoteTransport) -> Remote
 
 fn remote_shared_not_started(config: RemoteConfig, transport: TestRemoteTransport) -> RemoteShared {
   let system = create_noop_actor_system();
+  let config = config.with_allowed_remote_host("10.0.0.1");
   RemoteShared::new(Remote::new(transport, config, EventPublisher::new(system.downgrade()), serialization_extension()))
 }
 

--- a/modules/remote-adaptor-std/src/extension_installer_test.rs
+++ b/modules/remote-adaptor-std/src/extension_installer_test.rs
@@ -183,7 +183,7 @@ fn make_transport_with_addresses(addresses: Vec<Address>) -> TcpRemoteTransport 
 }
 
 fn remote_config() -> RemoteConfig {
-  RemoteConfig::new("127.0.0.1")
+  RemoteConfig::new("127.0.0.1").with_allowed_remote_host("10.0.0.1")
 }
 
 fn custom_serialization_installer() -> (SerializerId, SerializationExtensionInstaller) {

--- a/modules/remote-adaptor-std/src/provider/path_remote_actor_ref_provider.rs
+++ b/modules/remote-adaptor-std/src/provider/path_remote_actor_ref_provider.rs
@@ -5,21 +5,30 @@ use fraktor_actor_core_kernel_rs::actor::{
   actor_path::{ActorPath, ActorPathScheme},
 };
 use fraktor_remote_core_rs::{
-  address::RemoteNodeId,
+  address::{Address, RemoteNodeId},
   config::RemoteConfig,
+  extension::RemoteShared,
   provider::{ProviderError, RemoteActorRef, RemoteActorRefProvider, resolve_remote_address},
 };
 
 /// Resolves remote `fraktor.tcp` actor paths into data-only remote refs.
 pub struct PathRemoteActorRefProvider {
-  config: RemoteConfig,
+  config:        RemoteConfig,
+  remote_shared: Option<RemoteShared>,
 }
 
 impl PathRemoteActorRefProvider {
   /// Creates a provider using `config`'s automatic remote peer allowlist.
   #[must_use]
   pub fn new(config: RemoteConfig) -> Self {
-    Self { config }
+    Self { config, remote_shared: None }
+  }
+
+  /// Creates a provider using `config`'s allowlist plus peers explicitly
+  /// connected through `remote_shared`.
+  #[must_use]
+  pub fn new_with_remote(config: RemoteConfig, remote_shared: RemoteShared) -> Self {
+    Self { config, remote_shared: Some(remote_shared) }
   }
 }
 
@@ -36,7 +45,7 @@ impl RemoteActorRefProvider for PathRemoteActorRefProvider {
     }
     let unique = resolve_remote_address(&path).ok_or(ProviderError::MissingAuthority)?;
     let address = unique.address();
-    if !self.config.is_remote_peer_allowed(address) {
+    if !self.is_remote_peer_accepted(address) {
       return Err(ProviderError::RemotePeerNotAllowed);
     }
     let port = if address.port() == 0 { None } else { Some(address.port()) };
@@ -59,6 +68,11 @@ impl PathRemoteActorRefProvider {
       return Err(ProviderError::UnsupportedScheme);
     }
     let unique = resolve_remote_address(path).ok_or(ProviderError::MissingAuthority)?;
-    if self.config.is_remote_peer_allowed(unique.address()) { Ok(()) } else { Err(ProviderError::RemotePeerNotAllowed) }
+    if self.is_remote_peer_accepted(unique.address()) { Ok(()) } else { Err(ProviderError::RemotePeerNotAllowed) }
+  }
+
+  fn is_remote_peer_accepted(&self, remote: &Address) -> bool {
+    self.config.is_remote_peer_allowed(remote)
+      || self.remote_shared.as_ref().is_some_and(|remote_shared| remote_shared.is_explicit_peer(remote))
   }
 }

--- a/modules/remote-adaptor-std/src/provider/path_remote_actor_ref_provider.rs
+++ b/modules/remote-adaptor-std/src/provider/path_remote_actor_ref_provider.rs
@@ -6,12 +6,28 @@ use fraktor_actor_core_kernel_rs::actor::{
 };
 use fraktor_remote_core_rs::{
   address::RemoteNodeId,
+  config::RemoteConfig,
   provider::{ProviderError, RemoteActorRef, RemoteActorRefProvider, resolve_remote_address},
 };
 
 /// Resolves remote `fraktor.tcp` actor paths into data-only remote refs.
-#[derive(Default)]
-pub struct PathRemoteActorRefProvider;
+pub struct PathRemoteActorRefProvider {
+  config: RemoteConfig,
+}
+
+impl PathRemoteActorRefProvider {
+  /// Creates a provider using `config`'s automatic remote peer allowlist.
+  #[must_use]
+  pub fn new(config: RemoteConfig) -> Self {
+    Self { config }
+  }
+}
+
+impl Default for PathRemoteActorRefProvider {
+  fn default() -> Self {
+    Self::new(RemoteConfig::new(""))
+  }
+}
 
 impl RemoteActorRefProvider for PathRemoteActorRefProvider {
   fn actor_ref(&mut self, path: ActorPath) -> Result<RemoteActorRef, ProviderError> {
@@ -20,23 +36,29 @@ impl RemoteActorRefProvider for PathRemoteActorRefProvider {
     }
     let unique = resolve_remote_address(&path).ok_or(ProviderError::MissingAuthority)?;
     let address = unique.address();
+    if !self.config.is_remote_peer_allowed(address) {
+      return Err(ProviderError::RemotePeerNotAllowed);
+    }
     let port = if address.port() == 0 { None } else { Some(address.port()) };
     let node = RemoteNodeId::new(address.system(), address.host(), port, unique.uid());
     Ok(RemoteActorRef::new(path, node))
   }
 
   fn watch(&mut self, watchee: ActorPath, _watcher: Pid) -> Result<(), ProviderError> {
-    remote_path_result(&watchee)
+    self.remote_path_result(&watchee)
   }
 
   fn unwatch(&mut self, watchee: ActorPath, _watcher: Pid) -> Result<(), ProviderError> {
-    remote_path_result(&watchee)
+    self.remote_path_result(&watchee)
   }
 }
 
-fn remote_path_result(path: &ActorPath) -> Result<(), ProviderError> {
-  if path.parts().scheme() != ActorPathScheme::FraktorTcp {
-    return Err(ProviderError::UnsupportedScheme);
+impl PathRemoteActorRefProvider {
+  fn remote_path_result(&self, path: &ActorPath) -> Result<(), ProviderError> {
+    if path.parts().scheme() != ActorPathScheme::FraktorTcp {
+      return Err(ProviderError::UnsupportedScheme);
+    }
+    let unique = resolve_remote_address(path).ok_or(ProviderError::MissingAuthority)?;
+    if self.config.is_remote_peer_allowed(unique.address()) { Ok(()) } else { Err(ProviderError::RemotePeerNotAllowed) }
   }
-  resolve_remote_address(path).map(|_| ()).ok_or(ProviderError::MissingAuthority)
 }

--- a/modules/remote-adaptor-std/src/provider/provider_dispatch_error.rs
+++ b/modules/remote-adaptor-std/src/provider/provider_dispatch_error.rs
@@ -37,7 +37,8 @@ impl StdRemoteActorRefProviderError {
       | StdRemoteActorRefProviderError::LocalProvider(error) => error,
       | StdRemoteActorRefProviderError::CoreProvider(ProviderError::InvalidPath)
       | StdRemoteActorRefProviderError::CoreProvider(ProviderError::MissingAuthority)
-      | StdRemoteActorRefProviderError::CoreProvider(ProviderError::UnsupportedScheme) => {
+      | StdRemoteActorRefProviderError::CoreProvider(ProviderError::UnsupportedScheme)
+      | StdRemoteActorRefProviderError::CoreProvider(ProviderError::RemotePeerNotAllowed) => {
         ActorError::escalate(format!("{self}"))
       },
       | StdRemoteActorRefProviderError::CoreProvider(ProviderError::NotRemote)

--- a/modules/remote-adaptor-std/src/provider/std_remote_actor_ref_provider_installer.rs
+++ b/modules/remote-adaptor-std/src/provider/std_remote_actor_ref_provider_installer.rs
@@ -7,7 +7,7 @@ use fraktor_actor_core_kernel_rs::{
   serialization::default_serialization_extension_id,
   system::{ActorSystem, ActorSystemBuildError},
 };
-use fraktor_remote_core_rs::{address::UniqueAddress, extension::EventPublisher, provider::RemoteActorRefProvider};
+use fraktor_remote_core_rs::{address::UniqueAddress, extension::EventPublisher};
 use fraktor_utils_core_rs::sync::ArcShared;
 
 use super::{
@@ -25,7 +25,7 @@ const PROVIDER_LOCK_POISONED: &str = "std remote actor-ref provider installer lo
 /// Installs [`StdRemoteActorRefProvider`] through `ActorSystemConfig`.
 pub struct StdRemoteActorRefProviderInstaller {
   local_address:      UniqueAddress,
-  remote_provider:    Mutex<Option<Box<dyn RemoteActorRefProvider + Send + Sync>>>,
+  provider_available: Mutex<bool>,
   remoting_installer: ArcShared<RemotingExtensionInstaller>,
 }
 
@@ -36,8 +36,7 @@ impl StdRemoteActorRefProviderInstaller {
     local_address: UniqueAddress,
     remoting_installer: ArcShared<RemotingExtensionInstaller>,
   ) -> Self {
-    let remote_provider = Box::new(PathRemoteActorRefProvider::new(remoting_installer.config().clone()));
-    Self { local_address, remote_provider: Mutex::new(Some(remote_provider)), remoting_installer }
+    Self { local_address, provider_available: Mutex::new(true), remoting_installer }
   }
 
   fn event_sender_epoch_watcher_and_flush(&self) -> Result<RemoteProviderFlushHandles, ActorSystemBuildError> {
@@ -50,13 +49,13 @@ impl StdRemoteActorRefProviderInstaller {
 
 impl ActorRefProviderInstaller for StdRemoteActorRefProviderInstaller {
   fn install(&self, system: &ActorSystem) -> Result<(), ActorSystemBuildError> {
-    let mut remote_provider = self
-      .remote_provider
+    let mut provider_available = self
+      .provider_available
       .lock()
       .map_err(|_| ActorSystemBuildError::Configuration(String::from(PROVIDER_LOCK_POISONED)))?;
-    let Some(remote_provider) = remote_provider.take() else {
+    if !*provider_available {
       return Err(ActorSystemBuildError::Configuration(String::from(PROVIDER_ALREADY_INSTALLED)));
-    };
+    }
     let RemoteProviderFlushHandles {
       event_sender,
       monotonic_epoch,
@@ -67,6 +66,11 @@ impl ActorRefProviderInstaller for StdRemoteActorRefProviderInstaller {
       deployment_response_dispatcher,
       deployment_timeout,
     } = self.event_sender_epoch_watcher_and_flush()?;
+    *provider_available = false;
+    let remote_provider = Box::new(PathRemoteActorRefProvider::new_with_remote(
+      self.remoting_installer.config().clone(),
+      remote_shared.clone(),
+    ));
     let local_provider = ActorRefProviderHandleShared::new(LocalActorRefProvider::new_with_state(&system.state()));
     let registry = RemoteActorPathRegistry::new_shared();
     let provider = StdRemoteActorRefProvider::new_with_registry(

--- a/modules/remote-adaptor-std/src/provider/std_remote_actor_ref_provider_installer.rs
+++ b/modules/remote-adaptor-std/src/provider/std_remote_actor_ref_provider_installer.rs
@@ -36,7 +36,8 @@ impl StdRemoteActorRefProviderInstaller {
     local_address: UniqueAddress,
     remoting_installer: ArcShared<RemotingExtensionInstaller>,
   ) -> Self {
-    Self { local_address, remote_provider: Mutex::new(Some(Box::new(PathRemoteActorRefProvider))), remoting_installer }
+    let remote_provider = Box::new(PathRemoteActorRefProvider::new(remoting_installer.config().clone()));
+    Self { local_address, remote_provider: Mutex::new(Some(remote_provider)), remoting_installer }
   }
 
   fn event_sender_epoch_watcher_and_flush(&self) -> Result<RemoteProviderFlushHandles, ActorSystemBuildError> {

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -36,7 +36,7 @@ use fraktor_remote_core_rs::{
   envelope::{OutboundEnvelope, OutboundPriority},
   extension::{
     EventPublisher, REMOTE_ACTOR_REF_RESOLVE_CACHE_EXTENSION, Remote, RemoteActorRefResolveCacheEvent,
-    RemoteActorRefResolveCacheOutcome, RemoteEvent, RemoteShared,
+    RemoteActorRefResolveCacheOutcome, RemoteEvent, RemoteShared, Remoting,
   },
   provider::{ProviderError, RemoteActorRef, RemoteActorRefProvider},
   transport::{RemoteTransport, TransportEndpoint, TransportError},
@@ -708,6 +708,28 @@ fn path_remote_actor_ref_provider_accepts_allowed_remote_watch_target() {
 
   provider.watch(remote_path.clone(), watcher).expect("allowed remote watch target should be accepted");
   provider.unwatch(remote_path, watcher).expect("allowed remote unwatch target should be accepted");
+}
+
+#[test]
+fn path_remote_actor_ref_provider_accepts_explicitly_connected_remote_peer() {
+  let harness = EventHarness::new();
+  let serialization_extension = harness.system().extended().register_extension(&default_serialization_extension_id());
+  let remote_address = RemoteCoreAddress::new("remote-sys", "10.0.0.99", 2552);
+  let remote = Remote::new(
+    NoopRemoteTransport::new(vec![RemoteCoreAddress::new("local-sys", "127.0.0.1", 2551)]),
+    RemoteConfig::new("127.0.0.1"),
+    EventPublisher::new(harness.system().downgrade()),
+    serialization_extension,
+  );
+  let remote_shared = RemoteShared::new(remote);
+  remote_shared.start().expect("remote should start before explicit connect");
+  remote_shared.connect_peer(&remote_address).expect("explicit connect should be recorded");
+  let mut provider = PathRemoteActorRefProvider::new_with_remote(RemoteConfig::new("127.0.0.1"), remote_shared);
+  let remote_path = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.99:2552/user/worker").expect("parse");
+
+  let remote_ref = provider.actor_ref(remote_path.clone()).expect("explicitly connected remote peer should resolve");
+
+  assert_eq!(remote_ref.path().to_canonical_uri(), remote_path.to_canonical_uri());
 }
 
 #[test]

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -690,6 +690,27 @@ fn path_remote_actor_ref_provider_accepts_allowed_remote_peer() {
 }
 
 #[test]
+fn path_remote_actor_ref_provider_rejects_unallowed_remote_watch_target() {
+  let mut provider = PathRemoteActorRefProvider::default();
+  let remote_path = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.99:2552/user/worker").expect("parse");
+  let watcher = Pid::new(1, 1);
+
+  assert_eq!(provider.watch(remote_path.clone(), watcher).unwrap_err(), ProviderError::RemotePeerNotAllowed);
+  assert_eq!(provider.unwatch(remote_path, watcher).unwrap_err(), ProviderError::RemotePeerNotAllowed);
+}
+
+#[test]
+fn path_remote_actor_ref_provider_accepts_allowed_remote_watch_target() {
+  let config = RemoteConfig::new("127.0.0.1").with_allowed_remote_host("10.0.0.99");
+  let mut provider = PathRemoteActorRefProvider::new(config);
+  let remote_path = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.99:2552/user/worker").expect("parse");
+  let watcher = Pid::new(1, 1);
+
+  provider.watch(remote_path.clone(), watcher).expect("allowed remote watch target should be accepted");
+  provider.unwatch(remote_path, watcher).expect("allowed remote unwatch target should be accepted");
+}
+
+#[test]
 fn local_authority_path_is_normalized_to_local_provider() {
   let mut provider = make_provider();
   // Authority that exactly matches `local_address()`.

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -700,6 +700,16 @@ fn path_remote_actor_ref_provider_rejects_unallowed_remote_watch_target() {
 }
 
 #[test]
+fn path_remote_actor_ref_provider_rejects_local_watch_target() {
+  let mut provider = PathRemoteActorRefProvider::default();
+  let local_path = ActorPath::root().child("user").child("worker");
+  let watcher = Pid::new(1, 1);
+
+  assert_eq!(provider.watch(local_path.clone(), watcher).unwrap_err(), ProviderError::UnsupportedScheme);
+  assert_eq!(provider.unwatch(local_path, watcher).unwrap_err(), ProviderError::UnsupportedScheme);
+}
+
+#[test]
 fn path_remote_actor_ref_provider_accepts_allowed_remote_watch_target() {
   let config = RemoteConfig::new("127.0.0.1").with_allowed_remote_host("10.0.0.99");
   let mut provider = PathRemoteActorRefProvider::new(config);

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -55,6 +55,7 @@ use tokio::{
 
 use super::{
   StdRemoteActorRefProvider, StdRemoteActorRefProviderError, StdRemoteActorRefProviderInstaller,
+  path_remote_actor_ref_provider::PathRemoteActorRefProvider,
   remote_actor_path_registry::RemoteActorPathRegistry,
   remote_deployment_hook::StdRemoteDeploymentHook,
   remote_watch_hook::{StdRemoteWatchFlushConfig, StdRemoteWatchHook},
@@ -667,6 +668,28 @@ fn remote_path_with_non_matching_authority_is_dispatched_to_remote_provider() {
 }
 
 #[test]
+fn default_path_remote_actor_ref_provider_rejects_unallowed_remote_peer() {
+  let mut provider = PathRemoteActorRefProvider::default();
+  let remote_path = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.99:2552/user/worker").expect("parse");
+
+  let err = provider.actor_ref(remote_path).expect_err("unallowed remote peer should be rejected");
+
+  assert_eq!(err, ProviderError::RemotePeerNotAllowed);
+}
+
+#[test]
+fn path_remote_actor_ref_provider_accepts_allowed_remote_peer() {
+  let config =
+    RemoteConfig::new("127.0.0.1").with_allowed_remote_peer(RemoteCoreAddress::new("remote-sys", "10.0.0.99", 2552));
+  let mut provider = PathRemoteActorRefProvider::new(config);
+  let remote_path = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.99:2552/user/worker").expect("parse");
+
+  let remote_ref = provider.actor_ref(remote_path.clone()).expect("allowed remote peer should resolve");
+
+  assert_eq!(remote_ref.path().to_canonical_uri(), remote_path.to_canonical_uri());
+}
+
+#[test]
 fn local_authority_path_is_normalized_to_local_provider() {
   let mut provider = make_provider();
   // Authority that exactly matches `local_address()`.
@@ -857,7 +880,7 @@ fn remote_actor_ref_try_tell_pushes_outbound_enqueued_event() {
 async fn actor_system_config_registered_std_remote_actor_ref_provider_resolves_remote_actor_ref() {
   let remote_installer = ArcShared::new(RemotingExtensionInstaller::new(
     TcpRemoteTransport::new("127.0.0.1:0", vec![local_address().address().clone()]),
-    RemoteConfig::new("127.0.0.1"),
+    RemoteConfig::new("127.0.0.1").with_allowed_remote_host("10.0.0.1"),
   ));
   let extension_installers = ExtensionInstallers::default().with_shared_extension_installer(remote_installer.clone());
   let installer =

--- a/modules/remote-adaptor-std/tests/two_node_actor_system_delivery.rs
+++ b/modules/remote-adaptor-std/tests/two_node_actor_system_delivery.rs
@@ -447,6 +447,7 @@ fn build_node_with_remote_config_and_deployer(
 ) -> RemoteNode {
   let address = Address::new(SYSTEM_NAME, "127.0.0.1", port);
   let transport = TcpRemoteTransport::new(format!("127.0.0.1:{port}"), vec![address.clone()]);
+  let remote_config = remote_config.with_allowed_remote_host("127.0.0.1");
   let installer = ArcShared::new(RemotingExtensionInstaller::new(transport, remote_config));
   let extension_installers = ExtensionInstallers::default().with_shared_extension_installer(installer.clone());
   let provider_installer = StdRemoteActorRefProviderInstaller::from_remoting_extension_installer(
@@ -468,7 +469,10 @@ fn build_node_with_remote_config_and_deployer(
 fn build_stream_ref_node(port: u16, uid: u64) -> RemoteNode {
   let address = Address::new(SYSTEM_NAME, "127.0.0.1", port);
   let transport = TcpRemoteTransport::new(format!("127.0.0.1:{port}"), vec![address.clone()]);
-  let installer = ArcShared::new(RemotingExtensionInstaller::new(transport, RemoteConfig::new("127.0.0.1")));
+  let installer = ArcShared::new(RemotingExtensionInstaller::new(
+    transport,
+    RemoteConfig::new("127.0.0.1").with_allowed_remote_host("127.0.0.1"),
+  ));
   let system_slot = SerializationSystemSlot::new();
   let serialization_installer = stream_ref_serialization_installer(system_slot.clone());
   let extension_installers = ExtensionInstallers::default()

--- a/modules/remote-core/src/config/remote_config.rs
+++ b/modules/remote-core/src/config/remote_config.rs
@@ -1,9 +1,12 @@
 //! Typed `RemoteConfig` with a `self`-consuming builder API.
 
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 use core::time::Duration;
 
-use crate::config::{LargeMessageDestinations, RemoteCompressionConfig};
+use crate::{
+  address::Address,
+  config::{LargeMessageDestinations, RemoteCompressionConfig},
+};
 
 /// Default handshake timeout (20 seconds), matching Pekko Artery advanced defaults.
 pub(crate) const DEFAULT_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(20);
@@ -140,6 +143,8 @@ pub struct RemoteConfig {
   outbound_lanes: usize,
   maximum_frame_size: usize,
   buffer_pool_size: usize,
+  allowed_remote_peers: Vec<Address>,
+  allowed_remote_hosts: Vec<String>,
   untrusted_mode: bool,
   log_received_messages: bool,
   log_sent_messages: bool,
@@ -186,6 +191,8 @@ impl RemoteConfig {
       outbound_lanes: DEFAULT_OUTBOUND_LANES,
       maximum_frame_size: DEFAULT_MAXIMUM_FRAME_SIZE,
       buffer_pool_size: DEFAULT_BUFFER_POOL_SIZE,
+      allowed_remote_peers: Vec::new(),
+      allowed_remote_hosts: Vec::new(),
       untrusted_mode: false,
       log_received_messages: false,
       log_sent_messages: false,
@@ -528,6 +535,25 @@ impl RemoteConfig {
     self
   }
 
+  /// Returns a copy that permits automatic peer dialing for the exact remote address.
+  #[must_use]
+  pub fn with_allowed_remote_peer(mut self, peer: Address) -> Self {
+    if !self.allowed_remote_peers.iter().any(|allowed| allowed == &peer) {
+      self.allowed_remote_peers.push(peer);
+    }
+    self
+  }
+
+  /// Returns a copy that permits automatic peer dialing for any port on `host`.
+  #[must_use]
+  pub fn with_allowed_remote_host(mut self, host: impl Into<String>) -> Self {
+    let host = host.into();
+    if !self.allowed_remote_hosts.iter().any(|allowed| allowed == &host) {
+      self.allowed_remote_hosts.push(host);
+    }
+    self
+  }
+
   /// Returns a copy with untrusted mode enabled or disabled.
   #[must_use]
   pub const fn with_untrusted_mode(mut self, enabled: bool) -> Self {
@@ -758,6 +784,25 @@ impl RemoteConfig {
   #[must_use]
   pub const fn buffer_pool_size(&self) -> usize {
     self.buffer_pool_size
+  }
+
+  /// Returns the exact remote addresses allowed for automatic peer dialing.
+  #[must_use]
+  pub fn allowed_remote_peers(&self) -> &[Address] {
+    &self.allowed_remote_peers
+  }
+
+  /// Returns the remote hosts allowed for automatic peer dialing.
+  #[must_use]
+  pub fn allowed_remote_hosts(&self) -> &[String] {
+    &self.allowed_remote_hosts
+  }
+
+  /// Returns whether `remote` is allowed for automatic peer dialing.
+  #[must_use]
+  pub fn is_remote_peer_allowed(&self, remote: &Address) -> bool {
+    self.allowed_remote_peers.iter().any(|allowed| allowed == remote)
+      || self.allowed_remote_hosts.iter().any(|allowed| allowed == remote.host())
   }
 
   /// Returns whether untrusted mode is enabled.

--- a/modules/remote-core/src/config_test.rs
+++ b/modules/remote-core/src/config_test.rs
@@ -1,7 +1,10 @@
 extern crate std;
 use core::{num::NonZeroUsize, time::Duration};
 
-use crate::config::{LargeMessageDestinationPattern, LargeMessageDestinations, RemoteCompressionConfig, RemoteConfig};
+use crate::{
+  address::Address,
+  config::{LargeMessageDestinationPattern, LargeMessageDestinations, RemoteCompressionConfig, RemoteConfig},
+};
 
 const DEFAULT_MAXIMUM_FRAME_SIZE: usize = 256 * 1024;
 const DEFAULT_BUFFER_POOL_SIZE: usize = 128;
@@ -74,6 +77,8 @@ fn advanced_artery_settings_use_pekko_compatible_defaults() {
   assert!(!s.log_received_messages());
   assert!(!s.log_sent_messages());
   assert_eq!(s.log_frame_size_exceeding(), None);
+  assert!(s.allowed_remote_peers().is_empty());
+  assert!(s.allowed_remote_hosts().is_empty());
 }
 
 #[test]
@@ -151,6 +156,8 @@ fn advanced_artery_settings_method_chain_applies_all_changes() {
     .with_outbound_lanes(2)
     .with_maximum_frame_size(512 * 1024)
     .with_buffer_pool_size(64)
+    .with_allowed_remote_peer(Address::new("remote-sys", "10.0.0.1", 2552))
+    .with_allowed_remote_host("10.0.0.2")
     .with_outbound_message_queue_size(32)
     .with_outbound_control_queue_size(8)
     .with_remote_event_queue_size(64)
@@ -171,6 +178,9 @@ fn advanced_artery_settings_method_chain_applies_all_changes() {
   assert_eq!(s.outbound_lanes(), 2);
   assert_eq!(s.maximum_frame_size(), 512 * 1024);
   assert_eq!(s.buffer_pool_size(), 64);
+  assert!(s.is_remote_peer_allowed(&Address::new("remote-sys", "10.0.0.1", 2552)));
+  assert!(s.is_remote_peer_allowed(&Address::new("other-sys", "10.0.0.2", 9000)));
+  assert!(!s.is_remote_peer_allowed(&Address::new("other-sys", "10.0.0.3", 9000)));
   assert_eq!(s.outbound_message_queue_size(), 32);
   assert_eq!(s.outbound_control_queue_size(), 8);
   assert_eq!(s.remote_event_queue_size(), 64);

--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -388,10 +388,17 @@ impl Remote {
     }
   }
 
+  /// Returns whether `remote` has been explicitly connected through
+  /// [`Remote::connect_peer`].
+  #[must_use]
+  pub fn is_explicit_peer(&self, remote: &Address) -> bool {
+    self.explicit_peers.iter().any(|peer| peer == remote)
+  }
+
   fn can_use_peer_for_outbound(&self, remote: &Address) -> bool {
     self.config.is_remote_peer_allowed(remote)
       || self.association_index_for_remote(remote).is_some()
-      || self.explicit_peers.iter().any(|peer| peer == remote)
+      || self.is_explicit_peer(remote)
   }
 
   fn association_index_for_authority(&self, authority: &TransportEndpoint) -> Option<usize> {

--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -293,6 +293,14 @@ impl Remote {
   ) -> Result<(), RemotingError> {
     self.lifecycle.ensure_running()?;
     let remote = parse_authority(authority.authority()).ok_or(RemotingError::TransportUnavailable)?;
+    if self.association_index_for_remote(&remote).is_none() && !self.config.is_remote_peer_allowed(&remote) {
+      tracing::warn!(
+        remote = %remote,
+        "dropping outbound envelope because remote peer is not allowed for automatic dialing"
+      );
+      self.instrument.record_dropped_envelope(authority, &envelope, now_ms);
+      return Ok(());
+    }
     let association_index = self.ensure_association(remote)?;
     let should_start_handshake = self.associations[association_index].state().is_idle();
     let should_recover_handshake = self.associations[association_index].state().is_gated();
@@ -320,6 +328,13 @@ impl Remote {
 
   fn handle_outbound_control(&mut self, remote: &Address, pdu: ControlPdu, _now_ms: u64) -> Result<(), RemotingError> {
     self.lifecycle.ensure_running()?;
+    if !self.can_automatically_connect_peer(remote) {
+      tracing::warn!(
+        remote = %remote,
+        "dropping outbound control frame because remote peer is not allowed for automatic dialing"
+      );
+      return Ok(());
+    }
     self.transport.connect_peer(remote).map_err(|_| RemotingError::TransportUnavailable)?;
     map_wire_delivery_result(remote, self.transport.send_control(remote, pdu))
   }
@@ -331,6 +346,13 @@ impl Remote {
     _now_ms: u64,
   ) -> Result<(), RemotingError> {
     self.lifecycle.ensure_running()?;
+    if !self.can_automatically_connect_peer(remote) {
+      tracing::warn!(
+        remote = %remote,
+        "dropping outbound deployment frame because remote peer is not allowed for automatic dialing"
+      );
+      return Ok(());
+    }
     self.transport.connect_peer(remote).map_err(|_| RemotingError::TransportUnavailable)?;
     map_wire_delivery_result(remote, self.transport.send_deployment(remote, pdu))
   }
@@ -354,6 +376,10 @@ impl Remote {
 
   fn association_index_for_remote(&self, remote: &Address) -> Option<usize> {
     self.associations.iter().position(|association| association.remote() == remote)
+  }
+
+  fn can_automatically_connect_peer(&self, remote: &Address) -> bool {
+    self.config.is_remote_peer_allowed(remote) || self.association_index_for_remote(remote).is_some()
   }
 
   fn association_index_for_authority(&self, authority: &TransportEndpoint) -> Option<usize> {

--- a/modules/remote-core/src/extension/remote.rs
+++ b/modules/remote-core/src/extension/remote.rs
@@ -50,6 +50,7 @@ pub struct Remote {
   serialization:        ArcShared<SerializationExtensionShared>,
   instrument:           Box<dyn RemoteInstrument + Send>,
   advertised_addresses: Vec<Address>,
+  explicit_peers:       Vec<Address>,
   associations:         Vec<Association>,
   inbound_envelopes:    Vec<InboundEnvelope>,
   flush_outcomes:       Vec<RemoteFlushOutcome>,
@@ -128,6 +129,7 @@ impl Remote {
       serialization,
       instrument,
       advertised_addresses: Vec::new(),
+      explicit_peers: Vec::new(),
       associations: Vec::new(),
       inbound_envelopes: Vec::new(),
       flush_outcomes: Vec::new(),
@@ -227,7 +229,9 @@ impl Remote {
   /// establish the peer.
   pub fn connect_peer(&mut self, remote: &Address) -> Result<(), RemotingError> {
     self.lifecycle.ensure_running()?;
-    self.transport.connect_peer(remote).map_err(|_| RemotingError::TransportUnavailable)
+    self.transport.connect_peer(remote).map_err(|_| RemotingError::TransportUnavailable)?;
+    self.remember_explicit_peer(remote);
+    Ok(())
   }
 
   fn publish_listen_started(&self) {
@@ -293,7 +297,7 @@ impl Remote {
   ) -> Result<(), RemotingError> {
     self.lifecycle.ensure_running()?;
     let remote = parse_authority(authority.authority()).ok_or(RemotingError::TransportUnavailable)?;
-    if self.association_index_for_remote(&remote).is_none() && !self.config.is_remote_peer_allowed(&remote) {
+    if !self.can_use_peer_for_outbound(&remote) {
       tracing::warn!(
         remote = %remote,
         "dropping outbound envelope because remote peer is not allowed for automatic dialing"
@@ -328,7 +332,7 @@ impl Remote {
 
   fn handle_outbound_control(&mut self, remote: &Address, pdu: ControlPdu, _now_ms: u64) -> Result<(), RemotingError> {
     self.lifecycle.ensure_running()?;
-    if !self.can_automatically_connect_peer(remote) {
+    if !self.can_use_peer_for_outbound(remote) {
       tracing::warn!(
         remote = %remote,
         "dropping outbound control frame because remote peer is not allowed for automatic dialing"
@@ -346,7 +350,7 @@ impl Remote {
     _now_ms: u64,
   ) -> Result<(), RemotingError> {
     self.lifecycle.ensure_running()?;
-    if !self.can_automatically_connect_peer(remote) {
+    if !self.can_use_peer_for_outbound(remote) {
       tracing::warn!(
         remote = %remote,
         "dropping outbound deployment frame because remote peer is not allowed for automatic dialing"
@@ -378,8 +382,16 @@ impl Remote {
     self.associations.iter().position(|association| association.remote() == remote)
   }
 
-  fn can_automatically_connect_peer(&self, remote: &Address) -> bool {
-    self.config.is_remote_peer_allowed(remote) || self.association_index_for_remote(remote).is_some()
+  fn remember_explicit_peer(&mut self, remote: &Address) {
+    if !self.explicit_peers.iter().any(|peer| peer == remote) {
+      self.explicit_peers.push(remote.clone());
+    }
+  }
+
+  fn can_use_peer_for_outbound(&self, remote: &Address) -> bool {
+    self.config.is_remote_peer_allowed(remote)
+      || self.association_index_for_remote(remote).is_some()
+      || self.explicit_peers.iter().any(|peer| peer == remote)
   }
 
   fn association_index_for_authority(&self, authority: &TransportEndpoint) -> Option<usize> {

--- a/modules/remote-core/src/extension/remote_shared.rs
+++ b/modules/remote-core/src/extension/remote_shared.rs
@@ -137,6 +137,13 @@ impl RemoteShared {
   pub fn connect_peer(&self, remote: &Address) -> Result<(), RemotingError> {
     self.with_write(|remote_shared| remote_shared.connect_peer(remote))
   }
+
+  /// Returns whether `remote` has been explicitly connected through this shared
+  /// remoting handle.
+  #[must_use]
+  pub fn is_explicit_peer(&self, remote: &Address) -> bool {
+    self.with_read(|remote_shared| remote_shared.is_explicit_peer(remote))
+  }
 }
 
 impl Remoting for RemoteShared {

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -699,6 +699,43 @@ fn run_sends_outbound_enqueued_event_and_records_instrument() {
 }
 
 #[test]
+fn outbound_to_unallowed_idle_remote_does_not_connect_peer() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let transport = RecordingTransport::new(vec![local_address]);
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let send_calls = transport.send_calls.clone();
+  let instrument_send_calls = ArcShared::new(AtomicUsize::new(0));
+  let instrument_handshake_calls = ArcShared::new(AtomicUsize::new(0));
+  let instrument = CountingInstrument::new(instrument_send_calls, instrument_handshake_calls);
+  let dropped_calls = instrument.dropped_calls.clone();
+  let mut remote =
+    remote_with_instrument(transport, RemoteConfig::new("127.0.0.1"), event_publisher(), Box::new(instrument));
+  remote.start().expect("remote should start before outbound delivery");
+  let recipient = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.1:2552/user/worker").expect("recipient path");
+  let envelope = OutboundEnvelope::new(
+    recipient,
+    None,
+    AnyMessage::new(String::from("payload")),
+    OutboundPriority::User,
+    RemoteNodeId::new("remote-sys", "10.0.0.1", Some(2552), 1),
+    CorrelationId::nil(),
+  );
+  let event = RemoteEvent::OutboundEnqueued {
+    authority: TransportEndpoint::new(remote_address.to_string()),
+    envelope:  Box::new(envelope),
+    now_ms:    42,
+  };
+
+  remote.handle_remote_event(event).expect("unallowed outbound should be dropped without failing the loop");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 0);
+  assert_eq!(send_calls.load(Ordering::Relaxed), 0);
+  assert_eq!(dropped_calls.load(Ordering::Relaxed), 1);
+  assert_eq!(remote.association_count_for_test(), 0);
+}
+
+#[test]
 fn remote_new_default_instrument_accepts_event_loop_hooks() {
   let noop_address = Address::new("sys", "127.0.0.1", 2552);
   let mut noop_remote =
@@ -861,8 +898,8 @@ fn run_does_not_send_outbound_enqueued_event_before_association_is_active() {
   let instrument_send_calls = ArcShared::new(AtomicUsize::new(0));
   let instrument_handshake_calls = ArcShared::new(AtomicUsize::new(0));
   let instrument = CountingInstrument::new(instrument_send_calls.clone(), instrument_handshake_calls.clone());
-  let mut remote =
-    remote_with_instrument(transport, RemoteConfig::new("127.0.0.1"), event_publisher(), Box::new(instrument));
+  let config = RemoteConfig::new("127.0.0.1").with_allowed_remote_peer(remote_address.clone());
+  let mut remote = remote_with_instrument(transport, config, event_publisher(), Box::new(instrument));
   remote.start().expect("remote should start before outbound delivery");
   let recipient = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.1:2552/user/worker").expect("recipient path");
   let envelope = OutboundEnvelope::new(
@@ -898,7 +935,8 @@ fn start_handshake_backpressure_keeps_event_loop_alive() {
   let transport = RecordingTransport::with_send_result(vec![local_address], Err(TransportError::Backpressure));
   let handshake_calls = transport.handshake_calls.clone();
   let timeout_calls = transport.timeout_calls.clone();
-  let mut remote = remote_new(transport, RemoteConfig::new("127.0.0.1"), event_publisher());
+  let config = RemoteConfig::new("127.0.0.1").with_allowed_remote_peer(remote_address.clone());
+  let mut remote = remote_new(transport, config, event_publisher());
   remote.start().expect("remote should start before outbound delivery");
   let recipient = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.1:2552/user/worker").expect("recipient path");
   let envelope = OutboundEnvelope::new(

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -736,6 +736,39 @@ fn outbound_to_unallowed_idle_remote_does_not_connect_peer() {
 }
 
 #[test]
+fn explicit_connect_peer_allows_unlisted_idle_outbound() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let transport = RecordingTransport::new(vec![local_address]);
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let handshake_calls = transport.handshake_calls.clone();
+  let mut remote = remote_new(transport, RemoteConfig::new("127.0.0.1"), event_publisher());
+  remote.start().expect("remote should start before explicit connect");
+  remote.connect_peer(&remote_address).expect("explicit connect should succeed");
+  let recipient = ActorPathParser::parse("fraktor.tcp://remote-sys@10.0.0.1:2552/user/worker").expect("recipient path");
+  let envelope = OutboundEnvelope::new(
+    recipient,
+    None,
+    AnyMessage::new(String::from("payload")),
+    OutboundPriority::User,
+    RemoteNodeId::new("remote-sys", "10.0.0.1", Some(2552), 1),
+    CorrelationId::nil(),
+  );
+
+  remote
+    .handle_remote_event(RemoteEvent::OutboundEnqueued {
+      authority: TransportEndpoint::new(remote_address.to_string()),
+      envelope:  Box::new(envelope),
+      now_ms:    42,
+    })
+    .expect("explicitly connected peer should be allowed to start association");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 2);
+  assert_eq!(handshake_calls.load(Ordering::Relaxed), 1);
+  assert_eq!(remote.association_count_for_test(), 1);
+}
+
+#[test]
 fn outbound_control_to_unallowed_remote_does_not_connect_peer() {
   let local_address = Address::new("sys", "127.0.0.1", 2552);
   let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);

--- a/modules/remote-core/src/extension_test.rs
+++ b/modules/remote-core/src/extension_test.rs
@@ -736,6 +736,50 @@ fn outbound_to_unallowed_idle_remote_does_not_connect_peer() {
 }
 
 #[test]
+fn outbound_control_to_unallowed_remote_does_not_connect_peer() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let transport = RecordingTransport::new(vec![local_address]);
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let control_calls = transport.control_calls.clone();
+  let mut remote = remote_new(transport, RemoteConfig::new("127.0.0.1"), event_publisher());
+  remote.start().expect("remote should start before outbound control");
+
+  remote
+    .handle_remote_event(RemoteEvent::OutboundControl {
+      remote: remote_address.clone(),
+      pdu:    ControlPdu::Shutdown { authority: remote_address.to_string() },
+      now_ms: 42,
+    })
+    .expect("unallowed outbound control should be dropped without failing the loop");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 0);
+  assert_eq!(control_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn outbound_deployment_to_unallowed_remote_does_not_connect_peer() {
+  let local_address = Address::new("sys", "127.0.0.1", 2552);
+  let remote_address = Address::new("remote-sys", "10.0.0.1", 2552);
+  let transport = RecordingTransport::new(vec![local_address]);
+  let connect_peer_calls = transport.connect_peer_calls.clone();
+  let mut remote = remote_new(transport, RemoteConfig::new("127.0.0.1"), event_publisher());
+  remote.start().expect("remote should start before outbound deployment");
+  let pdu = RemoteDeploymentPdu::CreateFailure(RemoteDeploymentCreateFailure::new(
+    1,
+    2,
+    RemoteDeploymentFailureCode::SpawnFailed,
+    String::from("unallowed"),
+  ));
+
+  remote
+    .handle_remote_event(RemoteEvent::OutboundDeployment { remote: remote_address, pdu, now_ms: 42 })
+    .expect("unallowed outbound deployment should be dropped without failing the loop");
+
+  assert_eq!(connect_peer_calls.load(Ordering::Relaxed), 0);
+}
+
+#[test]
 fn remote_new_default_instrument_accepts_event_loop_hooks() {
   let noop_address = Address::new("sys", "127.0.0.1", 2552);
   let mut noop_remote =

--- a/modules/remote-core/src/provider/provider_error.rs
+++ b/modules/remote-core/src/provider/provider_error.rs
@@ -18,6 +18,8 @@ pub enum ProviderError {
   /// The `ActorPath` authority uses a transport scheme the provider does not
   /// understand.
   UnsupportedScheme,
+  /// The remote authority is not allowed for automatic remote peer dialing.
+  RemotePeerNotAllowed,
 }
 
 impl Display for ProviderError {
@@ -27,6 +29,7 @@ impl Display for ProviderError {
       | ProviderError::InvalidPath => f.write_str("provider: invalid actor path"),
       | ProviderError::MissingAuthority => f.write_str("provider: missing authority component"),
       | ProviderError::UnsupportedScheme => f.write_str("provider: unsupported path scheme"),
+      | ProviderError::RemotePeerNotAllowed => f.write_str("provider: remote peer is not allowed"),
     }
   }
 }

--- a/modules/remote-core/src/provider_test.rs
+++ b/modules/remote-core/src/provider_test.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 
 use fraktor_actor_core_kernel_rs::actor::{
   Pid,
@@ -161,4 +161,9 @@ fn watch_rejects_local_watchee() {
   let watcher = Pid::new(1, 1);
   assert_eq!(provider.watch(local.clone(), watcher).unwrap_err(), ProviderError::NotRemote);
   assert_eq!(provider.unwatch(local, watcher).unwrap_err(), ProviderError::NotRemote);
+}
+
+#[test]
+fn provider_error_display_mentions_remote_peer_allowlist() {
+  assert_eq!(format!("{}", ProviderError::RemotePeerNotAllowed), "provider: remote peer is not allowed");
 }


### PR DESCRIPTION
## Summary

- Add an explicit allowlist to `RemoteConfig` for automatic remote peer dialing.
- Reject default `PathRemoteActorRefProvider` resolution for remote authorities that are not allowed.
- Drop outbound events for new, unallowed idle remote peers before creating an association or calling `connect_peer`.

## Security impact

This changes automatic remote peer dialing from default-open to explicit opt-in. Applications must configure allowed remote peers or hosts before resolving/sending to remote `fraktor.tcp` authorities. Existing explicit `Remote::connect_peer` remains available as an application lifecycle action.

## Validation

- `cargo fmt --check --all`
- `cargo test -p fraktor-remote-core-rs`
- `cargo test -p fraktor-remote-adaptor-std-rs`
- `cargo clippy -p fraktor-remote-core-rs -p fraktor-remote-adaptor-std-rs --lib -- -D warnings`

## Note

- `cargo clippy -p fraktor-remote-core-rs -p fraktor-remote-adaptor-std-rs --all-targets -- -D warnings` still hits pre-existing test-target lints in `modules/remote-core/src/extension_test.rs` and `modules/remote-core/src/wire_test.rs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Tightens security around outbound remoting by making automatic peer dialing default-deny; this is a behavior change that can break existing deployments unless they configure `RemoteConfig` allowlists or explicitly connect peers.
> 
> **Overview**
> Adds an explicit allowlist to `RemoteConfig` (`with_allowed_remote_peer` / `with_allowed_remote_host`) and enforces it across remoting.
> 
> Remote path resolution via `PathRemoteActorRefProvider` now rejects unallowed `fraktor.tcp` authorities with a new `ProviderError::RemotePeerNotAllowed`, and `Remote` drops outbound envelopes/control/deployment frames for idle, unallowed peers before creating associations or calling `connect_peer` (while still permitting explicitly connected peers).
> 
> Wires the allowlist into the std adapter installer (provider now gets `RemoteConfig` + `RemoteShared`) and updates/extends tests to cover allow/deny behavior and to set allowlists where remoting is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6acc93bdc96a5e49f60294df07fed12f7b77a74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * リモートピア／ホストの許可リストを導入。許可されていない相手への自動接続や送信が抑止されます。
  * 明示的に接続済みのピアを記録する仕組みを追加し、許可判定に反映します。

* **改善**
  * リモート参照解決で許可チェックを早期に行い、未許可時は拒否されるよう強化しました。
  * 拒否時のエラー表現を明確化しました。

* **テスト**
  * 許可／拒否の動作を検証する多数のテストを追加・更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->