### PR TITLE
fix(persistence): bound default stash capacity for backoff store

### DIFF
--- a/modules/persistence-core-typed/src/persistence_effector_config.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_config.rs
@@ -35,7 +35,7 @@ impl<S, E, M> PersistenceEffectorConfig<S, E, M> {
       initial_state,
       apply_event: ArcShared::new(apply_event),
       persistence_mode: PersistenceMode::Persisted,
-      stash_capacity: usize::MAX,
+      stash_capacity: 1000,
       snapshot_criteria: SnapshotCriteria::never(),
       retention_criteria: RetentionCriteria::default(),
       backoff_config: BackoffConfig::default(),
@@ -184,4 +184,26 @@ where
 
 fn validation_error(message: &str) -> PersistenceError {
   PersistenceError::StateMachine(String::from(message))
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  fn apply_event(state: &u32, event: &u32) -> u32 {
+    state + event
+  }
+
+  #[test]
+  fn default_stash_capacity_is_bounded() {
+    let config = PersistenceEffectorConfig::<u32, u32, ()>::new(
+      PersistenceId::of_unique_id("test"),
+      0,
+      apply_event,
+    );
+
+    assert_eq!(config.stash_capacity(), 1000);
+    assert!(config.validate().is_ok());
+  }
 }

--- a/modules/persistence-core-typed/src/persistence_effector_config.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_config.rs
@@ -1,5 +1,9 @@
 //! Persistence effector configuration.
 
+#[cfg(test)]
+#[path = "persistence_effector_config_test.rs"]
+mod tests;
+
 use alloc::string::String;
 
 use fraktor_persistence_core_kernel_rs::error::PersistenceError;
@@ -184,21 +188,4 @@ where
 
 fn validation_error(message: &str) -> PersistenceError {
   PersistenceError::StateMachine(String::from(message))
-}
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-
-  fn apply_event(state: &u32, event: &u32) -> u32 {
-    state + event
-  }
-
-  #[test]
-  fn default_stash_capacity_is_bounded() {
-    let config = PersistenceEffectorConfig::<u32, u32, ()>::new(PersistenceId::of_unique_id("test"), 0, apply_event);
-
-    assert_eq!(config.stash_capacity(), 1000);
-    assert!(config.validate().is_ok());
-  }
 }

--- a/modules/persistence-core-typed/src/persistence_effector_config.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_config.rs
@@ -186,7 +186,6 @@ fn validation_error(message: &str) -> PersistenceError {
   PersistenceError::StateMachine(String::from(message))
 }
 
-
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -197,11 +196,7 @@ mod tests {
 
   #[test]
   fn default_stash_capacity_is_bounded() {
-    let config = PersistenceEffectorConfig::<u32, u32, ()>::new(
-      PersistenceId::of_unique_id("test"),
-      0,
-      apply_event,
-    );
+    let config = PersistenceEffectorConfig::<u32, u32, ()>::new(PersistenceId::of_unique_id("test"), 0, apply_event);
 
     assert_eq!(config.stash_capacity(), 1000);
     assert!(config.validate().is_ok());

--- a/modules/persistence-core-typed/src/persistence_effector_config_test.rs
+++ b/modules/persistence-core-typed/src/persistence_effector_config_test.rs
@@ -1,0 +1,13 @@
+use crate::{PersistenceEffectorConfig, PersistenceId};
+
+fn apply_event(state: &u32, event: &u32) -> u32 {
+  state + event
+}
+
+#[test]
+fn default_stash_capacity_is_bounded() {
+  let config = PersistenceEffectorConfig::<u32, u32, ()>::new(PersistenceId::of_unique_id("test"), 0, apply_event);
+
+  assert_eq!(config.stash_capacity(), 1000);
+  assert!(config.validate().is_ok());
+}


### PR DESCRIPTION
### Motivation
- BackoffSupervisor が `PersistenceEffectorConfig` の `stash_capacity` デフォルト（従来 `usize::MAX`）を流用してバックオフ中に無制限でメッセージを蓄積し、ストア障害時にメモリ枯渇を引き起こすリスクがあるため、デフォルトを有限にして安全側に寄せます。

### Description
- `modules/persistence-core-typed/src/persistence_effector_config.rs` の `PersistenceEffectorConfig::new` で `stash_capacity` のデフォルト値を `usize::MAX` から `1000` に変更し、同ファイルに `default_stash_capacity_is_bounded` という単体テストを追加してデフォルト値と `validate()` の動作を検証するコードを追加しました。

### Testing
- 追加したテスト `default_stash_capacity_is_bounded` を `cargo test -p fraktor-persistence-core-typed-rs default_stash_capacity_is_bounded` で実行し、テストは成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2007c2f0832d810fafa8095e756d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `stash_capacity` from effectively unbounded to `1000`, which can alter runtime behavior under backoff/stashing (messages may now be dropped/failed once the stash fills). Otherwise the change is small and covered by a unit test.
> 
> **Overview**
> **Bounds the default stash size used by typed persistence effectors/backoff supervision.** `PersistenceEffectorConfig::new` now defaults `stash_capacity` to `1000` instead of `usize::MAX`, preventing unbounded message accumulation during backoff.
> 
> Adds a small unit test (`default_stash_capacity_is_bounded`) and wires it via a `#[cfg(test)]` module to assert the new default and that `validate()` still passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070bf18a3cc01f8bbceed579c5b94beba0a32725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * デフォルトのスタッシュ容量を最適化し、メモリ使用量の管理をより効率的にしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->