### PR TITLE
Define EventStream replay and panic contract

### DIFF
--- a/modules/actor-core-kernel/src/event/stream/base_test.rs
+++ b/modules/actor-core-kernel/src/event/stream/base_test.rs
@@ -207,9 +207,9 @@ fn publish_snapshot_is_not_changed_by_unsubscribe_during_callback() {
   let second_subscription = stream.subscribe_with_key(ClassifierKey::Log, &second_subscriber);
   *unsubscribe_target.lock() = Some(second_subscription.id());
 
-  // The first subscriber removes the second while the current publish snapshot
-  // is being consumed. The second subscriber must still receive that snapshot's
-  // event, then stop receiving later publishes.
+  // Registration gives the first subscriber a lower id than the second, so the
+  // current snapshot notifies first before second. The second subscriber must
+  // still receive that snapshot's event, then stop receiving later publishes.
   stream.publish(&EventStreamEvent::Log(log_event("snapshot-fixed", 1)));
   stream.publish(&EventStreamEvent::Log(log_event("after-unsubscribe", 2)));
 

--- a/modules/actor-core-kernel/src/event/stream/base_test.rs
+++ b/modules/actor-core-kernel/src/event/stream/base_test.rs
@@ -207,6 +207,9 @@ fn publish_snapshot_is_not_changed_by_unsubscribe_during_callback() {
   let second_subscription = stream.subscribe_with_key(ClassifierKey::Log, &second_subscriber);
   *unsubscribe_target.lock() = Some(second_subscription.id());
 
+  // The first subscriber removes the second while the current publish snapshot
+  // is being consumed. The second subscriber must still receive that snapshot's
+  // event, then stop receiving later publishes.
   stream.publish(&EventStreamEvent::Log(log_event("snapshot-fixed", 1)));
   stream.publish(&EventStreamEvent::Log(log_event("after-unsubscribe", 2)));
 

--- a/modules/actor-core-kernel/src/event/stream/base_test.rs
+++ b/modules/actor-core-kernel/src/event/stream/base_test.rs
@@ -17,7 +17,8 @@ use crate::{
     logging::{LogEvent, LogLevel},
     stream::{
       AddressTerminatedEvent, ClassifierKey, EventStream, EventStreamEvent, EventStreamShared, EventStreamSubscriber,
-      RemoteAuthorityEvent, RemotingLifecycleEvent, tests::subscriber_handle,
+      EventStreamSubscriberShared, EventStreamSubscription, RemoteAuthorityEvent, RemotingLifecycleEvent,
+      tests::subscriber_handle,
     },
   },
   system::state::AuthorityState,
@@ -40,23 +41,76 @@ impl EventStreamSubscriber for RecordingSubscriber {
 }
 
 struct PanicOnceSubscriber {
-  events:         ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>,
-  has_panicked:   bool,
-  panic_on_first: bool,
+  events:       ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>,
+  has_panicked: bool,
 }
 
 impl PanicOnceSubscriber {
   fn new(events: ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>) -> Self {
-    Self { events, has_panicked: false, panic_on_first: true }
+    Self { events, has_panicked: false }
   }
 }
 
 impl EventStreamSubscriber for PanicOnceSubscriber {
   fn on_event(&mut self, event: &EventStreamEvent) {
     self.events.lock().push(event.clone());
-    if self.panic_on_first && !self.has_panicked {
+    if !self.has_panicked {
       self.has_panicked = true;
       panic!("subscriber callback panic");
+    }
+  }
+}
+
+struct UnsubscribeOnEventSubscriber {
+  stream:    EventStreamShared,
+  target_id: ArcShared<SpinSyncMutex<Option<u64>>>,
+  events:    ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>,
+}
+
+impl UnsubscribeOnEventSubscriber {
+  fn new(
+    stream: EventStreamShared,
+    target_id: ArcShared<SpinSyncMutex<Option<u64>>>,
+    events: ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>,
+  ) -> Self {
+    Self { stream, target_id, events }
+  }
+}
+
+impl EventStreamSubscriber for UnsubscribeOnEventSubscriber {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    self.events.lock().push(event.clone());
+    if let Some(id) = *self.target_id.lock() {
+      self.stream.unsubscribe(id);
+    }
+  }
+}
+
+struct SubscribeOnEventSubscriber {
+  stream:       EventStreamShared,
+  subscriber:   EventStreamSubscriberShared,
+  subscription: ArcShared<SpinSyncMutex<Option<EventStreamSubscription>>>,
+  events:       ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>,
+}
+
+impl SubscribeOnEventSubscriber {
+  fn new(
+    stream: EventStreamShared,
+    subscriber: EventStreamSubscriberShared,
+    subscription: ArcShared<SpinSyncMutex<Option<EventStreamSubscription>>>,
+    events: ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>,
+  ) -> Self {
+    Self { stream, subscriber, subscription, events }
+  }
+}
+
+impl EventStreamSubscriber for SubscribeOnEventSubscriber {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    self.events.lock().push(event.clone());
+    let mut subscription_slot = self.subscription.lock();
+    if subscription_slot.is_none() {
+      let subscription = self.stream.subscribe_no_replay(&self.subscriber);
+      *subscription_slot = Some(subscription);
     }
   }
 }
@@ -134,6 +188,70 @@ fn publish_returns_after_subscriber_callback_observes_event() {
   let recorded = events.lock().clone();
   assert_eq!(recorded.len(), 1);
   assert!(matches!(&recorded[0], EventStreamEvent::Log(event) if event.message() == "sync-publish"));
+}
+
+#[test]
+fn publish_snapshot_is_not_changed_by_unsubscribe_during_callback() {
+  let stream = EventStreamShared::default();
+  let unsubscribe_target = ArcShared::new(SpinSyncMutex::new(None));
+  let first_events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let first_subscriber = subscriber_handle(UnsubscribeOnEventSubscriber::new(
+    stream.clone(),
+    unsubscribe_target.clone(),
+    first_events.clone(),
+  ));
+  let _first_subscription = stream.subscribe_with_key(ClassifierKey::Log, &first_subscriber);
+
+  let second_events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let second_subscriber = subscriber_handle(RecordingSubscriber::new(second_events.clone()));
+  let second_subscription = stream.subscribe_with_key(ClassifierKey::Log, &second_subscriber);
+  *unsubscribe_target.lock() = Some(second_subscription.id());
+
+  stream.publish(&EventStreamEvent::Log(log_event("snapshot-fixed", 1)));
+  stream.publish(&EventStreamEvent::Log(log_event("after-unsubscribe", 2)));
+
+  let first_recorded = first_events.lock().clone();
+  assert_eq!(first_recorded.len(), 2);
+  assert!(matches!(&first_recorded[0], EventStreamEvent::Log(event) if event.message() == "snapshot-fixed"));
+  assert!(matches!(&first_recorded[1], EventStreamEvent::Log(event) if event.message() == "after-unsubscribe"));
+
+  let second_recorded = second_events.lock().clone();
+  assert_eq!(second_recorded.len(), 1);
+  assert!(matches!(&second_recorded[0], EventStreamEvent::Log(event) if event.message() == "snapshot-fixed"));
+}
+
+#[test]
+fn publish_snapshot_is_not_changed_by_subscribe_during_callback() {
+  let stream = EventStreamShared::default();
+  let added_events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let added_subscriber = subscriber_handle(RecordingSubscriber::new(added_events.clone()));
+  let added_subscription = ArcShared::new(SpinSyncMutex::new(None));
+  let first_events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let first_subscriber = subscriber_handle(SubscribeOnEventSubscriber::new(
+    stream.clone(),
+    added_subscriber,
+    added_subscription,
+    first_events.clone(),
+  ));
+  let _first_subscription = stream.subscribe_with_key(ClassifierKey::Log, &first_subscriber);
+
+  stream.publish(&EventStreamEvent::Log(log_event("before-subscribe-takes-effect", 1)));
+  stream.publish(&EventStreamEvent::Log(log_event("after-subscribe-takes-effect", 2)));
+
+  let first_recorded = first_events.lock().clone();
+  assert_eq!(first_recorded.len(), 2);
+  assert!(
+    matches!(&first_recorded[0], EventStreamEvent::Log(event) if event.message() == "before-subscribe-takes-effect")
+  );
+  assert!(
+    matches!(&first_recorded[1], EventStreamEvent::Log(event) if event.message() == "after-subscribe-takes-effect")
+  );
+
+  let added_recorded = added_events.lock().clone();
+  assert_eq!(added_recorded.len(), 1);
+  assert!(
+    matches!(&added_recorded[0], EventStreamEvent::Log(event) if event.message() == "after-subscribe-takes-effect")
+  );
 }
 
 #[test]

--- a/modules/actor-core-kernel/src/event/stream/base_test.rs
+++ b/modules/actor-core-kernel/src/event/stream/base_test.rs
@@ -2,6 +2,7 @@ extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
 use core::time::Duration;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use fraktor_utils_core_rs::sync::{ArcShared, SpinSyncMutex};
 
@@ -35,6 +36,28 @@ impl RecordingSubscriber {
 impl EventStreamSubscriber for RecordingSubscriber {
   fn on_event(&mut self, event: &EventStreamEvent) {
     self.events.lock().push(event.clone());
+  }
+}
+
+struct PanicOnceSubscriber {
+  events:         ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>,
+  has_panicked:   bool,
+  panic_on_first: bool,
+}
+
+impl PanicOnceSubscriber {
+  fn new(events: ArcShared<SpinSyncMutex<Vec<EventStreamEvent>>>) -> Self {
+    Self { events, has_panicked: false, panic_on_first: true }
+  }
+}
+
+impl EventStreamSubscriber for PanicOnceSubscriber {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    self.events.lock().push(event.clone());
+    if self.panic_on_first && !self.has_panicked {
+      self.has_panicked = true;
+      panic!("subscriber callback panic");
+    }
   }
 }
 
@@ -83,6 +106,54 @@ fn event_stream_replays_buffer_for_new_subscribers() {
   let events = events.lock().clone();
   assert!(events.iter().any(|event| matches!(event, EventStreamEvent::Log(_))));
   assert!(events.iter().any(|event| matches!(event, EventStreamEvent::Lifecycle(_))));
+}
+
+#[test]
+fn subscribe_returns_after_matching_replay_is_observed() {
+  let stream = EventStreamShared::default();
+  stream.publish(&EventStreamEvent::Log(log_event("buffered-before-subscribe", 1)));
+
+  let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let subscriber = subscriber_handle(RecordingSubscriber::new(events.clone()));
+  let _subscription = stream.subscribe_with_key(ClassifierKey::Log, &subscriber);
+
+  let recorded = events.lock().clone();
+  assert_eq!(recorded.len(), 1);
+  assert!(matches!(&recorded[0], EventStreamEvent::Log(event) if event.message() == "buffered-before-subscribe"));
+}
+
+#[test]
+fn publish_returns_after_subscriber_callback_observes_event() {
+  let stream = EventStreamShared::default();
+  let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let subscriber = subscriber_handle(RecordingSubscriber::new(events.clone()));
+  let _subscription = stream.subscribe_with_key(ClassifierKey::Log, &subscriber);
+
+  stream.publish(&EventStreamEvent::Log(log_event("sync-publish", 1)));
+
+  let recorded = events.lock().clone();
+  assert_eq!(recorded.len(), 1);
+  assert!(matches!(&recorded[0], EventStreamEvent::Log(event) if event.message() == "sync-publish"));
+}
+
+#[test]
+fn subscriber_panic_propagates_without_automatic_unsubscribe() {
+  let stream = EventStreamShared::default();
+  let events = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let subscriber = subscriber_handle(PanicOnceSubscriber::new(events.clone()));
+  let _subscription = stream.subscribe_with_key(ClassifierKey::Log, &subscriber);
+
+  let first_publish = catch_unwind(AssertUnwindSafe(|| {
+    stream.publish(&EventStreamEvent::Log(log_event("panic-on-first", 1)));
+  }));
+  assert!(first_publish.is_err());
+
+  stream.publish(&EventStreamEvent::Log(log_event("still-subscribed", 2)));
+
+  let recorded = events.lock().clone();
+  assert_eq!(recorded.len(), 2);
+  assert!(matches!(&recorded[0], EventStreamEvent::Log(event) if event.message() == "panic-on-first"));
+  assert!(matches!(&recorded[1], EventStreamEvent::Log(event) if event.message() == "still-subscribed"));
 }
 
 #[test]

--- a/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
+++ b/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
@@ -105,10 +105,12 @@ impl EventStreamShared {
   /// Publishes the provided event to all registered subscribers.
   ///
   /// Subscribers are notified synchronously after releasing the lock to prevent
-  /// deadlocks. If a subscriber callback panics, the panic propagates to the
-  /// caller and remaining subscribers are not guaranteed to receive this event.
-  /// Panicking subscribers remain subscribed unless the caller explicitly
-  /// unsubscribes them.
+  /// deadlocks. When no callback panics, this method returns after every
+  /// subscriber in the publish snapshot has completed its callback. If a
+  /// subscriber callback panics, the panic propagates to the caller and
+  /// remaining subscribers are not guaranteed to receive this event. Panicking
+  /// subscribers remain subscribed unless the caller explicitly unsubscribes
+  /// them.
   pub fn publish(&self, event: &EventStreamEvent) {
     // ロック中に配送先を確定してから解放し、通知中の再入や競合で購読者集合がぶれないようにする。
     let subscribers = self.inner.with_write(|guard| guard.publish_prepare(event.clone()));

--- a/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
+++ b/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
@@ -107,6 +107,8 @@ impl EventStreamShared {
   /// Subscribers are notified synchronously after releasing the lock to prevent
   /// deadlocks. If a subscriber callback panics, the panic propagates to the
   /// caller and remaining subscribers are not guaranteed to receive this event.
+  /// Panicking subscribers remain subscribed unless the caller explicitly
+  /// unsubscribes them.
   pub fn publish(&self, event: &EventStreamEvent) {
     // ロック中に配送先を確定してから解放し、通知中の再入や競合で購読者集合がぶれないようにする。
     let subscribers = self.inner.with_write(|guard| guard.publish_prepare(event.clone()));

--- a/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
+++ b/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
@@ -108,9 +108,9 @@ impl EventStreamShared {
   /// deadlocks. When no callback panics, this method returns after every
   /// subscriber in the publish snapshot has completed its callback. If a
   /// subscriber callback panics, the panic propagates to the caller and
-  /// remaining subscribers are not guaranteed to receive this event. Panicking
-  /// subscribers remain subscribed unless the caller explicitly unsubscribes
-  /// them.
+  /// subscribers later in the same publish snapshot are not guaranteed to
+  /// receive this event. Panicking subscribers remain subscribed unless the
+  /// caller explicitly unsubscribes them.
   pub fn publish(&self, event: &EventStreamEvent) {
     // ロック中に配送先を確定してから解放し、通知中の再入や競合で購読者集合がぶれないようにする。
     let subscribers = self.inner.with_write(|guard| guard.publish_prepare(event.clone()));

--- a/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
+++ b/modules/actor-core-kernel/src/event/stream/event_stream_shared.rs
@@ -60,7 +60,10 @@ impl EventStreamShared {
   /// Subscribes with an explicit classifier and replays matching buffered events
   /// to the subscriber.
   ///
-  /// Events are replayed after releasing the lock to prevent deadlocks.
+  /// Matching buffered events are replayed synchronously before this method
+  /// returns. A concurrent publish from another thread may still interleave with
+  /// replay callbacks; strict cross-thread buffered-before-live ordering is not
+  /// part of this contract.
   #[must_use]
   pub fn subscribe_with_key(
     &self,
@@ -101,7 +104,9 @@ impl EventStreamShared {
 
   /// Publishes the provided event to all registered subscribers.
   ///
-  /// Subscribers are notified after releasing the lock to prevent deadlocks.
+  /// Subscribers are notified synchronously after releasing the lock to prevent
+  /// deadlocks. If a subscriber callback panics, the panic propagates to the
+  /// caller and remaining subscribers are not guaranteed to receive this event.
   pub fn publish(&self, event: &EventStreamEvent) {
     // ロック中に配送先を確定してから解放し、通知中の再入や競合で購読者集合がぶれないようにする。
     let subscribers = self.inner.with_write(|guard| guard.publish_prepare(event.clone()));

--- a/modules/actor-core-kernel/src/event/stream/event_stream_subscriber_shared.rs
+++ b/modules/actor-core-kernel/src/event/stream/event_stream_subscriber_shared.rs
@@ -25,6 +25,9 @@ impl EventStreamSubscriberShared {
   }
 
   /// Delivers an event to the wrapped subscriber under the subscriber lock.
+  ///
+  /// Callback panics are not caught here. A panic propagates to the caller and
+  /// does not mutate the subscription lifecycle by itself.
   pub fn notify(&self, event: &EventStreamEvent) {
     self.inner.with_lock(|subscriber| subscriber.on_event(event));
   }

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/.openspec.yaml
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
@@ -30,6 +30,8 @@ actor-core-kernel は no_std core であり、panic isolation を core contract 
 
 `EventStreamShared::subscribe_with_key` は write lock 中に subscriber registration と replay snapshot selection を行い、lock 解放後に snapshot を subscriber へ通知してから `EventStreamSubscription` を返す。このため、単一 thread / happens-before の範囲では、`subscribe_with_key` return 後に buffered replay は観測済みである。
 
+`subscribe_no_replay` は replay snapshot を持たない live-only registration として扱い、本 change の replay 同期通知契約には含めない。既存どおり return 時点で subscription registration は完了しているが、buffered event の同期観測は `subscribe_with_key` / `subscribe` の契約である。
+
 代替案として、登録前に replay を通知してから subscriber を追加する設計も考えられるが、replay と registration の間に publish された live event を落とすため採用しない。
 
 ### 決定 2: subscribe 中の並行 publish との厳密順序は保証しない

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
@@ -50,6 +50,8 @@ actor-core-kernel は no_std core であり、panic isolation を core contract 
 
 core 側で panic を catch しない。`publish()` 中に panic した callback 以降の subscriber への配送は保証しないが、panic した subscriber の subscription entry は自動削除しない。これは no_std core に std unwind boundary を持ち込まないための最小契約である。
 
+panic 後も subscription が残る契約は、subscriber lock guard が unwind 経路でも drop される現行 lock backend に依存する。lock poisoning のような std-only policy は本 change では導入しない。
+
 automatic unsubscribe は callback 実装者にとって便利に見えるが、panic と lifecycle policy を event stream が勝手に結合し、再現性の低い購読喪失を生むため採用しない。
 
 ## Risks / Trade-offs

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`EventStreamShared` は `EventStream` の write lock を短く保持し、callback は lock 解放後に同期実行する。subchannel change では classifier による配送先 snapshot と buffered replay filtering が実装済みだが、次の 3 点は仕様化されていない。
+
+- late subscriber が受ける replay と、同時に別 thread から publish される live event の順序
+- `publish()` が return した時点で subscriber callback が完了済みかどうか
+- subscriber callback が panic した場合に subscription を自動解除するかどうか
+
+actor-core-kernel は no_std core であり、panic isolation を core contract に入れると `std::panic::catch_unwind` や unwind safety boundary が混入する。現行の `EventStreamSubscriberShared::notify` は subscriber lock の中で callback を直接呼ぶため、panic は呼び出し元に伝播する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `subscribe_with_key` return 後には、登録時点で確定した replay snapshot が対象 subscriber へ同期通知済みであることを明文化する。
+- `publish` return 後には、panic が発生しない限り、対象 subscriber callback が同期完了済みであることを明文化する。
+- subscriber callback panic は catch せず、subscription を自動解除しない契約として固定する。
+- 契約を rustdoc と targeted tests で検証可能にする。
+
+**Non-Goals:**
+
+- subscribe 中の並行 publish に対する strict `buffered -> live` ordering の実装。
+- callback panic isolation、fail-fast policy registry、automatic unsubscribe policy の追加。
+- 非同期 flush queue や background dispatcher の追加。
+- `EventStreamSubscriber` trait の戻り値や error model の変更。
+
+## Decisions
+
+### 決定 1: replay は subscribe return 前の同期通知まで保証する
+
+`EventStreamShared::subscribe_with_key` は write lock 中に subscriber registration と replay snapshot selection を行い、lock 解放後に snapshot を subscriber へ通知してから `EventStreamSubscription` を返す。このため、単一 thread / happens-before の範囲では、`subscribe_with_key` return 後に buffered replay は観測済みである。
+
+代替案として、登録前に replay を通知してから subscriber を追加する設計も考えられるが、replay と registration の間に publish された live event を落とすため採用しない。
+
+### 決定 2: subscribe 中の並行 publish との厳密順序は保証しない
+
+現行実装は event stream lock を callback 実行中に保持しない。これにより deadlock risk を抑える一方、subscriber registration 後かつ replay callback 完了前に別 thread が publish した live event は、subscriber lock の獲得順によって replay と interleave し得る。これを strict `buffered -> live` にするには per-subscriber pending queue や replay barrier が必要で、current use case に対して重い。
+
+本 change では concurrent publish との厳密順序を保証しないことを仕様に書く。必要になった場合は、別 change で per-subscriber replay barrier を設計する。
+
+### 決定 3: publish は同期 callback 契約を維持する
+
+`EventStreamShared::publish` は write lock 中に event buffer と delivery target snapshot を確定し、lock 解放後に対象 subscriber を順に `notify` する。panic が発生しない限り、関数 return 時点で対象 subscriber の callback は完了済みである。
+
+非同期 flush queue を導入すると publish latency は下がるが、event stream の観測契約が actor mailbox delivery と混ざり、既存 tests と診断 subscriber の扱いが複雑になるため採用しない。
+
+### 決定 4: subscriber panic は呼び出し元へ伝播し subscription lifecycle を変更しない
+
+core 側で panic を catch しない。panic した callback 以降の subscriber への配送は保証しないが、panic した subscriber の subscription entry は自動削除しない。これは no_std core に std unwind boundary を持ち込まないための最小契約である。
+
+automatic unsubscribe は callback 実装者にとって便利に見えるが、panic と lifecycle policy を event stream が勝手に結合し、再現性の低い購読喪失を生むため採用しない。
+
+## Risks / Trade-offs
+
+- [Risk] subscribe 中の concurrent publish で live event が replay より先に callback される可能性が残る -> spec に非保証として明記し、strict ordering が必要な subscriber は subscribe 完了後に publisher を開始する運用にする。
+- [Risk] panic した subscriber が残るため、後続 publish でも再 panic し得る -> subscriber 側の責務として panic しない callback を実装し、event stream は lifecycle を勝手に変更しない。
+- [Risk] `publish` が同期 callback なので遅い subscriber が publisher をブロックする -> 既存 contract として維持し、非同期化は別 change で検討する。

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/design.md
@@ -4,7 +4,7 @@
 
 - late subscriber が受ける replay と、同時に別 thread から publish される live event の順序
 - `publish()` が return した時点で subscriber callback が完了済みかどうか
-- subscriber callback が panic した場合に subscription を自動解除するかどうか
+- `publish()` 中の subscriber callback が panic した場合に subscription を自動解除するかどうか
 
 actor-core-kernel は no_std core であり、panic isolation を core contract に入れると `std::panic::catch_unwind` や unwind safety boundary が混入する。現行の `EventStreamSubscriberShared::notify` は subscriber lock の中で callback を直接呼ぶため、panic は呼び出し元に伝播する。
 
@@ -14,7 +14,7 @@ actor-core-kernel は no_std core であり、panic isolation を core contract 
 
 - `subscribe_with_key` return 後には、登録時点で確定した replay snapshot が対象 subscriber へ同期通知済みであることを明文化する。
 - `publish` return 後には、panic が発生しない限り、対象 subscriber callback が同期完了済みであることを明文化する。
-- subscriber callback panic は catch せず、subscription を自動解除しない契約として固定する。
+- `publish()` 中の subscriber callback panic は catch せず、subscription を自動解除しない契約として固定する。
 - 契約を rustdoc と targeted tests で検証可能にする。
 
 **Non-Goals:**
@@ -44,9 +44,9 @@ actor-core-kernel は no_std core であり、panic isolation を core contract 
 
 非同期 flush queue を導入すると publish latency は下がるが、event stream の観測契約が actor mailbox delivery と混ざり、既存 tests と診断 subscriber の扱いが複雑になるため採用しない。
 
-### 決定 4: subscriber panic は呼び出し元へ伝播し subscription lifecycle を変更しない
+### 決定 4: publish 中の subscriber panic は呼び出し元へ伝播し subscription lifecycle を変更しない
 
-core 側で panic を catch しない。panic した callback 以降の subscriber への配送は保証しないが、panic した subscriber の subscription entry は自動削除しない。これは no_std core に std unwind boundary を持ち込まないための最小契約である。
+core 側で panic を catch しない。`publish()` 中に panic した callback 以降の subscriber への配送は保証しないが、panic した subscriber の subscription entry は自動削除しない。これは no_std core に std unwind boundary を持ち込まないための最小契約である。
 
 automatic unsubscribe は callback 実装者にとって便利に見えるが、panic と lifecycle policy を event stream が勝手に結合し、再現性の低い購読喪失を生むため採用しない。
 

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/proposal.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`EventStream` の subchannel 実装は classifier による配送絞り込みを満たしているが、late subscriber の replay と live publish の観測順序、`publish()` return 時点の同期契約、subscriber callback panic 時の購読ライフサイクルが仕様として未定義のまま残っている。これらを未規定にしたままだと、subscriber 実装や remote / cluster 側の診断 subscriber が、偶然の実装挙動に依存しやすくなる。
+
+## What Changes
+
+- `EventStreamShared::subscribe_with_key` は、登録時点で確定した buffered replay を `subscribe_with_key` が return する前に同期通知する契約として明文化する。
+- `subscribe_with_key` と同時に別 thread から実行される `publish()` については、replay と live event の厳密な cross-thread 順序を保証しない契約として明文化する。
+- `EventStreamShared::publish` は、panic が発生しない限り、対象 subscriber への callback が完了してから return する同期配送契約として明文化する。
+- subscriber callback panic は catch / isolate / automatic unsubscribe しない。panic は呼び出し元へ伝播し、subscription lifecycle は自動変更しない。
+- 上記契約に対応する tests と rustdoc を追加する。
+
+## Capabilities
+
+### New Capabilities
+
+なし。
+
+### Modified Capabilities
+
+- `pekko-eventstream-subchannel`: subchannel event stream の replay/live ordering、publish observation、subscriber panic lifecycle の契約を追加する。
+
+## Impact
+
+- `openspec/specs/pekko-eventstream-subchannel/spec.md` への delta spec
+- `modules/actor-core-kernel/src/event/stream/base_test.rs`
+- `modules/actor-core-kernel/src/event/stream/event_stream_shared.rs`
+- `modules/actor-core-kernel/src/event/stream/event_stream_subscriber_shared.rs`
+
+`actor-core-kernel` は no_std を維持する。panic isolation のための `std::panic::catch_unwind` は導入しない。

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/proposal.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/proposal.md
@@ -1,13 +1,13 @@
 ## Why
 
-`EventStream` の subchannel 実装は classifier による配送絞り込みを満たしているが、late subscriber の replay と live publish の観測順序、`publish()` return 時点の同期契約、subscriber callback panic 時の購読ライフサイクルが仕様として未定義のまま残っている。これらを未規定にしたままだと、subscriber 実装や remote / cluster 側の診断 subscriber が、偶然の実装挙動に依存しやすくなる。
+`EventStream` の subchannel 実装は classifier による配送絞り込みを満たしているが、late subscriber の replay と live publish の観測順序、`publish()` return 時点の同期契約、`publish()` 中の subscriber callback panic 時の購読ライフサイクルが仕様として未定義のまま残っている。これらを未規定にしたままだと、subscriber 実装や remote / cluster 側の診断 subscriber が、偶然の実装挙動に依存しやすくなる。
 
 ## What Changes
 
 - `EventStreamShared::subscribe_with_key` は、登録時点で確定した buffered replay を `subscribe_with_key` が return する前に同期通知する契約として明文化する。
 - `subscribe_with_key` と同時に別 thread から実行される `publish()` については、replay と live event の厳密な cross-thread 順序を保証しない契約として明文化する。
 - `EventStreamShared::publish` は、panic が発生しない限り、対象 subscriber への callback が完了してから return する同期配送契約として明文化する。
-- subscriber callback panic は catch / isolate / automatic unsubscribe しない。panic は呼び出し元へ伝播し、subscription lifecycle は自動変更しない。
+- `publish()` 中の subscriber callback panic は catch / isolate / automatic unsubscribe しない。panic は呼び出し元へ伝播し、subscription lifecycle は自動変更しない。
 - 上記契約に対応する tests と rustdoc を追加する。
 
 ## Capabilities
@@ -18,7 +18,7 @@
 
 ### Modified Capabilities
 
-- `pekko-eventstream-subchannel`: subchannel event stream の replay/live ordering、publish observation、subscriber panic lifecycle の契約を追加する。
+- `pekko-eventstream-subchannel`: subchannel event stream の replay/live ordering、publish observation、publish-time subscriber panic lifecycle の契約を追加する。
 
 ## Impact
 

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
@@ -32,9 +32,9 @@
 - **WHEN** subscriber callback が event stream の subscribe または unsubscribe を実行する
 - **THEN** その変更は進行中の publish の配送対象集合を変更しない
 
-### Requirement: subscriber panic は subscription lifecycle を自動変更してはならない
+### Requirement: publish 中の subscriber panic は subscription lifecycle を自動変更してはならない
 
-`EventStreamShared` は subscriber callback panic を catch / isolate してはならない（MUST NOT）。panic は `publish()` または replay 中の `subscribe_with_key()` 呼び出し元へ伝播しなければならず（MUST）、panic した subscriber の subscription は自動解除してはならない（MUST NOT）。panic 発生後に、panic した subscriber より後続の subscriber へ同じ event が配送されることは保証しない。
+`EventStreamShared::publish(event)` は subscriber callback panic を catch / isolate してはならない（MUST NOT）。panic は `publish()` 呼び出し元へ伝播しなければならず（MUST）、panic した subscriber の subscription は自動解除してはならない（MUST NOT）。panic 発生後に、panic した subscriber より後続の subscriber へ同じ event が配送されることは保証しない。
 
 #### Scenario: publish 中の subscriber panic は呼び出し元へ伝播する
 

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
@@ -4,7 +4,7 @@
 
 `EventStreamShared::subscribe_with_key(key, subscriber)` は、登録時点で key にマッチする buffered events の replay snapshot を確定し、`EventStreamSubscription` を返す前に対象 subscriber へ同期通知しなければならない（MUST）。この契約は subscribe 呼び出しと同じ thread の happens-before に限定され、subscribe 実行中に別 thread から実行される `publish()` との厳密な replay/live 順序は保証してはならない（MUST NOT）。
 
-`subscribe_no_replay(subscriber)` は replay snapshot を持たない live-only registration であり、この replay 同期通知契約の対象外である。buffered event の同期観測を必要とする caller は `subscribe_with_key` または `subscribe` を使用する。
+`subscribe_no_replay(subscriber)` は replay snapshot を持たない live-only registration であり、この replay 同期通知契約の対象外である。ただし、`EventStreamSubscription` を返す前に live registration は完了していなければならない（MUST）。buffered event の同期観測を必要とする caller は `subscribe_with_key` または `subscribe` を使用する。
 
 #### Scenario: subscribe return 後は replay が観測済み
 

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: subscribe replay は return 前に同期通知されなければならない
+
+`EventStreamShared::subscribe_with_key(key, subscriber)` は、登録時点で key にマッチする buffered events の replay snapshot を確定し、`EventStreamSubscription` を返す前に対象 subscriber へ同期通知しなければならない（MUST）。この契約は subscribe 呼び出しと同じ thread の happens-before に限定され、subscribe 実行中に別 thread から実行される `publish()` との厳密な replay/live 順序は保証してはならない（MUST NOT）。
+
+#### Scenario: subscribe return 後は replay が観測済み
+
+- **GIVEN** `EventStreamShared` に Log event が buffered 済みである
+- **WHEN** subscriber が `subscribe_with_key(ClassifierKey::Log, subscriber)` で登録され、その呼び出しが return する
+- **THEN** subscriber は buffered Log event を既に受信している
+
+#### Scenario: concurrent publish との replay/live 順序は未規定
+
+- **GIVEN** subscriber が `subscribe_with_key` で登録中である
+- **WHEN** 別 thread が同じ subscriber に match する live event を `publish()` する
+- **THEN** implementation は replay callback と live callback の厳密な `buffered -> live` 順序を保証しない
+
+### Requirement: publish は callback 完了を同期観測できなければならない
+
+`EventStreamShared::publish(event)` は、panic が発生しない限り、配送対象 snapshot に含まれる subscriber callback を同期実行し、すべての対象 callback が完了してから return しなければならない（MUST）。配送対象 snapshot は `publish()` の event stream lock 区間で確定され、callback 実行中の subscribe / unsubscribe によって当該 publish の対象集合を変更してはならない（MUST NOT）。
+
+#### Scenario: publish return 後は callback が完了済み
+
+- **GIVEN** subscriber が `ClassifierKey::Log` で購読済みである
+- **WHEN** caller が Log event を `publish()` し、その呼び出しが return する
+- **THEN** subscriber callback はその Log event を観測済みである
+
+#### Scenario: callback 中の購読変更は当該 publish の snapshot を変更しない
+
+- **GIVEN** publish target snapshot が確定済みである
+- **WHEN** subscriber callback が event stream の subscribe または unsubscribe を実行する
+- **THEN** その変更は進行中の publish の配送対象集合を変更しない
+
+### Requirement: subscriber panic は subscription lifecycle を自動変更してはならない
+
+`EventStreamShared` は subscriber callback panic を catch / isolate してはならない（MUST NOT）。panic は `publish()` または replay 中の `subscribe_with_key()` 呼び出し元へ伝播しなければならず（MUST）、panic した subscriber の subscription は自動解除してはならない（MUST NOT）。panic 発生後に、panic した subscriber より後続の subscriber へ同じ event が配送されることは保証しない。
+
+#### Scenario: publish 中の subscriber panic は呼び出し元へ伝播する
+
+- **GIVEN** subscriber callback が Log event で panic する
+- **WHEN** caller が Log event を `publish()` する
+- **THEN** panic は `publish()` の呼び出し元へ伝播する
+
+#### Scenario: panic した subscriber は自動解除されない
+
+- **GIVEN** subscriber callback が最初の Log event で panic する
+- **AND** caller がその panic を捕捉して処理を継続する
+- **WHEN** caller が次の Log event を `publish()` する
+- **THEN** 同じ subscriber は明示的に unsubscribe されていない限り次の Log event も受信する
+
+#### Scenario: panic 後の後続 subscriber 配送は保証されない
+
+- **GIVEN** panic する subscriber と別の subscriber が同じ key で購読済みである
+- **WHEN** panic する subscriber の callback が `publish()` 中に panic する
+- **THEN** implementation は同じ event を後続 subscriber へ配送することを保証しない

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/specs/pekko-eventstream-subchannel/spec.md
@@ -4,6 +4,8 @@
 
 `EventStreamShared::subscribe_with_key(key, subscriber)` は、登録時点で key にマッチする buffered events の replay snapshot を確定し、`EventStreamSubscription` を返す前に対象 subscriber へ同期通知しなければならない（MUST）。この契約は subscribe 呼び出しと同じ thread の happens-before に限定され、subscribe 実行中に別 thread から実行される `publish()` との厳密な replay/live 順序は保証してはならない（MUST NOT）。
 
+`subscribe_no_replay(subscriber)` は replay snapshot を持たない live-only registration であり、この replay 同期通知契約の対象外である。buffered event の同期観測を必要とする caller は `subscribe_with_key` または `subscribe` を使用する。
+
 #### Scenario: subscribe return 後は replay が観測済み
 
 - **GIVEN** `EventStreamShared` に Log event が buffered 済みである

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/tasks.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/tasks.md
@@ -1,0 +1,17 @@
+## 1. 契約文書化
+
+- [x] 1.1 `EventStreamShared::subscribe_with_key` の rustdoc に replay は return 前に同期通知されるが concurrent publish との厳密順序は未保証であることを追記する。
+- [x] 1.2 `EventStreamShared::publish` の rustdoc に callback 完了の同期観測契約と panic 伝播契約を追記する。
+- [x] 1.3 `EventStreamSubscriberShared::notify` の rustdoc に callback panic を catch せず subscription lifecycle を変更しないことを追記する。
+
+## 2. 回帰テスト
+
+- [x] 2.1 `subscribe_with_key` return 後に replay が観測済みであることを確認する test を追加する。
+- [x] 2.2 `publish` return 後に subscriber callback が観測済みであることを確認する test を追加する。
+- [x] 2.3 `publish` 中の subscriber panic が呼び出し元へ伝播し、subscription が自動解除されないことを確認する test を追加する。
+
+## 3. 検証
+
+- [x] 3.1 actor-core event stream の targeted tests を実行する。
+- [x] 3.2 `mise exec -- openspec validate define-eventstream-replay-publish-panic-contract --strict` を実行する。
+- [x] 3.3 `cargo fmt --check` または `cargo fmt` と `git diff --check` を実行する。

--- a/openspec/changes/define-eventstream-replay-publish-panic-contract/tasks.md
+++ b/openspec/changes/define-eventstream-replay-publish-panic-contract/tasks.md
@@ -9,6 +9,8 @@
 - [x] 2.1 `subscribe_with_key` return 後に replay が観測済みであることを確認する test を追加する。
 - [x] 2.2 `publish` return 後に subscriber callback が観測済みであることを確認する test を追加する。
 - [x] 2.3 `publish` 中の subscriber panic が呼び出し元へ伝播し、subscription が自動解除されないことを確認する test を追加する。
+- [x] 2.4 `publish` callback 中の unsubscribe が進行中 publish の配送 snapshot を変更しないことを確認する test を追加する。
+- [x] 2.5 `publish` callback 中の subscribe が進行中 publish の配送 snapshot を変更しないことを確認する test を追加する。
 
 ## 3. 検証
 


### PR DESCRIPTION
## Summary

- Add OpenSpec change `define-eventstream-replay-publish-panic-contract` for issue #1598.
- Document EventStream replay/live ordering, synchronous publish observation, publish snapshot stability, and publish-time subscriber panic lifecycle.
- Add targeted regression tests for replay-before-return, publish-before-return, subscribe/unsubscribe during publish snapshot stability, and panic propagation without automatic unsubscribe.

Closes #1598

## Validation

- `cargo test -p fraktor-actor-core-kernel-rs event::stream::base::tests -- --nocapture`
- `mise exec -- openspec validate define-eventstream-replay-publish-panic-contract --strict`
- `cargo fmt --check`
- `git diff --check`
- `./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds/clarifies documentation/specs and regression tests; runtime behavior is unchanged but expectations around replay ordering and panic propagation are now enforced by tests.
> 
> **Overview**
> **Defines and documents the `EventStreamShared` contract** around buffered replay, synchronous publish observation, publish snapshot stability, and subscriber-callback panic behavior.
> 
> Updates rustdoc to state that `subscribe_with_key` replays matching buffered events *before returning* (without guaranteeing strict replay-vs-live ordering across threads), and that `publish` is synchronous, uses a fixed snapshot for the publish, and **propagates subscriber panics without auto-unsubscribing**.
> 
> Adds targeted tests covering replay-before-return, publish-before-return, subscribe/unsubscribe during callback not affecting the current publish snapshot, and panic propagation while leaving the subscriber subscribed, plus an OpenSpec change package capturing these requirements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7516881a6e94d41625cbf686d167eb10bf9009ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **テスト**
  * イベント配信中の購読者の動作検証テストを拡張
  * コールバック内での購読管理とパニック時の伝播を検証

* **ドキュメント**
  * イベント再生と同期実行の動作を明確化
  * パニック発生時の購読者状態保持と例外処理の挙動を説明

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->