### PR TITLE
[codex] Add persistence typed Phase 1 parity change

### DIFF
--- a/openspec/changes/add-persistence-typed-phase1-parity/.openspec.yaml
+++ b/openspec/changes/add-persistence-typed-phase1-parity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/add-persistence-typed-phase1-parity/design.md
+++ b/openspec/changes/add-persistence-typed-phase1-parity/design.md
@@ -1,0 +1,91 @@
+## Context
+
+`modules/persistence-core-typed` currently exposes the effector-first API: `PersistenceEffector`, `PersistenceEffectorConfig`, `PersistenceEffectorSignal`, `PersistenceEffectorMessageAdapter`, `PersistenceId`, `PersistenceMode`, `SnapshotCriteria`, and `RetentionCriteria`. This is enough to persist event-sourced aggregates through a hidden store actor, but the Phase 1 gap-analysis still lists three low-cost parity gaps:
+
+- typed `Recovery` / typed `SnapshotSelectionCriteria`
+- typed `EventAdapter` / `EventSeq` / `SnapshotAdapter`
+- `DurableStateSignal` family
+
+The kernel crate already owns classic persistence runtime contracts such as journal event adapters, `EventSeq`, snapshot selection, snapshot stores, and durable state store traits. This change should not redesign those kernel contracts. It should add typed-facing public API wrappers in `persistence-core-typed` so later Phase 2 work can build serializer and durable state behavior contracts on stable names.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add typed recovery selection API without replacing `PersistenceEffector` or adding a new recovery engine.
+- Add typed event adapter contracts that can register typed event adaptation with the existing kernel erased event adapter pipeline.
+- Add a typed snapshot adapter contract as a public conversion boundary for later serializer / durable state behavior work.
+- Add typed durable state signal types for future `DurableStateBehavior` implementation.
+- Keep `modules/persistence-core-typed` no_std and allocation-only.
+- Keep new public types in one-type-per-file modules and re-export them from `lib.rs`.
+- Add focused public-surface and behavior tests for the new contracts.
+
+**Non-Goals:**
+
+- Implement typed `EventSourcedBehavior`, `EffectBuilder`, or `ReplyEffect`.
+- Implement typed `DurableStateBehavior` or durable state effects.
+- Add persistence serializer registry, `AtomicWrite`, or storage plugin selection.
+- Add `persistence-adaptor-std` or filesystem-backed snapshot stores.
+- Change kernel journal / snapshot / durable state store protocols.
+- Add compatibility aliases for deprecated or intermediate names.
+
+## Decisions
+
+### Decision 1: typed recovery selection is an explicit API, not a rename of `SnapshotCriteria`
+
+`SnapshotCriteria<S, E>` controls when the effector writes snapshots after events are persisted. Pekko typed `Recovery` / `SnapshotSelectionCriteria` controls which persisted state is selected during recovery and which event range is replayed. These are different decisions, so this change will add separate typed recovery selection types instead of overloading `SnapshotCriteria`.
+
+The typed recovery API should translate into the existing kernel `persistent::Recovery`. `PersistenceStoreActor` already implements `Eventsourced`, so implementation should override `Eventsourced::recovery()` and return the config-selected kernel recovery. This keeps recovery execution inside `PersistenceContext::start_recovery()` instead of adding a second recovery path.
+
+Alternative considered: treat current `SnapshotCriteria` as enough and only update the gap document. That would leave the API ambiguous because snapshot write policy and recovery read selection would share one name but not one meaning.
+
+### Decision 2: typed event adapters bridge to the kernel event adapter registry
+
+Kernel event adapters work with erased `Any` payloads because journal storage is classic-runtime oriented. Typed APIs should let users implement event adaptation in terms of typed `E`, then provide conversion points into the kernel event adapter pipeline. Snapshot adaptation is handled separately as a typed conversion contract because there is no kernel snapshot adapter registry yet.
+
+The typed `EventSeq<E>` should represent zero, one, or many typed events, matching kernel `EventSeq` semantics without requiring callers to downcast. The typed event adapter should expose manifest handling and bidirectional event adaptation, then be wrapped into kernel `ReadEventAdapter` / `WriteEventAdapter` implementations when registered on `PersistenceEffectorConfig`.
+
+Alternative considered: re-export kernel `EventSeq`, `ReadEventAdapter`, and `WriteEventAdapter` directly. That keeps the type surface small but forces typed users to write erased payload code and does not close the typed parity gap.
+
+### Decision 3: typed snapshot adapter is a standalone conversion contract in this phase
+
+Kernel snapshot persistence currently stores erased snapshot payloads directly and does not have a dedicated snapshot adapter registry equivalent to journal event adapters. This change will still add a typed `SnapshotAdapter<S>` contract because Phase 1 parity needs the public boundary, but it will not claim runtime snapshot-store integration yet.
+
+The first implementation should provide typed state to snapshot payload conversion, manifest access, and snapshot payload to typed state conversion. Wiring that contract into serializer registry or snapshot store IO is Phase 2 serializer / durable state behavior work.
+
+Alternative considered: delay `SnapshotAdapter` entirely. That would keep Phase 1 smaller but leave one of the three explicit Phase 1 gap rows open.
+
+### Decision 4: durable state signals are separate from `PersistenceEffectorSignal`
+
+`PersistenceEffectorSignal<S, E>` represents event-sourced effector outcomes: recovery, persisted events, persisted snapshot, deleted snapshots, and failure. Durable state behavior has different lifecycle concepts: state recovery completed, recovery failed, durable state persisted, durable state deleted, and persistence failure.
+
+This change will add a distinct `DurableStateSignal<S>` family. It should be public and stable enough for a future durable state behavior wrapper, but it should not imply that durable state behavior itself is implemented in this change.
+
+Alternative considered: extend `PersistenceEffectorSignal` with durable-state variants. That would mix event-sourced and durable-state protocols and make later behavior-specific APIs harder to separate.
+
+### Decision 5: this change only adds core typed contracts
+
+All new types live in `modules/persistence-core-typed/src/` and use `alloc` plus existing core dependencies only. No `std::*`, filesystem, runtime task, or plugin-loading dependency is introduced. Tests should be either sibling unit tests or focused crate tests under `modules/persistence-core-typed/tests/`.
+
+## Risks / Trade-offs
+
+- Typed recovery selection may duplicate existing kernel names -> Use typed names to expose typed crate parity, but translate them into kernel `persistent::Recovery` at the `Eventsourced::recovery()` boundary.
+- Adapter wrappers may become too broad -> Keep event adapter integration to kernel event adapter registration, and keep snapshot adapter as a standalone conversion contract until serializer work.
+- Durable state signals may pre-decide too much of Phase 3 -> Limit them to signal data and construction / matching tests; do not add durable state behavior or effects.
+- Public API naming may conflict with later Pekko direct DSL work -> Use names that match the Phase 1 gap and keep direct `EventSourcedBehavior` / `DurableStateBehavior` outside this change.
+
+## Migration Plan
+
+1. Add typed recovery selection types and config wiring, preserving existing default behavior through `Eventsourced::recovery()`.
+2. Add typed event adapter contracts, config registration, kernel adapter wrappers, and public-surface tests.
+3. Add typed snapshot adapter contract and public-surface tests without runtime snapshot store integration.
+4. Add durable state signal types and public-surface tests.
+5. Re-export new public types from `fraktor-persistence-core-typed-rs`.
+6. Update `docs/gap-analysis/persistence-gap-analysis.md` Phase 1 statuses.
+7. Run targeted `persistence-core-typed` tests, OpenSpec validation, and diff checks.
+
+Rollback is deleting this active change before implementation. After implementation, rollback is a normal revert because this repository is pre-release and no compatibility layer is required.
+
+## Open Questions
+
+No unresolved semantic questions. Exact method names should follow existing `SnapshotCriteria`, `PersistenceEffectorConfig`, and kernel adapter naming during implementation.

--- a/openspec/changes/add-persistence-typed-phase1-parity/proposal.md
+++ b/openspec/changes/add-persistence-typed-phase1-parity/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`docs/gap-analysis/persistence-gap-analysis.md` の Phase 1 では、typed persistence の低コストな Pekko parity gap が 3 件だけ残っている。既存 `PersistenceEffector` は write-side typed API として動くが、typed recovery selection、typed adapter wrapper、typed durable state signal の public contract がないため、Phase 2 の serializer / durable state behavior に進む前の足場が不足している。
+
+## What Changes
+
+- typed persistence crate に Pekko typed `Recovery` / `SnapshotSelectionCriteria` 相当の public API を追加し、既存 `SnapshotCriteria` と混同しない境界を定義する。
+- kernel の `ReadEventAdapter` / `WriteEventAdapter` / `EventSeq` を typed API から型付きに扱える `EventAdapter` / typed `EventSeq` 契約を追加し、`SnapshotAdapter` は runtime integration なしの typed snapshot conversion contract として追加する。
+- typed durable state API の将来実装で使う `DurableStateSignal` family を追加する。
+- `modules/persistence-core-typed` の no_std 境界、1 public type per file、crate root re-export を維持する。
+- 実装後に `docs/gap-analysis/persistence-gap-analysis.md` の Phase 1 状態を更新する。
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `persistence-effector-typed-api`: Phase 1 parity として typed recovery selection、typed event / snapshot adapter wrapper、typed durable state signal の public contract を追加する。
+
+## Impact
+
+- `modules/persistence-core-typed/src/`
+- `modules/persistence-core-typed/tests/`
+- `openspec/specs/persistence-effector-typed-api/spec.md`
+- `docs/gap-analysis/persistence-gap-analysis.md`
+
+`modules/persistence-core-kernel` の journal event adapter 契約は再利用対象であり、この change では kernel storage protocol、snapshot-store runtime protocol、serializer contract を変更しない。

--- a/openspec/changes/add-persistence-typed-phase1-parity/specs/persistence-effector-typed-api/spec.md
+++ b/openspec/changes/add-persistence-typed-phase1-parity/specs/persistence-effector-typed-api/spec.md
@@ -1,0 +1,108 @@
+## ADDED Requirements
+
+### Requirement: typed recovery selection API を提供する
+
+typed persistence API は recovery 実行時にどの snapshot を読み込み、どの event 範囲を replay するかを表す `Recovery` と `SnapshotSelectionCriteria` 相当の public contract を提供しなければならない (MUST)。この recovery selection API は snapshot 書き込みタイミングを表す既存 `SnapshotCriteria<S, E>` と別契約でなければならない (MUST)。
+
+typed recovery selection API は default recovery を表現できなければならない (MUST)。また、snapshot を無効化する recovery、指定 sequence number 以前の snapshot を選択する recovery、指定 timestamp 以前の snapshot を選択する recovery を表現できなければならない (MUST)。
+
+typed persistence config は recovery selection を受け取り、未指定時は既存と同じ default recovery を使わなければならない (MUST)。typed recovery selection は `PersistenceStoreActor` の `Eventsourced::recovery()` を通じて kernel `persistent::Recovery` に変換されなければならない (MUST)。
+
+#### Scenario: default recovery は既存挙動を維持する
+
+- **WHEN** user が recovery selection を明示せずに `PersistenceEffectorConfig` を作成する
+- **THEN** config は default recovery を使う
+- **AND** recovery は最新利用可能 snapshot とそれ以降の event replay を選択する
+
+#### Scenario: snapshot write criteria と recovery selection は別契約である
+
+- **WHEN** user が `SnapshotCriteria::Every { number_of_events: 10 }` を設定する
+- **THEN** その設定は snapshot write timing だけを制御する
+- **AND** recovery snapshot selection は typed `Recovery` / typed `SnapshotSelectionCriteria` 側で制御される
+
+#### Scenario: snapshot disabled recovery を表現できる
+
+- **WHEN** user が snapshot を使わない recovery を設定する
+- **THEN** recovery は journal event replay だけで state を復元する
+- **AND** snapshot write criteria の設定値はこの recovery read decision を上書きしない
+
+#### Scenario: replay limit は kernel recovery へ渡される
+
+- **WHEN** user が replay upper bound と replay max を持つ typed recovery を設定する
+- **THEN** `PersistenceStoreActor` は kernel `persistent::Recovery` へ同じ replay bound を渡す
+- **AND** `PersistenceContext::start_recovery()` が既存 recovery engine でその bound を使う
+
+### Requirement: typed event adapter と typed snapshot adapter を提供する
+
+typed persistence API は typed event payload を扱う `EventAdapter`、zero / one / many の typed event sequence を表す `EventSeq<E>`、typed state snapshot を変換する `SnapshotAdapter` を提供しなければならない (MUST)。
+
+typed `EventSeq<E>` は empty、single、multiple を表現できなければならない (MUST)。typed `EventAdapter` は event を journal payload へ変換し、journal payload と manifest から typed event sequence へ戻せなければならない (MUST)。typed `SnapshotAdapter` は typed state を snapshot payload へ変換し、snapshot payload と manifest から typed state へ戻せなければならない (MUST)。
+
+typed event adapter API は `PersistenceEffectorConfig` から登録でき、既存 kernel event adapter pipeline と接続できなければならない (MUST)。typed snapshot adapter API は public conversion contract として提供されなければならない (MUST)。ただしこの change は snapshot adapter registry、serializer registry、persisted binary format を追加してはならない (MUST NOT)。
+
+#### Scenario: typed event adapter は one-to-many read adaptation を表現できる
+
+- **GIVEN** journal payload が typed event `E1` と `E2` に展開される
+- **WHEN** typed event adapter が journal payload と manifest を読む
+- **THEN** adapter は `EventSeq::Multiple([E1, E2])` 相当を返せる
+
+#### Scenario: typed event adapter は manifest を提供できる
+
+- **GIVEN** typed event `E` を journal へ保存する
+- **WHEN** typed event adapter が event を journal payload へ変換する
+- **THEN** adapter は storage 側へ渡す manifest を返せる
+
+#### Scenario: typed snapshot adapter は state snapshot を round trip できる
+
+- **GIVEN** typed state `S` を snapshot として保存する
+- **WHEN** typed snapshot adapter が state を snapshot payload に変換し、その payload と manifest を読み戻す
+- **THEN** adapter は typed state `S` を復元できる
+
+#### Scenario: typed snapshot adapter は runtime snapshot store integration を要求しない
+
+- **WHEN** user が typed `SnapshotAdapter<S>` を実装する
+- **THEN** adapter は typed snapshot conversion contract として利用できる
+- **AND** snapshot store runtime はこの change で snapshot adapter registry を要求しない
+
+### Requirement: typed durable state signal family を提供する
+
+typed persistence API は future `DurableStateBehavior` integration で使う `DurableStateSignal<S>` family を提供しなければならない (MUST)。この signal family は event-sourced `PersistenceEffectorSignal<S, E>` と別型でなければならない (MUST)。
+
+`DurableStateSignal<S>` は recovery completed、recovery failed、state persisted、state deleted、persistence failed を表現できなければならない (MUST)。failure variants は persistence kernel の durable state / persistence error contract と接続できる error payload を持たなければならない (MUST)。
+
+この change は durable state behavior execution、durable state effect builder、reply effect を実装してはならない (MUST NOT)。
+
+#### Scenario: durable state recovery completed を private message に包める
+
+- **GIVEN** typed durable state actor が private message type を持つ
+- **WHEN** durable state recovery が完了する
+- **THEN** actor は `DurableStateSignal::RecoveryCompleted` 相当を private message に包んで処理できる
+
+#### Scenario: durable state persisted signal は event-sourced signal と混同されない
+
+- **WHEN** durable state update が保存される
+- **THEN** durable state API は `DurableStateSignal` の persisted variant を使う
+- **AND** event-sourced `PersistenceEffectorSignal::PersistedEvents` は使わない
+
+#### Scenario: durable state API は behavior implementation を要求しない
+
+- **WHEN** user が `DurableStateSignal` を import する
+- **THEN** signal type は利用できる
+- **AND** `DurableStateBehavior` や durable state `EffectBuilder` はこの change の public API として要求されない
+
+### Requirement: Phase 1 typed parity API は crate root から re-export される
+
+`fraktor-persistence-core-typed-rs` は Phase 1 typed parity API を crate root から re-export しなければならない (MUST)。new public types は `modules/persistence-core-typed/src/` に one public type per file で配置しなければならない (MUST)。
+
+new public API は `no_std` core 境界を維持し、`std::*` に依存してはならない (MUST NOT)。
+
+#### Scenario: crate user は Phase 1 typed parity API を import できる
+
+- **WHEN** crate user が `fraktor_persistence_core_typed_rs` の crate root を import する
+- **THEN** typed `Recovery`、typed `SnapshotSelectionCriteria`、typed `EventAdapter`、typed `EventSeq`、typed `SnapshotAdapter`、`DurableStateSignal` を利用できる
+
+#### Scenario: typed crate は no_std を維持する
+
+- **WHEN** implementation diff を確認する
+- **THEN** `modules/persistence-core-typed/src/` に `std::` import は追加されない
+- **AND** new public types は `alloc` と existing core dependencies だけで構成される

--- a/openspec/changes/add-persistence-typed-phase1-parity/tasks.md
+++ b/openspec/changes/add-persistence-typed-phase1-parity/tasks.md
@@ -1,0 +1,40 @@
+## 1. Baseline and API Boundary
+
+- [ ] 1.1 Confirm current `modules/persistence-core-typed` public exports, sibling test layout, and no_std constraints before editing.
+- [ ] 1.2 Confirm kernel recovery, snapshot selection, event adapter, event sequence, and snapshot adapter contracts that typed wrappers should reuse instead of duplicating.
+- [ ] 1.3 Run the current targeted typed persistence tests to capture the baseline behavior.
+
+## 2. Typed Recovery Selection API
+
+- [ ] 2.1 Add one-type-per-file public typed recovery selection types for `Recovery` and `SnapshotSelectionCriteria`.
+- [ ] 2.2 Wire recovery selection into `PersistenceEffectorConfig` with default behavior unchanged.
+- [ ] 2.3 Override `Eventsourced::recovery()` in `PersistenceStoreActor` so typed recovery selection translates into kernel `persistent::Recovery`.
+- [ ] 2.4 Add focused tests for default recovery, snapshot-disabled recovery, sequence-bound snapshot selection, timestamp-bound snapshot selection, and replay limit propagation.
+
+## 3. Typed Event and Snapshot Adapter API
+
+- [ ] 3.1 Add typed `EventSeq<E>` with empty, single, multiple, length, and into-events behavior.
+- [ ] 3.2 Add typed `EventAdapter<E>` contract for manifest, to-journal, and from-journal adaptation.
+- [ ] 3.3 Add typed `SnapshotAdapter<S>` contract for manifest, to-snapshot, and from-snapshot adaptation.
+- [ ] 3.4 Add config registration and kernel adapter wrappers needed to connect typed event adapters to the existing kernel erased event adapter pipeline.
+- [ ] 3.5 Keep typed snapshot adapter as a standalone conversion contract; do not add snapshot-store runtime integration in this change.
+- [ ] 3.6 Add tests covering one-to-many event read adaptation, manifest propagation, event adapter registration, and snapshot round trip.
+
+## 4. Typed Durable State Signals
+
+- [ ] 4.1 Add `DurableStateSignal<S>` as a separate public signal family from `PersistenceEffectorSignal<S, E>`.
+- [ ] 4.2 Include recovery completed, recovery failed, state persisted, state deleted, and persistence failed variants with appropriate error payloads.
+- [ ] 4.3 Add public-surface tests proving durable state signals can be wrapped by user private messages without importing internal store protocol.
+
+## 5. Re-exports, Docs, and Gap Status
+
+- [ ] 5.1 Re-export all Phase 1 parity types from `modules/persistence-core-typed/src/lib.rs`.
+- [ ] 5.2 Keep new public types in one-type-per-file modules and add sibling unit tests where behavior is local to the type.
+- [ ] 5.3 Update `docs/gap-analysis/persistence-gap-analysis.md` so Phase 1 marks the three implemented items as done or clearly explains any intentional non-goal.
+
+## 6. Verification
+
+- [ ] 6.1 Run targeted tests for `modules/persistence-core-typed`.
+- [ ] 6.2 Run targeted no_std / dylint checks required by the touched persistence crate.
+- [ ] 6.3 Run `mise exec -- openspec validate add-persistence-typed-phase1-parity --strict`.
+- [ ] 6.4 Run `git diff --check`.


### PR DESCRIPTION
## 概要

`docs/gap-analysis/persistence-gap-analysis.md` の Phase 1 未実装 3 件をまとめて実装するための OpenSpec change を追加します。

対象は次の public contract です。

- typed `Recovery` / typed `SnapshotSelectionCriteria`
- typed `EventAdapter` / typed `EventSeq` / `SnapshotAdapter`
- `DurableStateSignal` family

## 方針

- recovery は新しい recovery engine を作らず、既存 `Eventsourced::recovery()` から kernel `persistent::Recovery` へ変換する方針に固定しました。
- typed event adapter は kernel event adapter pipeline へ接続する対象として定義しました。
- typed snapshot adapter は Phase 1 では conversion contract に留め、snapshot-store runtime integration / serializer registry は Phase 2 以降に分離しました。
- durable state signal は `PersistenceEffectorSignal` と混ぜず、将来の `DurableStateBehavior` 用の別 signal family として定義しました。

## 追加したもの

- `proposal.md`
- `design.md`
- `specs/persistence-effector-typed-api/spec.md`
- `tasks.md`

## 検証

- `mise exec -- openspec validate add-persistence-typed-phase1-parity --strict`
- `git diff --cached --check`

## 備考

この PR は OpenSpec change の追加のみです。実装コードは含みません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only adds OpenSpec change documentation/specs and does not modify any runtime code, APIs, or behavior.
> 
> **Overview**
> Adds a new OpenSpec change (`add-persistence-typed-phase1-parity`) defining Phase 1 parity requirements for typed persistence, covering typed recovery selection (`Recovery`/`SnapshotSelectionCriteria`), typed event/snapshot adapter contracts (`EventAdapter`, `EventSeq`, `SnapshotAdapter`), and a separate `DurableStateSignal` family.
> 
> Includes design/proposal/spec/tasks documents that constrain implementation (no new recovery engine, bridge typed adapters into the existing kernel adapter pipeline, keep snapshot adapter as conversion-only, maintain `no_std`, and re-export the new typed contracts from the crate root).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1731fd69990fbdf2bb55a971291af145956559d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->