### PR TITLE
fix(remote): treat full watcher queue as consumed

### DIFF
--- a/modules/actor-core-kernel/src/actor/actor_context_test.rs
+++ b/modules/actor-core-kernel/src/actor/actor_context_test.rs
@@ -1146,8 +1146,15 @@ fn remote_watch_full_error_rolls_back_watching_entry_to_allow_retry() {
   assert!(matches!(result, Err(WatchRegistrationError::Send(SendError::Full(_)))));
   assert!(!watcher.is_watching(target_pid));
 
+  let mut full_hook = FullRemoteWatchHook;
+  assert!(matches!(full_hook.handle_unwatch(target_pid, watcher_pid), Err(SendError::Full(_))));
+  assert!(!full_hook.handle_deathwatch_notification(watcher_pid, target_pid));
+
   let calls = ArcShared::new(SpinSyncMutex::new(0));
-  system.state().register_remote_watch_hook(Box::new(CountingRemoteWatchHook::new(calls.clone())));
+  let mut counting_hook = CountingRemoteWatchHook::new(calls.clone());
+  assert!(matches!(counting_hook.handle_unwatch(target_pid, watcher_pid), Ok(true)));
+  assert!(!counting_hook.handle_deathwatch_notification(watcher_pid, target_pid));
+  system.state().register_remote_watch_hook(Box::new(counting_hook));
 
   assert!(context.watch(&target).is_ok());
   assert_eq!(*calls.lock(), 1);

--- a/modules/actor-core-kernel/src/actor/actor_context_test.rs
+++ b/modules/actor-core-kernel/src/actor/actor_context_test.rs
@@ -23,7 +23,7 @@ use crate::{
   },
   event::logging::LogLevel,
   support::futures::{ActorFuture, ActorFutureListener},
-  system::ActorSystem,
+  system::{ActorSystem, remote::RemoteWatchHook},
 };
 
 struct TestActor;
@@ -37,6 +37,47 @@ impl ReceiveTimeoutState {
 impl Actor for TestActor {
   fn receive(&mut self, _context: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
     Ok(())
+  }
+}
+
+struct FullRemoteWatchHook;
+
+impl RemoteWatchHook for FullRemoteWatchHook {
+  fn handle_watch(&mut self, _target: Pid, watcher: Pid) -> Result<bool, SendError> {
+    Err(SendError::full(AnyMessage::new(SystemMessage::Watch(watcher))))
+  }
+
+  fn handle_unwatch(&mut self, _target: Pid, watcher: Pid) -> Result<bool, SendError> {
+    Err(SendError::full(AnyMessage::new(SystemMessage::Unwatch(watcher))))
+  }
+
+  fn handle_deathwatch_notification(&mut self, _watcher: Pid, _terminated: Pid) -> bool {
+    false
+  }
+}
+
+struct CountingRemoteWatchHook {
+  calls: ArcShared<SpinSyncMutex<usize>>,
+}
+
+impl CountingRemoteWatchHook {
+  fn new(calls: ArcShared<SpinSyncMutex<usize>>) -> Self {
+    Self { calls }
+  }
+}
+
+impl RemoteWatchHook for CountingRemoteWatchHook {
+  fn handle_watch(&mut self, _target: Pid, _watcher: Pid) -> Result<bool, SendError> {
+    *self.calls.lock() += 1;
+    Ok(true)
+  }
+
+  fn handle_unwatch(&mut self, _target: Pid, _watcher: Pid) -> Result<bool, SendError> {
+    Ok(true)
+  }
+
+  fn handle_deathwatch_notification(&mut self, _watcher: Pid, _terminated: Pid) -> bool {
+    false
   }
 }
 
@@ -1085,6 +1126,31 @@ fn watch_rolls_back_watching_entry_when_dispatch_fails() {
 
   assert!(matches!(result, Err(WatchRegistrationError::Send(_))));
   assert!(!watcher.is_watching(target_pid));
+}
+
+#[test]
+fn remote_watch_full_error_rolls_back_watching_entry_to_allow_retry() {
+  use crate::actor::actor_ref::ActorRef;
+
+  let system = ActorSystem::new_empty();
+  let watcher_pid = system.allocate_pid();
+  let target_pid = system.allocate_pid();
+  let props = Props::from_fn(|| TestActor);
+  let watcher = register_cell(&system, watcher_pid, "remote-full-watcher", &props);
+  let target = ActorRef::new_with_builtin_lock(target_pid, NullSender);
+  system.state().register_remote_watch_hook(Box::new(FullRemoteWatchHook));
+
+  let mut context = ActorContext::new(&system, watcher_pid);
+  let result = context.watch(&target);
+
+  assert!(matches!(result, Err(WatchRegistrationError::Send(SendError::Full(_)))));
+  assert!(!watcher.is_watching(target_pid));
+
+  let calls = ArcShared::new(SpinSyncMutex::new(0));
+  system.state().register_remote_watch_hook(Box::new(CountingRemoteWatchHook::new(calls.clone())));
+
+  assert!(context.watch(&target).is_ok());
+  assert_eq!(*calls.lock(), 1);
 }
 
 #[test]

--- a/modules/actor-core-kernel/src/system/remote/noop_remote_watch_hook.rs
+++ b/modules/actor-core-kernel/src/system/remote/noop_remote_watch_hook.rs
@@ -1,7 +1,7 @@
 //! No-op implementation of [`RemoteWatchHook`].
 
 use super::RemoteWatchHook;
-use crate::actor::Pid;
+use crate::actor::{Pid, error::SendError};
 
 /// A no-op implementation of [`RemoteWatchHook`] that always returns `false`.
 ///
@@ -9,12 +9,12 @@ use crate::actor::Pid;
 pub(crate) struct NoopRemoteWatchHook;
 
 impl RemoteWatchHook for NoopRemoteWatchHook {
-  fn handle_watch(&mut self, _target: Pid, _watcher: Pid) -> bool {
-    false
+  fn handle_watch(&mut self, _target: Pid, _watcher: Pid) -> Result<bool, SendError> {
+    Ok(false)
   }
 
-  fn handle_unwatch(&mut self, _target: Pid, _watcher: Pid) -> bool {
-    false
+  fn handle_unwatch(&mut self, _target: Pid, _watcher: Pid) -> Result<bool, SendError> {
+    Ok(false)
   }
 
   fn handle_deathwatch_notification(&mut self, _watcher: Pid, _terminated: Pid) -> bool {

--- a/modules/actor-core-kernel/src/system/remote/remote_watch_hook.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_watch_hook.rs
@@ -1,6 +1,6 @@
 //! Hook used by actor-ref providers to intercept remote watch/unwatch signals.
 
-use crate::actor::Pid;
+use crate::actor::{Pid, error::SendError};
 
 /// Allows custom providers to reroute `SystemMessage::Watch/Unwatch` for remote actors.
 ///
@@ -8,10 +8,19 @@ use crate::actor::Pid;
 /// The `&mut self` signature makes state changes explicit in the type system.
 pub trait RemoteWatchHook: Send + 'static {
   /// Handles a watch request. Returns `true` when the provider consumed the message.
-  fn handle_watch(&mut self, target: Pid, watcher: Pid) -> bool;
+  ///
+  /// # Errors
+  ///
+  /// Returns [`SendError`] when the provider owns the target but cannot enqueue the watch request.
+  fn handle_watch(&mut self, target: Pid, watcher: Pid) -> Result<bool, SendError>;
 
   /// Handles an unwatch request. Returns `true` when the provider consumed the message.
-  fn handle_unwatch(&mut self, target: Pid, watcher: Pid) -> bool;
+  ///
+  /// # Errors
+  ///
+  /// Returns [`SendError`] when the provider owns the target but cannot enqueue the unwatch
+  /// request.
+  fn handle_unwatch(&mut self, target: Pid, watcher: Pid) -> Result<bool, SendError>;
 
   /// Handles a remote-bound termination notification. Returns `true` when the provider consumed the
   /// message.

--- a/modules/actor-core-kernel/src/system/remote/remote_watch_hook_dyn_shared.rs
+++ b/modules/actor-core-kernel/src/system/remote/remote_watch_hook_dyn_shared.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 use fraktor_utils_core_rs::sync::{DefaultMutex, SharedAccess, SharedLock};
 
 use super::{RemoteWatchHook, noop_remote_watch_hook::NoopRemoteWatchHook};
-use crate::actor::Pid;
+use crate::actor::{Pid, error::SendError};
 
 /// Shared wrapper that provides thread-safe access to a boxed [`RemoteWatchHook`].
 ///
@@ -47,12 +47,12 @@ impl RemoteWatchHookDynShared {
   }
 
   /// Handles a watch request by delegating to the inner hook.
-  pub(crate) fn handle_watch(&self, target: Pid, watcher: Pid) -> bool {
+  pub(crate) fn handle_watch(&self, target: Pid, watcher: Pid) -> Result<bool, SendError> {
     self.with_write(|inner| inner.handle_watch(target, watcher))
   }
 
   /// Handles an unwatch request by delegating to the inner hook.
-  pub(crate) fn handle_unwatch(&self, target: Pid, watcher: Pid) -> bool {
+  pub(crate) fn handle_unwatch(&self, target: Pid, watcher: Pid) -> Result<bool, SendError> {
     self.with_write(|inner| inner.handle_unwatch(target, watcher))
   }
 

--- a/modules/actor-core-kernel/src/system/state/system_state_shared.rs
+++ b/modules/actor-core-kernel/src/system/state/system_state_shared.rs
@@ -783,6 +783,14 @@ impl SystemStateShared {
     self.cell(&parent).map_or_else(Vec::new, |cell| cell.children())
   }
 
+  fn normalize_remote_watch_hook_error(error: SendError) -> SendError {
+    match error {
+      // `ActorContext` reserves `Closed` for "target actor is already terminated".
+      | SendError::Closed(message) => SendError::full(message),
+      | error => error,
+    }
+  }
+
   /// Sends a system message to the specified actor.
   ///
   /// # Errors
@@ -799,7 +807,7 @@ impl SystemStateShared {
           match self.remote_watch_hook.handle_watch(pid, watcher) {
             | Ok(true) => return Ok(()),
             | Ok(false) => {},
-            | Err(error) => return Err(error),
+            | Err(error) => return Err(Self::normalize_remote_watch_hook_error(error)),
           }
           if let Err(e) = self.send_system_message(watcher, SystemMessage::DeathWatchNotification(pid)) {
             self.record_send_error(Some(watcher), &e);
@@ -809,7 +817,7 @@ impl SystemStateShared {
         | SystemMessage::Unwatch(watcher) => {
           match self.remote_watch_hook.handle_unwatch(pid, watcher) {
             | Ok(true) | Ok(false) => {},
-            | Err(error) => return Err(error),
+            | Err(error) => return Err(Self::normalize_remote_watch_hook_error(error)),
           }
           Ok(())
         },

--- a/modules/actor-core-kernel/src/system/state/system_state_shared.rs
+++ b/modules/actor-core-kernel/src/system/state/system_state_shared.rs
@@ -796,8 +796,10 @@ impl SystemStateShared {
     } else {
       match message {
         | SystemMessage::Watch(watcher) => {
-          if self.remote_watch_hook.handle_watch(pid, watcher) {
-            return Ok(());
+          match self.remote_watch_hook.handle_watch(pid, watcher) {
+            | Ok(true) => return Ok(()),
+            | Ok(false) => {},
+            | Err(error) => return Err(error),
           }
           if let Err(e) = self.send_system_message(watcher, SystemMessage::DeathWatchNotification(pid)) {
             self.record_send_error(Some(watcher), &e);
@@ -805,8 +807,9 @@ impl SystemStateShared {
           Ok(())
         },
         | SystemMessage::Unwatch(watcher) => {
-          if self.remote_watch_hook.handle_unwatch(pid, watcher) {
-            return Ok(());
+          match self.remote_watch_hook.handle_unwatch(pid, watcher) {
+            | Ok(true) | Ok(false) => {},
+            | Err(error) => return Err(error),
           }
           Ok(())
         },

--- a/modules/actor-core-kernel/src/system/state/system_state_test.rs
+++ b/modules/actor-core-kernel/src/system/state/system_state_test.rs
@@ -700,6 +700,23 @@ fn remote_watch_hook_consumes_unwatch_is_invoked() {
 }
 
 #[test]
+fn remote_watch_hook_unwatch_error_is_propagated() {
+  let state = build_shared_state();
+  let watcher_pid = state.allocate_pid();
+  let target_pid = state.allocate_pid();
+
+  let calls = ArcShared::new(SpinSyncMutex::new(RemoteWatchHookCalls::default()));
+  state.register_remote_watch_hook(Box::new(RecordingRemoteWatchHook::with_unwatch_error(calls.clone())));
+
+  let result = state.send_system_message(target_pid, SystemMessage::Unwatch(watcher_pid));
+
+  assert!(matches!(result, Err(SendError::Full(_))));
+  let calls = calls.lock();
+  assert_eq!(calls.unwatch_calls, 1);
+  assert_eq!(calls.last_unwatch, Some((target_pid, watcher_pid)));
+}
+
+#[test]
 fn remote_watch_hook_consumes_deathwatch_notification_is_invoked() {
   let state = build_shared_state();
   let watcher_pid = state.allocate_pid();
@@ -807,6 +824,7 @@ struct RecordingRemoteWatchHook {
   consume_watch:        bool,
   consume_unwatch:      bool,
   consume_notification: bool,
+  fail_unwatch:         bool,
 }
 
 impl RecordingRemoteWatchHook {
@@ -820,7 +838,11 @@ impl RecordingRemoteWatchHook {
     consume_unwatch: bool,
     consume_notification: bool,
   ) -> Self {
-    Self { calls, consume_watch, consume_unwatch, consume_notification }
+    Self { calls, consume_watch, consume_unwatch, consume_notification, fail_unwatch: false }
+  }
+
+  fn with_unwatch_error(calls: ArcShared<SpinSyncMutex<RemoteWatchHookCalls>>) -> Self {
+    Self { calls, consume_watch: false, consume_unwatch: false, consume_notification: false, fail_unwatch: true }
   }
 }
 
@@ -836,6 +858,9 @@ impl RemoteWatchHook for RecordingRemoteWatchHook {
     let mut calls = self.calls.lock();
     calls.unwatch_calls += 1;
     calls.last_unwatch = Some((target, watcher));
+    if self.fail_unwatch {
+      return Err(SendError::full(AnyMessage::new(SystemMessage::Unwatch(watcher))));
+    }
     Ok(self.consume_unwatch)
   }
 

--- a/modules/actor-core-kernel/src/system/state/system_state_test.rs
+++ b/modules/actor-core-kernel/src/system/state/system_state_test.rs
@@ -684,6 +684,30 @@ fn remote_watch_hook_non_consuming_watch_runs_fallback() {
 }
 
 #[test]
+fn remote_watch_hook_watch_closed_error_is_normalized() {
+  let state = build_shared_state_with_noop_dispatcher();
+  let watcher_pid = state.allocate_pid();
+  let target_pid = state.allocate_pid();
+
+  let props = Props::from_fn(|| RestartProbeActor).with_dispatcher_id("noop");
+  let watcher_cell =
+    ActorCell::create(state.clone(), watcher_pid, None, "watcher".to_string(), &props).expect("watcher cell");
+  state.register_cell(watcher_cell);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(RemoteWatchHookCalls::default()));
+  state.register_remote_watch_hook(Box::new(RecordingRemoteWatchHook::with_watch_closed_error(calls.clone())));
+
+  let result = state.send_system_message(target_pid, SystemMessage::Watch(watcher_pid));
+
+  assert!(matches!(result, Err(SendError::Full(_))));
+  let mailbox_snapshot = state.cell(&watcher_pid).expect("watcher cell").mailbox();
+  assert_eq!(mailbox_snapshot.system_len(), 0);
+  let calls = calls.lock();
+  assert_eq!(calls.watch_calls, 1);
+  assert_eq!(calls.last_watch, Some((target_pid, watcher_pid)));
+}
+
+#[test]
 fn remote_watch_hook_consumes_unwatch_is_invoked() {
   let state = build_shared_state();
   let watcher_pid = state.allocate_pid();
@@ -700,13 +724,13 @@ fn remote_watch_hook_consumes_unwatch_is_invoked() {
 }
 
 #[test]
-fn remote_watch_hook_unwatch_error_is_propagated() {
+fn remote_watch_hook_unwatch_closed_error_is_normalized() {
   let state = build_shared_state();
   let watcher_pid = state.allocate_pid();
   let target_pid = state.allocate_pid();
 
   let calls = ArcShared::new(SpinSyncMutex::new(RemoteWatchHookCalls::default()));
-  state.register_remote_watch_hook(Box::new(RecordingRemoteWatchHook::with_unwatch_error(calls.clone())));
+  state.register_remote_watch_hook(Box::new(RecordingRemoteWatchHook::with_unwatch_closed_error(calls.clone())));
 
   let result = state.send_system_message(target_pid, SystemMessage::Unwatch(watcher_pid));
 
@@ -824,7 +848,8 @@ struct RecordingRemoteWatchHook {
   consume_watch:        bool,
   consume_unwatch:      bool,
   consume_notification: bool,
-  fail_unwatch:         bool,
+  close_watch:          bool,
+  close_unwatch:        bool,
 }
 
 impl RecordingRemoteWatchHook {
@@ -838,11 +863,29 @@ impl RecordingRemoteWatchHook {
     consume_unwatch: bool,
     consume_notification: bool,
   ) -> Self {
-    Self { calls, consume_watch, consume_unwatch, consume_notification, fail_unwatch: false }
+    Self { calls, consume_watch, consume_unwatch, consume_notification, close_watch: false, close_unwatch: false }
   }
 
-  fn with_unwatch_error(calls: ArcShared<SpinSyncMutex<RemoteWatchHookCalls>>) -> Self {
-    Self { calls, consume_watch: false, consume_unwatch: false, consume_notification: false, fail_unwatch: true }
+  fn with_watch_closed_error(calls: ArcShared<SpinSyncMutex<RemoteWatchHookCalls>>) -> Self {
+    Self {
+      calls,
+      consume_watch: false,
+      consume_unwatch: false,
+      consume_notification: false,
+      close_watch: true,
+      close_unwatch: false,
+    }
+  }
+
+  fn with_unwatch_closed_error(calls: ArcShared<SpinSyncMutex<RemoteWatchHookCalls>>) -> Self {
+    Self {
+      calls,
+      consume_watch: false,
+      consume_unwatch: false,
+      consume_notification: false,
+      close_watch: false,
+      close_unwatch: true,
+    }
   }
 }
 
@@ -851,6 +894,9 @@ impl RemoteWatchHook for RecordingRemoteWatchHook {
     let mut calls = self.calls.lock();
     calls.watch_calls += 1;
     calls.last_watch = Some((target, watcher));
+    if self.close_watch {
+      return Err(SendError::closed(AnyMessage::new(SystemMessage::Watch(watcher))));
+    }
     Ok(self.consume_watch)
   }
 
@@ -858,8 +904,8 @@ impl RemoteWatchHook for RecordingRemoteWatchHook {
     let mut calls = self.calls.lock();
     calls.unwatch_calls += 1;
     calls.last_unwatch = Some((target, watcher));
-    if self.fail_unwatch {
-      return Err(SendError::full(AnyMessage::new(SystemMessage::Unwatch(watcher))));
+    if self.close_unwatch {
+      return Err(SendError::closed(AnyMessage::new(SystemMessage::Unwatch(watcher))));
     }
     Ok(self.consume_unwatch)
   }

--- a/modules/actor-core-kernel/src/system/state/system_state_test.rs
+++ b/modules/actor-core-kernel/src/system/state/system_state_test.rs
@@ -36,7 +36,7 @@ use crate::{
   system::{
     RegisterExtraTopLevelError, TerminationSignal,
     guardian::GuardianKind,
-    remote::RemotingConfig,
+    remote::{RemoteWatchHook, RemotingConfig},
     state::{AuthorityState, SystemStateShared, system_state::LogLevel},
   },
 };
@@ -824,19 +824,19 @@ impl RecordingRemoteWatchHook {
   }
 }
 
-impl crate::system::remote::RemoteWatchHook for RecordingRemoteWatchHook {
-  fn handle_watch(&mut self, target: Pid, watcher: Pid) -> bool {
+impl RemoteWatchHook for RecordingRemoteWatchHook {
+  fn handle_watch(&mut self, target: Pid, watcher: Pid) -> Result<bool, SendError> {
     let mut calls = self.calls.lock();
     calls.watch_calls += 1;
     calls.last_watch = Some((target, watcher));
-    self.consume_watch
+    Ok(self.consume_watch)
   }
 
-  fn handle_unwatch(&mut self, target: Pid, watcher: Pid) -> bool {
+  fn handle_unwatch(&mut self, target: Pid, watcher: Pid) -> Result<bool, SendError> {
     let mut calls = self.calls.lock();
     calls.unwatch_calls += 1;
     calls.last_unwatch = Some((target, watcher));
-    self.consume_unwatch
+    Ok(self.consume_unwatch)
   }
 
   fn handle_deathwatch_notification(&mut self, watcher: Pid, terminated: Pid) -> bool {

--- a/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
@@ -83,7 +83,7 @@ impl StdRemoteWatchHook {
       | Ok(()) => true,
       | Err(TrySendError::Full(command)) => {
         tracing::warn!(?command, "remote watch command queue is full");
-        false
+        true
       },
       | Err(TrySendError::Closed(command)) => {
         tracing::warn!(?command, "remote watch command queue is closed");

--- a/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
+++ b/modules/remote-adaptor-std/src/provider/remote_watch_hook.rs
@@ -6,6 +6,7 @@ use fraktor_actor_core_kernel_rs::{
   actor::{
     Pid,
     actor_path::ActorPath,
+    error::SendError,
     messaging::{AnyMessage, system_message::SystemMessage},
   },
   event::stream::CorrelationId,
@@ -78,16 +79,16 @@ impl StdRemoteWatchHook {
     self.registry.with_read(|registry| registry.path_for_pid(pid))
   }
 
-  fn send_watcher_command(&self, command: WatcherCommand) -> bool {
+  fn send_watcher_command(&self, command: WatcherCommand, overflow_message: SystemMessage) -> Result<bool, SendError> {
     match self.watcher_sender.try_send(command) {
-      | Ok(()) => true,
+      | Ok(()) => Ok(true),
       | Err(TrySendError::Full(command)) => {
         tracing::warn!(?command, "remote watch command queue is full");
-        true
+        Err(SendError::full(AnyMessage::new(overflow_message)))
       },
       | Err(TrySendError::Closed(command)) => {
         tracing::warn!(?command, "remote watch command queue is closed");
-        true
+        Ok(true)
       },
     }
   }
@@ -142,24 +143,26 @@ impl StdRemoteWatchHook {
 }
 
 impl RemoteWatchHook for StdRemoteWatchHook {
-  fn handle_watch(&mut self, target: Pid, watcher: Pid) -> bool {
+  fn handle_watch(&mut self, target: Pid, watcher: Pid) -> Result<bool, SendError> {
+    let watcher_pid = watcher;
     let Some(target) = self.remote_path_for(&target) else {
-      return false;
+      return Ok(false);
     };
     let Some(watcher) = self.state.canonical_actor_path(&watcher) else {
-      return false;
+      return Ok(false);
     };
-    self.send_watcher_command(WatcherCommand::Watch { target, watcher })
+    self.send_watcher_command(WatcherCommand::Watch { target, watcher }, SystemMessage::Watch(watcher_pid))
   }
 
-  fn handle_unwatch(&mut self, target: Pid, watcher: Pid) -> bool {
+  fn handle_unwatch(&mut self, target: Pid, watcher: Pid) -> Result<bool, SendError> {
+    let watcher_pid = watcher;
     let Some(target) = self.remote_path_for(&target) else {
-      return false;
+      return Ok(false);
     };
     let Some(watcher) = self.state.canonical_actor_path(&watcher) else {
-      return false;
+      return Ok(false);
     };
-    self.send_watcher_command(WatcherCommand::Unwatch { target, watcher })
+    self.send_watcher_command(WatcherCommand::Unwatch { target, watcher }, SystemMessage::Unwatch(watcher_pid))
   }
 
   fn handle_deathwatch_notification(&mut self, watcher: Pid, terminated: Pid) -> bool {

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -1082,7 +1082,7 @@ fn remote_watch_hook_forwards_watch_command() {
 }
 
 #[test]
-fn remote_watch_hook_returns_false_when_watcher_queue_is_full() {
+fn remote_watch_hook_returns_true_when_watcher_queue_is_full() {
   let registry = RemoteActorPathRegistry::new_shared();
   let remote_pid = Pid::new(905, 0);
   let remote_path = remote_actor_path();
@@ -1093,7 +1093,7 @@ fn remote_watch_hook_returns_false_when_watcher_queue_is_full() {
   let _local_path = register_local_path(harness.system(), local_pid, "watcher-full");
 
   assert!(hook.handle_watch(remote_pid, local_pid));
-  assert!(!hook.handle_watch(remote_pid, local_pid));
+  assert!(hook.handle_watch(remote_pid, local_pid));
   assert!(matches!(watcher_rx.try_recv(), Ok(WatcherCommand::Watch { .. })));
   assert!(watcher_rx.try_recv().is_err());
 }

--- a/modules/remote-adaptor-std/src/provider_test.rs
+++ b/modules/remote-adaptor-std/src/provider_test.rs
@@ -1070,7 +1070,7 @@ fn remote_watch_hook_forwards_watch_command() {
   let local_pid = Pid::new(901, 0);
   let local_path = register_local_path(harness.system(), local_pid, "watcher");
 
-  assert!(hook.handle_watch(remote_pid, local_pid));
+  assert!(matches!(hook.handle_watch(remote_pid, local_pid), Ok(true)));
 
   let command = watcher_rx.try_recv().expect("watch command should be enqueued");
   assert!(matches!(
@@ -1082,7 +1082,7 @@ fn remote_watch_hook_forwards_watch_command() {
 }
 
 #[test]
-fn remote_watch_hook_returns_true_when_watcher_queue_is_full() {
+fn remote_watch_hook_returns_send_error_when_watcher_queue_is_full() {
   let registry = RemoteActorPathRegistry::new_shared();
   let remote_pid = Pid::new(905, 0);
   let remote_path = remote_actor_path();
@@ -1092,8 +1092,8 @@ fn remote_watch_hook_returns_true_when_watcher_queue_is_full() {
   let local_pid = Pid::new(906, 0);
   let _local_path = register_local_path(harness.system(), local_pid, "watcher-full");
 
-  assert!(hook.handle_watch(remote_pid, local_pid));
-  assert!(hook.handle_watch(remote_pid, local_pid));
+  assert!(matches!(hook.handle_watch(remote_pid, local_pid), Ok(true)));
+  assert!(matches!(hook.handle_watch(remote_pid, local_pid), Err(SendError::Full(_))));
   assert!(matches!(watcher_rx.try_recv(), Ok(WatcherCommand::Watch { .. })));
   assert!(watcher_rx.try_recv().is_err());
 }
@@ -1109,7 +1109,7 @@ fn remote_watch_hook_returns_true_when_watcher_queue_is_closed() {
   let _local_path = register_local_path(harness.system(), local_pid, "watcher-closed");
   drop(watcher_rx);
 
-  assert!(hook.handle_watch(remote_pid, local_pid));
+  assert!(matches!(hook.handle_watch(remote_pid, local_pid), Ok(true)));
 }
 
 #[test]
@@ -1120,7 +1120,7 @@ fn remote_watch_hook_returns_false_when_watcher_path_is_unresolved() {
   registry.with_lock(|registry| registry.record(remote_pid, remote_path));
   let (mut hook, _event_rx, mut watcher_rx, _harness) = make_remote_watch_hook_fixture(registry);
 
-  assert!(!hook.handle_watch(remote_pid, Pid::new(909, 1)));
+  assert!(matches!(hook.handle_watch(remote_pid, Pid::new(909, 1)), Ok(false)));
   assert!(watcher_rx.try_recv().is_err());
 }
 
@@ -1134,7 +1134,7 @@ fn remote_watch_hook_forwards_unwatch_command() {
   let local_pid = Pid::new(911, 0);
   let local_path = register_local_path(harness.system(), local_pid, "watcher");
 
-  assert!(hook.handle_unwatch(remote_pid, local_pid));
+  assert!(matches!(hook.handle_unwatch(remote_pid, local_pid), Ok(true)));
 
   let command = watcher_rx.try_recv().expect("unwatch command should be enqueued");
   assert!(matches!(
@@ -1150,7 +1150,7 @@ fn remote_watch_hook_returns_false_when_mapping_is_unresolved() {
   let registry = RemoteActorPathRegistry::new_shared();
   let (mut hook, _event_rx, mut watcher_rx, _harness) = make_remote_watch_hook_fixture(registry);
 
-  assert!(!hook.handle_watch(Pid::new(920, 0), Pid::new(921, 0)));
+  assert!(matches!(hook.handle_watch(Pid::new(920, 0), Pid::new(921, 0)), Ok(false)));
   assert!(watcher_rx.try_recv().is_err());
 }
 
@@ -1159,7 +1159,7 @@ fn remote_watch_hook_returns_false_when_unwatch_mapping_is_unresolved() {
   let registry = RemoteActorPathRegistry::new_shared();
   let (mut hook, _event_rx, mut watcher_rx, _harness) = make_remote_watch_hook_fixture(registry);
 
-  assert!(!hook.handle_unwatch(Pid::new(920, 0), Pid::new(921, 0)));
+  assert!(matches!(hook.handle_unwatch(Pid::new(920, 0), Pid::new(921, 0)), Ok(false)));
   assert!(watcher_rx.try_recv().is_err());
 }
 
@@ -1171,7 +1171,7 @@ fn remote_watch_hook_returns_false_when_unwatch_watcher_path_is_unresolved() {
   registry.with_lock(|registry| registry.record(remote_pid, remote_path));
   let (mut hook, _event_rx, mut watcher_rx, _harness) = make_remote_watch_hook_fixture(registry);
 
-  assert!(!hook.handle_unwatch(remote_pid, Pid::new(922, 1)));
+  assert!(matches!(hook.handle_unwatch(remote_pid, Pid::new(922, 1)), Ok(false)));
   assert!(watcher_rx.try_recv().is_err());
 }
 


### PR DESCRIPTION
### Motivation
- ネットワーク経由の制御フレームで `watcher` コマンドキューが飽和した場合に、`StdRemoteWatchHook::send_watcher_command` が `TrySendError::Full` を返して `false` となり、actor-core が未消費の Watch を「対象アクター不在/死亡」と誤解して `SystemMessage::DeathWatchNotification` を送出することで誤った終了通知が発生する脆弱性が検出されました。 

### Description
- `StdRemoteWatchHook::send_watcher_command` の `TrySendError::Full` 分岐で `false` を返していた挙動を、警告ログは残したまま `true`（消費済み扱い）に戻しました（`modules/remote-adaptor-std/src/provider/remote_watch_hook.rs`）。
- 満杯時の期待動作を検証するユニットテストを `remote_watch_hook_returns_true_when_watcher_queue_is_full` として更新しました（`modules/remote-adaptor-std/src/provider_test.rs`）。
- 変更は該当箇所のみの小さな修正で、既存の機能や他のコードの振る舞いは維持しています。 

### Testing
- 変更後に `cargo test -p fraktor-remote-adaptor-std-rs remote_watch_hook_returns_true_when_watcher_queue_is_full` を実行し、該当テストは `ok` になりました.
- 影響範囲を限定するため修正は最小限に留め、該当パッケージの関連ユニットテストを手元で実行して検証しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7b6c9488832dbbf9ac0ed523f1aa)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `RemoteWatchHook` API and how `SystemStateShared::send_system_message` handles remote watch/unwatch failures, which can affect deathwatch semantics and retry behavior across remoting. Coverage is improved with targeted unit tests, but the change touches core actor lifecycle messaging.
> 
> **Overview**
> Updates `RemoteWatchHook` so `handle_watch`/`handle_unwatch` return `Result<bool, SendError>`, allowing remote providers to signal *enqueue failures* instead of only “consumed vs not consumed”.
> 
> `SystemStateShared::send_system_message` now propagates hook `SendError`s (with a normalization that maps `Closed` to `Full` to avoid colliding with the “target terminated” meaning), preventing the missing-actor fallback from emitting spurious `DeathWatchNotification`s when the remote watch pipeline is saturated.
> 
> `StdRemoteWatchHook` now returns `SendError::Full` when its watcher command queue overflows (instead of `false`), and tests are updated/added to verify error propagation, normalization, and watch-state rollback enabling retry after a remote-full condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e3f26ebc326b14a0c2909f1bd6ab6cd1904487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->