### PR TITLE
[codex] Skip code checks for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,23 +90,39 @@ jobs:
             exit 0
           fi
 
-          changed_paths="$(git diff --name-only "${base}" "${head}")"
-          if [[ -z "${changed_paths}" ]]; then
+          changed_entries="$(git diff --name-status -M "${base}" "${head}")"
+          if [[ -z "${changed_entries}" ]]; then
             echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
-          run_code_checks=false
-          while IFS= read -r path; do
-            case "${path}" in
-              *.md | openspec/*)
+          is_docs_only_path() {
+            case "$1" in
+              *.md | *.rst | *.txt | docs/* | openspec/* | README* | CHANGELOG* | LICENSE*)
+                return 0
                 ;;
               *)
-                run_code_checks=true
-                break
+                return 1
                 ;;
             esac
-          done <<< "${changed_paths}"
+          }
+
+          run_code_checks=false
+          while IFS=$'\t' read -r status path_a path_b; do
+            paths=("${path_a}")
+            case "${status}" in
+              R* | C*)
+                paths=("${path_a}" "${path_b}")
+                ;;
+            esac
+
+            for path in "${paths[@]}"; do
+              if ! is_docs_only_path "${path}"; then
+                run_code_checks=true
+                break 2
+              fi
+            done
+          done <<< "${changed_entries}"
 
           echo "run_code_checks=${run_code_checks}" >> "${GITHUB_OUTPUT}"
 
@@ -468,8 +484,12 @@ jobs:
             echo "changes failed"
             exit 1
           fi
-          if [[ "${run_code_checks}" != "true" && "${run_code_checks}" != "false" ]]; then
+          if [[ -z "${run_code_checks}" ]]; then
             echo "changes did not report run_code_checks"
+            exit 1
+          fi
+          if [[ "${run_code_checks}" != "true" && "${run_code_checks}" != "false" ]]; then
+            echo "changes reported invalid run_code_checks: ${run_code_checks}"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,23 @@ jobs:
             exit 0
           fi
 
+          changed_paths="$(git diff --name-only "${base}" "${head}")"
+          if [[ -z "${changed_paths}" ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
           run_code_checks=false
           while IFS= read -r path; do
-            if [[ "${path}" != *.md && "${path}" != openspec/* ]]; then
-              run_code_checks=true
-              break
-            fi
-          done < <(git diff --name-only "${base}" "${head}")
+            case "${path}" in
+              *.md | openspec/*)
+                ;;
+              *)
+                run_code_checks=true
+                break
+                ;;
+            esac
+          done <<< "${changed_paths}"
 
           echo "run_code_checks=${run_code_checks}" >> "${GITHUB_OUTPUT}"
 
@@ -289,7 +299,7 @@ jobs:
     needs:
       - changes
       - coverage
-    if: ${{ always() && needs.changes.outputs.run_code_checks == 'true' }}
+    if: ${{ always() && needs.changes.result == 'success' && needs.changes.outputs.run_code_checks == 'true' }}
     permissions:
       contents: read
       checks: read
@@ -454,32 +464,35 @@ jobs:
             exit 1
           fi
           run_code_checks="${{ needs.changes.outputs.run_code_checks }}"
-          if [[ "${run_code_checks}" == "true" && "${{ needs.lint.result }}" != "success" ]]; then
-            echo "lint failed"
+          if [[ "${{ needs.changes.result }}" != "success" ]]; then
+            echo "changes failed"
             exit 1
           fi
-          if [[ "${run_code_checks}" == "true" && "${{ needs.test.result }}" != "success" ]]; then
-            echo "test failed"
+          if [[ "${run_code_checks}" != "true" && "${run_code_checks}" != "false" ]]; then
+            echo "changes did not report run_code_checks"
             exit 1
           fi
-          if [[ "${run_code_checks}" == "true" && "${{ needs['integration-e2e'].result }}" != "success" ]]; then
-            echo "integration-e2e failed"
-            exit 1
+
+          expected_code_job_result="skipped"
+          if [[ "${run_code_checks}" == "true" ]]; then
+            expected_code_job_result="success"
           fi
-          if [[ "${run_code_checks}" == "true" && "${{ needs.coverage.result }}" != "success" ]]; then
-            echo "coverage failed"
-            exit 1
-          fi
-          if [[ "${run_code_checks}" == "true" && "${{ needs['codecov-status'].result }}" != "success" ]]; then
-            echo "codecov-status failed"
-            exit 1
-          fi
-          if [[ "${run_code_checks}" == "true" && "${{ needs.docs.result }}" != "success" ]]; then
-            echo "docs failed"
-            exit 1
-          fi
-          if [[ "${run_code_checks}" == "true" && "${{ needs.examples.result }}" != "success" ]]; then
-            echo "examples failed"
-            exit 1
-          fi
+
+          require_result() {
+            local name="$1"
+            local actual="$2"
+            local expected="$3"
+            if [[ "${actual}" != "${expected}" ]]; then
+              echo "${name} was ${actual}; expected ${expected}"
+              exit 1
+            fi
+          }
+
+          require_result "lint" "${{ needs.lint.result }}" "${expected_code_job_result}"
+          require_result "test" "${{ needs.test.result }}" "${expected_code_job_result}"
+          require_result "integration-e2e" "${{ needs['integration-e2e'].result }}" "${expected_code_job_result}"
+          require_result "coverage" "${{ needs.coverage.result }}" "${expected_code_job_result}"
+          require_result "codecov-status" "${{ needs['codecov-status'].result }}" "${expected_code_job_result}"
+          require_result "docs" "${{ needs.docs.result }}" "${expected_code_job_result}"
+          require_result "examples" "${{ needs.examples.result }}" "${expected_code_job_result}"
           echo "✅ All CI checks passed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,12 @@ jobs:
             head="${HEAD_SHA}"
           fi
 
-          if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+          if [[ -z "${base}" ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [[ "${base}" =~ ^0+$ ]]; then
             echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
@@ -97,14 +102,15 @@ jobs:
           fi
 
           is_docs_only_path() {
-            case "$1" in
-              *.md | *.rst | *.txt | docs/* | openspec/* | README* | CHANGELOG* | LICENSE*)
-                return 0
-                ;;
-              *)
-                return 1
-                ;;
-            esac
+            local path="$1"
+            [[ "${path}" == *.md \
+              || "${path}" == *.rst \
+              || "${path}" == *.txt \
+              || "${path}" == docs/* \
+              || "${path}" == openspec/* \
+              || "${path}" == README* \
+              || "${path}" == CHANGELOG* \
+              || "${path}" == LICENSE* ]]
           }
 
           run_code_checks=false
@@ -474,12 +480,14 @@ jobs:
     if: always()
     steps:
       - name: All checks passed
+        env:
+          RUN_CODE_CHECKS: ${{ needs.changes.outputs.run_code_checks }}
         run: |
           if [[ "${{ needs.format.result }}" != "success" ]]; then
             echo "format failed"
             exit 1
           fi
-          run_code_checks="${{ needs.changes.outputs.run_code_checks }}"
+          run_code_checks="${RUN_CODE_CHECKS}"
           if [[ "${{ needs.changes.result }}" != "success" ]]; then
             echo "changes failed"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,52 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  changes:
+    name: Detect CI-relevant changes
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
+    outputs:
+      run_code_checks: ${{ steps.filter.outputs.run_code_checks }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Detect changed paths
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "schedule" || "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            base="${BASE_SHA}"
+            head="${HEAD_SHA}"
+          else
+            base="${BEFORE_SHA}"
+            head="${HEAD_SHA}"
+          fi
+
+          if [[ -z "${base}" || "${base}" =~ ^0+$ ]]; then
+            echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          run_code_checks=false
+          while IFS= read -r path; do
+            if [[ "${path}" != *.md && "${path}" != openspec/* ]]; then
+              run_code_checks=true
+              break
+            fi
+          done < <(git diff --name-only "${base}" "${head}")
+
+          echo "run_code_checks=${run_code_checks}" >> "${GITHUB_OUTPUT}"
+
   # Format check (fastest, prerequisite for other jobs)
   format:
     name: Format Check
@@ -78,7 +124,10 @@ jobs:
   lint:
     name: Lint Check
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: format
+    needs:
+      - changes
+      - format
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     strategy:
       matrix:
         check:
@@ -113,7 +162,10 @@ jobs:
   test:
     name: Test (${{ matrix.target.name }})
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: format
+    needs:
+      - changes
+      - format
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     env:
       TEST_TIME_FACTOR: "2.0"
     strategy:
@@ -152,7 +204,10 @@ jobs:
   integration-e2e:
     name: Integration / E2E
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: test
+    needs:
+      - changes
+      - test
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     env:
       TEST_TIME_FACTOR: "2.0"
       CI_CHECK_GUARD_TIMEOUT_INTEGRATION_SEC: "5400"
@@ -182,7 +237,10 @@ jobs:
   coverage:
     name: Coverage Report
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: integration-e2e
+    needs:
+      - changes
+      - integration-e2e
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     permissions:
       contents: read
       id-token: write
@@ -228,8 +286,10 @@ jobs:
   codecov-status:
     name: Codecov Status
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: coverage
-    if: always()
+    needs:
+      - changes
+      - coverage
+    if: ${{ always() && needs.changes.outputs.run_code_checks == 'true' }}
     permissions:
       contents: read
       checks: read
@@ -325,7 +385,10 @@ jobs:
   docs:
     name: Documentation
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: format
+    needs:
+      - changes
+      - format
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -347,7 +410,10 @@ jobs:
   examples:
     name: Examples
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
-    needs: format
+    needs:
+      - changes
+      - format
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -370,6 +436,7 @@ jobs:
     name: CI Success
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     needs:
+      - changes
       - format
       - lint
       - test
@@ -386,31 +453,32 @@ jobs:
             echo "format failed"
             exit 1
           fi
-          if [[ "${{ needs.lint.result }}" != "success" ]]; then
+          run_code_checks="${{ needs.changes.outputs.run_code_checks }}"
+          if [[ "${run_code_checks}" == "true" && "${{ needs.lint.result }}" != "success" ]]; then
             echo "lint failed"
             exit 1
           fi
-          if [[ "${{ needs.test.result }}" != "success" ]]; then
+          if [[ "${run_code_checks}" == "true" && "${{ needs.test.result }}" != "success" ]]; then
             echo "test failed"
             exit 1
           fi
-          if [[ "${{ needs['integration-e2e'].result }}" != "success" ]]; then
+          if [[ "${run_code_checks}" == "true" && "${{ needs['integration-e2e'].result }}" != "success" ]]; then
             echo "integration-e2e failed"
             exit 1
           fi
-          if [[ "${{ needs.coverage.result }}" != "success" ]]; then
+          if [[ "${run_code_checks}" == "true" && "${{ needs.coverage.result }}" != "success" ]]; then
             echo "coverage failed"
             exit 1
           fi
-          if [[ "${{ needs['codecov-status'].result }}" != "success" ]]; then
+          if [[ "${run_code_checks}" == "true" && "${{ needs['codecov-status'].result }}" != "success" ]]; then
             echo "codecov-status failed"
             exit 1
           fi
-          if [[ "${{ needs.docs.result }}" != "success" ]]; then
+          if [[ "${run_code_checks}" == "true" && "${{ needs.docs.result }}" != "success" ]]; then
             echo "docs failed"
             exit 1
           fi
-          if [[ "${{ needs.examples.result }}" != "success" ]]; then
+          if [[ "${run_code_checks}" == "true" && "${{ needs.examples.result }}" != "success" ]]; then
             echo "examples failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "${base}" =~ ^0+$ ]]; then
+          if [[ "${base}" =~ ^0{40}$ ]]; then
             echo "run_code_checks=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
@@ -492,19 +492,18 @@ jobs:
             echo "changes failed"
             exit 1
           fi
-          if [[ -z "${run_code_checks}" ]]; then
-            echo "changes did not report run_code_checks"
-            exit 1
-          fi
-          if [[ "${run_code_checks}" != "true" && "${run_code_checks}" != "false" ]]; then
-            echo "changes reported invalid run_code_checks: ${run_code_checks}"
-            exit 1
-          fi
-
-          expected_code_job_result="skipped"
-          if [[ "${run_code_checks}" == "true" ]]; then
-            expected_code_job_result="success"
-          fi
+          case "${run_code_checks}" in
+            true)
+              expected_code_job_result="success"
+              ;;
+            false)
+              expected_code_job_result="skipped"
+              ;;
+            *)
+              echo "changes did not report valid run_code_checks: ${run_code_checks}"
+              exit 1
+              ;;
+          esac
 
           require_result() {
             local name="$1"


### PR DESCRIPTION
### **User description**
## Summary

- Add a `changes` job to detect whether a CI run only touches Markdown files or `openspec/**`.
- Skip code-heavy jobs for docs-only/OpenSpec-only changes: lint, test, integration-e2e, coverage, Codecov status, docs, and examples.
- Keep scheduled and manually dispatched CI runs on the full check path.
- Let `CI Success` accept skipped code-heavy jobs when the change detector marks the run as docs-only.

## Validation

- `mise exec -- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`
- `git diff --check -- .github/workflows/ci.yml`

`actionlint` was not available locally, so it was not run.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `changes` job to detect CI-relevant file modifications

- Skip code-heavy jobs for docs-only and OpenSpec-only changes

- Keep scheduled and manually dispatched runs on full check path

- Harden CI gate logic with improved result validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  changes["changes: Detect<br/>file modifications"]
  format["format: Format Check"]
  lint["lint: Lint Check"]
  test["test: Unit Tests"]
  integration["integration-e2e:<br/>Integration/E2E"]
  coverage["coverage: Coverage"]
  codecov["codecov-status:<br/>Codecov Status"]
  docs["docs: Documentation"]
  examples["examples: Examples"]
  ci_success["ci-success:<br/>CI Success Gate"]
  
  changes -->|run_code_checks| lint
  changes -->|run_code_checks| test
  changes -->|run_code_checks| integration
  changes -->|run_code_checks| coverage
  changes -->|run_code_checks| codecov
  changes -->|run_code_checks| docs
  changes -->|run_code_checks| examples
  format --> lint
  format --> test
  format --> docs
  format --> examples
  test --> integration
  integration --> coverage
  coverage --> codecov
  lint --> ci_success
  test --> ci_success
  integration --> ci_success
  coverage --> ci_success
  codecov --> ci_success
  docs --> ci_success
  examples --> ci_success
  changes --> ci_success
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Add change detection and conditional job skipping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Add new <code>changes</code> job that detects whether PR only modifies <br>documentation files (<code>.md</code>, <code>.rst</code>, <code>.txt</code>, <code>docs/</code>, <code>openspec/</code>, <code>README*</code>, <br><code>CHANGELOG*</code>, <code>LICENSE*</code>)<br> <li> Add conditional <code>if</code> statements to skip code-heavy jobs (<code>lint</code>, <code>test</code>, <br><code>integration-e2e</code>, <code>coverage</code>, <code>codecov-status</code>, <code>docs</code>, <code>examples</code>) when <br><code>run_code_checks</code> is false<br> <li> Always run code checks for scheduled and manually dispatched workflows<br> <li> Refactor <code>ci-success</code> job to validate that skipped jobs have correct <br>result status based on change detection</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1864/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+142/-34</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

