### PR TITLE
[codex] Clean up terminal stream islands

### DIFF
--- a/modules/actor-adaptor-std/src/tick_driver/test_tick_driver.rs
+++ b/modules/actor-adaptor-std/src/tick_driver/test_tick_driver.rs
@@ -107,18 +107,23 @@ struct TestTickDriverStopper {
   exec_thread: Option<JoinHandle<()>>,
 }
 
+fn join_driver_thread(handle: JoinHandle<()>, label: &str) {
+  if handle.thread().id() == thread::current().id() {
+    return;
+  }
+  if handle.join().is_err() {
+    std::eprintln!("warn: test tick driver {label} thread panicked during shutdown");
+  }
+}
+
 impl TickDriverStopper for TestTickDriverStopper {
   fn stop(mut self: Box<Self>) {
     self.running.store(false, Ordering::Release);
-    if let Some(h) = self.tick_thread.take()
-      && h.join().is_err()
-    {
-      std::eprintln!("warn: test tick driver tick thread panicked during shutdown");
+    if let Some(handle) = self.tick_thread.take() {
+      join_driver_thread(handle, "tick");
     }
-    if let Some(h) = self.exec_thread.take()
-      && h.join().is_err()
-    {
-      std::eprintln!("warn: test tick driver executor thread panicked during shutdown");
+    if let Some(handle) = self.exec_thread.take() {
+      join_driver_thread(handle, "executor");
     }
   }
 }

--- a/modules/actor-adaptor-std/src/tick_driver/test_tick_driver.rs
+++ b/modules/actor-adaptor-std/src/tick_driver/test_tick_driver.rs
@@ -107,23 +107,22 @@ struct TestTickDriverStopper {
   exec_thread: Option<JoinHandle<()>>,
 }
 
-fn join_driver_thread(handle: JoinHandle<()>, label: &str) {
+fn join_driver_thread(handle: JoinHandle<()>) {
   if handle.thread().id() == thread::current().id() {
     return;
   }
-  if handle.join().is_err() {
-    std::eprintln!("warn: test tick driver {label} thread panicked during shutdown");
-  }
+  // must-ignore: shutdown is already in progress; a panicked helper thread has no recovery path here.
+  drop(handle.join());
 }
 
 impl TickDriverStopper for TestTickDriverStopper {
   fn stop(mut self: Box<Self>) {
     self.running.store(false, Ordering::Release);
     if let Some(handle) = self.tick_thread.take() {
-      join_driver_thread(handle, "tick");
+      join_driver_thread(handle);
     }
     if let Some(handle) = self.exec_thread.take() {
-      join_driver_thread(handle, "executor");
+      join_driver_thread(handle);
     }
   }
 }

--- a/modules/actor-core-kernel/src/actor/scheduler/cancellable/cancellable_entry.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/cancellable/cancellable_entry.rs
@@ -44,17 +44,20 @@ impl CancellableEntry {
     self.state.store(CancellableState::Scheduled as u8, Ordering::Release);
   }
 
-  /// Attempts to cancel the entry while it is scheduled.
+  /// Attempts to cancel the entry while it is scheduled or executing.
   pub fn try_cancel(&self) -> bool {
-    self
-      .state
-      .compare_exchange(
-        CancellableState::Scheduled as u8,
-        CancellableState::Cancelled as u8,
-        Ordering::AcqRel,
-        Ordering::Acquire,
-      )
-      .is_ok()
+    let mut current = self.state.load(Ordering::Acquire);
+    loop {
+      let state = CancellableState::from(current);
+      if !matches!(state, CancellableState::Scheduled | CancellableState::Executing) {
+        return false;
+      }
+      match self.state.compare_exchange(current, CancellableState::Cancelled as u8, Ordering::AcqRel, Ordering::Acquire)
+      {
+        | Ok(_) => return true,
+        | Err(actual) => current = actual,
+      }
+    }
   }
 
   /// Forces the entry into the cancelled state regardless of the current state.

--- a/modules/actor-core-kernel/src/actor/scheduler/cancellable/cancellable_entry.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/cancellable/cancellable_entry.rs
@@ -40,8 +40,16 @@ impl CancellableEntry {
   }
 
   /// Transitions back to the scheduled state (used for periodic jobs).
-  pub fn reset_to_scheduled(&self) {
-    self.state.store(CancellableState::Scheduled as u8, Ordering::Release);
+  pub fn try_reset_to_scheduled(&self) -> bool {
+    self
+      .state
+      .compare_exchange(
+        CancellableState::Executing as u8,
+        CancellableState::Scheduled as u8,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+      )
+      .is_ok()
   }
 
   /// Attempts to cancel the entry while it is scheduled or executing.

--- a/modules/actor-core-kernel/src/actor/scheduler/cancellable/cancellable_entry.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/cancellable/cancellable_entry.rs
@@ -54,18 +54,14 @@ impl CancellableEntry {
 
   /// Attempts to cancel the entry while it is scheduled or executing.
   pub fn try_cancel(&self) -> bool {
-    let mut current = self.state.load(Ordering::Acquire);
-    loop {
-      let state = CancellableState::from(current);
-      if !matches!(state, CancellableState::Scheduled | CancellableState::Executing) {
-        return false;
-      }
-      match self.state.compare_exchange(current, CancellableState::Cancelled as u8, Ordering::AcqRel, Ordering::Acquire)
-      {
-        | Ok(_) => return true,
-        | Err(actual) => current = actual,
-      }
-    }
+    self
+      .state
+      .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+        let state = CancellableState::from(current);
+        matches!(state, CancellableState::Scheduled | CancellableState::Executing)
+          .then_some(CancellableState::Cancelled as u8)
+      })
+      .is_ok()
   }
 
   /// Forces the entry into the cancelled state regardless of the current state.

--- a/modules/actor-core-kernel/src/actor/scheduler/handle.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/handle.rs
@@ -44,16 +44,17 @@ impl SchedulerHandle {
 
   /// Attempts to cancel the scheduled job.
   ///
-  /// Returns `true` only when the entry is in the `Scheduled` state and the
-  /// cancellation transition succeeds. Returns `false` in all other cases:
-  /// `Pending` (not yet scheduled), `Executing` (already running), or when
-  /// already in a terminal state (`Cancelled` or `Completed`).
+  /// Returns `true` when the entry is in the `Scheduled` or `Executing` state
+  /// and the cancellation transition succeeds. Returns `false` in all other
+  /// cases: `Pending` (not yet scheduled), or already terminal
+  /// (`Cancelled` or `Completed`).
   ///
   /// Corresponds to Pekko's `Cancellable.cancel`.
   ///
-  /// Note: this marks the entry as cancelled but does not remove it from the
-  /// scheduler's job queue. The scheduler will skip cancelled entries on the
-  /// next tick.
+  /// Note: this marks the entry as cancelled but does not directly remove it
+  /// from the scheduler's job queue. A scheduled entry is skipped on the next
+  /// tick; an executing periodic entry is not rescheduled after the current
+  /// run returns.
   #[must_use]
   pub fn cancel(&self) -> bool {
     self.entry.try_cancel()

--- a/modules/actor-core-kernel/src/actor/scheduler/handle_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/handle_test.rs
@@ -59,16 +59,16 @@ fn cancel_on_completed_handle_returns_false() {
   assert!(handle.is_completed(), "handle should remain completed");
 }
 
-/// `cancel` on an executing handle returns `false`.
+/// `cancel` on an executing handle succeeds and prevents periodic rescheduling.
 #[test]
-fn cancel_on_executing_handle_returns_false() {
+fn cancel_on_executing_handle_succeeds() {
   let handle = SchedulerHandle::new(5);
   handle.entry().mark_scheduled();
   assert!(handle.entry().try_begin_execute(), "try_begin_execute should succeed from Scheduled state");
 
   let result = handle.cancel();
-  assert!(!result, "cancel should fail on executing handle");
-  assert!(!handle.is_cancelled(), "executing handle should not be marked cancelled");
+  assert!(result, "cancel should succeed on executing handle");
+  assert!(handle.is_cancelled(), "executing handle should be marked cancelled");
 }
 
 /// `is_cancelled` returns `true` after successful `cancel`.

--- a/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
@@ -338,8 +338,14 @@ impl Scheduler {
 
           if job.periodic.is_some() {
             if self.reschedule_job(&mut job).is_ok() {
-              cancellable.reset_to_scheduled();
-              self.jobs.insert(handle_id, job);
+              if cancellable.try_reset_to_scheduled() {
+                self.jobs.insert(handle_id, job);
+              } else {
+                // must-ignore: job is not reinserted, so the wheel entry must only be best-effort removed.
+                let _ = self.wheel.cancel(job.wheel_id);
+                self.registry.remove(handle_id);
+                self.metrics.decrement_active();
+              }
             } else {
               cancellable.mark_completed();
               self.registry.remove(handle_id);

--- a/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
@@ -239,7 +239,8 @@ impl Scheduler {
       if entry.is_completed() {
         return false;
       }
-      if !entry.try_cancel() {
+      let newly_cancelled = entry.try_cancel();
+      if !newly_cancelled && !entry.is_cancelled() {
         return false;
       }
       let removed_job = self.jobs.remove(&handle.raw());
@@ -248,6 +249,8 @@ impl Scheduler {
         let _ = self.wheel.cancel(job.wheel_id);
         self.registry.remove(handle.raw());
         self.metrics.decrement_active();
+      } else if !newly_cancelled {
+        return false;
       }
       self.metrics.increment_dropped();
       self.record_cancel_event(handle.raw());

--- a/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
@@ -239,7 +239,7 @@ impl Scheduler {
       if entry.is_completed() {
         return false;
       }
-      if !entry.try_cancel() && !entry.is_cancelled() {
+      if !entry.try_cancel() {
         return false;
       }
       let removed_job = self.jobs.remove(&handle.raw());

--- a/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
@@ -242,12 +242,13 @@ impl Scheduler {
       if !entry.try_cancel() && !entry.is_cancelled() {
         return false;
       }
-      if let Some(job) = self.jobs.remove(&handle.raw()) {
+      let removed_job = self.jobs.remove(&handle.raw());
+      if let Some(job) = removed_job {
         // must-ignore: registry / jobs から削除済みの handle に対する wheel.cancel の bool は参照不要。
         let _ = self.wheel.cancel(job.wheel_id);
+        self.registry.remove(handle.raw());
+        self.metrics.decrement_active();
       }
-      self.registry.remove(handle.raw());
-      self.metrics.decrement_active();
       self.metrics.increment_dropped();
       self.record_cancel_event(handle.raw());
       true

--- a/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/scheduler_core.rs
@@ -330,6 +330,12 @@ impl Scheduler {
           self.record_fire_event(handle_id, batch);
           executed += 1;
 
+          if cancellable.is_cancelled() {
+            self.registry.remove(handle_id);
+            self.metrics.decrement_active();
+            continue;
+          }
+
           if job.periodic.is_some() {
             if self.reschedule_job(&mut job).is_ok() {
               cancellable.reset_to_scheduled();

--- a/modules/actor-core-kernel/src/actor/scheduler/scheduler_core_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/scheduler_core_test.rs
@@ -13,6 +13,11 @@ impl Scheduler {
     self.jobs.get(&handle.raw()).map(|job| &job.command)
   }
 
+  /// Removes the job entry while leaving the cancellable registry intact.
+  pub fn remove_job_for_test(&mut self, handle: &SchedulerHandle) -> bool {
+    self.jobs.remove(&handle.raw()).is_some()
+  }
+
   /// Advances the scheduler by the requested ticks (testing helper).
   pub fn run_for_test(&mut self, ticks: u64) {
     self.run_for_ticks(ticks);

--- a/modules/actor-core-kernel/src/actor/scheduler/test_tick_driver_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/test_tick_driver_test.rs
@@ -109,23 +109,22 @@ struct TestTickDriverStopper {
   exec_thread: Option<JoinHandle<()>>,
 }
 
-fn join_driver_thread(handle: JoinHandle<()>, label: &str) {
+fn join_driver_thread(handle: JoinHandle<()>) {
   if handle.thread().id() == thread::current().id() {
     return;
   }
-  if handle.join().is_err() {
-    std::eprintln!("warn: test tick driver {label} thread panicked during shutdown");
-  }
+  // must-ignore: shutdown is already in progress; a panicked helper thread has no recovery path here.
+  drop(handle.join());
 }
 
 impl TickDriverStopper for TestTickDriverStopper {
   fn stop(mut self: Box<Self>) {
     self.running.store(false, Ordering::Release);
     if let Some(handle) = self.tick_thread.take() {
-      join_driver_thread(handle, "tick");
+      join_driver_thread(handle);
     }
     if let Some(handle) = self.exec_thread.take() {
-      join_driver_thread(handle, "executor");
+      join_driver_thread(handle);
     }
   }
 }

--- a/modules/actor-core-kernel/src/actor/scheduler/test_tick_driver_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler/test_tick_driver_test.rs
@@ -109,18 +109,23 @@ struct TestTickDriverStopper {
   exec_thread: Option<JoinHandle<()>>,
 }
 
+fn join_driver_thread(handle: JoinHandle<()>, label: &str) {
+  if handle.thread().id() == thread::current().id() {
+    return;
+  }
+  if handle.join().is_err() {
+    std::eprintln!("warn: test tick driver {label} thread panicked during shutdown");
+  }
+}
+
 impl TickDriverStopper for TestTickDriverStopper {
   fn stop(mut self: Box<Self>) {
     self.running.store(false, Ordering::Release);
-    if let Some(h) = self.tick_thread.take()
-      && h.join().is_err()
-    {
-      std::eprintln!("warn: test tick driver tick thread panicked during shutdown");
+    if let Some(handle) = self.tick_thread.take() {
+      join_driver_thread(handle, "tick");
     }
-    if let Some(h) = self.exec_thread.take()
-      && h.join().is_err()
-    {
-      std::eprintln!("warn: test tick driver executor thread panicked during shutdown");
+    if let Some(handle) = self.exec_thread.take() {
+      join_driver_thread(handle, "executor");
     }
   }
 }

--- a/modules/actor-core-kernel/src/actor/scheduler_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler_test.rs
@@ -506,6 +506,31 @@ fn fixed_rate_handle_can_be_cancelled_after_multiple_runs() {
 }
 
 #[test]
+fn fixed_rate_runnable_cancelled_while_executing_is_not_rescheduled() {
+  let mut scheduler = build_scheduler();
+  let handle_slot: ArcShared<SpinSyncMutex<Option<SchedulerHandle>>> = ArcShared::new(SpinSyncMutex::new(None));
+  let handle_slot_for_runnable = handle_slot.clone();
+  let runnable: ArcShared<dyn SchedulerRunnable> = ArcShared::new(move |_batch: &ExecutionBatch| {
+    let handle = { handle_slot_for_runnable.lock().as_ref().cloned().expect("handle should be registered") };
+    assert!(handle.cancel(), "executing periodic handle should be cancellable");
+  });
+  let handle = scheduler
+    .schedule_at_fixed_rate(Duration::from_millis(1), Duration::from_millis(1), SchedulerCommand::RunRunnable {
+      runnable: runnable.clone(),
+    })
+    .expect("handle");
+  *handle_slot.lock() = Some(handle.clone());
+
+  scheduler.run_for_test(1);
+
+  assert!(handle.is_cancelled());
+  assert_eq!(scheduler.job_count_for_test(), 0);
+  assert_eq!(scheduler.metrics().active_timers(), 0);
+  scheduler.run_for_test(1);
+  assert_eq!(scheduler.job_count_for_test(), 0);
+}
+
+#[test]
 fn fixed_rate_policy_enforces_independent_backlog_limit() {
   let rate_policy = FixedRatePolicy::new(nz(1), nz(8));
   let delay_policy = FixedDelayPolicy::new(nz(8), nz(16));

--- a/modules/actor-core-kernel/src/actor/scheduler_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler_test.rs
@@ -532,6 +532,22 @@ fn fixed_rate_runnable_cancelled_while_executing_is_not_rescheduled() {
 }
 
 #[test]
+fn scheduler_cancel_during_execution_defers_active_timer_decrement() {
+  let mut scheduler = build_scheduler();
+  let handle = scheduler
+    .schedule_at_fixed_rate(Duration::from_millis(1), Duration::from_millis(1), SchedulerCommand::Noop)
+    .expect("handle");
+  assert!(handle.entry().try_begin_execute(), "entry should simulate an executing job");
+  assert!(scheduler.remove_job_for_test(&handle), "executing job should already be out of the job map");
+
+  assert!(scheduler.cancel(&handle));
+
+  assert!(handle.is_cancelled());
+  assert_eq!(scheduler.metrics().active_timers(), 1);
+  assert_eq!(scheduler.job_count_for_test(), 0);
+}
+
+#[test]
 fn fixed_rate_runnable_completed_while_executing_is_not_rescheduled() {
   let mut scheduler = build_scheduler();
   let entry_slot: ArcShared<SpinSyncMutex<Option<ArcShared<CancellableEntry>>>> =

--- a/modules/actor-core-kernel/src/actor/scheduler_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler_test.rs
@@ -544,7 +544,12 @@ fn scheduler_cancel_during_execution_defers_active_timer_decrement() {
 
   assert!(handle.is_cancelled());
   assert_eq!(scheduler.metrics().active_timers(), 1);
+  assert_eq!(scheduler.metrics().dropped_total(), 1);
   assert_eq!(scheduler.job_count_for_test(), 0);
+
+  assert!(!scheduler.cancel(&handle));
+  assert_eq!(scheduler.metrics().active_timers(), 1);
+  assert_eq!(scheduler.metrics().dropped_total(), 1);
 }
 
 #[test]

--- a/modules/actor-core-kernel/src/actor/scheduler_test.rs
+++ b/modules/actor-core-kernel/src/actor/scheduler_test.rs
@@ -24,6 +24,7 @@ use proptest::prelude::*;
 use super::{
   BatchMode, ExecutionBatch, Scheduler, SchedulerBackedDelayProvider, SchedulerConfig, SchedulerContext,
   SchedulerError, SchedulerMode, SchedulerRunnable, SchedulerRunner, SchedulerWarning,
+  cancellable::CancellableEntry,
   command::SchedulerCommand,
   diagnostics::{DeterministicEvent, SchedulerDiagnosticsEvent},
   handle::SchedulerHandle,
@@ -528,6 +529,30 @@ fn fixed_rate_runnable_cancelled_while_executing_is_not_rescheduled() {
   assert_eq!(scheduler.metrics().active_timers(), 0);
   scheduler.run_for_test(1);
   assert_eq!(scheduler.job_count_for_test(), 0);
+}
+
+#[test]
+fn fixed_rate_runnable_completed_while_executing_is_not_rescheduled() {
+  let mut scheduler = build_scheduler();
+  let entry_slot: ArcShared<SpinSyncMutex<Option<ArcShared<CancellableEntry>>>> =
+    ArcShared::new(SpinSyncMutex::new(None));
+  let entry_slot_for_runnable = entry_slot.clone();
+  let runnable: ArcShared<dyn SchedulerRunnable> = ArcShared::new(move |_batch: &ExecutionBatch| {
+    let entry = { entry_slot_for_runnable.lock().as_ref().cloned().expect("entry should be registered") };
+    entry.mark_completed();
+  });
+  let handle = scheduler
+    .schedule_at_fixed_rate(Duration::from_millis(1), Duration::from_millis(1), SchedulerCommand::RunRunnable {
+      runnable: runnable.clone(),
+    })
+    .expect("handle");
+  *entry_slot.lock() = Some(handle.entry());
+
+  scheduler.run_for_test(1);
+
+  assert!(handle.is_completed());
+  assert_eq!(scheduler.job_count_for_test(), 0);
+  assert_eq!(scheduler.metrics().active_timers(), 0);
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/dsl/source_test.rs
+++ b/modules/stream-core-kernel/src/dsl/source_test.rs
@@ -1325,7 +1325,7 @@ fn source_create_tolerates_producer_delay_without_std_sleep() {
   }
   assert_eq!(second_value, Some(61_u32));
 
-  for _ in 0..scaled_attempts(16) {
+  for _ in 0..scaled_attempts(THREAD_SYNC_ATTEMPTS) {
     let _ = materialized.stream().drive();
     if materialized.stream().state().is_terminal() {
       break;

--- a/modules/stream-core-kernel/src/impl/materialization/stream_island_actor.rs
+++ b/modules/stream-core-kernel/src/impl/materialization/stream_island_actor.rs
@@ -46,7 +46,7 @@ impl StreamIslandActor {
     Ok(())
   }
 
-  fn stop_self_after_terminal(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
+  fn stop_self_after_terminal(ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
     if ctx.system().state().cell(&ctx.pid()).is_none() {
       return Ok(());
     }
@@ -57,7 +57,7 @@ impl StreamIslandActor {
 
   fn cleanup_terminal(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
     self.cancel_scheduled_tick()?;
-    self.stop_self_after_terminal(ctx)
+    Self::stop_self_after_terminal(ctx)
   }
 
   fn abort_graph_streams(&self, error: &StreamError) {

--- a/modules/stream-core-kernel/src/impl/materialization/stream_island_actor.rs
+++ b/modules/stream-core-kernel/src/impl/materialization/stream_island_actor.rs
@@ -34,30 +34,28 @@ impl StreamIslandActor {
     Self { stream, drive_gate, downstream_cancellation_control_plane, graph_streams, tick_handle_slot }
   }
 
-  fn cancel_scheduled_tick(&self) -> Result<(), ActorError> {
+  fn cancel_scheduled_tick(&self) {
     let handle = self.tick_handle_slot.lock().take();
     let Some(handle) = handle else {
-      return Ok(());
+      return;
     };
-    let cancelled = handle.cancel();
-    if !(cancelled || handle.is_cancelled() || handle.is_completed()) {
-      return Err(ActorError::fatal("stream island scheduled tick cancellation failed"));
-    }
-    Ok(())
+    // must-ignore: completed/cancelled handles are already terminal, and active
+    // scheduled/executing handles transition to cancelled through the handle.
+    let _cancelled = handle.cancel();
   }
 
-  fn stop_self_after_terminal(ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
+  fn stop_self_after_terminal(ctx: &mut ActorContext<'_>) {
     if ctx.system().state().cell(&ctx.pid()).is_none() {
-      return Ok(());
+      return;
     }
-    ctx
-      .stop_self()
-      .map_err(|error| ActorError::fatal(format!("stream island actor stop failed after terminal stream: {error:?}")))
+    // must-ignore: materializer shutdown still performs authoritative resource
+    // teardown; normal terminal cleanup should not make later shutdown fail.
+    drop(ctx.stop_self());
   }
 
-  fn cleanup_terminal(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
-    self.cancel_scheduled_tick()?;
-    Self::stop_self_after_terminal(ctx)
+  fn cleanup_terminal(&self, ctx: &mut ActorContext<'_>) {
+    self.cancel_scheduled_tick();
+    Self::stop_self_after_terminal(ctx);
   }
 
   fn abort_graph_streams(&self, error: &StreamError) {
@@ -115,19 +113,20 @@ impl StreamIslandActor {
   fn drive(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
     if self.stream.state().is_terminal() {
       self.drive_gate.mark_idle();
-      return self.cleanup_terminal(ctx);
+      self.cleanup_terminal(ctx);
+      return Ok(());
     }
 
     if let Err(error) = self.propagate_downstream_cancellation() {
       self.drive_gate.mark_idle();
-      self.cancel_scheduled_tick()?;
+      self.cancel_scheduled_tick();
       return Err(error);
     }
 
     let _outcome = self.stream.drive();
     self.drive_gate.mark_idle();
     if self.stream.state().is_terminal() {
-      self.cleanup_terminal(ctx)?;
+      self.cleanup_terminal(ctx);
     }
     Ok(())
   }
@@ -138,9 +137,9 @@ impl StreamIslandActor {
       | None => ActorError::fatal(format!("stream island cancel failed: {e:?}")),
     });
     if result.is_ok() {
-      self.cleanup_terminal(ctx)?;
+      self.cleanup_terminal(ctx);
     } else {
-      self.cancel_scheduled_tick()?;
+      self.cancel_scheduled_tick();
     }
     result
   }
@@ -150,17 +149,17 @@ impl StreamIslandActor {
     if result.is_ok() {
       let _outcome = self.stream.drive();
       if self.stream.state().is_terminal() {
-        self.cleanup_terminal(ctx)?;
+        self.cleanup_terminal(ctx);
       }
     } else {
-      self.cancel_scheduled_tick()?;
+      self.cancel_scheduled_tick();
     }
     result
   }
 
   fn abort(&self, error: &StreamError) -> Result<(), ActorError> {
     self.stream.abort(error);
-    self.cancel_scheduled_tick()?;
+    self.cancel_scheduled_tick();
     Err(ActorError::fatal(format!("stream island abort requested: {error:?}")))
   }
 }

--- a/modules/stream-core-kernel/src/impl/materialization/stream_island_actor.rs
+++ b/modules/stream-core-kernel/src/impl/materialization/stream_island_actor.rs
@@ -34,17 +34,30 @@ impl StreamIslandActor {
     Self { stream, drive_gate, downstream_cancellation_control_plane, graph_streams, tick_handle_slot }
   }
 
-  fn cancel_scheduled_tick(&self, _ctx: &ActorContext<'_>) {
+  fn cancel_scheduled_tick(&self) -> Result<(), ActorError> {
     let handle = self.tick_handle_slot.lock().take();
     let Some(handle) = handle else {
-      return;
+      return Ok(());
     };
     let cancelled = handle.cancel();
     if !(cancelled || handle.is_cancelled() || handle.is_completed()) {
-      // ベストエフォート: island が terminal に到達する瞬間は scheduler 側の
-      // 遷移と競合し得る。その場合は次に発火した tick が terminal 状態を観測して
-      // no-op になる。
+      return Err(ActorError::fatal("stream island scheduled tick cancellation failed"));
     }
+    Ok(())
+  }
+
+  fn stop_self_after_terminal(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
+    if ctx.system().state().cell(&ctx.pid()).is_none() {
+      return Ok(());
+    }
+    ctx
+      .stop_self()
+      .map_err(|error| ActorError::fatal(format!("stream island actor stop failed after terminal stream: {error:?}")))
+  }
+
+  fn cleanup_terminal(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
+    self.cancel_scheduled_tick()?;
+    self.stop_self_after_terminal(ctx)
   }
 
   fn abort_graph_streams(&self, error: &StreamError) {
@@ -99,52 +112,55 @@ impl StreamIslandActor {
     Ok(())
   }
 
-  fn drive(&self, ctx: &ActorContext<'_>) -> Result<(), ActorError> {
+  fn drive(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
     if self.stream.state().is_terminal() {
       self.drive_gate.mark_idle();
-      self.cancel_scheduled_tick(ctx);
-      return Ok(());
+      return self.cleanup_terminal(ctx);
     }
 
     if let Err(error) = self.propagate_downstream_cancellation() {
       self.drive_gate.mark_idle();
-      self.cancel_scheduled_tick(ctx);
+      self.cancel_scheduled_tick()?;
       return Err(error);
     }
 
     let _outcome = self.stream.drive();
     self.drive_gate.mark_idle();
     if self.stream.state().is_terminal() {
-      self.cancel_scheduled_tick(ctx);
+      self.cleanup_terminal(ctx)?;
     }
     Ok(())
   }
 
-  fn cancel(&self, ctx: &ActorContext<'_>, cause: Option<&StreamError>) -> Result<(), ActorError> {
+  fn cancel(&self, ctx: &mut ActorContext<'_>, cause: Option<&StreamError>) -> Result<(), ActorError> {
     let result = self.stream.cancel().map_err(|e| match cause {
       | Some(cause) => ActorError::fatal(format!("stream island cancel failed after {cause:?}: {e:?}")),
       | None => ActorError::fatal(format!("stream island cancel failed: {e:?}")),
     });
-    self.cancel_scheduled_tick(ctx);
-    result
-  }
-
-  fn shutdown(&self, ctx: &ActorContext<'_>) -> Result<(), ActorError> {
-    let result = self.stream.shutdown().map_err(|e| ActorError::fatal(format!("stream island shutdown failed: {e:?}")));
     if result.is_ok() {
-      let _outcome = self.stream.drive();
-      if self.stream.state().is_terminal() {
-        self.cancel_scheduled_tick(ctx);
-      }
+      self.cleanup_terminal(ctx)?;
     } else {
-      self.cancel_scheduled_tick(ctx);
+      self.cancel_scheduled_tick()?;
     }
     result
   }
 
-  fn abort(&self, ctx: &ActorContext<'_>, error: &StreamError) -> Result<(), ActorError> {
+  fn shutdown(&self, ctx: &mut ActorContext<'_>) -> Result<(), ActorError> {
+    let result = self.stream.shutdown().map_err(|e| ActorError::fatal(format!("stream island shutdown failed: {e:?}")));
+    if result.is_ok() {
+      let _outcome = self.stream.drive();
+      if self.stream.state().is_terminal() {
+        self.cleanup_terminal(ctx)?;
+      }
+    } else {
+      self.cancel_scheduled_tick()?;
+    }
+    result
+  }
+
+  fn abort(&self, error: &StreamError) -> Result<(), ActorError> {
     self.stream.abort(error);
-    self.cancel_scheduled_tick(ctx);
+    self.cancel_scheduled_tick()?;
     Err(ActorError::fatal(format!("stream island abort requested: {error:?}")))
   }
 }
@@ -163,7 +179,7 @@ impl Actor for StreamIslandActor {
           self.shutdown(ctx)?;
         },
         | StreamIslandCommand::Abort(error) => {
-          self.abort(ctx, error)?;
+          self.abort(error)?;
         },
       }
     }

--- a/modules/stream-core-kernel/src/impl/materialization/stream_island_actor_test.rs
+++ b/modules/stream-core-kernel/src/impl/materialization/stream_island_actor_test.rs
@@ -97,6 +97,19 @@ fn new_stream_island_actor(stream: StreamShared) -> StreamIslandActor {
   )
 }
 
+fn new_stream_island_actor_with_tick_handle_slot(
+  stream: StreamShared,
+  tick_handle_slot: ArcShared<SpinSyncMutex<Option<SchedulerHandle>>>,
+) -> StreamIslandActor {
+  StreamIslandActor::new(
+    stream.clone(),
+    new_drive_gate(),
+    new_downstream_cancellation_control_plane(),
+    vec![stream],
+    tick_handle_slot,
+  )
+}
+
 fn cancel_failing_stream() -> StreamShared {
   let graph = Source::<u32, StreamNotUsed>::from_logic(StageKind::SourceSingle, CancelFailingSourceLogic)
     .into_mat(Sink::ignore(), KeepRight);
@@ -151,6 +164,20 @@ fn drive_command_does_not_drive_terminal_stream() {
   receive_command(&mut actor, StreamIslandCommand::Drive);
 
   assert_eq!(pull_count(&pulls), pulls_before);
+}
+
+#[test]
+fn drive_command_reports_tick_cancellation_failure() {
+  let pulls = new_pull_counter();
+  let stream = counting_stream(pulls);
+  stream.cancel().expect("cancel should reach terminal state");
+  let tick_handle_slot = new_tick_handle_slot();
+  *tick_handle_slot.lock() = Some(SchedulerHandle::new(42));
+  let mut actor = new_stream_island_actor_with_tick_handle_slot(stream, tick_handle_slot);
+
+  let result = receive_command_result(&mut actor, StreamIslandCommand::Drive);
+
+  assert!(result.is_err());
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/impl/materialization/stream_island_actor_test.rs
+++ b/modules/stream-core-kernel/src/impl/materialization/stream_island_actor_test.rs
@@ -97,19 +97,6 @@ fn new_stream_island_actor(stream: StreamShared) -> StreamIslandActor {
   )
 }
 
-fn new_stream_island_actor_with_tick_handle_slot(
-  stream: StreamShared,
-  tick_handle_slot: ArcShared<SpinSyncMutex<Option<SchedulerHandle>>>,
-) -> StreamIslandActor {
-  StreamIslandActor::new(
-    stream.clone(),
-    new_drive_gate(),
-    new_downstream_cancellation_control_plane(),
-    vec![stream],
-    tick_handle_slot,
-  )
-}
-
 fn cancel_failing_stream() -> StreamShared {
   let graph = Source::<u32, StreamNotUsed>::from_logic(StageKind::SourceSingle, CancelFailingSourceLogic)
     .into_mat(Sink::ignore(), KeepRight);
@@ -164,20 +151,6 @@ fn drive_command_does_not_drive_terminal_stream() {
   receive_command(&mut actor, StreamIslandCommand::Drive);
 
   assert_eq!(pull_count(&pulls), pulls_before);
-}
-
-#[test]
-fn drive_command_reports_tick_cancellation_failure() {
-  let pulls = new_pull_counter();
-  let stream = counting_stream(pulls);
-  stream.cancel().expect("cancel should reach terminal state");
-  let tick_handle_slot = new_tick_handle_slot();
-  *tick_handle_slot.lock() = Some(SchedulerHandle::new(42));
-  let mut actor = new_stream_island_actor_with_tick_handle_slot(stream, tick_handle_slot);
-
-  let result = receive_command_result(&mut actor, StreamIslandCommand::Drive);
-
-  assert!(result.is_err());
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -450,10 +450,13 @@ impl ActorMaterializer {
     result
   }
 
-  fn finish_resource_teardown(resources: MaterializedStreamResources) -> Result<(), StreamError> {
+  fn finish_resource_teardown(system: &ActorSystem, resources: MaterializedStreamResources) -> Result<(), StreamError> {
     let MaterializedStreamResources { streams, island_actors, .. } = resources;
     let mut result = Ok(());
     for actor in &island_actors {
+      if system.state().cell(&actor.pid()).is_none() {
+        continue;
+      }
       if actor.stop().is_err() {
         Self::record_first_error(&mut result, StreamError::Failed);
       }
@@ -477,7 +480,7 @@ impl ActorMaterializer {
         Self::record_first_error(&mut result, error);
       }
     }
-    if let Err(error) = Self::finish_resource_teardown(resources) {
+    if let Err(error) = Self::finish_resource_teardown(system, resources) {
       Self::record_first_error(&mut result, error);
     }
     result
@@ -503,7 +506,7 @@ impl ActorMaterializer {
         Self::record_first_error(&mut result, error);
       }
     }
-    if let Err(error) = Self::finish_resource_teardown(resources) {
+    if let Err(error) = Self::finish_resource_teardown(system, resources) {
       Self::record_first_error(&mut result, error);
     }
     result

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -400,6 +400,23 @@ impl ActorMaterializer {
     result
   }
 
+  fn request_non_terminal_actor_shutdown(
+    system: &ActorSystem,
+    resources: &MaterializedStreamResources,
+  ) -> Result<(), StreamError> {
+    if resources.island_actors.len() != resources.streams.len() {
+      return Err(StreamError::InvalidConnection);
+    }
+
+    let actors: Vec<ChildRef> = resources
+      .island_actors
+      .iter()
+      .zip(&resources.streams)
+      .filter_map(|(actor, stream)| if stream.state().is_terminal() { None } else { Some(actor.clone()) })
+      .collect();
+    Self::request_actor_shutdown(system, &actors)
+  }
+
   fn all_streams_terminal(streams: &[StreamShared]) -> bool {
     streams.iter().all(|stream| stream.state().is_terminal())
   }
@@ -501,9 +518,7 @@ impl ActorMaterializer {
         Self::record_first_error(&mut result, error);
       }
     } else {
-      if !Self::all_streams_terminal(&resources.streams) {
-        result = result.and(Self::request_actor_shutdown(system, &resources.island_actors));
-      }
+      result = result.and(Self::request_non_terminal_actor_shutdown(system, &resources));
       if let Err(error) = Self::request_stream_shutdown(&resources.streams) {
         Self::record_first_error(&mut result, error);
       }

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -386,6 +386,13 @@ impl ActorMaterializer {
     result
   }
 
+  fn actor_mailbox_closed_or_missing(system: &ActorSystem, actor: &ChildRef) -> bool {
+    match system.state().cell(&actor.pid()) {
+      | Some(cell) => cell.mailbox().is_closed(),
+      | None => true,
+    }
+  }
+
   fn request_actor_shutdown(system: &ActorSystem, actors: &[ChildRef]) -> Result<(), StreamError> {
     let mut result = Ok(());
     for actor in actors {
@@ -394,7 +401,9 @@ impl ActorMaterializer {
       }
       let mut actor = actor.clone();
       if let Err(error) = actor.try_tell(AnyMessage::new(StreamIslandCommand::Shutdown)) {
-        if matches!(error, SendError::Closed(_)) || system.state().cell(&actor.pid()).is_none() {
+        if system.state().cell(&actor.pid()).is_none()
+          || (matches!(error, SendError::Closed(_)) && Self::actor_mailbox_closed_or_missing(system, &actor))
+        {
           continue;
         }
         Self::record_first_error(&mut result, StreamError::Failed);
@@ -465,7 +474,9 @@ impl ActorMaterializer {
         continue;
       }
       if let Err(error) = actor.stop() {
-        if matches!(error, SendError::Closed(_)) || system.state().cell(&actor.pid()).is_none() {
+        if system.state().cell(&actor.pid()).is_none()
+          || (matches!(error, SendError::Closed(_)) && Self::actor_mailbox_closed_or_missing(system, actor))
+        {
           continue;
         }
         Self::record_first_error(&mut result, StreamError::Failed);

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -456,10 +456,11 @@ impl ActorMaterializer {
 
   fn finish_resource_teardown(system: &ActorSystem, resources: MaterializedStreamResources) -> Result<(), StreamError> {
     let MaterializedStreamResources { streams, island_actors, .. } = resources;
+    let streams_terminal = !streams.is_empty() && Self::all_streams_terminal(&streams);
     let mut result = Ok(());
     for actor in &island_actors {
       if let Err(error) = actor.stop() {
-        if matches!(error, SendError::Closed(_)) && system.state().cell(&actor.pid()).is_none() {
+        if matches!(error, SendError::Closed(_)) && (streams_terminal || system.state().cell(&actor.pid()).is_none()) {
           continue;
         }
         Self::record_first_error(&mut result, StreamError::Failed);
@@ -500,7 +501,9 @@ impl ActorMaterializer {
         Self::record_first_error(&mut result, error);
       }
     } else {
-      result = result.and(Self::request_actor_shutdown(system, &resources.island_actors));
+      if !Self::all_streams_terminal(&resources.streams) {
+        result = result.and(Self::request_actor_shutdown(system, &resources.island_actors));
+      }
       if let Err(error) = Self::request_stream_shutdown(&resources.streams) {
         Self::record_first_error(&mut result, error);
       }

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -385,9 +385,12 @@ impl ActorMaterializer {
     result
   }
 
-  fn request_actor_shutdown(actors: &[ChildRef]) -> Result<(), StreamError> {
+  fn request_actor_shutdown(system: &ActorSystem, actors: &[ChildRef]) -> Result<(), StreamError> {
     let mut result = Ok(());
     for actor in actors {
+      if system.state().cell(&actor.pid()).is_none() {
+        continue;
+      }
       let mut actor = actor.clone();
       if let Err(error) = Self::send_command(&mut actor, StreamIslandCommand::Shutdown) {
         Self::record_first_error(&mut result, error);
@@ -496,7 +499,7 @@ impl ActorMaterializer {
         Self::record_first_error(&mut result, error);
       }
     } else {
-      if let Err(error) = Self::request_actor_shutdown(&resources.island_actors) {
+      if let Err(error) = Self::request_actor_shutdown(system, &resources.island_actors) {
         Self::record_first_error(&mut result, error);
       }
       if let Err(error) = Self::request_stream_shutdown(&resources.streams) {

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -386,24 +386,12 @@ impl ActorMaterializer {
     result
   }
 
-  fn actor_mailbox_closed_or_missing(system: &ActorSystem, actor: &ChildRef) -> bool {
-    match system.state().cell(&actor.pid()) {
-      | Some(cell) => cell.mailbox().is_closed(),
-      | None => true,
-    }
-  }
-
   fn request_actor_shutdown(system: &ActorSystem, actors: &[ChildRef]) -> Result<(), StreamError> {
     let mut result = Ok(());
     for actor in actors {
-      if system.state().cell(&actor.pid()).is_none() {
-        continue;
-      }
       let mut actor = actor.clone();
       if let Err(error) = actor.try_tell(AnyMessage::new(StreamIslandCommand::Shutdown)) {
-        if system.state().cell(&actor.pid()).is_none()
-          || (matches!(error, SendError::Closed(_)) && Self::actor_mailbox_closed_or_missing(system, &actor))
-        {
+        if matches!(error, SendError::Closed(_)) && system.state().cell(&actor.pid()).is_none() {
           continue;
         }
         Self::record_first_error(&mut result, StreamError::Failed);
@@ -470,13 +458,8 @@ impl ActorMaterializer {
     let MaterializedStreamResources { streams, island_actors, .. } = resources;
     let mut result = Ok(());
     for actor in &island_actors {
-      if system.state().cell(&actor.pid()).is_none() {
-        continue;
-      }
       if let Err(error) = actor.stop() {
-        if system.state().cell(&actor.pid()).is_none()
-          || (matches!(error, SendError::Closed(_)) && Self::actor_mailbox_closed_or_missing(system, actor))
-        {
+        if matches!(error, SendError::Closed(_)) && system.state().cell(&actor.pid()).is_none() {
           continue;
         }
         Self::record_first_error(&mut result, StreamError::Failed);

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -499,9 +499,7 @@ impl ActorMaterializer {
         Self::record_first_error(&mut result, error);
       }
     } else {
-      if let Err(error) = Self::request_actor_shutdown(system, &resources.island_actors) {
-        Self::record_first_error(&mut result, error);
-      }
+      result = result.and(Self::request_actor_shutdown(system, &resources.island_actors));
       if let Err(error) = Self::request_stream_shutdown(&resources.streams) {
         Self::record_first_error(&mut result, error);
       }

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -4,6 +4,7 @@ use core::{hint, time::Duration};
 use fraktor_actor_core_kernel_rs::{
   actor::{
     ChildRef,
+    error::SendError,
     messaging::AnyMessage,
     props::Props,
     scheduler::{ExecutionBatch, SchedulerCommand, SchedulerError, SchedulerHandle, SchedulerRunnable},
@@ -392,8 +393,11 @@ impl ActorMaterializer {
         continue;
       }
       let mut actor = actor.clone();
-      if let Err(error) = Self::send_command(&mut actor, StreamIslandCommand::Shutdown) {
-        Self::record_first_error(&mut result, error);
+      if let Err(error) = actor.try_tell(AnyMessage::new(StreamIslandCommand::Shutdown)) {
+        if matches!(error, SendError::Closed(_)) || system.state().cell(&actor.pid()).is_none() {
+          continue;
+        }
+        Self::record_first_error(&mut result, StreamError::Failed);
       }
     }
     result

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -464,7 +464,10 @@ impl ActorMaterializer {
       if system.state().cell(&actor.pid()).is_none() {
         continue;
       }
-      if actor.stop().is_err() {
+      if let Err(error) = actor.stop() {
+        if matches!(error, SendError::Closed(_)) || system.state().cell(&actor.pid()).is_none() {
+          continue;
+        }
         Self::record_first_error(&mut result, StreamError::Failed);
       }
     }

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -366,24 +366,27 @@ fn inline_executor_shared() -> ExecutorShared {
   ExecutorShared::new(Box::new(InlineExec), TrampolineState::new())
 }
 
-struct ClosedUserDispatcherFactory {
-  id: &'static str,
+struct RejectingUserDispatcherFactory {
+  id:     &'static str,
+  closed: bool,
 }
 
-impl MessageDispatcherFactory for ClosedUserDispatcherFactory {
+impl MessageDispatcherFactory for RejectingUserDispatcherFactory {
   fn dispatcher(&self) -> MessageDispatcherShared {
     let settings = DispatcherConfig::new(self.id, nz(8), None, Duration::from_secs(1));
-    MessageDispatcherShared::new(Box::new(ClosedUserDispatcher {
-      core: DispatcherCore::new(&settings, inline_executor_shared()),
+    MessageDispatcherShared::new(Box::new(RejectingUserDispatcher {
+      core:   DispatcherCore::new(&settings, inline_executor_shared()),
+      closed: self.closed,
     }))
   }
 }
 
-struct ClosedUserDispatcher {
-  core: DispatcherCore,
+struct RejectingUserDispatcher {
+  core:   DispatcherCore,
+  closed: bool,
 }
 
-impl MessageDispatcher for ClosedUserDispatcher {
+impl MessageDispatcher for RejectingUserDispatcher {
   fn core(&self) -> &DispatcherCore {
     &self.core
   }
@@ -397,31 +400,38 @@ impl MessageDispatcher for ClosedUserDispatcher {
     _receiver: &ArcShared<ActorCell>,
     envelope: Envelope,
   ) -> Result<Vec<ArcShared<Mailbox>>, SendError> {
-    Err(SendError::closed(envelope.into_payload()))
+    if self.closed {
+      Err(SendError::closed(envelope.into_payload()))
+    } else {
+      Err(SendError::full(envelope.into_payload()))
+    }
   }
 }
 
-struct StopClosedDispatcherFactory {
-  id:         &'static str,
-  close_stop: ArcShared<SpinSyncMutex<bool>>,
+struct RejectingStopDispatcherFactory {
+  id:          &'static str,
+  reject_stop: ArcShared<SpinSyncMutex<bool>>,
+  closed:      bool,
 }
 
-impl MessageDispatcherFactory for StopClosedDispatcherFactory {
+impl MessageDispatcherFactory for RejectingStopDispatcherFactory {
   fn dispatcher(&self) -> MessageDispatcherShared {
     let settings = DispatcherConfig::new(self.id, nz(8), None, Duration::from_secs(1));
-    MessageDispatcherShared::new(Box::new(StopClosedDispatcher {
-      default:    DefaultDispatcher::new(&settings, inline_executor_shared()),
-      close_stop: self.close_stop.clone(),
+    MessageDispatcherShared::new(Box::new(RejectingStopDispatcher {
+      default:     DefaultDispatcher::new(&settings, inline_executor_shared()),
+      reject_stop: self.reject_stop.clone(),
+      closed:      self.closed,
     }))
   }
 }
 
-struct StopClosedDispatcher {
-  default:    DefaultDispatcher,
-  close_stop: ArcShared<SpinSyncMutex<bool>>,
+struct RejectingStopDispatcher {
+  default:     DefaultDispatcher,
+  reject_stop: ArcShared<SpinSyncMutex<bool>>,
+  closed:      bool,
 }
 
-impl MessageDispatcher for StopClosedDispatcher {
+impl MessageDispatcher for RejectingStopDispatcher {
   fn core(&self) -> &DispatcherCore {
     self.default.core()
   }
@@ -435,8 +445,11 @@ impl MessageDispatcher for StopClosedDispatcher {
     receiver: &ArcShared<ActorCell>,
     message: SystemMessage,
   ) -> Result<Vec<ArcShared<Mailbox>>, SendError> {
-    if matches!(message, SystemMessage::Stop) && *self.close_stop.lock() {
-      return Err(SendError::closed(AnyMessage::new(message)));
+    if matches!(message, SystemMessage::Stop) && *self.reject_stop.lock() {
+      if self.closed {
+        return Err(SendError::closed(AnyMessage::new(message)));
+      }
+      return Err(SendError::full(AnyMessage::new(message)));
     }
     self.default.system_dispatch(receiver, message)
   }
@@ -458,8 +471,9 @@ fn build_system_with_dispatcher(dispatcher_id: &'static str) -> (ActorSystem, Me
   (ActorSystem::create_from_props(&props, config).expect("system should build"), dispatcher)
 }
 
-fn build_system_with_closed_user_dispatcher(dispatcher_id: &'static str) -> ActorSystem {
-  let configurator: Box<dyn MessageDispatcherFactory> = Box::new(ClosedUserDispatcherFactory { id: dispatcher_id });
+fn build_system_with_rejecting_user_dispatcher(dispatcher_id: &'static str, closed: bool) -> ActorSystem {
+  let configurator: Box<dyn MessageDispatcherFactory> =
+    Box::new(RejectingUserDispatcherFactory { id: dispatcher_id, closed });
   let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
@@ -469,12 +483,13 @@ fn build_system_with_closed_user_dispatcher(dispatcher_id: &'static str) -> Acto
   ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
-fn build_system_with_stop_closed_dispatcher(
+fn build_system_with_rejecting_stop_dispatcher(
   dispatcher_id: &'static str,
-  close_stop: ArcShared<SpinSyncMutex<bool>>,
+  reject_stop: ArcShared<SpinSyncMutex<bool>>,
+  closed: bool,
 ) -> ActorSystem {
   let configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(StopClosedDispatcherFactory { id: dispatcher_id, close_stop });
+    Box::new(RejectingStopDispatcherFactory { id: dispatcher_id, reject_stop, closed });
   let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
@@ -546,11 +561,17 @@ fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
 }
 
 fn wait_for_scheduler_job_count(system: &ActorSystem, expected: usize) {
-  let deadline = Instant::now() + Duration::from_secs(5);
-  while Instant::now() < deadline && scheduler_job_count(system) != expected {
+  let mut actual = scheduler_job_count(system);
+  let mut first_poll = true;
+  for _ in 0..4096 {
     thread::yield_now();
+    actual = scheduler_job_count(system);
+    if !first_poll && actual == expected {
+      break;
+    }
+    first_poll = false;
   }
-  assert_eq!(scheduler_job_count(system), expected);
+  assert_eq!(actual, expected);
 }
 
 fn wait_for_actor_cell_removed(system: &ActorSystem, pid: Pid) {
@@ -1380,7 +1401,7 @@ fn drive_actor_owned_streams_until_terminal_reports_direct_drain_round_limit() {
 
 #[test]
 fn request_actor_shutdown_ignores_closed_live_actor_mailbox() {
-  let system = build_system_with_closed_user_dispatcher("closed-user-shutdown");
+  let system = build_system_with_rejecting_user_dispatcher("closed-user-shutdown", true);
   let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-user-shutdown");
   let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
 
@@ -1391,18 +1412,46 @@ fn request_actor_shutdown_ignores_closed_live_actor_mailbox() {
 }
 
 #[test]
+fn request_actor_shutdown_reports_live_actor_delivery_failure() {
+  let system = build_system_with_rejecting_user_dispatcher("full-user-shutdown", false);
+  let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("full-user-shutdown");
+  let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+
+  let result = ActorMaterializer::request_actor_shutdown(&system, &[actor.clone()]);
+
+  assert_eq!(result, Err(StreamError::Failed));
+  assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
 fn finish_resource_teardown_ignores_closed_live_actor_stop() {
-  let close_stop = ArcShared::new(SpinSyncMutex::new(false));
-  let system = build_system_with_stop_closed_dispatcher("closed-stop-teardown", close_stop.clone());
+  let reject_stop = ArcShared::new(SpinSyncMutex::new(false));
+  let system = build_system_with_rejecting_stop_dispatcher("closed-stop-teardown", reject_stop.clone(), true);
   let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-stop-teardown");
   let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
-  *close_stop.lock() = true;
+  *reject_stop.lock() = true;
 
   let mut resources = MaterializedStreamResources::new(Vec::new(), empty_downstream_cancellation_control_plane());
   resources.island_actors.push(actor.clone());
   let result = ActorMaterializer::finish_resource_teardown(&system, resources);
 
   assert_eq!(result, Ok(()));
+  assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
+fn finish_resource_teardown_reports_live_actor_stop_failure() {
+  let reject_stop = ArcShared::new(SpinSyncMutex::new(false));
+  let system = build_system_with_rejecting_stop_dispatcher("full-stop-teardown", reject_stop.clone(), false);
+  let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("full-stop-teardown");
+  let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+  *reject_stop.lock() = true;
+
+  let mut resources = MaterializedStreamResources::new(Vec::new(), empty_downstream_cancellation_control_plane());
+  resources.island_actors.push(actor.clone());
+  let result = ActorMaterializer::finish_resource_teardown(&system, resources);
+
+  assert_eq!(result, Err(StreamError::Failed));
   assert!(system.state().cell(&actor.pid()).is_some());
 }
 

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -1444,6 +1444,42 @@ fn request_actor_shutdown_reports_live_actor_delivery_failure() {
 }
 
 #[test]
+fn request_non_terminal_actor_shutdown_reports_invalid_resource_shape() {
+  let system = build_system();
+  let mut resources = MaterializedStreamResources::new(Vec::new(), empty_downstream_cancellation_control_plane());
+  resources.island_actors.push(stopped_system_actor(&system));
+
+  let result = ActorMaterializer::request_non_terminal_actor_shutdown(&system, &resources);
+
+  assert_eq!(result, Err(StreamError::InvalidConnection));
+}
+
+#[test]
+fn shutdown_resources_skips_terminal_actor_shutdown_request_in_mixed_graph() {
+  let system = build_system_with_rejecting_user_dispatcher("closed-terminal-user-shutdown", true);
+  let terminal_props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-terminal-user-shutdown");
+  let terminal_actor = system.extended().spawn_system_actor(&terminal_props).expect("terminal actor should spawn");
+  let live_actor =
+    system.extended().spawn_system_actor(&Props::from_fn(|| GuardianActor)).expect("live actor should spawn");
+  system.state().cell(&terminal_actor.pid()).expect("terminal actor cell should exist").mailbox().become_closed();
+  let terminal_stream = running_stream_from_graph(Source::single(1_u32).into_mat(Sink::head(), KeepRight));
+  let live_stream = running_stream_from_graph(Source::single(2_u32).into_mat(Sink::head(), KeepRight));
+  let _outcome = terminal_stream.drive();
+  assert!(terminal_stream.state().is_terminal());
+  assert!(!live_stream.state().is_terminal());
+
+  let mut resources =
+    MaterializedStreamResources::new(vec![terminal_stream, live_stream], empty_downstream_cancellation_control_plane());
+  resources.island_actors.push(terminal_actor.clone());
+  resources.island_actors.push(live_actor);
+  resources.drive_gates.push(StreamIslandDriveGate::new());
+  resources.drive_gates.push(StreamIslandDriveGate::new());
+  let result = ActorMaterializer::shutdown_resources(&system, resources);
+
+  assert_eq!(result, Ok(()));
+}
+
+#[test]
 fn finish_resource_teardown_reports_closed_live_actor_stop() {
   let reject_stop = ArcShared::new(SpinSyncMutex::new(false));
   let system = build_system_with_rejecting_stop_dispatcher("closed-stop-teardown", reject_stop.clone(), true);

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -440,7 +440,13 @@ fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
 }
 
 fn wait_for_scheduler_job_count(system: &ActorSystem, expected: usize) {
-  for _ in 0..4096 {
+  let deadline = Instant::now() + Duration::from_secs(5);
+  let mut first_poll = true;
+  while Instant::now() < deadline {
+    if !first_poll && scheduler_job_count(system) == expected {
+      return;
+    }
+    first_poll = false;
     thread::yield_now();
   }
   assert_eq!(scheduler_job_count(system), expected);
@@ -1276,7 +1282,8 @@ fn shutdown_resources_skips_stopped_actor_and_reports_direct_drain_failure() {
   let system = build_system();
   let actor = stopped_system_actor(&system);
   let stream = running_stream_from_graph(
-    Source::<u32, _>::from_logic(StageKind::Custom, CancelFailingSourceLogic).into_mat(Sink::ignore(), KeepRight),
+    Source::<u32, _>::from_logic(StageKind::Custom, DrainOnShutdownCancelFailingPendingSourceLogic)
+      .into_mat(Sink::ignore(), KeepRight),
   );
   let mut resources = MaterializedStreamResources::new(vec![stream], empty_downstream_cancellation_control_plane());
   resources.island_actors.push(actor);

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -966,6 +966,9 @@ fn terminal_async_stream_stops_island_actors_and_cancels_scheduler_jobs() {
   assert_eq!(materialized.materialized().value(), Completion::Ready(Ok(1_u32)));
   wait_for_system_child_count(&system, child_count_before_start);
   wait_for_scheduler_job_count(&system, scheduler_jobs_before_start);
+
+  materializer.shutdown().expect("shutdown after terminal cleanup");
+  assert!(materializer.streams().is_empty());
 }
 
 #[test]
@@ -1276,7 +1279,7 @@ fn drive_actor_owned_streams_until_terminal_reports_direct_drain_round_limit() {
 }
 
 #[test]
-fn shutdown_resources_reports_stopped_actor_and_cancel_failure() {
+fn shutdown_resources_skips_stopped_actor_and_reports_direct_drain_failure() {
   let system = build_system();
   let actor = stopped_system_actor(&system);
   let stream = running_stream_from_graph(
@@ -1284,10 +1287,11 @@ fn shutdown_resources_reports_stopped_actor_and_cancel_failure() {
   );
   let mut resources = MaterializedStreamResources::new(vec![stream], empty_downstream_cancellation_control_plane());
   resources.island_actors.push(actor);
+  resources.drive_gates.push(StreamIslandDriveGate::new());
 
   let result = ActorMaterializer::shutdown_resources(&system, resources);
 
-  assert_eq!(result, Err(StreamError::Failed));
+  assert!(matches!(result, Err(StreamError::FailedWithContext { .. })));
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -1400,10 +1400,23 @@ fn drive_actor_owned_streams_until_terminal_reports_direct_drain_round_limit() {
 }
 
 #[test]
-fn request_actor_shutdown_ignores_closed_live_actor_mailbox() {
+fn request_actor_shutdown_reports_closed_live_actor_mailbox() {
   let system = build_system_with_rejecting_user_dispatcher("closed-user-shutdown", true);
   let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-user-shutdown");
   let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+
+  let result = ActorMaterializer::request_actor_shutdown(&system, &[actor.clone()]);
+
+  assert_eq!(result, Err(StreamError::Failed));
+  assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
+fn request_actor_shutdown_ignores_closed_stopping_actor_mailbox() {
+  let system = build_system_with_rejecting_user_dispatcher("closed-stopping-user-shutdown", true);
+  let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-stopping-user-shutdown");
+  let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+  system.state().cell(&actor.pid()).expect("actor cell should exist").mailbox().become_closed();
 
   let result = ActorMaterializer::request_actor_shutdown(&system, &[actor.clone()]);
 
@@ -1424,11 +1437,28 @@ fn request_actor_shutdown_reports_live_actor_delivery_failure() {
 }
 
 #[test]
-fn finish_resource_teardown_ignores_closed_live_actor_stop() {
+fn finish_resource_teardown_reports_closed_live_actor_stop() {
   let reject_stop = ArcShared::new(SpinSyncMutex::new(false));
   let system = build_system_with_rejecting_stop_dispatcher("closed-stop-teardown", reject_stop.clone(), true);
   let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-stop-teardown");
   let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+  *reject_stop.lock() = true;
+
+  let mut resources = MaterializedStreamResources::new(Vec::new(), empty_downstream_cancellation_control_plane());
+  resources.island_actors.push(actor.clone());
+  let result = ActorMaterializer::finish_resource_teardown(&system, resources);
+
+  assert_eq!(result, Err(StreamError::Failed));
+  assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
+fn finish_resource_teardown_ignores_closed_stopping_actor_stop() {
+  let reject_stop = ArcShared::new(SpinSyncMutex::new(false));
+  let system = build_system_with_rejecting_stop_dispatcher("closed-stopping-stop-teardown", reject_stop.clone(), true);
+  let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-stopping-stop-teardown");
+  let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+  system.state().cell(&actor.pid()).expect("actor cell should exist").mailbox().become_closed();
   *reject_stop.lock() = true;
 
   let mut resources = MaterializedStreamResources::new(Vec::new(), empty_downstream_cancellation_control_plane());

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -6,16 +6,19 @@ use std::{boxed::Box, thread, time::Instant};
 use fraktor_actor_adaptor_std_rs::tick_driver::TestTickDriver;
 use fraktor_actor_core_kernel_rs::{
   actor::{
-    Actor, ActorContext, ChildRef, Pid,
-    error::ActorError,
+    Actor, ActorCell, ActorContext, ChildRef, Pid,
+    error::{ActorError, SendError},
     messaging::{AnyMessageView, system_message::SystemMessage},
     props::Props,
     scheduler::{SchedulerConfig, SchedulerHandle},
     setup::ActorSystemConfig,
   },
-  dispatch::dispatcher::{
-    DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, ExecuteError, Executor, ExecutorShared,
-    MessageDispatcherFactory, MessageDispatcherShared, TrampolineState,
+  dispatch::{
+    dispatcher::{
+      DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, DispatcherCore, ExecuteError, Executor,
+      ExecutorShared, MessageDispatcher, MessageDispatcherFactory, MessageDispatcherShared, TrampolineState,
+    },
+    mailbox::{Envelope, Mailbox},
   },
   system::{ActorSystem, remote::RemotingConfig},
 };
@@ -362,6 +365,41 @@ fn inline_executor_shared() -> ExecutorShared {
   ExecutorShared::new(Box::new(InlineExec), TrampolineState::new())
 }
 
+struct ClosedUserDispatcherFactory {
+  id: &'static str,
+}
+
+impl MessageDispatcherFactory for ClosedUserDispatcherFactory {
+  fn dispatcher(&self) -> MessageDispatcherShared {
+    let settings = DispatcherConfig::new(self.id, nz(8), None, Duration::from_secs(1));
+    MessageDispatcherShared::new(Box::new(ClosedUserDispatcher {
+      core: DispatcherCore::new(&settings, inline_executor_shared()),
+    }))
+  }
+}
+
+struct ClosedUserDispatcher {
+  core: DispatcherCore,
+}
+
+impl MessageDispatcher for ClosedUserDispatcher {
+  fn core(&self) -> &DispatcherCore {
+    &self.core
+  }
+
+  fn core_mut(&mut self) -> &mut DispatcherCore {
+    &mut self.core
+  }
+
+  fn dispatch(
+    &mut self,
+    _receiver: &ArcShared<ActorCell>,
+    envelope: Envelope,
+  ) -> Result<Vec<ArcShared<Mailbox>>, SendError> {
+    Err(SendError::closed(envelope.into_payload()))
+  }
+}
+
 fn build_system_with_dispatcher(dispatcher_id: &'static str) -> (ActorSystem, MessageDispatcherShared) {
   let executor = inline_executor_shared();
   let settings = DispatcherConfig::new(dispatcher_id, nz(8), None, Duration::from_secs(1));
@@ -376,6 +414,17 @@ fn build_system_with_dispatcher(dispatcher_id: &'static str) -> (ActorSystem, Me
     .with_scheduler_config(scheduler)
     .with_dispatcher_factory(dispatcher_id, configurator_handle);
   (ActorSystem::create_from_props(&props, config).expect("system should build"), dispatcher)
+}
+
+fn build_system_with_closed_user_dispatcher(dispatcher_id: &'static str) -> ActorSystem {
+  let configurator: Box<dyn MessageDispatcherFactory> = Box::new(ClosedUserDispatcherFactory { id: dispatcher_id });
+  let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+  let props = Props::from_fn(|| GuardianActor);
+  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
+  let config = ActorSystemConfig::new(TestTickDriver::default())
+    .with_scheduler_config(scheduler)
+    .with_dispatcher_factory(dispatcher_id, configurator_handle);
+  ActorSystem::create_from_props(&props, config).expect("system should build")
 }
 
 fn system_child_names(system: &ActorSystem) -> Vec<String> {
@@ -441,12 +490,7 @@ fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
 
 fn wait_for_scheduler_job_count(system: &ActorSystem, expected: usize) {
   let deadline = Instant::now() + Duration::from_secs(5);
-  let mut first_poll = true;
-  while Instant::now() < deadline {
-    if !first_poll && scheduler_job_count(system) == expected {
-      return;
-    }
-    first_poll = false;
+  while Instant::now() < deadline && scheduler_job_count(system) != expected {
     thread::yield_now();
   }
   assert_eq!(scheduler_job_count(system), expected);
@@ -1275,6 +1319,18 @@ fn drive_actor_owned_streams_until_terminal_reports_direct_drain_round_limit() {
   let result = ActorMaterializer::drive_actor_owned_streams_until_terminal(&resources);
 
   assert!(result.is_err());
+}
+
+#[test]
+fn request_actor_shutdown_ignores_closed_live_actor_mailbox() {
+  let system = build_system_with_closed_user_dispatcher("closed-user-shutdown");
+  let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-user-shutdown");
+  let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+
+  let result = ActorMaterializer::request_actor_shutdown(&system, &[actor.clone()]);
+
+  assert_eq!(result, Ok(()));
+  assert!(system.state().cell(&actor.pid()).is_some());
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -552,14 +552,6 @@ fn wait_for_counter(counter: &ArcShared<SpinSyncMutex<u32>>, expected: u32) {
   assert_eq!(*counter.lock(), expected);
 }
 
-fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
-  let deadline = Instant::now() + Duration::from_secs(5);
-  while Instant::now() < deadline && system_child_names(system).len() != expected {
-    thread::yield_now();
-  }
-  assert_eq!(system_child_names(system).len(), expected);
-}
-
 fn wait_for_scheduler_job_count(system: &ActorSystem, expected: usize) {
   let mut actual = scheduler_job_count(system);
   let mut first_poll = true;
@@ -1076,6 +1068,8 @@ fn terminal_async_stream_stops_island_actors_and_cancels_scheduler_jobs() {
 
   assert_eq!(system_child_names(&system).len(), child_count_before_start + 2);
   assert_eq!(scheduler_job_count(&system), scheduler_jobs_before_start + 2);
+  let island_pids: Vec<Pid> =
+    materializer.materialized.iter().flat_map(|resources| &resources.island_actors).map(ChildRef::pid).collect();
 
   let deadline = Instant::now() + Duration::from_secs(5);
   while Instant::now() < deadline {
@@ -1087,7 +1081,10 @@ fn terminal_async_stream_stops_island_actors_and_cancels_scheduler_jobs() {
   assert_eq!(materialized.materialized().value(), Completion::Ready(Ok(1_u32)));
 
   materializer.shutdown().expect("shutdown after terminal cleanup");
-  wait_for_system_child_count(&system, child_count_before_start);
+  for pid in island_pids {
+    wait_for_actor_cell_removed(&system, pid);
+  }
+  assert_eq!(system_child_names(&system).len(), child_count_before_start);
   wait_for_scheduler_job_count(&system, scheduler_jobs_before_start);
   assert!(materializer.streams().is_empty());
 }
@@ -1485,10 +1482,10 @@ fn finish_resource_teardown_ignores_closed_terminal_actor_stop() {
   let system = build_system_with_rejecting_stop_dispatcher("closed-terminal-stop-teardown", reject_stop.clone(), true);
   let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-terminal-stop-teardown");
   let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
-  let stream = running_stream_from_graph(Source::<u32, _>::empty().into_mat(Sink::ignore(), KeepRight));
-  while !stream.state().is_terminal() {
-    let _outcome = stream.drive();
-  }
+  let stream = running_stream_from_graph(Source::single(1_u32).into_mat(Sink::head(), KeepRight));
+  assert!(!stream.state().is_terminal());
+  let _outcome = stream.drive();
+  assert!(stream.state().is_terminal());
   *reject_stop.lock() = true;
 
   let mut resources = MaterializedStreamResources::new(vec![stream], empty_downstream_cancellation_control_plane());

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -1085,10 +1085,10 @@ fn terminal_async_stream_stops_island_actors_and_cancels_scheduler_jobs() {
     thread::yield_now();
   }
   assert_eq!(materialized.materialized().value(), Completion::Ready(Ok(1_u32)));
-  wait_for_system_child_count(&system, child_count_before_start);
-  wait_for_scheduler_job_count(&system, scheduler_jobs_before_start);
 
   materializer.shutdown().expect("shutdown after terminal cleanup");
+  wait_for_system_child_count(&system, child_count_before_start);
+  wait_for_scheduler_job_count(&system, scheduler_jobs_before_start);
   assert!(materializer.streams().is_empty());
 }
 
@@ -1476,6 +1476,26 @@ fn finish_resource_teardown_reports_closed_registered_actor_stop() {
   let result = ActorMaterializer::finish_resource_teardown(&system, resources);
 
   assert_eq!(result, Err(StreamError::Failed));
+  assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
+fn finish_resource_teardown_ignores_closed_terminal_actor_stop() {
+  let reject_stop = ArcShared::new(SpinSyncMutex::new(false));
+  let system = build_system_with_rejecting_stop_dispatcher("closed-terminal-stop-teardown", reject_stop.clone(), true);
+  let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-terminal-stop-teardown");
+  let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+  let stream = running_stream_from_graph(Source::<u32, _>::empty().into_mat(Sink::ignore(), KeepRight));
+  while !stream.state().is_terminal() {
+    let _outcome = stream.drive();
+  }
+  *reject_stop.lock() = true;
+
+  let mut resources = MaterializedStreamResources::new(vec![stream], empty_downstream_cancellation_control_plane());
+  resources.island_actors.push(actor.clone());
+  let result = ActorMaterializer::finish_resource_teardown(&system, resources);
+
+  assert_eq!(result, Ok(()));
   assert!(system.state().cell(&actor.pid()).is_some());
 }
 

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -433,10 +433,7 @@ fn wait_for_counter(counter: &ArcShared<SpinSyncMutex<u32>>, expected: u32) {
 
 fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
   let deadline = Instant::now() + Duration::from_secs(5);
-  while Instant::now() < deadline {
-    if system_child_names(system).len() == expected {
-      return;
-    }
+  while Instant::now() < deadline && system_child_names(system).len() != expected {
     thread::yield_now();
   }
   assert_eq!(system_child_names(system).len(), expected);
@@ -444,10 +441,7 @@ fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
 
 fn wait_for_scheduler_job_count(system: &ActorSystem, expected: usize) {
   let deadline = Instant::now() + Duration::from_secs(5);
-  while Instant::now() < deadline {
-    if scheduler_job_count(system) == expected {
-      return;
-    }
+  while Instant::now() < deadline && scheduler_job_count(system) != expected {
     thread::yield_now();
   }
   assert_eq!(scheduler_job_count(system), expected);
@@ -1291,7 +1285,7 @@ fn shutdown_resources_skips_stopped_actor_and_reports_direct_drain_failure() {
 
   let result = ActorMaterializer::shutdown_resources(&system, resources);
 
-  assert!(matches!(result, Err(StreamError::FailedWithContext { .. })));
+  assert!(result.is_err());
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -440,8 +440,7 @@ fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
 }
 
 fn wait_for_scheduler_job_count(system: &ActorSystem, expected: usize) {
-  let deadline = Instant::now() + Duration::from_secs(5);
-  while Instant::now() < deadline && scheduler_job_count(system) != expected {
+  for _ in 0..4096 {
     thread::yield_now();
   }
   assert_eq!(scheduler_job_count(system), expected);

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -8,15 +8,16 @@ use fraktor_actor_core_kernel_rs::{
   actor::{
     Actor, ActorCell, ActorContext, ChildRef, Pid,
     error::{ActorError, SendError},
-    messaging::{AnyMessageView, system_message::SystemMessage},
+    messaging::{AnyMessage, AnyMessageView, system_message::SystemMessage},
     props::Props,
     scheduler::{SchedulerConfig, SchedulerHandle},
     setup::ActorSystemConfig,
   },
   dispatch::{
     dispatcher::{
-      DEFAULT_DISPATCHER_ID, DefaultDispatcherFactory, DispatcherConfig, DispatcherCore, ExecuteError, Executor,
-      ExecutorShared, MessageDispatcher, MessageDispatcherFactory, MessageDispatcherShared, TrampolineState,
+      DEFAULT_DISPATCHER_ID, DefaultDispatcher, DefaultDispatcherFactory, DispatcherConfig, DispatcherCore,
+      ExecuteError, Executor, ExecutorShared, MessageDispatcher, MessageDispatcherFactory, MessageDispatcherShared,
+      TrampolineState,
     },
     mailbox::{Envelope, Mailbox},
   },
@@ -400,6 +401,47 @@ impl MessageDispatcher for ClosedUserDispatcher {
   }
 }
 
+struct StopClosedDispatcherFactory {
+  id:         &'static str,
+  close_stop: ArcShared<SpinSyncMutex<bool>>,
+}
+
+impl MessageDispatcherFactory for StopClosedDispatcherFactory {
+  fn dispatcher(&self) -> MessageDispatcherShared {
+    let settings = DispatcherConfig::new(self.id, nz(8), None, Duration::from_secs(1));
+    MessageDispatcherShared::new(Box::new(StopClosedDispatcher {
+      default:    DefaultDispatcher::new(&settings, inline_executor_shared()),
+      close_stop: self.close_stop.clone(),
+    }))
+  }
+}
+
+struct StopClosedDispatcher {
+  default:    DefaultDispatcher,
+  close_stop: ArcShared<SpinSyncMutex<bool>>,
+}
+
+impl MessageDispatcher for StopClosedDispatcher {
+  fn core(&self) -> &DispatcherCore {
+    self.default.core()
+  }
+
+  fn core_mut(&mut self) -> &mut DispatcherCore {
+    self.default.core_mut()
+  }
+
+  fn system_dispatch(
+    &mut self,
+    receiver: &ArcShared<ActorCell>,
+    message: SystemMessage,
+  ) -> Result<Vec<ArcShared<Mailbox>>, SendError> {
+    if matches!(message, SystemMessage::Stop) && *self.close_stop.lock() {
+      return Err(SendError::closed(AnyMessage::new(message)));
+    }
+    self.default.system_dispatch(receiver, message)
+  }
+}
+
 fn build_system_with_dispatcher(dispatcher_id: &'static str) -> (ActorSystem, MessageDispatcherShared) {
   let executor = inline_executor_shared();
   let settings = DispatcherConfig::new(dispatcher_id, nz(8), None, Duration::from_secs(1));
@@ -418,6 +460,21 @@ fn build_system_with_dispatcher(dispatcher_id: &'static str) -> (ActorSystem, Me
 
 fn build_system_with_closed_user_dispatcher(dispatcher_id: &'static str) -> ActorSystem {
   let configurator: Box<dyn MessageDispatcherFactory> = Box::new(ClosedUserDispatcherFactory { id: dispatcher_id });
+  let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
+  let props = Props::from_fn(|| GuardianActor);
+  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
+  let config = ActorSystemConfig::new(TestTickDriver::default())
+    .with_scheduler_config(scheduler)
+    .with_dispatcher_factory(dispatcher_id, configurator_handle);
+  ActorSystem::create_from_props(&props, config).expect("system should build")
+}
+
+fn build_system_with_stop_closed_dispatcher(
+  dispatcher_id: &'static str,
+  close_stop: ArcShared<SpinSyncMutex<bool>>,
+) -> ActorSystem {
+  let configurator: Box<dyn MessageDispatcherFactory> =
+    Box::new(StopClosedDispatcherFactory { id: dispatcher_id, close_stop });
   let configurator_handle: ArcShared<Box<dyn MessageDispatcherFactory>> = ArcShared::new(configurator);
   let props = Props::from_fn(|| GuardianActor);
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
@@ -1328,6 +1385,22 @@ fn request_actor_shutdown_ignores_closed_live_actor_mailbox() {
   let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
 
   let result = ActorMaterializer::request_actor_shutdown(&system, &[actor.clone()]);
+
+  assert_eq!(result, Ok(()));
+  assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
+fn finish_resource_teardown_ignores_closed_live_actor_stop() {
+  let close_stop = ArcShared::new(SpinSyncMutex::new(false));
+  let system = build_system_with_stop_closed_dispatcher("closed-stop-teardown", close_stop.clone());
+  let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-stop-teardown");
+  let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
+  *close_stop.lock() = true;
+
+  let mut resources = MaterializedStreamResources::new(Vec::new(), empty_downstream_cancellation_control_plane());
+  resources.island_actors.push(actor.clone());
+  let result = ActorMaterializer::finish_resource_teardown(&system, resources);
 
   assert_eq!(result, Ok(()));
   assert!(system.state().cell(&actor.pid()).is_some());

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -431,6 +431,28 @@ fn wait_for_counter(counter: &ArcShared<SpinSyncMutex<u32>>, expected: u32) {
   assert_eq!(*counter.lock(), expected);
 }
 
+fn wait_for_system_child_count(system: &ActorSystem, expected: usize) {
+  let deadline = Instant::now() + Duration::from_secs(5);
+  while Instant::now() < deadline {
+    if system_child_names(system).len() == expected {
+      return;
+    }
+    thread::yield_now();
+  }
+  assert_eq!(system_child_names(system).len(), expected);
+}
+
+fn wait_for_scheduler_job_count(system: &ActorSystem, expected: usize) {
+  let deadline = Instant::now() + Duration::from_secs(5);
+  while Instant::now() < deadline {
+    if scheduler_job_count(system) == expected {
+      return;
+    }
+    thread::yield_now();
+  }
+  assert_eq!(scheduler_job_count(system), expected);
+}
+
 fn wait_for_actor_cell_removed(system: &ActorSystem, pid: Pid) {
   let deadline = Instant::now() + Duration::from_secs(5);
   while Instant::now() < deadline {
@@ -452,9 +474,9 @@ fn stopped_system_actor(system: &ActorSystem) -> ChildRef {
 }
 
 fn upstream_cancel_command_count(materializer: &ActorMaterializer) -> u32 {
-  let diagnostics: Vec<StreamIslandActorDiagnostic> =
-    materializer.island_actor_diagnostics_for_test().expect("island actor diagnostics should be available");
-  diagnostics.first().expect("upstream island actor should be diagnosable").cancel_command_count()
+  let resources = materializer.materialized.first().expect("materialized resources should be available");
+  let actor = resources.island_actors.first().expect("upstream island actor should be registered");
+  resources.downstream_cancellation_control_plane.with_locked(|plane| plane.cancel_command_count_for_actor(actor.pid()))
 }
 
 fn wait_for_upstream_cancel_command_count(materializer: &ActorMaterializer, expected: u32) {
@@ -916,6 +938,34 @@ fn materialize_registers_one_scheduler_job_per_island_actor() {
   let _materialized = graph.run(&mut materializer).expect("materialize");
 
   assert_eq!(scheduler_job_count(&system), scheduler_jobs_before_start + 2);
+}
+
+#[test]
+fn terminal_async_stream_stops_island_actors_and_cancels_scheduler_jobs() {
+  let system = build_system();
+  let child_count_before_start = system_child_names(&system).len();
+  let scheduler_jobs_before_start = scheduler_job_count(&system);
+  let mut materializer = ActorMaterializer::new(
+    system.clone(),
+    ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)),
+  );
+  materializer.start().expect("start");
+  let graph = Source::single(1_u32).r#async().into_mat(Sink::head(), KeepRight);
+  let materialized = graph.run(&mut materializer).expect("materialize");
+
+  assert_eq!(system_child_names(&system).len(), child_count_before_start + 2);
+  assert_eq!(scheduler_job_count(&system), scheduler_jobs_before_start + 2);
+
+  let deadline = Instant::now() + Duration::from_secs(5);
+  while Instant::now() < deadline {
+    if matches!(materialized.materialized().value(), Completion::Ready(_)) {
+      break;
+    }
+    thread::yield_now();
+  }
+  assert_eq!(materialized.materialized().value(), Completion::Ready(Ok(1_u32)));
+  wait_for_system_child_count(&system, child_count_before_start);
+  wait_for_scheduler_job_count(&system, scheduler_jobs_before_start);
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -1412,7 +1412,7 @@ fn request_actor_shutdown_reports_closed_live_actor_mailbox() {
 }
 
 #[test]
-fn request_actor_shutdown_ignores_closed_stopping_actor_mailbox() {
+fn request_actor_shutdown_reports_closed_registered_actor_mailbox() {
   let system = build_system_with_rejecting_user_dispatcher("closed-stopping-user-shutdown", true);
   let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-stopping-user-shutdown");
   let actor = system.extended().spawn_system_actor(&props).expect("actor should spawn");
@@ -1420,8 +1420,18 @@ fn request_actor_shutdown_ignores_closed_stopping_actor_mailbox() {
 
   let result = ActorMaterializer::request_actor_shutdown(&system, &[actor.clone()]);
 
-  assert_eq!(result, Ok(()));
+  assert_eq!(result, Err(StreamError::Failed));
   assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
+fn request_actor_shutdown_ignores_closed_missing_actor_cell() {
+  let system = build_system();
+  let actor = stopped_system_actor(&system);
+
+  let result = ActorMaterializer::request_actor_shutdown(&system, &[actor]);
+
+  assert_eq!(result, Ok(()));
 }
 
 #[test]
@@ -1453,7 +1463,7 @@ fn finish_resource_teardown_reports_closed_live_actor_stop() {
 }
 
 #[test]
-fn finish_resource_teardown_ignores_closed_stopping_actor_stop() {
+fn finish_resource_teardown_reports_closed_registered_actor_stop() {
   let reject_stop = ArcShared::new(SpinSyncMutex::new(false));
   let system = build_system_with_rejecting_stop_dispatcher("closed-stopping-stop-teardown", reject_stop.clone(), true);
   let props = Props::from_fn(|| GuardianActor).with_dispatcher_id("closed-stopping-stop-teardown");
@@ -1465,8 +1475,20 @@ fn finish_resource_teardown_ignores_closed_stopping_actor_stop() {
   resources.island_actors.push(actor.clone());
   let result = ActorMaterializer::finish_resource_teardown(&system, resources);
 
-  assert_eq!(result, Ok(()));
+  assert_eq!(result, Err(StreamError::Failed));
   assert!(system.state().cell(&actor.pid()).is_some());
+}
+
+#[test]
+fn finish_resource_teardown_ignores_closed_missing_actor_cell() {
+  let system = build_system();
+  let actor = stopped_system_actor(&system);
+  let mut resources = MaterializedStreamResources::new(Vec::new(), empty_downstream_cancellation_control_plane());
+  resources.island_actors.push(actor);
+
+  let result = ActorMaterializer::finish_resource_teardown(&system, resources);
+
+  assert_eq!(result, Ok(()));
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_test.rs
@@ -1080,12 +1080,13 @@ fn terminal_async_stream_stops_island_actors_and_cancels_scheduler_jobs() {
   }
   assert_eq!(materialized.materialized().value(), Completion::Ready(Ok(1_u32)));
 
-  materializer.shutdown().expect("shutdown after terminal cleanup");
   for pid in island_pids {
     wait_for_actor_cell_removed(&system, pid);
   }
   assert_eq!(system_child_names(&system).len(), child_count_before_start);
   wait_for_scheduler_job_count(&system, scheduler_jobs_before_start);
+
+  materializer.shutdown().expect("shutdown after terminal cleanup");
   assert!(materializer.streams().is_empty());
 }
 


### PR DESCRIPTION
## Summary
- Cancel stream island scheduled ticks when an island reaches a terminal state, including ticks cancelled while the scheduler job is executing.
- Stop terminal island actors and tolerate already-stopped actors during materializer shutdown cleanup.
- Add a regression test that waits for a completed async stream to return scheduler jobs and island actors to the pre-materialization counts.
- Update the test tick driver stopper so it does not try to join its own executor thread during cleanup.

## Root Cause
Per-island fixed-rate scheduler jobs could outlive normally completed streams because terminal island handling only made the drive gate idle. A scheduler handle cancelled from inside the executing scheduler job was also unable to mark itself cancelled, so periodic jobs could be rescheduled after terminal completion.

## Validation
- `cargo fmt --check`
- `cargo test -p fraktor-stream-core-kernel-rs terminal_async_stream_stops_island_actors_and_cancels_scheduler_jobs -- --nocapture`
- `cargo test -p fraktor-stream-core-kernel-rs shutdown_stops_island_actors_and_cancels_scheduler_jobs -- --nocapture`
- `cargo test -p fraktor-actor-core-kernel-rs cancel_on_executing_handle_succeeds -- --nocapture`
- `cargo test -p fraktor-stream-core-kernel-rs actor_materializer -- --nocapture`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches scheduler cancellation/state transitions and stream-island actor shutdown/teardown paths; mistakes could leave periodic jobs running or leak actor resources under racey terminal conditions.
> 
> **Overview**
> Ensures periodic scheduler jobs can be **cancelled while executing** and are then **not rescheduled**, by expanding `CancellableEntry::try_cancel` to cover `Executing`, making periodic reset conditional (`try_reset_to_scheduled`), and tightening `Scheduler::cancel`/reschedule cleanup + metrics behavior.
> 
> Makes stream islands clean up on terminal: `StreamIslandActor` now cancels its scheduled tick and stops itself when reaching a terminal state, and the materializer’s shutdown/teardown logic tolerates already-stopped/closed actors while avoiding shutdown requests for already-terminal streams.
> 
> Adds targeted regression tests for terminal async streams reclaiming island actors + scheduler jobs, executing-periodic cancellation behavior, and various actor shutdown/stop failure modes; also hardens test tick driver shutdown to avoid joining the current thread and reduces flakiness in a stream source test by reusing `THREAD_SYNC_ATTEMPTS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c0a4daabf3d96ccfb05edec8f75498a68c1e1cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * キャンセル挙動を拡張し、スケジュール済み・実行中の周期ジョブが適切にキャンセルされ再スケジュールされなくなりました
  * シャットダウン/後始末の振る舞いを整理し、終了時の停止・キャンセル処理や送信失敗の扱いが一貫化されました
  * 停止時のスレッド終了処理を簡素化し、自己結合回避が導入され警告出力を削除しました

* **ドキュメント**
  * キャンセル期待挙動の記述を明確化しました

* **テスト**
  * 終了・シャットダウン・キャンセル周りの検証テストとテスト用ユーティリティを追加・強化しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->