### PR TITLE
[codex] Propose Pekko persistence serialization change

### DIFF
--- a/openspec/changes/add-pekko-persistence-serialization/.openspec.yaml
+++ b/openspec/changes/add-pekko-persistence-serialization/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/add-pekko-persistence-serialization/design.md
+++ b/openspec/changes/add-pekko-persistence-serialization/design.md
@@ -26,6 +26,8 @@ Pekko keeps the plugin API typed around `PersistentRepr`, `AtomicWrite`, `Snapsh
 
    `AtomicWrite` SHALL contain a non-empty `Vec<PersistentRepr>` and SHALL validate that all entries use the same persistence id. It exposes `persistence_id`, `lowest_sequence_nr`, `highest_sequence_nr`, `size`, and `payload` accessors. This follows Pekko `AtomicWrite` and makes `persist_all` all-or-none semantics explicit. The alternative, keeping `Vec<PersistentRepr>`, leaves the atomicity boundary implicit and makes a Pekko-compatible `MessageSerializer` incomplete.
 
+   Journal implementations SHALL either persist each `AtomicWrite` atomically or reject it before any partial write when the backend cannot guarantee atomicity. This follows Pekko's plugin contract, where unsupported multi-event atomic writes are rejected instead of silently degrading to non-atomic behavior.
+
 2. Change journal write contracts to `AtomicWrite`.
 
    `Journal::write_messages` SHALL receive `&[AtomicWrite]`, and `JournalMessage::WriteMessages` SHALL carry `Vec<AtomicWrite>`. `JournalActor` responses can still emit per-`PersistentRepr` success/failure messages by iterating atomic writes. This is intentionally breaking because the project is pre-release and the old contract hides a domain invariant.
@@ -44,7 +46,7 @@ Pekko keeps the plugin API typed around `PersistentRepr`, `AtomicWrite`, `Snapsh
 
 6. Fail fast on persistence serializer registration collisions.
 
-   Persistence serializer IDs are runtime contracts. If an ID required by `MessageSerializer` or `SnapshotSerializer` is already occupied by a different serializer, bootstrap SHALL fail before binding persistence types. Re-registering the same persistence serializer set is idempotent. Silent skip is not allowed because it can bind `PersistentRepr`, `AtomicWrite`, or snapshot wrappers to an unintended serializer.
+   Persistence serializer IDs and persistence type bindings are runtime contracts. If an ID required by `MessageSerializer` or `SnapshotSerializer` is already occupied by a different serializer, or if a persistence type is already bound to a different serializer ID, bootstrap SHALL fail before binding persistence types. Re-registering the same persistence serializer set is idempotent. Silent skip or overwrite is not allowed because it can bind `PersistentRepr`, `AtomicWrite`, or snapshot wrappers to an unintended serializer.
 
 7. Use fraktor internal wire structures.
 
@@ -54,17 +56,18 @@ Pekko keeps the plugin API typed around `PersistentRepr`, `AtomicWrite`, `Snapsh
 
    `MessageSerializer` and `SnapshotSerializer` deserialize nested objects from durable `SerializedMessage` data, not from the caller's concrete Rust type hint. A nested serializer is eligible for the round-trip guarantee only when it can reconstruct the object from serializer id plus encoded manifest. Serializers that require an external type hint must fail with a serialization error instead of producing a partially typed or erased value.
 
-9. Keep runtime event adapter registries out of the durable wire format.
+9. Keep runtime replay context out of the durable wire format.
 
-   `PersistentRepr` contains an `EventAdapters` registry for runtime adaptation and an `adapter_type_id` for adapter resolution. The serializer SHALL preserve durable replay metadata, including `sender` and `adapter_type_id`, but SHALL NOT encode the `EventAdapters` registry internals because it contains runtime trait objects and configuration. Replay paths that require non-identity adapters must reattach the configured runtime registry around deserialized representations before adaptation.
+   `PersistentRepr` contains runtime-only replay context such as `sender`, an `EventAdapters` registry, and an `adapter_type_id` based on Rust `TypeId`. Journal serialization SHALL NOT encode those values as durable bytes. `sender` is ephemeral routing state and is cleared before journal writes. `EventAdapters` contains runtime trait objects and configuration. Rust `TypeId` is not stable across builds or deployments, so it cannot be a durable adapter lookup key. Replay paths that require non-identity adapters must resolve them from runtime configuration and stable payload metadata, or a future change must introduce an explicit stable adapter manifest before persisting adapter selection.
 
 ## Risks / Trade-offs
 
 - Breaking journal API changes → Update all in-tree `Journal` implementations, tests, and examples in the same change.
-- Serializer registration collisions → Use fixed runtime serializer IDs outside existing built-in IDs, make duplicate persistence registration idempotent, and fail fast when a different serializer occupies the required ID.
+- Backends without multi-entry atomic writes → Return an unsupported-operation journal error before writing any part of the `AtomicWrite`.
+- Serializer registration collisions → Use fixed runtime serializer IDs outside existing built-in IDs, make duplicate persistence registration idempotent, and fail fast when a different serializer occupies the required ID or a persistence type binding points elsewhere.
 - Installer ordering → Compose persistence serializer setup with custom serialization setup before extension instantiation so persistence does not accidentally install the default serialization extension first.
 - Nested payloads without registered serializers → Surface `SerializationError::NotSerializable` during persistence serialization; do not silently store erased payloads.
 - Nested payloads without manifest-resolvable deserialization → Surface a serialization error; do not overpromise round-trip for serializers that require a concrete type hint during decode.
-- Event adapter registry is runtime state → Preserve the adapter type id in bytes, and test that deserialization does not pretend to reconstruct the runtime adapter registry from durable data.
+- Runtime replay context is not durable state → Do not serialize sender, `EventAdapters`, or Rust `TypeId`; document any future stable adapter manifest separately before using it in durable bytes.
 - Snapshot naming collision with existing `snapshot::Snapshot` → Keep the existing public snapshot container and add a clearly scoped serialization wrapper type in a `serialization` module if a separate wrapper is required.
 - Byte-level incompatibility with Pekko → Document as a non-goal and keep field semantics close enough that a future protobuf-compatible serializer can be added without changing journal contracts again.

--- a/openspec/changes/add-pekko-persistence-serialization/design.md
+++ b/openspec/changes/add-pekko-persistence-serialization/design.md
@@ -46,10 +46,15 @@ Pekko keeps the plugin API typed around `PersistentRepr`, `AtomicWrite`, `Snapsh
 
    The persistence serializers SHALL encode enough metadata to round-trip `PersistentRepr`, `AtomicWrite`, and snapshot payload wrappers inside fraktor-rs. They do not need to match Pekko protobuf bytes. The nested payload representation SHOULD use existing `SerializedMessage` data (`serializer_id`, optional manifest, bytes) so all domain object evolution remains owned by the actor serialization registry.
 
+7. Keep runtime event adapter registries out of the durable wire format.
+
+   `PersistentRepr` contains an `EventAdapters` registry for runtime adaptation and an `adapter_type_id` for adapter resolution. The serializer SHALL preserve durable replay metadata, including `sender` and `adapter_type_id`, but SHALL NOT encode the `EventAdapters` registry internals because it contains runtime trait objects and configuration. Replay paths that require non-identity adapters must reattach the configured runtime registry around deserialized representations before adaptation.
+
 ## Risks / Trade-offs
 
 - Breaking journal API changes → Update all in-tree `Journal` implementations, tests, and examples in the same change.
 - Serializer registration collisions → Use fixed runtime serializer IDs outside existing built-in IDs and make registration idempotent with collision reporting consistent with existing built-ins.
 - Nested payloads without registered serializers → Surface `SerializationError::NotSerializable` during persistence serialization; do not silently store erased payloads.
+- Event adapter registry is runtime state → Preserve the adapter type id in bytes, and test that deserialization does not pretend to reconstruct the runtime adapter registry from durable data.
 - Snapshot naming collision with existing `snapshot::Snapshot` → Keep the existing public snapshot container and add a clearly scoped serialization wrapper type in a `serialization` module if a separate wrapper is required.
 - Byte-level incompatibility with Pekko → Document as a non-goal and keep field semantics close enough that a future protobuf-compatible serializer can be added without changing journal contracts again.

--- a/openspec/changes/add-pekko-persistence-serialization/design.md
+++ b/openspec/changes/add-pekko-persistence-serialization/design.md
@@ -1,0 +1,55 @@
+## Context
+
+Issue #529 covers the G-020 persistence serialization gap. Current fraktor-rs persistence has `PersistentRepr`, `Journal`, `Snapshot`, and `SnapshotStore`, but journal writes are represented as raw `Vec<PersistentRepr>` batches and snapshot / journal payloads remain erased `dyn Any` values without a durable serialization boundary.
+
+Pekko keeps the plugin API typed around `PersistentRepr`, `AtomicWrite`, `SnapshotMetadata`, and `SelectedSnapshot`. Durable stores such as LevelDB and LocalSnapshotStore serialize at the store boundary by calling the common `SerializationExtension`; the persistence serializers then delegate domain payload and metadata encoding to the configured serializer registry. This change ports that responsibility model, not the JVM protobuf byte format.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Represent journal atomicity with a public `AtomicWrite` type.
+- Make `Journal` and `JournalMessage::WriteMessages` use `AtomicWrite` units instead of unstructured `Vec<PersistentRepr>` batches.
+- Add `MessageSerializer` and `SnapshotSerializer` in `persistence-core-kernel` that implement the actor serialization `Serializer` contract.
+- Delegate nested payload and metadata serialization to the existing actor `SerializationRegistry` through `SerializationDelegator`.
+- Automatically register persistence serializers and bindings when `PersistenceExtensionInstaller` installs the persistence extension.
+- Preserve no_std core constraints by using `alloc` and existing actor-core serialization primitives.
+
+**Non-Goals:**
+- Pekko protobuf byte-level compatibility for `MessageFormats.proto`.
+- A disk-backed journal, local snapshot store, or `persistence-adaptor-std` crate.
+- JVM migration behavior such as Akka/Pekko manifest auto-migration.
+- Backward-compatible support for the pre-change `Vec<PersistentRepr>` write API.
+
+## Decisions
+
+1. Add `AtomicWrite` as a public persistence type.
+
+   `AtomicWrite` SHALL contain a non-empty `Vec<PersistentRepr>` and SHALL validate that all entries use the same persistence id. It exposes `persistence_id`, `lowest_sequence_nr`, `highest_sequence_nr`, `size`, and `payload` accessors. This follows Pekko `AtomicWrite` and makes `persist_all` all-or-none semantics explicit. The alternative, keeping `Vec<PersistentRepr>`, leaves the atomicity boundary implicit and makes a Pekko-compatible `MessageSerializer` incomplete.
+
+2. Change journal write contracts to `AtomicWrite`.
+
+   `Journal::write_messages` SHALL receive `&[AtomicWrite]`, and `JournalMessage::WriteMessages` SHALL carry `Vec<AtomicWrite>`. `JournalActor` responses can still emit per-`PersistentRepr` success/failure messages by iterating atomic writes. This is intentionally breaking because the project is pre-release and the old contract hides a domain invariant.
+
+3. Implement persistence serializers in `persistence-core-kernel`.
+
+   `persistence-core-kernel` already depends on `actor-core-kernel`, so the serializers can implement `fraktor_actor_core_kernel_rs::serialization::Serializer` without creating a dependency cycle. Placing them in actor-core would invert the domain dependency and make actor-core know persistence types.
+
+4. Use weak registry delegation for nested payloads.
+
+   `MessageSerializer` and `SnapshotSerializer` SHALL hold a `WeakShared<SerializationRegistry>`, matching the existing `MiscMessageSerializer` pattern. This avoids reference cycles because the registry stores serializer instances and the serializers need the registry for nested payload encode/decode.
+
+5. Register serializers from the persistence installer.
+
+   `PersistenceExtensionInstaller` SHALL ensure a `SerializationExtensionShared` exists via `default_serialization_extension_id()` and register persistence serializers plus type bindings against its registry. If a user installed a custom serialization extension first, put-if-absent extension semantics preserve that extension and persistence registration augments it.
+
+6. Use fraktor internal wire structures.
+
+   The persistence serializers SHALL encode enough metadata to round-trip `PersistentRepr`, `AtomicWrite`, and snapshot payload wrappers inside fraktor-rs. They do not need to match Pekko protobuf bytes. The nested payload representation SHOULD use existing `SerializedMessage` data (`serializer_id`, optional manifest, bytes) so all domain object evolution remains owned by the actor serialization registry.
+
+## Risks / Trade-offs
+
+- Breaking journal API changes → Update all in-tree `Journal` implementations, tests, and examples in the same change.
+- Serializer registration collisions → Use fixed runtime serializer IDs outside existing built-in IDs and make registration idempotent with collision reporting consistent with existing built-ins.
+- Nested payloads without registered serializers → Surface `SerializationError::NotSerializable` during persistence serialization; do not silently store erased payloads.
+- Snapshot naming collision with existing `snapshot::Snapshot` → Keep the existing public snapshot container and add a clearly scoped serialization wrapper type in a `serialization` module if a separate wrapper is required.
+- Byte-level incompatibility with Pekko → Document as a non-goal and keep field semantics close enough that a future protobuf-compatible serializer can be added without changing journal contracts again.

--- a/openspec/changes/add-pekko-persistence-serialization/design.md
+++ b/openspec/changes/add-pekko-persistence-serialization/design.md
@@ -11,7 +11,7 @@ Pekko keeps the plugin API typed around `PersistentRepr`, `AtomicWrite`, `Snapsh
 - Make `Journal` and `JournalMessage::WriteMessages` use `AtomicWrite` units instead of unstructured `Vec<PersistentRepr>` batches.
 - Add `MessageSerializer` and `SnapshotSerializer` in `persistence-core-kernel` that implement the actor serialization `Serializer` contract.
 - Delegate nested payload and metadata serialization to the existing actor `SerializationRegistry` through `SerializationDelegator`.
-- Automatically register persistence serializers and bindings when `PersistenceExtensionInstaller` installs the persistence extension.
+- Automatically contribute persistence serializers and bindings to the actor serialization extension during actor system bootstrap.
 - Preserve no_std core constraints by using `alloc` and existing actor-core serialization primitives.
 
 **Non-Goals:**
@@ -38,23 +38,33 @@ Pekko keeps the plugin API typed around `PersistentRepr`, `AtomicWrite`, `Snapsh
 
    `MessageSerializer` and `SnapshotSerializer` SHALL hold a `WeakShared<SerializationRegistry>`, matching the existing `MiscMessageSerializer` pattern. This avoids reference cycles because the registry stores serializer instances and the serializers need the registry for nested payload encode/decode.
 
-5. Register serializers from the persistence installer.
+5. Register serializers through an order-independent bootstrap contribution.
 
-   `PersistenceExtensionInstaller` SHALL ensure a `SerializationExtensionShared` exists via `default_serialization_extension_id()` and register persistence serializers plus type bindings against its registry. If a user installed a custom serialization extension first, put-if-absent extension semantics preserve that extension and persistence registration augments it.
+   `PersistenceExtensionInstaller` SHALL NOT create the default `SerializationExtension` as a side effect that can block a later custom `SerializationExtensionInstaller`. Instead, persistence SHALL contribute serializers, manifest routes, and type bindings to the final serialization setup before the serialization extension is instantiated, or augment an already-instantiated serialization extension only when no later custom serialization setup can be shadowed. Installing persistence before or after custom serialization setup must produce the same registry contents.
 
-6. Use fraktor internal wire structures.
+6. Fail fast on persistence serializer registration collisions.
+
+   Persistence serializer IDs are runtime contracts. If an ID required by `MessageSerializer` or `SnapshotSerializer` is already occupied by a different serializer, bootstrap SHALL fail before binding persistence types. Re-registering the same persistence serializer set is idempotent. Silent skip is not allowed because it can bind `PersistentRepr`, `AtomicWrite`, or snapshot wrappers to an unintended serializer.
+
+7. Use fraktor internal wire structures.
 
    The persistence serializers SHALL encode enough metadata to round-trip `PersistentRepr`, `AtomicWrite`, and snapshot payload wrappers inside fraktor-rs. They do not need to match Pekko protobuf bytes. The nested payload representation SHOULD use existing `SerializedMessage` data (`serializer_id`, optional manifest, bytes) so all domain object evolution remains owned by the actor serialization registry.
 
-7. Keep runtime event adapter registries out of the durable wire format.
+8. Limit nested payload round-trip guarantees to manifest-resolvable serializers.
+
+   `MessageSerializer` and `SnapshotSerializer` deserialize nested objects from durable `SerializedMessage` data, not from the caller's concrete Rust type hint. A nested serializer is eligible for the round-trip guarantee only when it can reconstruct the object from serializer id plus encoded manifest. Serializers that require an external type hint must fail with a serialization error instead of producing a partially typed or erased value.
+
+9. Keep runtime event adapter registries out of the durable wire format.
 
    `PersistentRepr` contains an `EventAdapters` registry for runtime adaptation and an `adapter_type_id` for adapter resolution. The serializer SHALL preserve durable replay metadata, including `sender` and `adapter_type_id`, but SHALL NOT encode the `EventAdapters` registry internals because it contains runtime trait objects and configuration. Replay paths that require non-identity adapters must reattach the configured runtime registry around deserialized representations before adaptation.
 
 ## Risks / Trade-offs
 
 - Breaking journal API changes → Update all in-tree `Journal` implementations, tests, and examples in the same change.
-- Serializer registration collisions → Use fixed runtime serializer IDs outside existing built-in IDs and make registration idempotent with collision reporting consistent with existing built-ins.
+- Serializer registration collisions → Use fixed runtime serializer IDs outside existing built-in IDs, make duplicate persistence registration idempotent, and fail fast when a different serializer occupies the required ID.
+- Installer ordering → Compose persistence serializer setup with custom serialization setup before extension instantiation so persistence does not accidentally install the default serialization extension first.
 - Nested payloads without registered serializers → Surface `SerializationError::NotSerializable` during persistence serialization; do not silently store erased payloads.
+- Nested payloads without manifest-resolvable deserialization → Surface a serialization error; do not overpromise round-trip for serializers that require a concrete type hint during decode.
 - Event adapter registry is runtime state → Preserve the adapter type id in bytes, and test that deserialization does not pretend to reconstruct the runtime adapter registry from durable data.
 - Snapshot naming collision with existing `snapshot::Snapshot` → Keep the existing public snapshot container and add a clearly scoped serialization wrapper type in a `serialization` module if a separate wrapper is required.
 - Byte-level incompatibility with Pekko → Document as a non-goal and keep field semantics close enough that a future protobuf-compatible serializer can be added without changing journal contracts again.

--- a/openspec/changes/add-pekko-persistence-serialization/proposal.md
+++ b/openspec/changes/add-pekko-persistence-serialization/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+fraktor-rs persistence currently stores `PersistentRepr` and `Snapshot` payloads as erased `dyn Any` values, which is sufficient for in-memory execution but does not define the Pekko-style serialization boundary needed by durable journal and snapshot store implementations.
+Issue #529 tracks this gap as G-020; closing it requires a first-class persistence serialization layer that delegates domain payload encoding to the existing actor serialization registry.
+
+## What Changes
+
+- Add Pekko-compatible persistence serialization concepts for `PersistentRepr`, `AtomicWrite`, and snapshot payload wrappers.
+- **BREAKING**: Change journal write contracts from raw `Vec<PersistentRepr>` batches to explicit `AtomicWrite` units so all-or-none write boundaries are represented in the public persistence API.
+- Register persistence serializers automatically when the persistence extension is installed, using the actor serialization extension as the nested payload serializer registry.
+- Keep byte-level compatibility with Pekko protobuf formats out of scope; this change targets responsibility/API compatibility under fraktor-rs no_std constraints.
+- Keep disk-backed journal and local snapshot store implementations out of scope; future std adapters can use the serializer contracts introduced here.
+
+## Capabilities
+
+### New Capabilities
+- `persistence-serialization`: Pekko-style persistence serialization contracts for journal records, atomic writes, and snapshot payload wrappers.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected crates: `modules/persistence-core-kernel`, `modules/actor-core-kernel`.
+- Affected APIs: `Journal`, `JournalMessage::WriteMessages`, `InMemoryJournal`, persistence extension installation, serialization registry runtime registration surface.
+- Affected tests: persistence journal actor tests, in-memory journal tests, serializer round-trip tests, no_std/check and relevant dylints.
+- References: Pekko `Persistent.scala`, `MessageSerializer.scala`, `SnapshotSerializer.scala`, `AsyncWriteJournal.scala`, `LeveldbStore.scala`, and `LocalSnapshotStore.scala`.

--- a/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
+++ b/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
@@ -27,11 +27,15 @@ The journal write contract SHALL accept batches of `AtomicWrite` units, and each
 - **THEN** replay returns the contained `PersistentRepr` entries in sequence order for the matching persistence id
 
 ### Requirement: Message serializer delegates persistent payloads
-The persistence kernel SHALL provide a `MessageSerializer` that serializes and deserializes `PersistentRepr` and `AtomicWrite` while delegating each persistent payload and metadata value to the actor serialization registry.
+The persistence kernel SHALL provide a `MessageSerializer` that serializes and deserializes `PersistentRepr` and `AtomicWrite` while delegating each persistent payload and metadata value to the actor serialization registry and preserving durable persistent representation metadata.
 
 #### Scenario: Persistent representation round trip
 - **WHEN** `MessageSerializer` serializes a `PersistentRepr` whose payload serializer is registered
-- **THEN** deserializing the bytes restores the persistence id, sequence number, manifest, writer uuid, timestamp, deleted flag, payload, and metadata values
+- **THEN** deserializing the bytes restores the persistence id, sequence number, manifest, writer uuid, timestamp, deleted flag, sender, adapter type id, payload, and metadata values
+
+#### Scenario: Runtime event adapter registry is not durable data
+- **WHEN** `MessageSerializer` serializes a `PersistentRepr` with a configured `EventAdapters` runtime registry
+- **THEN** deserializing the bytes preserves the adapter type id needed for replay adapter resolution without encoding the runtime registry internals
 
 #### Scenario: Atomic write round trip
 - **WHEN** `MessageSerializer` serializes an `AtomicWrite`

--- a/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
+++ b/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
@@ -30,7 +30,7 @@ The journal write contract SHALL accept batches of `AtomicWrite` units, and each
 The persistence kernel SHALL provide a `MessageSerializer` that serializes and deserializes `PersistentRepr` and `AtomicWrite` while delegating each persistent payload and metadata value to the actor serialization registry and preserving durable persistent representation metadata.
 
 #### Scenario: Persistent representation round trip
-- **WHEN** `MessageSerializer` serializes a `PersistentRepr` whose payload serializer is registered
+- **WHEN** `MessageSerializer` serializes a `PersistentRepr` whose payload and metadata serializers can deserialize from serializer id plus encoded manifest
 - **THEN** deserializing the bytes restores the persistence id, sequence number, manifest, writer uuid, timestamp, deleted flag, sender, adapter type id, payload, and metadata values
 
 #### Scenario: Runtime event adapter registry is not durable data
@@ -49,7 +49,7 @@ The persistence kernel SHALL provide a `MessageSerializer` that serializes and d
 The persistence kernel SHALL provide a `SnapshotSerializer` that serializes and deserializes snapshot payload wrappers while delegating snapshot data to the actor serialization registry.
 
 #### Scenario: Snapshot payload round trip
-- **WHEN** `SnapshotSerializer` serializes a snapshot payload wrapper whose data serializer is registered
+- **WHEN** `SnapshotSerializer` serializes a snapshot payload wrapper whose data serializer can deserialize from serializer id plus encoded manifest
 - **THEN** deserializing the bytes restores the wrapped snapshot data
 
 #### Scenario: Snapshot data serializer id is retained
@@ -57,15 +57,19 @@ The persistence kernel SHALL provide a `SnapshotSerializer` that serializes and 
 - **THEN** the encoded snapshot record contains the nested serializer id and manifest needed to deserialize through the actor serialization registry
 
 ### Requirement: Persistence installer registers serializers
-The persistence extension installer SHALL automatically register persistence serializers and type bindings with the actor serialization extension during actor system bootstrap.
+The persistence extension installer SHALL automatically register persistence serializers and type bindings with the actor serialization extension during actor system bootstrap without making custom serialization setup depend on installer insertion order.
 
 #### Scenario: Default serialization extension registration
-- **WHEN** a system installs `PersistenceExtensionInstaller` without a preinstalled serialization extension
-- **THEN** the installer registers the default serialization extension and then registers persistence serializers on it
+- **WHEN** a system installs `PersistenceExtensionInstaller` without custom serialization setup
+- **THEN** actor system bootstrap creates a serialization extension containing default actor serializers and persistence serializers
 
-#### Scenario: Existing serialization extension augmented
-- **WHEN** a system installs a custom serialization extension before `PersistenceExtensionInstaller`
-- **THEN** the persistence installer augments the existing serialization registry instead of replacing it
+#### Scenario: Custom serialization setup is order independent
+- **WHEN** a system installs both custom serialization setup and `PersistenceExtensionInstaller` in either insertion order
+- **THEN** actor system bootstrap creates one serialization extension containing the custom serializers, default actor serializers, and persistence serializers
+
+#### Scenario: Persistence serializer id collision rejected
+- **WHEN** persistence serializer registration finds a serializer id already occupied by a different serializer
+- **THEN** actor system bootstrap fails before binding persistence types to the occupied serializer id
 
 #### Scenario: Persistent messages serialize after persistence install
 - **WHEN** the persistence extension has been installed

--- a/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
+++ b/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
@@ -16,7 +16,7 @@ The persistence kernel SHALL expose an `AtomicWrite` type that represents one al
 - **THEN** creation fails without producing an atomic write
 
 ### Requirement: Journal writes use atomic writes
-The journal write contract SHALL accept batches of `AtomicWrite` units, and each `AtomicWrite` SHALL be persisted atomically by a journal implementation.
+The journal write contract SHALL accept batches of `AtomicWrite` units, and each `AtomicWrite` SHALL be persisted atomically by a journal implementation or rejected without partial persistence when the backend cannot guarantee atomicity.
 
 #### Scenario: Journal actor writes atomic batches
 - **WHEN** `JournalMessage::WriteMessages` is handled by `JournalActor`
@@ -26,16 +26,20 @@ The journal write contract SHALL accept batches of `AtomicWrite` units, and each
 - **WHEN** `InMemoryJournal` stores a batch of atomic writes
 - **THEN** replay returns the contained `PersistentRepr` entries in sequence order for the matching persistence id
 
+#### Scenario: Unsupported multi-event atomic write rejected
+- **WHEN** a journal backend receives a multi-entry `AtomicWrite` but cannot guarantee all-or-none persistence for that backend
+- **THEN** the journal returns a deterministic unsupported-operation error without persisting a prefix of the atomic write
+
 ### Requirement: Message serializer delegates persistent payloads
 The persistence kernel SHALL provide a `MessageSerializer` that serializes and deserializes `PersistentRepr` and `AtomicWrite` while delegating each persistent payload and metadata value to the actor serialization registry and preserving durable persistent representation metadata.
 
 #### Scenario: Persistent representation round trip
 - **WHEN** `MessageSerializer` serializes a `PersistentRepr` whose payload and metadata serializers can deserialize from serializer id plus encoded manifest
-- **THEN** deserializing the bytes restores the persistence id, sequence number, manifest, writer uuid, timestamp, deleted flag, sender, adapter type id, payload, and metadata values
+- **THEN** deserializing the bytes restores the persistence id, sequence number, manifest, writer uuid, timestamp, deleted flag, payload, and metadata values
 
-#### Scenario: Runtime event adapter registry is not durable data
-- **WHEN** `MessageSerializer` serializes a `PersistentRepr` with a configured `EventAdapters` runtime registry
-- **THEN** deserializing the bytes preserves the adapter type id needed for replay adapter resolution without encoding the runtime registry internals
+#### Scenario: Runtime replay context is not durable data
+- **WHEN** `MessageSerializer` serializes a journal `PersistentRepr` that was created from actor runtime context
+- **THEN** deserializing the bytes does not restore sender, the `EventAdapters` runtime registry, or a Rust `TypeId` adapter key from durable bytes
 
 #### Scenario: Atomic write round trip
 - **WHEN** `MessageSerializer` serializes an `AtomicWrite`
@@ -70,6 +74,10 @@ The persistence extension installer SHALL automatically register persistence ser
 #### Scenario: Persistence serializer id collision rejected
 - **WHEN** persistence serializer registration finds a serializer id already occupied by a different serializer
 - **THEN** actor system bootstrap fails before binding persistence types to the occupied serializer id
+
+#### Scenario: Persistence type binding collision rejected
+- **WHEN** persistence serializer registration finds `PersistentRepr`, `AtomicWrite`, or snapshot payload wrapper already bound to a different serializer id
+- **THEN** actor system bootstrap fails before overwriting the existing type binding
 
 #### Scenario: Persistent messages serialize after persistence install
 - **WHEN** the persistence extension has been installed

--- a/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
+++ b/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
@@ -73,7 +73,7 @@ The persistence extension installer SHALL automatically register persistence ser
 
 #### Scenario: Persistence serializer id collision rejected
 - **WHEN** persistence serializer registration finds a serializer id already occupied by a different serializer
-- **THEN** actor system bootstrap fails before binding persistence types to the occupied serializer id
+- **THEN** actor system bootstrap fails before registering persistence bindings that would resolve through the occupied serializer id
 
 #### Scenario: Persistence type binding collision rejected
 - **WHEN** persistence serializer registration finds `PersistentRepr`, `AtomicWrite`, or snapshot payload wrapper already bound to a different serializer id

--- a/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
+++ b/openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md
@@ -1,0 +1,79 @@
+## ADDED Requirements
+
+### Requirement: Atomic write boundary
+The persistence kernel SHALL expose an `AtomicWrite` type that represents one all-or-none journal write unit containing one or more `PersistentRepr` entries for a single persistence id.
+
+#### Scenario: Valid atomic write
+- **WHEN** an `AtomicWrite` is created from non-empty persistent representations with the same persistence id
+- **THEN** the atomic write exposes the persistence id, lowest sequence number, highest sequence number, size, and payload entries
+
+#### Scenario: Empty atomic write rejected
+- **WHEN** an `AtomicWrite` is created from an empty payload
+- **THEN** creation fails without producing an atomic write
+
+#### Scenario: Mixed persistence ids rejected
+- **WHEN** an `AtomicWrite` is created from persistent representations with different persistence ids
+- **THEN** creation fails without producing an atomic write
+
+### Requirement: Journal writes use atomic writes
+The journal write contract SHALL accept batches of `AtomicWrite` units, and each `AtomicWrite` SHALL be persisted atomically by a journal implementation.
+
+#### Scenario: Journal actor writes atomic batches
+- **WHEN** `JournalMessage::WriteMessages` is handled by `JournalActor`
+- **THEN** the actor passes atomic write units to `Journal::write_messages`
+
+#### Scenario: In-memory journal preserves atomic write entries
+- **WHEN** `InMemoryJournal` stores a batch of atomic writes
+- **THEN** replay returns the contained `PersistentRepr` entries in sequence order for the matching persistence id
+
+### Requirement: Message serializer delegates persistent payloads
+The persistence kernel SHALL provide a `MessageSerializer` that serializes and deserializes `PersistentRepr` and `AtomicWrite` while delegating each persistent payload and metadata value to the actor serialization registry.
+
+#### Scenario: Persistent representation round trip
+- **WHEN** `MessageSerializer` serializes a `PersistentRepr` whose payload serializer is registered
+- **THEN** deserializing the bytes restores the persistence id, sequence number, manifest, writer uuid, timestamp, deleted flag, payload, and metadata values
+
+#### Scenario: Atomic write round trip
+- **WHEN** `MessageSerializer` serializes an `AtomicWrite`
+- **THEN** deserializing the bytes restores an atomic write with the same contained persistent representations
+
+#### Scenario: Unregistered payload rejected
+- **WHEN** `MessageSerializer` serializes a persistent payload that has no matching actor serializer
+- **THEN** serialization fails with a serialization error instead of storing an erased value
+
+### Requirement: Snapshot serializer delegates snapshot data
+The persistence kernel SHALL provide a `SnapshotSerializer` that serializes and deserializes snapshot payload wrappers while delegating snapshot data to the actor serialization registry.
+
+#### Scenario: Snapshot payload round trip
+- **WHEN** `SnapshotSerializer` serializes a snapshot payload wrapper whose data serializer is registered
+- **THEN** deserializing the bytes restores the wrapped snapshot data
+
+#### Scenario: Snapshot data serializer id is retained
+- **WHEN** snapshot data is serialized
+- **THEN** the encoded snapshot record contains the nested serializer id and manifest needed to deserialize through the actor serialization registry
+
+### Requirement: Persistence installer registers serializers
+The persistence extension installer SHALL automatically register persistence serializers and type bindings with the actor serialization extension during actor system bootstrap.
+
+#### Scenario: Default serialization extension registration
+- **WHEN** a system installs `PersistenceExtensionInstaller` without a preinstalled serialization extension
+- **THEN** the installer registers the default serialization extension and then registers persistence serializers on it
+
+#### Scenario: Existing serialization extension augmented
+- **WHEN** a system installs a custom serialization extension before `PersistenceExtensionInstaller`
+- **THEN** the persistence installer augments the existing serialization registry instead of replacing it
+
+#### Scenario: Persistent messages serialize after persistence install
+- **WHEN** the persistence extension has been installed
+- **THEN** `PersistentRepr`, `AtomicWrite`, and snapshot payload wrappers can be resolved by the actor serialization registry
+
+### Requirement: Pekko responsibility compatibility
+The persistence serialization layer SHALL follow Pekko responsibility boundaries for `PersistentRepr`, `AtomicWrite`, message payload delegation, and snapshot payload delegation without requiring Pekko protobuf byte-level compatibility.
+
+#### Scenario: Durable store boundary
+- **WHEN** a future durable journal or snapshot store needs bytes
+- **THEN** it can call the actor serialization extension on persistence objects and rely on persistence serializers to delegate nested payloads
+
+#### Scenario: Pekko bytes are not required
+- **WHEN** bytes produced by Pekko JVM serializers are provided directly to fraktor-rs persistence serializers
+- **THEN** compatibility is not guaranteed by this capability

--- a/openspec/changes/add-pekko-persistence-serialization/tasks.md
+++ b/openspec/changes/add-pekko-persistence-serialization/tasks.md
@@ -1,0 +1,31 @@
+## 1. Atomic Write Contract
+
+- [ ] 1.1 Add `AtomicWrite` as a public persistence type with non-empty and single-persistence-id construction checks.
+- [ ] 1.2 Add focused unit tests for valid creation, empty payload rejection, mixed persistence id rejection, and sequence accessors.
+- [ ] 1.3 Update `Journal` to accept `&[AtomicWrite]` for write operations.
+- [ ] 1.4 Update `JournalMessage::WriteMessages`, `JournalActor`, and journal response paths to iterate atomic write payloads for per-event responses.
+- [ ] 1.5 Update `InMemoryJournal` and persistence tests/examples to use `AtomicWrite`.
+
+## 2. Persistence Serializer Types
+
+- [ ] 2.1 Add a `serialization` module under `persistence-core-kernel` with public `MessageSerializer` and `SnapshotSerializer` exports.
+- [ ] 2.2 Add any required persistence serialization wrapper type for snapshot data without conflicting with the existing `snapshot::Snapshot` container.
+- [ ] 2.3 Implement internal no_std encoding/decoding helpers for nested `SerializedMessage` records and persistence metadata fields.
+- [ ] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator`.
+- [ ] 2.5 Implement `SnapshotSerializer` for snapshot payload wrappers, delegating data through `SerializationDelegator`.
+- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, and unregistered payload failure.
+
+## 3. Automatic Registration
+
+- [ ] 3.1 Add persistence serializer ids and a registration helper that registers serializers and type bindings against `SerializationRegistry`.
+- [ ] 3.2 Expose the minimal actor serialization extension API needed to register serializer instances at runtime, following existing collision behavior.
+- [ ] 3.3 Update `PersistenceExtensionInstaller` to ensure the actor serialization extension exists and register persistence serializers before installing persistence actors.
+- [ ] 3.4 Add installer tests for default serialization extension creation and augmentation of an existing custom serialization extension.
+
+## 4. Documentation and Validation
+
+- [ ] 4.1 Update persistence gap analysis to mark `AtomicWrite`, `MessageSerializer`, and `SnapshotSerializer` according to the implemented scope.
+- [ ] 4.2 Run targeted persistence-core-kernel tests.
+- [ ] 4.3 Run serialization-related actor-core-kernel tests touched by runtime registration changes.
+- [ ] 4.4 Run `cargo fmt --check`.
+- [ ] 4.5 Run the relevant `./scripts/ci-check.sh ai ...` checks for persistence, no_std, and dylint coverage.

--- a/openspec/changes/add-pekko-persistence-serialization/tasks.md
+++ b/openspec/changes/add-pekko-persistence-serialization/tasks.md
@@ -5,15 +5,16 @@
 - [ ] 1.3 Update `Journal` to accept `&[AtomicWrite]` for write operations.
 - [ ] 1.4 Update `JournalMessage::WriteMessages`, `JournalActor`, and journal response paths to iterate atomic write payloads for per-event responses.
 - [ ] 1.5 Update `InMemoryJournal` and persistence tests/examples to use `AtomicWrite`.
+- [ ] 1.6 Add tests for backends that reject unsupported multi-entry atomic writes without partial persistence.
 
 ## 2. Persistence Serializer Types
 
 - [ ] 2.1 Add a `serialization` module under `persistence-core-kernel` with public `MessageSerializer` and `SnapshotSerializer` exports.
 - [ ] 2.2 Add any required persistence serialization wrapper type for snapshot data without conflicting with the existing `snapshot::Snapshot` container.
 - [ ] 2.3 Implement internal no_std encoding/decoding helpers for nested `SerializedMessage` records and persistence metadata fields.
-- [ ] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator` while preserving durable metadata including sender and adapter type id.
+- [ ] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator` while preserving durable metadata and excluding runtime-only sender, `EventAdapters`, and Rust `TypeId` adapter keys from durable bytes.
 - [ ] 2.5 Implement `SnapshotSerializer` for snapshot payload wrappers, delegating data through `SerializationDelegator`.
-- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, sender, adapter type id, runtime event adapter registry behavior, unregistered payload failure, and non-manifest-resolvable payload failure.
+- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, runtime replay context exclusion, unregistered payload failure, and non-manifest-resolvable payload failure.
 
 ## 3. Automatic Registration
 
@@ -21,7 +22,7 @@
 - [ ] 3.2 Define fail-fast collision handling for occupied persistence serializer ids and conflicting persistence type bindings.
 - [ ] 3.3 Expose the minimal actor serialization bootstrap API needed to compose persistence serializers with default and custom serialization setup before `SerializationExtension` instantiation.
 - [ ] 3.4 Update `PersistenceExtensionInstaller` to contribute persistence serializers without installing a default serialization extension that can shadow later custom setup.
-- [ ] 3.5 Add installer tests for default serialization extension creation, custom setup installed before persistence, custom setup installed after persistence, and serializer id collision failure.
+- [ ] 3.5 Add installer tests for default serialization extension creation, custom setup installed before persistence, custom setup installed after persistence, serializer id collision failure, and persistence type binding collision failure.
 
 ## 4. Documentation and Validation
 

--- a/openspec/changes/add-pekko-persistence-serialization/tasks.md
+++ b/openspec/changes/add-pekko-persistence-serialization/tasks.md
@@ -11,9 +11,9 @@
 - [ ] 2.1 Add a `serialization` module under `persistence-core-kernel` with public `MessageSerializer` and `SnapshotSerializer` exports.
 - [ ] 2.2 Add any required persistence serialization wrapper type for snapshot data without conflicting with the existing `snapshot::Snapshot` container.
 - [ ] 2.3 Implement internal no_std encoding/decoding helpers for nested `SerializedMessage` records and persistence metadata fields.
-- [ ] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator`.
+- [ ] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator` while preserving durable metadata including sender and adapter type id.
 - [ ] 2.5 Implement `SnapshotSerializer` for snapshot payload wrappers, delegating data through `SerializationDelegator`.
-- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, and unregistered payload failure.
+- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, sender, adapter type id, runtime event adapter registry behavior, and unregistered payload failure.
 
 ## 3. Automatic Registration
 

--- a/openspec/changes/add-pekko-persistence-serialization/tasks.md
+++ b/openspec/changes/add-pekko-persistence-serialization/tasks.md
@@ -13,14 +13,15 @@
 - [ ] 2.3 Implement internal no_std encoding/decoding helpers for nested `SerializedMessage` records and persistence metadata fields.
 - [ ] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator` while preserving durable metadata including sender and adapter type id.
 - [ ] 2.5 Implement `SnapshotSerializer` for snapshot payload wrappers, delegating data through `SerializationDelegator`.
-- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, sender, adapter type id, runtime event adapter registry behavior, and unregistered payload failure.
+- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, sender, adapter type id, runtime event adapter registry behavior, unregistered payload failure, and non-manifest-resolvable payload failure.
 
 ## 3. Automatic Registration
 
 - [ ] 3.1 Add persistence serializer ids and a registration helper that registers serializers and type bindings against `SerializationRegistry`.
-- [ ] 3.2 Expose the minimal actor serialization extension API needed to register serializer instances at runtime, following existing collision behavior.
-- [ ] 3.3 Update `PersistenceExtensionInstaller` to ensure the actor serialization extension exists and register persistence serializers before installing persistence actors.
-- [ ] 3.4 Add installer tests for default serialization extension creation and augmentation of an existing custom serialization extension.
+- [ ] 3.2 Define fail-fast collision handling for occupied persistence serializer ids and conflicting persistence type bindings.
+- [ ] 3.3 Expose the minimal actor serialization bootstrap API needed to compose persistence serializers with default and custom serialization setup before `SerializationExtension` instantiation.
+- [ ] 3.4 Update `PersistenceExtensionInstaller` to contribute persistence serializers without installing a default serialization extension that can shadow later custom setup.
+- [ ] 3.5 Add installer tests for default serialization extension creation, custom setup installed before persistence, custom setup installed after persistence, and serializer id collision failure.
 
 ## 4. Documentation and Validation
 


### PR DESCRIPTION
### **User description**
## Summary

- Proposes the OpenSpec change `add-pekko-persistence-serialization` for Issue #529 / G-020.
- Defines Pekko-style responsibility/API compatibility for persistence serialization.
- Captures the agreed design: first-class `AtomicWrite`, journal write contracts based on atomic write units, persistence `MessageSerializer` / `SnapshotSerializer`, and automatic serializer registration from the persistence installer.

## Scope

This PR only adds the OpenSpec proposal artifacts. Implementation is intentionally left to the follow-up apply phase.

Out of scope for this change proposal:
- Pekko protobuf byte-level compatibility.
- Disk-backed journal or local snapshot store implementation.
- Backward-compatible support for the current raw `Vec<PersistentRepr>` journal write API.

Refs #529

## Validation

- `mise exec -- openspec status --change add-pekko-persistence-serialization`
- `git diff --check -- openspec/changes/add-pekko-persistence-serialization`


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Proposes Pekko-style persistence serialization layer design

- Introduces `AtomicWrite` type for explicit journal atomicity boundaries

- Defines `MessageSerializer` and `SnapshotSerializer` contracts

- Establishes automatic serializer registration during bootstrap

- Documents durable persistence boundaries and wire format decisions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PersistentRepr<br/>AtomicWrite"] -->|MessageSerializer| B["SerializedMessage<br/>with metadata"]
  C["Snapshot<br/>payload"] -->|SnapshotSerializer| D["SerializedMessage<br/>with data"]
  B -->|delegates via| E["SerializationRegistry"]
  D -->|delegates via| E
  F["PersistenceExtensionInstaller"] -->|registers| E
  E -->|provides| G["Journal/SnapshotStore<br/>durable boundary"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.openspec.yaml</strong><dd><code>OpenSpec change metadata initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-pekko-persistence-serialization/.openspec.yaml

<ul><li>Initializes OpenSpec change metadata file<br> <li> Declares spec-driven schema type<br> <li> Records creation timestamp</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1862/files#diff-ccb04df921e526fbfc0d31387f4057f8f355258b14441d27d2637ead0de06c65">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>design.md</strong><dd><code>Comprehensive persistence serialization design specification</code></dd></summary>
<hr>

openspec/changes/add-pekko-persistence-serialization/design.md

<ul><li>Establishes context for G-020 persistence serialization gap<br> <li> Defines 9 key design decisions covering <code>AtomicWrite</code>, journal <br>contracts, serializer delegation, and bootstrap ordering<br> <li> Documents risks and trade-offs including breaking API changes and <br>collision handling<br> <li> Clarifies non-goals: Pekko protobuf compatibility, disk-backed <br>implementations, and JVM migration</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1862/files#diff-f7fada2b9ba15677a1a786c34dbc9d7171fa4facb9f8f1bda8a189d547a4a628">+73/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>proposal.md</strong><dd><code>High-level proposal and impact summary</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-pekko-persistence-serialization/proposal.md

<ul><li>Explains rationale for persistence serialization layer<br> <li> Summarizes breaking changes to journal write contracts<br> <li> Lists new capabilities and affected crates/APIs<br> <li> References Pekko implementation patterns for compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1862/files#diff-9de901e52d3bea5da9144614e557821d8f526fc675187ee1cbf18cf35292633e">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>spec.md</strong><dd><code>Formal requirements and acceptance scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-pekko-persistence-serialization/specs/persistence-serialization/spec.md

<ul><li>Defines 5 core requirements with BDD-style scenarios<br> <li> Specifies <code>AtomicWrite</code> validation and journal write contracts<br> <li> Documents <code>MessageSerializer</code> and <code>SnapshotSerializer</code> delegation behavior<br> <li> Establishes automatic registration and collision handling requirements<br> <li> Clarifies Pekko responsibility compatibility without byte-level <br>requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1862/files#diff-869fd9a7a5b191544c8c77b952e7c64822fd80dc0a2168a7c9892bc9521bd8e0">+95/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>tasks.md</strong><dd><code>Detailed implementation task breakdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

openspec/changes/add-pekko-persistence-serialization/tasks.md

<ul><li>Breaks implementation into 4 phases: atomic write contract, serializer <br>types, automatic registration, and validation<br> <li> Provides 33 granular checkboxes for implementation tracking<br> <li> Covers unit tests, integration tests, and CI validation steps<br> <li> Includes documentation updates and gap analysis closure</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1862/files#diff-da424871970d4312fd5bdc22e8c3eaa7271165a03e82e517154c5f327beffdaf">+33/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

