### PR TITLE
Add Pekko-style persistence serialization

### DIFF
--- a/docs/gap-analysis/persistence-gap-analysis.md
+++ b/docs/gap-analysis/persistence-gap-analysis.md
@@ -62,7 +62,7 @@ classic write-side persistence は、persistent actor、journal、snapshot、eve
 
 | 層 | Pekko 対応範囲 | fraktor-rs 現状 | 評価 |
 |----|----------------|-----------------|------|
-| core / classic write-side | `PersistentActor`, `Eventsourced`, `Recovery`, journal, snapshot, adapter, delivery, durable state store | `Eventsourced`, `PersistentActor`, `Journal`, `SnapshotStore`, `EventAdapters`, `AtLeastOnceDelivery`, `DurableStateStore` が存在 | 主要契約は中程度以上に対応。AtomicWrite、revision、serializer、設定型が不足 |
+| core / classic write-side | `PersistentActor`, `Eventsourced`, `Recovery`, journal, snapshot, adapter, delivery, durable state store | `Eventsourced`, `PersistentActor`, `Journal`, `AtomicWrite`, `SnapshotStore`, `EventAdapters`, `AtLeastOnceDelivery`, `DurableStateStore` が存在 | 主要契約は中程度以上に対応。revision、std serializer backend、設定型が不足 |
 | core / typed write-side | `EventSourcedBehavior`, `Effect`, signal, typed recovery / retention, `DurableStateBehavior` | `fraktor-persistence-core-typed-rs` が `PersistenceEffector`, `PersistenceEffectorConfig`, `PersistenceEffectorSignal`, `PersistenceMode`, `SnapshotCriteria`, `RetentionCriteria`, `BackoffConfig`, `PersistenceEffectorMessageAdapter`, `Recovery`, `SnapshotSelectionCriteria`, `EventAdapter`, `EventSeq`, `SnapshotAdapter`, `DurableStateSignal` を提供 | effector-first と Phase 1 typed parity surface は実装済み。Pekko 互換の behavior DSL と typed durable state behavior は未実装 |
 | std / adaptor | local snapshot store、runtime plugin adapter | 対応 crate なし。in-memory store は kernel に存在 | ファイル IO / runtime adapter は未対応 |
 
@@ -79,7 +79,7 @@ fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventso
 | `RecoveryCompleted` signal type | `PersistentActor.scala:29`, `PersistentActor.scala:35` | 実装済み / non-goal | core | n/a | classic は `on_recovery_completed` callback と internal `JournalResponseAction::RecoveryCompleted` で表現済み。typed は `PersistenceEffectorSignal::RecoveryCompleted` を公開済み。Pekko 同名の classic 公開型追加は現設計では不要 |
 | `SnapshotOffer` | `SnapshotProtocol.scala:157` | 実装済み | core | done | `SnapshotOffer` と `receive_snapshot_offer` を追加し、既存 `receive_snapshot` callback と互換 |
 | `PersistenceSettings` | `Persistence.scala:40` | 実装済み | core/config | done | `PersistenceSettings` が `JournalActorConfig` / `SnapshotActorConfig` を束ね、store actor retry 設定を公開 |
-| `AtomicWrite` | `Persistent.scala:45`, `Persistent.scala:49` | 部分実装 | core/journal | medium | `JournalMessage::WriteMessages` は `Vec<PersistentRepr>` を送るが、原子書き込み単位を表す公開型がない |
+| `AtomicWrite` | `Persistent.scala:45`, `Persistent.scala:49` | 実装済み | core/journal | done | `AtomicWrite` が非空・単一 persistence id を検証し、`Journal` / `JournalMessage::WriteMessages` は atomic write 単位を受ける |
 
 ### 2. Journal / snapshot store protocol　✅ 実装済み 13/16 (81%)
 
@@ -91,14 +91,14 @@ fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventso
 | `LocalSnapshotStore` | `snapshot/local/LocalSnapshotStore.scala:40` | 未対応 | std/snapshot | medium | ファイルシステム依存。core ではなく std adapter が妥当 |
 | snapshot retry settings の公開契約 | `Persistence.scala:40`, `SnapshotProtocol.scala:235` | 実装済み | core/config | done | `SnapshotActorConfig` を `PersistenceSettings` から渡せる。plugin settings は fraktor-rs の trait 実装注入モデルでは non-goal |
 
-### 3. Persistent representation / adapters / serialization　✅ 実装済み 11/14 (79%)
+### 3. Persistent representation / adapters / serialization　✅ 実装済み 13/14 (93%)
 
 `PersistentRepr` は persistence id、sequence number、manifest、writer uuid、timestamp、deleted、sender、metadata を保持する。`WriteEventAdapter`、`ReadEventAdapter`、`IdentityEventAdapter`、`EventSeq`、`EventAdapters`、`Tagged` も存在する。根拠は `modules/persistence-core-kernel/src/persistent/persistent_repr.rs:20`、`modules/persistence-core-kernel/src/journal/write_event_adapter.rs:13`、`modules/persistence-core-kernel/src/journal/read_event_adapter.rs:14`、`modules/persistence-core-kernel/src/journal/event_adapters.rs:20`、`modules/persistence-core-kernel/src/journal/tagged.rs:16`。
 
 | Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
 |------------------|-----------|-------------|----------|--------|------|
-| `MessageSerializer` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/serialization/MessageSerializer.scala:43` | 未対応 | kernel/serialization | medium | `PersistentRepr` / `AtomicWrite` / journal protocol の serialization contract がない |
-| `SnapshotSerializer` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala:56` | 未対応 | kernel/serialization | medium | snapshot payload と metadata の serialization contract がない |
+| `MessageSerializer` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/serialization/MessageSerializer.scala:43` | 実装済み | kernel/serialization | done | `PersistentRepr` / `AtomicWrite` を actor serialization registry 経由で payload / metadata へ委譲する。Pekko protobuf byte 互換は non-goal |
+| `SnapshotSerializer` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala:56` | 実装済み | kernel/serialization | done | `SnapshotPayload` wrapper を追加し、snapshot data を actor serialization registry 経由で委譲する。local snapshot store は未対応 |
 | adapter manifest と serializer manifest の接続 | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapter.scala:42` | 部分実装 | kernel/serialization | medium | `WriteEventAdapter::manifest` 相当は `modules/persistence-core-kernel/src/journal/write_event_adapter.rs:17` にあるが、永続化 serializer registry との接続点がない |
 
 ### 4. At-least-once delivery / unconfirmed delivery　✅ 実装済み 6/7 (86%)
@@ -200,10 +200,7 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 
 | 項目 | 実装先層 | 根拠 |
 |------|----------|------|
-| `AtomicWrite` | core/journal | カテゴリ1 |
 | `LocalSnapshotStore` | std/snapshot | カテゴリ2 |
-| `MessageSerializer` | core/serialization | カテゴリ3 |
-| `SnapshotSerializer` | core/serialization | カテゴリ3 |
 | adapter manifest と serializer manifest の接続 | core/serialization | カテゴリ3 |
 | revision / tag aware update store | core/durable_state | カテゴリ5 |
 | plugin target location / proxy extension semantics | core/plugin + std/runtime | カテゴリ6 |
@@ -221,14 +218,14 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 
 ## 内部モジュール構造ギャップ
 
-今回は API ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 58/80 (73%) で、特に typed `EventSourcedBehavior` direct DSL、typed `DurableStateBehavior`、serialization contract、durable state revision model が未達である。責務分割の細部比較より先に、behavior DSL と storage / serialization contract の境界を決める段階である。
+今回は API ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 61/80 (76%) で、特に typed `EventSourcedBehavior` direct DSL、typed `DurableStateBehavior`、std durable serializer backend、durable state revision model が未達である。責務分割の細部比較より先に、behavior DSL と storage backend contract の境界を決める段階である。
 
 次版で構造分析へ進む場合の観点は以下になる。
 
 | 構造観点 | 現状 | 次に見るべき点 |
 |----------|------|----------------|
 | classic と typed の境界 | `persistence-core-kernel` が classic runtime、`persistence-core-typed` が effector-first typed API を担当 | typed `DurableStateBehavior` を同じ typed crate に追加するか別 change に分けるか |
-| journal / serializer の境界 | `Journal` は `PersistentRepr` を受けるが serialization contract がない | serializer registry を persistence-core に置くか actor-core serialization と接続するか |
+| journal / serializer の境界 | `Journal` は `AtomicWrite` を受け、persistence serializers は actor-core serialization registry に contributor として登録される | std durable journal / local snapshot store がこの contract をどう呼び出すか |
 | durable state revision model | store trait は value 中心で revision / tag を持たない | revision を store API に入れるか typed DurableStateBehavior 側に閉じるか |
 | plugin adapter 境界 | core extension は generic journal / snapshot を直接受ける | std runtime で plugin selection / local snapshot store をどう表すか |
 | typed effector と Pekko typed DSL の境界 | `PersistenceEffector` は通常 `Behavior` に統合されるが、Pekko の `EffectBuilder` / signal / adapter をそのまま露出しない | parity 目標を effector-first で固定するか、Pekko direct DSL を追加するか |
@@ -239,4 +236,4 @@ persistence は classic write-side の基礎部品はかなり揃っている。
 
 Phase 1 の kernel 側低コスト項目は `SnapshotOffer`、`PersistenceSettings`、`NoSnapshotStore`、snapshot retry settings、`MaxUnconfirmedMessagesExceededException` 相当、`GetObjectResult[A]`、`DeleteRevisionException` まで実装済みである。`RecoveryCompleted` の classic 同名公開型と `RuntimePluginConfig` / plugin settings は現設計では non-goal とした。
 
-主要ギャップは、`AtomicWrite`、serialization contract、revision / tag-aware durable state update、typed `EventSourcedBehavior` / `EffectBuilder`、typed `DurableStateBehavior` である。typed write-side は effector-first API として前進し、Phase 1 typed parity surface は閉じたが、Pekko parity の観点では behavior-level failure supervision と durable state behavior execution がまだ閉じていない。内部構造比較は、serializer / revision model と typed durable state behavior の実行契約を決めた後に進めるのが妥当である。
+主要ギャップは、std durable journal / local snapshot store、revision / tag-aware durable state update、typed `EventSourcedBehavior` / `EffectBuilder`、typed `DurableStateBehavior` である。typed write-side は effector-first API として前進し、Phase 1 typed parity surface は閉じたが、Pekko parity の観点では behavior-level failure supervision と durable state behavior execution がまだ閉じていない。内部構造比較は、revision model と typed durable state behavior の実行契約を決めた後に進めるのが妥当である。

--- a/docs/gap-analysis/persistence-gap-analysis.md
+++ b/docs/gap-analysis/persistence-gap-analysis.md
@@ -44,8 +44,8 @@ fraktor-rs 側は `modules/persistence-core-kernel/src/` と `modules/persistenc
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象概念 | 80 |
-| fraktor-rs 固定スコープ対応概念 | 58 |
-| 固定スコープ概念カバレッジ | 58/80 (73%) |
+| fraktor-rs 固定スコープ対応概念 | 61 |
+| 固定スコープ概念カバレッジ | 61/80 (76%) |
 | raw public type declarations | 79（kernel: 59, typed: 20） |
 | raw public method declarations | 277（kernel: 202, typed: 75） |
 | hard / medium / easy / trivial gap | 4 / 10 / 3 / 6 |

--- a/modules/actor-core-kernel/src/serialization.rs
+++ b/modules/actor-core-kernel/src/serialization.rs
@@ -10,6 +10,8 @@ pub mod builtin;
 mod byte_buffer_serializer;
 mod call_scope;
 mod config_adapter;
+/// Runtime serialization registry contributions.
+pub mod contribution;
 mod default_setup;
 mod delegator;
 mod error;

--- a/modules/actor-core-kernel/src/serialization/contribution.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution.rs
@@ -1,0 +1,10 @@
+//! Runtime serialization registry contribution package.
+
+mod serialization_registry_contribution_error;
+mod serialization_registry_contributor;
+mod serialization_registry_contributors;
+
+pub use serialization_registry_contribution_error::SerializationRegistryContributionError;
+pub use serialization_registry_contributor::SerializationRegistryContributor;
+pub(crate) use serialization_registry_contributors::apply_serialization_registry_contributors;
+pub use serialization_registry_contributors::register_serialization_registry_contributor;

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error.rs
@@ -30,6 +30,6 @@ impl SerializationRegistryContributionError {
 
 impl Display for SerializationRegistryContributionError {
   fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
-    write!(formatter, "serialization registry contribution failed: {:?}", self.message)
+    write!(formatter, "serialization registry contribution failed: {}", self.message)
   }
 }

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error.rs
@@ -1,0 +1,31 @@
+//! Serialization registry contribution error.
+
+use core::fmt::{Display, Formatter, Result as FmtResult};
+
+use crate::serialization::SerializationError;
+
+/// Error returned while applying registry contributions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SerializationRegistryContributionError {
+  message: SerializationError,
+}
+
+impl SerializationRegistryContributionError {
+  /// Creates a new contribution error.
+  #[must_use]
+  pub const fn new(message: SerializationError) -> Self {
+    Self { message }
+  }
+
+  /// Returns the underlying serialization error.
+  #[must_use]
+  pub const fn message(&self) -> &SerializationError {
+    &self.message
+  }
+}
+
+impl Display for SerializationRegistryContributionError {
+  fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+    write!(formatter, "serialization registry contribution failed: {:?}", self.message)
+  }
+}

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error.rs
@@ -1,5 +1,9 @@
 //! Serialization registry contribution error.
 
+#[cfg(test)]
+#[path = "serialization_registry_contribution_error_test.rs"]
+mod tests;
+
 use core::fmt::{Display, Formatter, Result as FmtResult};
 
 use crate::serialization::SerializationError;

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error_test.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error_test.rs
@@ -1,0 +1,10 @@
+use super::SerializationRegistryContributionError;
+use crate::serialization::{SerializationError, SerializerId};
+
+#[test]
+fn contribution_error_exposes_message() {
+  let error =
+    SerializationRegistryContributionError::new(SerializationError::UnknownSerializer(SerializerId::from_raw(100)));
+
+  assert!(matches!(error.message(), SerializationError::UnknownSerializer(id) if *id == SerializerId::from_raw(100)));
+}

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error_test.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contribution_error_test.rs
@@ -8,3 +8,11 @@ fn contribution_error_exposes_message() {
 
   assert!(matches!(error.message(), SerializationError::UnknownSerializer(id) if *id == SerializerId::from_raw(100)));
 }
+
+#[test]
+fn contribution_error_uses_serialization_error_display() {
+  let error =
+    SerializationRegistryContributionError::new(SerializationError::UnknownSerializer(SerializerId::from_raw(100)));
+
+  assert_eq!(error.to_string(), "serialization registry contribution failed: unknown serializer id 100");
+}

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributor.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributor.rs
@@ -8,6 +8,8 @@ use crate::serialization::{SerializationError, serialization_registry::Serializa
 pub trait SerializationRegistryContributor: Send + Sync {
   /// Applies this contribution to the registry.
   ///
+  /// The registry accepts live serializer and binding updates through interior mutability.
+  ///
   /// # Errors
   ///
   /// Returns [`SerializationError`] when serializer or binding registration fails.

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributor.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributor.rs
@@ -1,0 +1,15 @@
+//! Serialization registry contributor trait.
+
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::serialization::{SerializationError, serialization_registry::SerializationRegistry};
+
+/// Adds serializers and bindings to a live serialization registry.
+pub trait SerializationRegistryContributor: Send + Sync {
+  /// Applies this contribution to the registry.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`SerializationError`] when serializer or binding registration fails.
+  fn contribute(&self, registry: &ArcShared<SerializationRegistry>) -> Result<(), SerializationError>;
+}

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributors.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributors.rs
@@ -1,0 +1,89 @@
+//! Serialization registry contributor collection.
+
+use alloc::vec::Vec;
+
+use fraktor_utils_core_rs::sync::{ArcShared, DefaultMutex, SharedAccess, SharedLock};
+
+use crate::{
+  actor::extension::{Extension, ExtensionId},
+  serialization::{
+    SerializationExtensionShared,
+    contribution::{
+      SerializationRegistryContributionError, serialization_registry_contributor::SerializationRegistryContributor,
+    },
+    serialization_registry::SerializationRegistry,
+  },
+  system::ActorSystem,
+};
+
+struct SerializationRegistryContributorsId;
+
+impl ExtensionId for SerializationRegistryContributorsId {
+  type Ext = SerializationRegistryContributors;
+
+  fn create_extension(&self, _system: &ActorSystem) -> Self::Ext {
+    SerializationRegistryContributors::new()
+  }
+}
+
+struct SerializationRegistryContributors {
+  contributors: SharedLock<Vec<ArcShared<dyn SerializationRegistryContributor>>>,
+}
+
+impl SerializationRegistryContributors {
+  fn new() -> Self {
+    Self { contributors: SharedLock::new_with_driver::<DefaultMutex<_>>(Vec::new()) }
+  }
+
+  fn add(&self, contributor: ArcShared<dyn SerializationRegistryContributor>) {
+    self.contributors.with_lock(|contributors| contributors.push(contributor));
+  }
+
+  fn apply_all(
+    &self,
+    registry: &ArcShared<SerializationRegistry>,
+  ) -> Result<(), SerializationRegistryContributionError> {
+    let contributors = self.contributors.with_lock(|contributors| contributors.clone());
+    for contributor in contributors {
+      contributor.contribute(registry).map_err(SerializationRegistryContributionError::new)?;
+    }
+    Ok(())
+  }
+}
+
+impl Extension for SerializationRegistryContributors {}
+
+/// Registers a serialization registry contributor and applies it immediately when possible.
+///
+/// # Errors
+///
+/// Returns [`SerializationRegistryContributionError`] when the contributor fails against an
+/// already-created serialization registry.
+pub fn register_serialization_registry_contributor<C>(
+  system: &ActorSystem,
+  contributor: C,
+) -> Result<(), SerializationRegistryContributionError>
+where
+  C: SerializationRegistryContributor + 'static, {
+  let contributors_id = SerializationRegistryContributorsId;
+  let contributor: ArcShared<dyn SerializationRegistryContributor> = ArcShared::new(contributor);
+  let contributors = system.extended().register_extension(&contributors_id);
+  contributors.add(contributor.clone());
+  if let Some(serialization) = system.extended().extension_by_type::<SerializationExtensionShared>() {
+    serialization
+      .with_read(|extension| contributor.contribute(&extension.registry()))
+      .map_err(SerializationRegistryContributionError::new)?;
+  }
+  Ok(())
+}
+
+pub(crate) fn apply_serialization_registry_contributors(
+  system: &ActorSystem,
+  registry: &ArcShared<SerializationRegistry>,
+) -> Result<(), SerializationRegistryContributionError> {
+  let contributors_id = SerializationRegistryContributorsId;
+  if let Some(contributors) = system.extended().extension(&contributors_id) {
+    contributors.apply_all(registry)?;
+  }
+  Ok(())
+}

--- a/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributors.rs
+++ b/modules/actor-core-kernel/src/serialization/contribution/serialization_registry_contributors.rs
@@ -68,12 +68,12 @@ where
   let contributors_id = SerializationRegistryContributorsId;
   let contributor: ArcShared<dyn SerializationRegistryContributor> = ArcShared::new(contributor);
   let contributors = system.extended().register_extension(&contributors_id);
-  contributors.add(contributor.clone());
   if let Some(serialization) = system.extended().extension_by_type::<SerializationExtensionShared>() {
     serialization
       .with_read(|extension| contributor.contribute(&extension.registry()))
       .map_err(SerializationRegistryContributionError::new)?;
   }
+  contributors.add(contributor);
   Ok(())
 }
 

--- a/modules/actor-core-kernel/src/serialization/error.rs
+++ b/modules/actor-core-kernel/src/serialization/error.rs
@@ -5,6 +5,7 @@
 mod tests;
 
 use alloc::string::String;
+use core::fmt::{Display, Formatter, Result as FmtResult};
 
 use super::{
   call_scope::SerializationCallScope, not_serializable_error::NotSerializableError, serializer_id::SerializerId,
@@ -39,6 +40,27 @@ pub enum SerializationError {
   UnknownManifest(String),
   /// Serialized payload could not be decoded.
   InvalidFormat,
+}
+
+impl Display for SerializationError {
+  fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+    match self {
+      | Self::Uninitialized => write!(formatter, "serialization runtime is uninitialized"),
+      | Self::ManifestMissing { scope } => write!(formatter, "manifest is missing for {:?} serialization", scope),
+      | Self::UnknownSerializer(id) => write!(formatter, "unknown serializer id {}", id.value()),
+      | Self::SerializerIdCollision(id) => write!(formatter, "serializer id {} is already registered", id.value()),
+      | Self::SerializerBindingCollision { type_name, existing, requested } => write!(
+        formatter,
+        "serializer binding collision for {}: existing id {}, requested id {}",
+        type_name,
+        existing.value(),
+        requested.value()
+      ),
+      | Self::NotSerializable(error) => write!(formatter, "type {} is not serializable", error.type_name()),
+      | Self::UnknownManifest(manifest) => write!(formatter, "unknown manifest {}", manifest),
+      | Self::InvalidFormat => write!(formatter, "invalid serialized format"),
+    }
+  }
 }
 
 impl SerializationError {

--- a/modules/actor-core-kernel/src/serialization/error.rs
+++ b/modules/actor-core-kernel/src/serialization/error.rs
@@ -22,6 +22,17 @@ pub enum SerializationError {
   },
   /// Serializer lookup failed for the provided identifier.
   UnknownSerializer(SerializerId),
+  /// Serializer id is already occupied by another serializer.
+  SerializerIdCollision(SerializerId),
+  /// Type binding is already assigned to another serializer id.
+  SerializerBindingCollision {
+    /// Bound type name.
+    type_name: String,
+    /// Existing serializer id.
+    existing:  SerializerId,
+    /// Requested serializer id.
+    requested: SerializerId,
+  },
   /// Requested type could not be serialized with the available registry configuration.
   NotSerializable(NotSerializableError),
   /// Manifest string was not recognised.
@@ -47,6 +58,22 @@ impl SerializationError {
   #[must_use]
   pub const fn unknown_serializer(id: SerializerId) -> Self {
     Self::UnknownSerializer(id)
+  }
+
+  /// Creates a serializer id collision error.
+  #[must_use]
+  pub const fn serializer_id_collision(id: SerializerId) -> Self {
+    Self::SerializerIdCollision(id)
+  }
+
+  /// Creates a serializer binding collision error.
+  #[must_use]
+  pub fn serializer_binding_collision(
+    type_name: impl Into<String>,
+    existing: SerializerId,
+    requested: SerializerId,
+  ) -> Self {
+    Self::SerializerBindingCollision { type_name: type_name.into(), existing, requested }
   }
 
   /// Creates a not serializable error with the provided details.
@@ -83,6 +110,18 @@ impl SerializationError {
   #[must_use]
   pub const fn is_unknown_serializer(&self) -> bool {
     matches!(self, Self::UnknownSerializer(_))
+  }
+
+  /// Returns `true` if the error is `SerializerIdCollision`.
+  #[must_use]
+  pub const fn is_serializer_id_collision(&self) -> bool {
+    matches!(self, Self::SerializerIdCollision(_))
+  }
+
+  /// Returns `true` if the error is `SerializerBindingCollision`.
+  #[must_use]
+  pub const fn is_serializer_binding_collision(&self) -> bool {
+    matches!(self, Self::SerializerBindingCollision { .. })
   }
 
   /// Returns `true` if the error is `NotSerializable`.

--- a/modules/actor-core-kernel/src/serialization/error_test.rs
+++ b/modules/actor-core-kernel/src/serialization/error_test.rs
@@ -28,6 +28,32 @@ fn unknown_serializer_display_representation() {
 }
 
 #[test]
+fn serialization_error_display_messages() {
+  let not_serializable = NotSerializableError::new("Example", None, None, None, None);
+
+  assert_eq!(SerializationError::Uninitialized.to_string(), "serialization runtime is uninitialized");
+  assert_eq!(
+    SerializationError::ManifestMissing { scope: SerializationCallScope::Local }.to_string(),
+    "manifest is missing for Local serialization"
+  );
+  assert_eq!(
+    SerializationError::SerializerIdCollision(SerializerId::try_from(101).unwrap()).to_string(),
+    "serializer id 101 is already registered"
+  );
+  assert_eq!(
+    SerializationError::serializer_binding_collision(
+      "Example",
+      SerializerId::try_from(102).unwrap(),
+      SerializerId::try_from(103).unwrap()
+    )
+    .to_string(),
+    "serializer binding collision for Example: existing id 102, requested id 103"
+  );
+  assert_eq!(SerializationError::NotSerializable(not_serializable).to_string(), "type Example is not serializable");
+  assert_eq!(SerializationError::UnknownManifest("old".into()).to_string(), "unknown manifest old");
+}
+
+#[test]
 fn not_serializable_variant_embeds_payload() {
   let payload = NotSerializableError::new(
     "Example",

--- a/modules/actor-core-kernel/src/serialization/error_test.rs
+++ b/modules/actor-core-kernel/src/serialization/error_test.rs
@@ -47,6 +47,18 @@ fn const_constructors_create_correct_variants() {
   let error = SerializationError::unknown_serializer(SerializerId::try_from(42).unwrap());
   assert!(error.is_unknown_serializer());
 
+  // SerializerIdCollision コンストラクタのテスト
+  let error = SerializationError::serializer_id_collision(SerializerId::try_from(43).unwrap());
+  assert!(error.is_serializer_id_collision());
+
+  // SerializerBindingCollision コンストラクタのテスト
+  let error = SerializationError::serializer_binding_collision(
+    "Example",
+    SerializerId::try_from(44).unwrap(),
+    SerializerId::try_from(45).unwrap(),
+  );
+  assert!(error.is_serializer_binding_collision());
+
   // InvalidFormat コンストラクタのテスト
   let error = SerializationError::invalid_format();
   assert!(error.is_invalid_format());
@@ -68,6 +80,8 @@ fn is_methods_return_correct_values() {
   assert!(uninitialized.is_uninitialized());
   assert!(!uninitialized.is_manifest_missing());
   assert!(!uninitialized.is_unknown_serializer());
+  assert!(!uninitialized.is_serializer_id_collision());
+  assert!(!uninitialized.is_serializer_binding_collision());
   assert!(!uninitialized.is_not_serializable());
   assert!(!uninitialized.is_unknown_manifest());
   assert!(!uninitialized.is_invalid_format());
@@ -81,6 +95,18 @@ fn is_methods_return_correct_values() {
   assert!(!unknown_serializer.is_uninitialized());
   assert!(!unknown_serializer.is_manifest_missing());
   assert!(unknown_serializer.is_unknown_serializer());
+
+  let serializer_id_collision = SerializationError::SerializerIdCollision(SerializerId::try_from(101).unwrap());
+  assert!(serializer_id_collision.is_serializer_id_collision());
+  assert!(!serializer_id_collision.is_unknown_serializer());
+
+  let serializer_binding_collision = SerializationError::SerializerBindingCollision {
+    type_name: String::from("Example"),
+    existing:  SerializerId::try_from(102).unwrap(),
+    requested: SerializerId::try_from(103).unwrap(),
+  };
+  assert!(serializer_binding_collision.is_serializer_binding_collision());
+  assert!(!serializer_binding_collision.is_unknown_serializer());
 
   let invalid_format = SerializationError::InvalidFormat;
   assert!(!invalid_format.is_uninitialized());

--- a/modules/actor-core-kernel/src/serialization/error_test.rs
+++ b/modules/actor-core-kernel/src/serialization/error_test.rs
@@ -14,6 +14,20 @@ fn invalid_format_debug_representation() {
 }
 
 #[test]
+fn invalid_format_display_representation() {
+  let error = SerializationError::InvalidFormat;
+
+  assert_eq!(error.to_string(), "invalid serialized format");
+}
+
+#[test]
+fn unknown_serializer_display_representation() {
+  let error = SerializationError::UnknownSerializer(SerializerId::try_from(100).unwrap());
+
+  assert_eq!(error.to_string(), "unknown serializer id 100");
+}
+
+#[test]
 fn not_serializable_variant_embeds_payload() {
   let payload = NotSerializableError::new(
     "Example",

--- a/modules/actor-core-kernel/src/serialization/extension.rs
+++ b/modules/actor-core-kernel/src/serialization/extension.rs
@@ -83,8 +83,8 @@ impl SerializationExtension {
     }
     if let Err(error) = apply_serialization_registry_contributors(system, &registry) {
       let message = format!("critical: failed to apply serialization registry contributors: {error}");
-      state.emit_log(LogLevel::Error, message, None, None);
-      panic!("failed to apply serialization registry contributors: {error}");
+      state.emit_log(LogLevel::Error, message.clone(), None, None);
+      panic!("{message}");
     }
     Self {
       registry,

--- a/modules/actor-core-kernel/src/serialization/extension.rs
+++ b/modules/actor-core-kernel/src/serialization/extension.rs
@@ -82,9 +82,9 @@ impl SerializationExtension {
       }
     }
     if let Err(error) = apply_serialization_registry_contributors(system, &registry) {
-      let message = format!("critical: failed to apply serialization registry contributors: {error}");
-      state.emit_log(LogLevel::Error, message, None, None);
-      panic!("failed to apply serialization registry contributors: {error}");
+      let message = format!("failed to apply serialization registry contributors: {error}");
+      state.emit_log(LogLevel::Error, format!("critical: {message}"), None, None);
+      panic!("{message}");
     }
     Self {
       registry,

--- a/modules/actor-core-kernel/src/serialization/extension.rs
+++ b/modules/actor-core-kernel/src/serialization/extension.rs
@@ -30,6 +30,7 @@ use crate::{
   serialization::{
     builtin,
     call_scope::SerializationCallScope,
+    contribution::apply_serialization_registry_contributors,
     error::SerializationError,
     error_event::SerializationErrorEvent,
     not_serializable_error::NotSerializableError,
@@ -79,6 +80,11 @@ impl SerializationExtension {
         state.emit_log(LogLevel::Error, message, None, None);
         panic!("failed to register builtin serializers: {error:?}");
       }
+    }
+    if let Err(error) = apply_serialization_registry_contributors(system, &registry) {
+      let message = format!("critical: failed to apply serialization registry contributors: {error}");
+      state.emit_log(LogLevel::Error, message, None, None);
+      panic!("failed to apply serialization registry contributors: {error}");
     }
     Self {
       registry,

--- a/modules/actor-core-kernel/src/serialization/extension.rs
+++ b/modules/actor-core-kernel/src/serialization/extension.rs
@@ -83,8 +83,8 @@ impl SerializationExtension {
     }
     if let Err(error) = apply_serialization_registry_contributors(system, &registry) {
       let message = format!("critical: failed to apply serialization registry contributors: {error}");
-      state.emit_log(LogLevel::Error, message.clone(), None, None);
-      panic!("{message}");
+      state.emit_log(LogLevel::Error, message, None, None);
+      panic!("failed to apply serialization registry contributors: {error}");
     }
     Self {
       registry,

--- a/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
@@ -170,7 +170,7 @@ impl SerializationRegistry {
       None
     });
     if let Some(existing_type_id) = collision {
-      let existing = self.binding_for(existing_type_id).unwrap_or(serializer_id);
+      let existing = self.binding_for(existing_type_id).ok_or(SerializationError::InvalidFormat)?;
       return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
     }
     self.bindings.with_write(|bindings| {

--- a/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
@@ -160,22 +160,21 @@ impl SerializationRegistry {
       return Err(SerializationError::UnknownSerializer(serializer_id));
     }
     let type_name = type_name.into();
-    let collision = self.binding_names.with_write(|binding_names| {
-      if let Some(existing_type_id) = binding_names.iter().find_map(|(existing_type_id, existing_name)| {
-        (*existing_type_id != type_id && existing_name == &type_name).then_some(*existing_type_id)
-      }) {
-        return Some(existing_type_id);
-      }
-      binding_names.insert(type_id, type_name.clone());
-      None
-    });
-    if let Some(existing_type_id) = collision {
-      let existing = self.binding_for(existing_type_id).ok_or(SerializationError::InvalidFormat)?;
-      return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
-    }
-    self.bindings.with_write(|bindings| {
+    let result: Result<(), SerializationError> = self.bindings.with_write(|bindings| {
+      self.binding_names.with_write(|binding_names| {
+        if let Some(existing_type_id) = binding_names.iter().find_map(|(existing_type_id, existing_name)| {
+          (*existing_type_id != type_id && existing_name == &type_name).then_some(*existing_type_id)
+        }) {
+          let existing = bindings.get(&existing_type_id).copied().ok_or(SerializationError::InvalidFormat)?;
+          return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
+        }
+        binding_names.insert(type_id, type_name);
+        Ok(())
+      })?;
       bindings.insert(type_id, serializer_id);
+      Ok(())
     });
+    result?;
     self.cache_remove(type_id);
     Ok(())
   }

--- a/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
@@ -132,6 +132,18 @@ impl SerializationRegistry {
     })
   }
 
+  /// Returns the serializer for an id without converting absence into an error.
+  #[must_use]
+  pub fn registered_serializer(&self, id: SerializerId) -> Option<ArcShared<dyn Serializer>> {
+    self.serializer_by_id_raw(id)
+  }
+
+  /// Returns the serializer id currently bound to the type.
+  #[must_use]
+  pub fn binding_for(&self, type_id: TypeId) -> Option<SerializerId> {
+    self.bindings.with_read(|bindings| bindings.get(&type_id).copied())
+  }
+
   /// Registers a binding at runtime (used by adapters/extensions).
   ///
   /// # Errors

--- a/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
@@ -159,11 +159,20 @@ impl SerializationRegistry {
     if self.serializer_by_id_raw(serializer_id).is_none() {
       return Err(SerializationError::UnknownSerializer(serializer_id));
     }
+    let type_name = type_name.into();
+    if let Some(existing_type_id) = self.binding_names.with_read(|binding_names| {
+      binding_names.iter().find_map(|(existing_type_id, existing_name)| {
+        (*existing_type_id != type_id && existing_name == &type_name).then_some(*existing_type_id)
+      })
+    }) {
+      let existing = self.binding_for(existing_type_id).unwrap_or(serializer_id);
+      return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
+    }
     self.bindings.with_write(|bindings| {
       bindings.insert(type_id, serializer_id);
     });
     self.binding_names.with_write(|binding_names| {
-      binding_names.insert(type_id, type_name.into());
+      binding_names.insert(type_id, type_name);
     });
     self.cache_remove(type_id);
     Ok(())

--- a/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
@@ -160,19 +160,21 @@ impl SerializationRegistry {
       return Err(SerializationError::UnknownSerializer(serializer_id));
     }
     let type_name = type_name.into();
-    if let Some(existing_type_id) = self.binding_names.with_read(|binding_names| {
-      binding_names.iter().find_map(|(existing_type_id, existing_name)| {
+    let collision = self.binding_names.with_write(|binding_names| {
+      if let Some(existing_type_id) = binding_names.iter().find_map(|(existing_type_id, existing_name)| {
         (*existing_type_id != type_id && existing_name == &type_name).then_some(*existing_type_id)
-      })
-    }) {
+      }) {
+        return Some(existing_type_id);
+      }
+      binding_names.insert(type_id, type_name.clone());
+      None
+    });
+    if let Some(existing_type_id) = collision {
       let existing = self.binding_for(existing_type_id).unwrap_or(serializer_id);
       return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
     }
     self.bindings.with_write(|bindings| {
       bindings.insert(type_id, serializer_id);
-    });
-    self.binding_names.with_write(|binding_names| {
-      binding_names.insert(type_id, type_name);
     });
     self.cache_remove(type_id);
     Ok(())

--- a/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry/registry.rs
@@ -188,6 +188,14 @@ impl SerializationRegistry {
     self.binding_names.with_read(|binding_names| binding_names.get(&type_id).cloned())
   }
 
+  /// Returns the type identifier recorded for the provided binding name.
+  #[must_use]
+  pub fn type_id_for_binding_name(&self, name: &str) -> Option<TypeId> {
+    self.binding_names.with_read(|binding_names| {
+      binding_names.iter().find_map(|(type_id, binding)| (binding == name).then_some(*type_id))
+    })
+  }
+
   /// Returns the remote manifest registered for the provided type identifier.
   #[must_use]
   pub fn manifest_for(&self, type_id: TypeId) -> Option<&str> {

--- a/modules/actor-core-kernel/src/serialization/serialization_registry_test.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry_test.rs
@@ -144,6 +144,8 @@ fn register_binding_rejects_duplicate_binding_name_for_different_type() {
       requested
     }) if binding_name == type_name::<u32>() && existing == alpha_id && requested == beta_id
   ));
+  assert_eq!(registry.binding_name(TypeId::of::<u64>()), None);
+  assert_eq!(registry.type_id_for_binding_name(type_name::<u32>()), Some(TypeId::of::<u32>()));
 }
 
 #[test]

--- a/modules/actor-core-kernel/src/serialization/serialization_registry_test.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry_test.rs
@@ -131,6 +131,15 @@ fn register_binding_allows_dynamic_resolution() {
 }
 
 #[test]
+fn binding_names_resolve_back_to_type_ids() {
+  let (registry, _serializer_id) = setup_with_binding();
+
+  assert_eq!(registry.binding_name(TypeId::of::<u32>()), Some(type_name::<u32>().into()));
+  assert_eq!(registry.type_id_for_binding_name(type_name::<u32>()), Some(TypeId::of::<u32>()));
+  assert_eq!(registry.type_id_for_binding_name("missing"), None);
+}
+
+#[test]
 fn manifest_routes_return_serializers_in_priority_order() {
   let alpha_id = SerializerId::try_from(150).expect("alpha");
   let beta_id = SerializerId::try_from(151).expect("beta");

--- a/modules/actor-core-kernel/src/serialization/serialization_registry_test.rs
+++ b/modules/actor-core-kernel/src/serialization/serialization_registry_test.rs
@@ -131,6 +131,22 @@ fn register_binding_allows_dynamic_resolution() {
 }
 
 #[test]
+fn register_binding_rejects_duplicate_binding_name_for_different_type() {
+  let (registry, alpha_id, beta_id) = setup_with_two_serializers();
+
+  let result = registry.register_binding(TypeId::of::<u64>(), type_name::<u32>(), beta_id);
+
+  assert!(matches!(
+    result,
+    Err(SerializationError::SerializerBindingCollision {
+      type_name: binding_name,
+      existing,
+      requested
+    }) if binding_name == type_name::<u32>() && existing == alpha_id && requested == beta_id
+  ));
+}
+
+#[test]
 fn binding_names_resolve_back_to_type_ids() {
   let (registry, _serializer_id) = setup_with_binding();
 

--- a/modules/actor-core-kernel/src/serialization/serialized_message.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message.rs
@@ -18,6 +18,14 @@ pub struct SerializedMessage {
 }
 
 impl SerializedMessage {
+  fn end_offset(bytes: &[u8], cursor: usize, len: usize) -> Result<usize, SerializationError> {
+    let end = cursor.checked_add(len).ok_or(SerializationError::InvalidFormat)?;
+    if bytes.len() < end {
+      return Err(SerializationError::InvalidFormat);
+    }
+    Ok(end)
+  }
+
   /// Creates a new serialized message.
   #[must_use]
   pub const fn new(serializer_id: SerializerId, manifest: Option<String>, bytes: Vec<u8>) -> Self {
@@ -86,18 +94,13 @@ impl SerializedMessage {
     let has_manifest = bytes[cursor];
     cursor += 1;
     let manifest = if has_manifest == 1 {
-      if bytes.len() < cursor + 4 {
-        return Err(SerializationError::InvalidFormat);
-      }
+      let len_end = Self::end_offset(bytes, cursor, 4)?;
       let manifest_len =
-        u32::from_le_bytes(bytes[cursor..cursor + 4].try_into().map_err(|_| SerializationError::InvalidFormat)?)
-          as usize;
-      cursor += 4;
-      if bytes.len() < cursor + manifest_len {
-        return Err(SerializationError::InvalidFormat);
-      }
-      let manifest_bytes = &bytes[cursor..cursor + manifest_len];
-      cursor += manifest_len;
+        u32::from_le_bytes(bytes[cursor..len_end].try_into().map_err(|_| SerializationError::InvalidFormat)?) as usize;
+      cursor = len_end;
+      let manifest_end = Self::end_offset(bytes, cursor, manifest_len)?;
+      let manifest_bytes = &bytes[cursor..manifest_end];
+      cursor = manifest_end;
       let manifest_str = core::str::from_utf8(manifest_bytes).map_err(|_| SerializationError::InvalidFormat)?;
       Some(manifest_str.to_owned())
     } else if has_manifest == 0 {
@@ -105,17 +108,13 @@ impl SerializedMessage {
     } else {
       return Err(SerializationError::InvalidFormat);
     };
-    if bytes.len() < cursor + 4 {
-      return Err(SerializationError::InvalidFormat);
-    }
+    let len_end = Self::end_offset(bytes, cursor, 4)?;
     let payload_len =
-      u32::from_le_bytes(bytes[cursor..cursor + 4].try_into().map_err(|_| SerializationError::InvalidFormat)?) as usize;
-    cursor += 4;
-    if bytes.len() < cursor + payload_len {
-      return Err(SerializationError::InvalidFormat);
-    }
-    let payload = bytes[cursor..cursor + payload_len].to_vec();
-    cursor += payload_len;
+      u32::from_le_bytes(bytes[cursor..len_end].try_into().map_err(|_| SerializationError::InvalidFormat)?) as usize;
+    cursor = len_end;
+    let payload_end = Self::end_offset(bytes, cursor, payload_len)?;
+    let payload = bytes[cursor..payload_end].to_vec();
+    cursor = payload_end;
     if cursor != bytes.len() {
       return Err(SerializationError::InvalidFormat);
     }

--- a/modules/actor-core-kernel/src/serialization/serialized_message.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message.rs
@@ -116,11 +116,10 @@ impl SerializedMessage {
     let payload_len = payload_len_u32 as usize;
     cursor = len_end;
     let payload_end = Self::end_offset(bytes, cursor, payload_len)?;
-    let payload = bytes[cursor..payload_end].to_vec();
-    cursor = payload_end;
-    if cursor != bytes.len() {
+    if payload_end != bytes.len() {
       return Err(SerializationError::InvalidFormat);
     }
+    let payload = bytes[cursor..payload_end].to_vec();
     Ok(Self::new(serializer_id, manifest, payload))
   }
 }

--- a/modules/actor-core-kernel/src/serialization/serialized_message.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message.rs
@@ -115,6 +115,10 @@ impl SerializedMessage {
       return Err(SerializationError::InvalidFormat);
     }
     let payload = bytes[cursor..cursor + payload_len].to_vec();
+    cursor += payload_len;
+    if cursor != bytes.len() {
+      return Err(SerializationError::InvalidFormat);
+    }
     Ok(Self::new(serializer_id, manifest, payload))
   }
 }

--- a/modules/actor-core-kernel/src/serialization/serialized_message.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message.rs
@@ -112,8 +112,8 @@ impl SerializedMessage {
     } else {
       return Err(SerializationError::InvalidFormat);
     };
-    let (payload_len, len_end) = Self::read_u32_at(bytes, cursor)?;
-    let payload_len = payload_len as usize;
+    let (payload_len_u32, len_end) = Self::read_u32_at(bytes, cursor)?;
+    let payload_len = payload_len_u32 as usize;
     cursor = len_end;
     let payload_end = Self::end_offset(bytes, cursor, payload_len)?;
     let payload = bytes[cursor..payload_end].to_vec();

--- a/modules/actor-core-kernel/src/serialization/serialized_message.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message.rs
@@ -5,7 +5,6 @@
 mod tests;
 
 use alloc::{borrow::ToOwned, string::String, vec::Vec};
-use core::convert::TryInto;
 
 use super::{error::SerializationError, serializer_id::SerializerId};
 
@@ -24,6 +23,13 @@ impl SerializedMessage {
       return Err(SerializationError::InvalidFormat);
     }
     Ok(end)
+  }
+
+  fn read_u32_at(bytes: &[u8], cursor: usize) -> Result<(u32, usize), SerializationError> {
+    let end = Self::end_offset(bytes, cursor, 4)?;
+    let mut raw = [0_u8; 4];
+    raw.copy_from_slice(&bytes[cursor..end]);
+    Ok((u32::from_le_bytes(raw), end))
   }
 
   /// Creates a new serialized message.
@@ -87,16 +93,14 @@ impl SerializedMessage {
     if bytes.len() < 5 {
       return Err(SerializationError::InvalidFormat);
     }
-    let serializer_raw =
-      u32::from_le_bytes(bytes[cursor..cursor + 4].try_into().map_err(|_| SerializationError::InvalidFormat)?);
-    cursor += 4;
+    let (serializer_raw, serializer_end) = Self::read_u32_at(bytes, cursor)?;
+    cursor = serializer_end;
     let serializer_id = SerializerId::from_raw(serializer_raw);
     let has_manifest = bytes[cursor];
     cursor += 1;
     let manifest = if has_manifest == 1 {
-      let len_end = Self::end_offset(bytes, cursor, 4)?;
-      let manifest_len =
-        u32::from_le_bytes(bytes[cursor..len_end].try_into().map_err(|_| SerializationError::InvalidFormat)?) as usize;
+      let (manifest_len, len_end) = Self::read_u32_at(bytes, cursor)?;
+      let manifest_len = manifest_len as usize;
       cursor = len_end;
       let manifest_end = Self::end_offset(bytes, cursor, manifest_len)?;
       let manifest_bytes = &bytes[cursor..manifest_end];
@@ -108,9 +112,8 @@ impl SerializedMessage {
     } else {
       return Err(SerializationError::InvalidFormat);
     };
-    let len_end = Self::end_offset(bytes, cursor, 4)?;
-    let payload_len =
-      u32::from_le_bytes(bytes[cursor..len_end].try_into().map_err(|_| SerializationError::InvalidFormat)?) as usize;
+    let (payload_len, len_end) = Self::read_u32_at(bytes, cursor)?;
+    let payload_len = payload_len as usize;
     cursor = len_end;
     let payload_end = Self::end_offset(bytes, cursor, payload_len)?;
     let payload = bytes[cursor..payload_end].to_vec();

--- a/modules/actor-core-kernel/src/serialization/serialized_message.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message.rs
@@ -87,7 +87,7 @@ impl SerializedMessage {
   /// # Errors
   ///
   /// Returns [`SerializationError::InvalidFormat`] when the bytes do not follow the expected
-  /// layout.
+  /// layout. The decoder consumes exactly one framed message and rejects trailing bytes.
   pub fn decode(bytes: &[u8]) -> Result<Self, SerializationError> {
     let mut cursor = 0;
     if bytes.len() < 5 {

--- a/modules/actor-core-kernel/src/serialization/serialized_message_test.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message_test.rs
@@ -43,3 +43,41 @@ fn rejects_trailing_bytes() {
   let error = SerializedMessage::decode(&encoded).expect_err("trailing bytes");
   assert_eq!(error, SerializationError::InvalidFormat);
 }
+
+#[test]
+fn rejects_truncated_manifest_length() {
+  let mut data = id(100).value().to_le_bytes().to_vec();
+  data.push(1);
+  data.extend_from_slice(&[1, 2]);
+
+  let error = SerializedMessage::decode(&data).expect_err("truncated manifest length");
+  assert_eq!(error, SerializationError::InvalidFormat);
+}
+
+#[test]
+fn rejects_truncated_manifest_payload() {
+  let mut data = id(100).value().to_le_bytes().to_vec();
+  data.push(1);
+  data.extend_from_slice(&4_u32.to_le_bytes());
+  data.extend_from_slice(b"ab");
+
+  let error = SerializedMessage::decode(&data).expect_err("truncated manifest payload");
+  assert_eq!(error, SerializationError::InvalidFormat);
+}
+
+#[test]
+fn rejects_truncated_payload_length() {
+  let mut data = id(100).value().to_le_bytes().to_vec();
+  data.push(0);
+  data.extend_from_slice(&[1, 2]);
+
+  let error = SerializedMessage::decode(&data).expect_err("truncated payload length");
+  assert_eq!(error, SerializationError::InvalidFormat);
+}
+
+#[test]
+fn rejects_end_offset_overflow() {
+  let error = SerializedMessage::end_offset(&[], usize::MAX, 1).expect_err("overflow");
+
+  assert_eq!(error, SerializationError::InvalidFormat);
+}

--- a/modules/actor-core-kernel/src/serialization/serialized_message_test.rs
+++ b/modules/actor-core-kernel/src/serialization/serialized_message_test.rs
@@ -33,3 +33,13 @@ fn rejects_invalid_format() {
   let error = SerializedMessage::decode(&data).expect_err("invalid format");
   assert_eq!(error, SerializationError::InvalidFormat);
 }
+
+#[test]
+fn rejects_trailing_bytes() {
+  let message = SerializedMessage::new(id(100), Some("example.Manifest".into()), vec![1]);
+  let mut encoded = message.encode();
+  encoded.push(2);
+
+  let error = SerializedMessage::decode(&encoded).expect_err("trailing bytes");
+  assert_eq!(error, SerializationError::InvalidFormat);
+}

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
@@ -4,13 +4,17 @@
 #[path = "persistence_extension_installer_test.rs"]
 mod tests;
 
+use alloc::string::ToString;
+
 use fraktor_actor_core_kernel_rs::{
   actor::extension::{ExtensionInstaller, install_extension_id},
+  serialization::contribution::register_serialization_registry_contributor,
   system::{ActorSystem, ActorSystemBuildError},
 };
 
 use crate::{
-  config::PersistenceSettings, extension::PersistenceExtensionId, journal::Journal, snapshot::SnapshotStore,
+  config::PersistenceSettings, extension::PersistenceExtensionId, journal::Journal,
+  serialization::PersistenceSerializationContributor, snapshot::SnapshotStore,
 };
 
 /// Installs the persistence extension into the actor system.
@@ -51,6 +55,8 @@ where
     let extension_id =
       PersistenceExtensionId::new_with_settings(self.journal.clone(), self.snapshot_store.clone(), self.settings);
     install_extension_id(system, &extension_id);
+    register_serialization_registry_contributor(system, PersistenceSerializationContributor::new())
+      .map_err(|error| ActorSystemBuildError::Configuration(error.to_string()))?;
     Ok(())
   }
 }

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
@@ -52,11 +52,11 @@ where
   for<'a> S::DeleteManyFuture<'a>: Send + 'static,
 {
   fn install(&self, system: &ActorSystem) -> Result<(), ActorSystemBuildError> {
+    register_serialization_registry_contributor(system, PersistenceSerializationContributor::new())
+      .map_err(|error| ActorSystemBuildError::Configuration(error.to_string()))?;
     let extension_id =
       PersistenceExtensionId::new_with_settings(self.journal.clone(), self.snapshot_store.clone(), self.settings);
     install_extension_id(system, &extension_id);
-    register_serialization_registry_contributor(system, PersistenceSerializationContributor::new())
-      .map_err(|error| ActorSystemBuildError::Configuration(error.to_string()))?;
     Ok(())
   }
 }

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer.rs
@@ -4,7 +4,7 @@
 #[path = "persistence_extension_installer_test.rs"]
 mod tests;
 
-use alloc::string::ToString;
+use alloc::format;
 
 use fraktor_actor_core_kernel_rs::{
   actor::extension::{ExtensionInstaller, install_extension_id},
@@ -52,8 +52,9 @@ where
   for<'a> S::DeleteManyFuture<'a>: Send + 'static,
 {
   fn install(&self, system: &ActorSystem) -> Result<(), ActorSystemBuildError> {
-    register_serialization_registry_contributor(system, PersistenceSerializationContributor::new())
-      .map_err(|error| ActorSystemBuildError::Configuration(error.to_string()))?;
+    register_serialization_registry_contributor(system, PersistenceSerializationContributor::new()).map_err(
+      |error| ActorSystemBuildError::Configuration(format!("persistence serialization registration failed: {error}")),
+    )?;
     let extension_id =
       PersistenceExtensionId::new_with_settings(self.journal.clone(), self.snapshot_store.clone(), self.settings);
     install_extension_id(system, &extension_id);

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
@@ -1,16 +1,26 @@
+use alloc::{boxed::Box, vec::Vec};
+use core::any::{Any, TypeId};
+
 use fraktor_actor_adaptor_std_rs::tick_driver::TestTickDriver;
 use fraktor_actor_core_kernel_rs::{
   actor::{
     Actor, ActorContext, error::ActorError, extension::ExtensionInstallers, messaging::AnyMessageView, props::Props,
     scheduler::SchedulerConfig, setup::ActorSystemConfig,
   },
+  serialization::{
+    SerializationError, SerializationExtensionInstaller, SerializationExtensionShared, SerializationSetupBuilder,
+    Serializer, SerializerId, default_serialization_setup,
+  },
   system::ActorSystem,
 };
+use fraktor_utils_core_rs::sync::{ArcShared, SharedAccess};
 
 use crate::{
   config::PersistenceSettings,
   extension::{PersistenceExtensionInstaller, PersistenceExtensionShared},
   journal::{InMemoryJournal, JournalActorConfig},
+  persistent::{AtomicWrite, PersistentRepr},
+  serialization::{MESSAGE_SERIALIZER_ID, SnapshotPayload},
   snapshot::{InMemorySnapshotStore, SnapshotActorConfig},
 };
 
@@ -22,22 +32,71 @@ impl Actor for NoopActor {
   }
 }
 
-#[test]
-fn installer_registers_persistence_extension() {
-  let journal = InMemoryJournal::new();
-  let snapshot_store = InMemorySnapshotStore::new();
-  let installer = PersistenceExtensionInstaller::new(journal, snapshot_store);
-  let installers = ExtensionInstallers::default().with_extension_installer(installer);
+struct DummySerializer {
+  id: SerializerId,
+}
+
+impl DummySerializer {
+  fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for DummySerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn to_binary(&self, _message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    Ok(Vec::new())
+  }
+
+  fn from_binary(
+    &self,
+    _bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    Ok(Box::new(()))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}
+
+fn persistence_installer() -> PersistenceExtensionInstaller<InMemoryJournal, InMemorySnapshotStore> {
+  PersistenceExtensionInstaller::new(InMemoryJournal::new(), InMemorySnapshotStore::new())
+}
+
+fn build_system(installers: ExtensionInstallers) -> ActorSystem {
   let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
   let config = ActorSystemConfig::new(TestTickDriver::default())
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
   let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_from_props(&props, config).expect("system");
+  ActorSystem::create_from_props(&props, config).expect("system")
+}
+
+fn assert_persistence_serializers_registered(system: &ActorSystem) {
+  let serialization =
+    system.extended().extension_by_type::<SerializationExtensionShared>().expect("serialization extension");
+  serialization.with_read(|extension| {
+    let registry = extension.registry();
+    assert_eq!(registry.binding_for(TypeId::of::<PersistentRepr>()), Some(MESSAGE_SERIALIZER_ID));
+    assert_eq!(registry.binding_for(TypeId::of::<AtomicWrite>()), Some(MESSAGE_SERIALIZER_ID));
+    assert!(registry.binding_for(TypeId::of::<SnapshotPayload>()).is_some());
+  });
+}
+
+#[test]
+fn installer_registers_persistence_extension() {
+  let installers = ExtensionInstallers::default().with_extension_installer(persistence_installer());
+  let system = build_system(installers);
 
   let extension = system.extended().extension_by_type::<PersistenceExtensionShared>();
 
   assert!(extension.is_some());
+  assert_persistence_serializers_registered(&system);
 }
 
 #[test]
@@ -49,14 +108,74 @@ fn installer_registers_extension_with_explicit_settings() {
     .with_snapshot_actor_config(SnapshotActorConfig::new(3));
   let installer = PersistenceExtensionInstaller::new_with_settings(journal, snapshot_store, settings);
   let installers = ExtensionInstallers::default().with_extension_installer(installer);
-  let scheduler = SchedulerConfig::default().with_runner_api_enabled(true);
-  let config = ActorSystemConfig::new(TestTickDriver::default())
-    .with_scheduler_config(scheduler)
-    .with_extension_installers(installers);
-  let props = Props::from_fn(|| NoopActor);
-  let system = ActorSystem::create_from_props(&props, config).expect("system");
+  let system = build_system(installers);
 
   let extension = system.extended().extension_by_type::<PersistenceExtensionShared>();
 
   assert!(extension.is_some());
+}
+
+#[test]
+fn installer_composes_with_custom_serialization_before_persistence() {
+  let serialization = SerializationExtensionInstaller::new(default_serialization_setup());
+  let installers = ExtensionInstallers::default()
+    .with_extension_installer(serialization)
+    .with_extension_installer(persistence_installer());
+
+  let system = build_system(installers);
+
+  assert_persistence_serializers_registered(&system);
+}
+
+#[test]
+fn installer_composes_with_custom_serialization_after_persistence() {
+  let serialization = SerializationExtensionInstaller::new(default_serialization_setup());
+  let installers = ExtensionInstallers::default()
+    .with_extension_installer(persistence_installer())
+    .with_extension_installer(serialization);
+
+  let system = build_system(installers);
+
+  assert_persistence_serializers_registered(&system);
+}
+
+#[test]
+#[should_panic(expected = "failed to apply serialization registry contributors")]
+fn installer_rejects_persistence_serializer_id_collision() {
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(DummySerializer::new(MESSAGE_SERIALIZER_ID));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("dummy", MESSAGE_SERIALIZER_ID, serializer)
+    .expect("register")
+    .set_fallback("dummy")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let serialization = SerializationExtensionInstaller::new(setup);
+  let installers = ExtensionInstallers::default()
+    .with_extension_installer(persistence_installer())
+    .with_extension_installer(serialization);
+
+  let _system = build_system(installers);
+}
+
+#[test]
+#[should_panic(expected = "failed to apply serialization registry contributors")]
+fn installer_rejects_persistence_type_binding_collision() {
+  let dummy_id = SerializerId::try_from(100).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(DummySerializer::new(dummy_id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("dummy", dummy_id, serializer)
+    .expect("register")
+    .set_fallback("dummy")
+    .expect("fallback")
+    .bind::<PersistentRepr>("dummy")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let serialization = SerializationExtensionInstaller::new(setup);
+  let installers = ExtensionInstallers::default()
+    .with_extension_installer(persistence_installer())
+    .with_extension_installer(serialization);
+
+  let _system = build_system(installers);
 }

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
@@ -3,10 +3,7 @@ use core::any::{Any, TypeId};
 
 use fraktor_actor_adaptor_std_rs::tick_driver::TestTickDriver;
 use fraktor_actor_core_kernel_rs::{
-  actor::{
-    Actor, ActorContext, error::ActorError, extension::ExtensionInstallers, messaging::AnyMessageView, props::Props,
-    scheduler::SchedulerConfig, setup::ActorSystemConfig,
-  },
+  actor::{extension::ExtensionInstallers, scheduler::SchedulerConfig, setup::ActorSystemConfig},
   serialization::{
     SerializationError, SerializationExtensionInstaller, SerializationExtensionShared, SerializationSetupBuilder,
     Serializer, SerializerId, default_serialization_setup,
@@ -23,14 +20,6 @@ use crate::{
   serialization::{MESSAGE_SERIALIZER_ID, SnapshotPayload},
   snapshot::{InMemorySnapshotStore, SnapshotActorConfig},
 };
-
-struct NoopActor;
-
-impl Actor for NoopActor {
-  fn receive(&mut self, _ctx: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
-    Ok(())
-  }
-}
 
 struct DummySerializer {
   id: SerializerId,
@@ -73,8 +62,7 @@ fn build_system(installers: ExtensionInstallers) -> ActorSystem {
   let config = ActorSystemConfig::new(TestTickDriver::default())
     .with_scheduler_config(scheduler)
     .with_extension_installers(installers);
-  let props = Props::from_fn(|| NoopActor);
-  ActorSystem::create_from_props(&props, config).expect("system")
+  ActorSystem::create_with_noop_guardian(config).expect("system")
 }
 
 fn assert_persistence_serializers_registered(system: &ActorSystem) {
@@ -86,6 +74,14 @@ fn assert_persistence_serializers_registered(system: &ActorSystem) {
     assert_eq!(registry.binding_for(TypeId::of::<AtomicWrite>()), Some(MESSAGE_SERIALIZER_ID));
     assert!(registry.binding_for(TypeId::of::<SnapshotPayload>()).is_some());
   });
+}
+
+#[test]
+fn dummy_serializer_round_trips_unit_payload() {
+  let serializer = DummySerializer::new(SerializerId::try_from(100).expect("serializer id"));
+
+  assert_eq!(serializer.to_binary(&()).expect("binary"), Vec::<u8>::new());
+  assert!(serializer.from_binary(&[], None).expect("value").downcast_ref::<()>().is_some());
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
+++ b/modules/persistence-core-kernel/src/extension/persistence_extension_installer_test.rs
@@ -3,7 +3,11 @@ use core::any::{Any, TypeId};
 
 use fraktor_actor_adaptor_std_rs::tick_driver::TestTickDriver;
 use fraktor_actor_core_kernel_rs::{
-  actor::{extension::ExtensionInstallers, scheduler::SchedulerConfig, setup::ActorSystemConfig},
+  actor::{
+    extension::{ExtensionInstaller, ExtensionInstallers},
+    scheduler::SchedulerConfig,
+    setup::ActorSystemConfig,
+  },
   serialization::{
     SerializationError, SerializationExtensionInstaller, SerializationExtensionShared, SerializationSetupBuilder,
     Serializer, SerializerId, default_serialization_setup,
@@ -152,6 +156,24 @@ fn installer_rejects_persistence_serializer_id_collision() {
     .with_extension_installer(serialization);
 
   let _system = build_system(installers);
+}
+
+#[test]
+fn installer_reports_persistence_serializer_registration_error() {
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(DummySerializer::new(MESSAGE_SERIALIZER_ID));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("dummy", MESSAGE_SERIALIZER_ID, serializer)
+    .expect("register")
+    .set_fallback("dummy")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let serialization = SerializationExtensionInstaller::new(setup);
+  let system = build_system(ExtensionInstallers::default().with_extension_installer(serialization));
+
+  let result = persistence_installer().install(&system);
+
+  assert!(matches!(result, Err(error) if error.to_string().contains("persistence serialization registration failed")));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
+++ b/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
@@ -151,7 +151,7 @@ fn first_write_message_repr(journal_store: &MessageStore) -> PersistentRepr {
     .find_map(|message| match message {
       | JournalMessage::WriteMessages { messages, .. } => {
         // AtomicWrite::payload() is guaranteed non-empty by AtomicWrite::new.
-        messages.first().and_then(|write| write.payload().first().cloned())
+        messages.first().map(|write| write.payload()[0].clone())
       },
       | _ => None,
     })

--- a/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
+++ b/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
@@ -151,7 +151,7 @@ fn first_write_message_repr(journal_store: &MessageStore) -> PersistentRepr {
     .find_map(|message| match message {
       | JournalMessage::WriteMessages { messages, .. } => {
         // AtomicWrite::payload() is guaranteed non-empty by AtomicWrite::new.
-        messages.first().map(|write| write.payload()[0].clone())
+        messages.first().and_then(|write| write.payload().first().cloned())
       },
       | _ => None,
     })

--- a/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
+++ b/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
@@ -149,7 +149,9 @@ fn first_write_message_repr(journal_store: &MessageStore) -> PersistentRepr {
     .iter()
     .filter_map(|message| message.payload().downcast_ref::<JournalMessage>())
     .find_map(|message| match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages.first().cloned(),
+      | JournalMessage::WriteMessages { messages, .. } => {
+        messages.first().and_then(|write| write.payload().first().cloned())
+      },
       | _ => None,
     })
     .expect("write message not found")

--- a/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
+++ b/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
@@ -151,7 +151,7 @@ fn first_write_message_repr(journal_store: &MessageStore) -> PersistentRepr {
     .find_map(|message| match message {
       | JournalMessage::WriteMessages { messages, .. } => {
         // AtomicWrite::payload() is guaranteed non-empty by AtomicWrite::new.
-        messages.first().and_then(|write| write.payload().first().cloned())
+        messages.first().and_then(|write| write.payload().first()).cloned()
       },
       | _ => None,
     })

--- a/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
+++ b/modules/persistence-core-kernel/src/fsm/persistent_fsm_test.rs
@@ -150,6 +150,7 @@ fn first_write_message_repr(journal_store: &MessageStore) -> PersistentRepr {
     .filter_map(|message| message.payload().downcast_ref::<JournalMessage>())
     .find_map(|message| match message {
       | JournalMessage::WriteMessages { messages, .. } => {
+        // AtomicWrite::payload() is guaranteed non-empty by AtomicWrite::new.
         messages.first().and_then(|write| write.payload().first().cloned())
       },
       | _ => None,

--- a/modules/persistence-core-kernel/src/journal/base.rs
+++ b/modules/persistence-core-kernel/src/journal/base.rs
@@ -3,7 +3,10 @@
 use alloc::vec::Vec;
 use core::future::Future;
 
-use crate::{journal::JournalError, persistent::PersistentRepr};
+use crate::{
+  journal::JournalError,
+  persistent::{AtomicWrite, PersistentRepr},
+};
 
 /// Event journal abstraction using GATs for no_std async.
 pub trait Journal: Send + Sync + 'static {
@@ -27,8 +30,8 @@ pub trait Journal: Send + Sync + 'static {
   where
     Self: 'a;
 
-  /// Writes a batch of messages.
-  fn write_messages<'a>(&'a mut self, messages: &'a [PersistentRepr]) -> Self::WriteFuture<'a>;
+  /// Writes a batch of atomic write units.
+  fn write_messages<'a>(&'a mut self, messages: &'a [AtomicWrite]) -> Self::WriteFuture<'a>;
 
   /// Replays messages in the requested range.
   fn replay_messages<'a>(

--- a/modules/persistence-core-kernel/src/journal/event_adapters.rs
+++ b/modules/persistence-core-kernel/src/journal/event_adapters.rs
@@ -108,6 +108,12 @@ impl EventAdapters {
     self.read_adapters.get(&type_id).cloned().unwrap_or_else(|| self.identity.clone())
   }
 
+  /// Returns whether a read adapter is explicitly registered for the specified type identifier.
+  #[must_use]
+  pub fn has_read_adapter_for_type_id(&self, type_id: TypeId) -> bool {
+    self.read_adapters.contains_key(&type_id)
+  }
+
   /// Converts an event to journal representation using the registered write adapter.
   #[must_use]
   pub fn to_journal<E>(&self, event: ArcShared<dyn Any + Send + Sync>) -> ArcShared<dyn Any + Send + Sync>

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -80,9 +80,7 @@ impl Journal for InMemoryJournal {
         expected = match expected.checked_add(1) {
           | Some(next_expected) => next_expected,
           | None => {
-            return ready(Err(JournalError::InvalidAtomicWrite(String::from(
-              "sequence number overflow in atomic write batch",
-            ))));
+            return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number overflow"))));
           },
         };
       }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -60,14 +60,13 @@ impl Journal for InMemoryJournal {
 
     let persistence_id = first.persistence_id().to_string();
 
-    // AtomicWrite validates each unit; the journal still validates the batch boundary.
-    for atomic_write in messages.iter().skip(1) {
-      if atomic_write.persistence_id() != persistence_id {
-        return ready(Err(JournalError::MixedPersistenceId {
-          expected: persistence_id,
-          actual:   atomic_write.persistence_id().to_string(),
-        }));
-      }
+    if let Some(atomic_write) =
+      messages.iter().skip(1).find(|atomic_write| atomic_write.persistence_id() != persistence_id)
+    {
+      return ready(Err(JournalError::MixedPersistenceId {
+        expected: persistence_id,
+        actual:   atomic_write.persistence_id().to_string(),
+      }));
     }
 
     let mut expected = self.expected_sequence_nr(&persistence_id);

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -62,6 +62,12 @@ impl Journal for InMemoryJournal {
     let mut expected = self.expected_sequence_nr(&persistence_id);
 
     for atomic_write in messages {
+      if atomic_write.persistence_id() != persistence_id {
+        return ready(Err(JournalError::MixedPersistenceId {
+          expected: persistence_id,
+          actual:   atomic_write.persistence_id().to_string(),
+        }));
+      }
       for message in atomic_write.payload() {
         if message.sequence_nr() != expected {
           return ready(Err(JournalError::SequenceMismatch { expected, actual: message.sequence_nr() }));

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -68,6 +68,9 @@ impl Journal for InMemoryJournal {
           actual:   atomic_write.persistence_id().to_string(),
         }));
       }
+    }
+
+    for atomic_write in messages {
       for message in atomic_write.payload() {
         if message.sequence_nr() != expected {
           return ready(Err(JournalError::SequenceMismatch { expected, actual: message.sequence_nr() }));

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -61,7 +61,7 @@ impl Journal for InMemoryJournal {
     let persistence_id = first.persistence_id().to_string();
 
     // AtomicWrite validates each unit; the journal still validates the batch boundary.
-    for atomic_write in messages {
+    for atomic_write in messages.iter().skip(1) {
       if atomic_write.persistence_id() != persistence_id {
         return ready(Err(JournalError::MixedPersistenceId {
           expected: persistence_id,
@@ -79,7 +79,11 @@ impl Journal for InMemoryJournal {
         }
         expected = match expected.checked_add(1) {
           | Some(next_expected) => next_expected,
-          | None => return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number overflow")))),
+          | None => {
+            return ready(Err(JournalError::InvalidAtomicWrite(String::from(
+              "sequence number overflow in atomic write batch",
+            ))));
+          },
         };
       }
     }
@@ -88,7 +92,8 @@ impl Journal for InMemoryJournal {
     for atomic_write in messages {
       entry.extend(atomic_write.payload().iter().cloned());
     }
-    self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
+    // expected_sequence_nr starts at >= 1 and only increases via checked_add.
+    self.highest_sequence_nrs.insert(persistence_id, expected - 1);
 
     ready(Ok(()))
   }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -80,7 +80,7 @@ impl Journal for InMemoryJournal {
         expected = match expected.checked_add(1) {
           | Some(next_expected) => next_expected,
           | None => {
-            return ready(Err(JournalError::WriteFailed(String::from("sequence number exhausted"))));
+            return ready(Err(JournalError::WriteFailed(String::from("sequence number overflow in write batch"))));
           },
         };
       }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -59,7 +59,6 @@ impl Journal for InMemoryJournal {
     };
 
     let persistence_id = first.persistence_id().to_string();
-    let mut expected = self.expected_sequence_nr(&persistence_id);
 
     for atomic_write in messages {
       if atomic_write.persistence_id() != persistence_id {
@@ -69,6 +68,8 @@ impl Journal for InMemoryJournal {
         }));
       }
     }
+
+    let mut expected = self.expected_sequence_nr(&persistence_id);
 
     for atomic_write in messages {
       for message in atomic_write.payload() {

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -13,7 +13,7 @@ use core::future::{Ready, ready};
 
 use crate::{
   journal::{Journal, JournalError},
-  persistent::PersistentRepr,
+  persistent::{AtomicWrite, PersistentRepr},
 };
 
 /// In-memory journal implementation.
@@ -53,7 +53,7 @@ impl Journal for InMemoryJournal {
   where
     Self: 'a;
 
-  fn write_messages<'a>(&'a mut self, messages: &'a [PersistentRepr]) -> Self::WriteFuture<'a> {
+  fn write_messages<'a>(&'a mut self, messages: &'a [AtomicWrite]) -> Self::WriteFuture<'a> {
     let Some(first) = messages.first() else {
       return ready(Ok(()));
     };
@@ -61,15 +61,19 @@ impl Journal for InMemoryJournal {
     let persistence_id = first.persistence_id().to_string();
     let mut expected = self.expected_sequence_nr(&persistence_id);
 
-    for message in messages {
-      if message.sequence_nr() != expected {
-        return ready(Err(JournalError::SequenceMismatch { expected, actual: message.sequence_nr() }));
+    for atomic_write in messages {
+      for message in atomic_write.payload() {
+        if message.sequence_nr() != expected {
+          return ready(Err(JournalError::SequenceMismatch { expected, actual: message.sequence_nr() }));
+        }
+        expected = expected.saturating_add(1);
       }
-      expected = expected.saturating_add(1);
     }
 
     let entry = self.entries.entry(persistence_id.clone()).or_default();
-    entry.extend(messages.iter().cloned());
+    for atomic_write in messages {
+      entry.extend(atomic_write.payload().iter().cloned());
+    }
     self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
 
     ready(Ok(()))

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -80,7 +80,7 @@ impl Journal for InMemoryJournal {
         expected = match expected.checked_add(1) {
           | Some(next_expected) => next_expected,
           | None => {
-            return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number overflow"))));
+            return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number exhausted"))));
           },
         };
       }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -78,7 +78,7 @@ impl Journal for InMemoryJournal {
           return ready(Err(JournalError::SequenceMismatch { expected, actual: message.sequence_nr() }));
         }
         let Some(next_expected) = expected.checked_add(1) else {
-          return ready(Err(JournalError::WriteFailed(String::from("sequence number overflow"))));
+          return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number overflow"))));
         };
         expected = next_expected;
       }
@@ -88,7 +88,7 @@ impl Journal for InMemoryJournal {
     for atomic_write in messages {
       entry.extend(atomic_write.payload().iter().cloned());
     }
-    self.highest_sequence_nrs.insert(persistence_id, expected - 1);
+    self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
 
     ready(Ok(()))
   }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -91,7 +91,7 @@ impl Journal for InMemoryJournal {
       entry.extend(atomic_write.payload().iter().cloned());
     }
     // expected_sequence_nr starts at >= 1 and only increases via checked_add.
-    self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
+    self.highest_sequence_nrs.insert(persistence_id, expected - 1);
 
     ready(Ok(()))
   }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -91,7 +91,7 @@ impl Journal for InMemoryJournal {
       entry.extend(atomic_write.payload().iter().cloned());
     }
     // expected_sequence_nr starts at >= 1 and only increases via checked_add.
-    self.highest_sequence_nrs.insert(persistence_id, expected - 1);
+    self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
 
     ready(Ok(()))
   }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -90,7 +90,7 @@ impl Journal for InMemoryJournal {
     for atomic_write in messages {
       entry.extend(atomic_write.payload().iter().cloned());
     }
-    // expected_sequence_nr starts at >= 1 and only increases via checked_add.
+    // At this point, expected >= 1 and was only incremented via checked_add, so subtraction is safe.
     self.highest_sequence_nrs.insert(persistence_id, expected - 1);
 
     ready(Ok(()))

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -60,6 +60,7 @@ impl Journal for InMemoryJournal {
 
     let persistence_id = first.persistence_id().to_string();
 
+    // AtomicWrite validates each unit; the journal still validates the batch boundary.
     for atomic_write in messages {
       if atomic_write.persistence_id() != persistence_id {
         return ready(Err(JournalError::MixedPersistenceId {

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -88,7 +88,10 @@ impl Journal for InMemoryJournal {
     for atomic_write in messages {
       entry.extend(atomic_write.payload().iter().cloned());
     }
-    self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
+    let Some(highest_sequence_nr) = expected.checked_sub(1) else {
+      return ready(Err(JournalError::InvalidAtomicWrite(String::from("empty write batch"))));
+    };
+    self.highest_sequence_nrs.insert(persistence_id, highest_sequence_nr);
 
     ready(Ok(()))
   }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -77,7 +77,10 @@ impl Journal for InMemoryJournal {
         if message.sequence_nr() != expected {
           return ready(Err(JournalError::SequenceMismatch { expected, actual: message.sequence_nr() }));
         }
-        expected = expected.saturating_add(1);
+        let Some(next_expected) = expected.checked_add(1) else {
+          return ready(Err(JournalError::WriteFailed(String::from("sequence number overflow"))));
+        };
+        expected = next_expected;
       }
     }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -88,7 +88,7 @@ impl Journal for InMemoryJournal {
     for atomic_write in messages {
       entry.extend(atomic_write.payload().iter().cloned());
     }
-    self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
+    self.highest_sequence_nrs.insert(persistence_id, expected - 1);
 
     ready(Ok(()))
   }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -80,7 +80,7 @@ impl Journal for InMemoryJournal {
         expected = match expected.checked_add(1) {
           | Some(next_expected) => next_expected,
           | None => {
-            return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number exhausted"))));
+            return ready(Err(JournalError::WriteFailed(String::from("sequence number exhausted"))));
           },
         };
       }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -77,10 +77,10 @@ impl Journal for InMemoryJournal {
         if message.sequence_nr() != expected {
           return ready(Err(JournalError::SequenceMismatch { expected, actual: message.sequence_nr() }));
         }
-        let Some(next_expected) = expected.checked_add(1) else {
-          return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number overflow"))));
+        expected = match expected.checked_add(1) {
+          | Some(next_expected) => next_expected,
+          | None => return ready(Err(JournalError::InvalidAtomicWrite(String::from("sequence number overflow")))),
         };
-        expected = next_expected;
       }
     }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal.rs
@@ -88,10 +88,7 @@ impl Journal for InMemoryJournal {
     for atomic_write in messages {
       entry.extend(atomic_write.payload().iter().cloned());
     }
-    let Some(highest_sequence_nr) = expected.checked_sub(1) else {
-      return ready(Err(JournalError::InvalidAtomicWrite(String::from("empty write batch"))));
-    };
-    self.highest_sequence_nrs.insert(persistence_id, highest_sequence_nr);
+    self.highest_sequence_nrs.insert(persistence_id, expected.saturating_sub(1));
 
     ready(Ok(()))
   }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -138,7 +138,7 @@ fn in_memory_journal_rejects_sequence_overflow_without_partial_persistence() {
 
   let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
 
-  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number overflow".into())));
+  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number exhausted".into())));
   assert!(poll_ready(journal.replay_messages("pid-1", u64::MAX, u64::MAX, 10)).expect("replay pid-1").is_empty());
 }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -32,7 +32,7 @@ fn build_messages(persistence_id: &str, start: u64, count: u64) -> Vec<Persisten
 }
 
 fn atomic_write(payload: Vec<PersistentRepr>) -> AtomicWrite {
-  AtomicWrite::new(payload).expect("atomic write")
+  AtomicWrite::new(payload).expect("atomic write creation failed")
 }
 
 #[derive(Default)]

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -138,7 +138,7 @@ fn in_memory_journal_rejects_sequence_overflow_without_partial_persistence() {
 
   let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
 
-  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number overflow in atomic write batch".into())));
+  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number overflow".into())));
   assert!(poll_ready(journal.replay_messages("pid-1", u64::MAX, u64::MAX, 10)).expect("replay pid-1").is_empty());
 }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -130,6 +130,18 @@ fn in_memory_journal_sequence_mismatch() {
 }
 
 #[test]
+fn in_memory_journal_rejects_sequence_overflow_without_partial_persistence() {
+  let mut journal = InMemoryJournal::new();
+  journal.highest_sequence_nrs.insert("pid-1".into(), u64::MAX - 1);
+  let messages = build_messages("pid-1", u64::MAX, 1);
+
+  let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
+
+  assert_eq!(result, Err(JournalError::WriteFailed("sequence number overflow".into())));
+  assert!(poll_ready(journal.replay_messages("pid-1", u64::MAX, u64::MAX, 10)).expect("replay pid-1").is_empty());
+}
+
+#[test]
 fn in_memory_journal_rejects_mixed_persistence_ids_without_partial_persistence() {
   let mut journal = InMemoryJournal::new();
   let first = atomic_write(build_messages("pid-1", 1, 1));

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 use core::{
   any::Any,
-  future::{Future, Ready, pending, ready},
+  future::{Future, Ready, ready},
   task::{Context, Poll, Waker},
 };
 
@@ -90,12 +90,6 @@ impl Journal for SingleEntryOnlyJournal {
 }
 
 #[test]
-#[should_panic(expected = "future was pending")]
-fn poll_ready_helper_panics_on_pending_future() {
-  poll_ready(pending::<()>());
-}
-
-#[test]
 fn in_memory_journal_write_and_replay() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 1, 3);
@@ -138,7 +132,7 @@ fn in_memory_journal_rejects_sequence_overflow_without_partial_persistence() {
 
   let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
 
-  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number exhausted".into())));
+  assert_eq!(result, Err(JournalError::WriteFailed("sequence number exhausted".into())));
   assert!(poll_ready(journal.replay_messages("pid-1", u64::MAX, u64::MAX, 10)).expect("replay pid-1").is_empty());
 }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -114,6 +114,19 @@ fn in_memory_journal_sequence_mismatch() {
 }
 
 #[test]
+fn in_memory_journal_rejects_mixed_persistence_ids_without_partial_persistence() {
+  let mut journal = InMemoryJournal::new();
+  let first = atomic_write(build_messages("pid-1", 1, 1));
+  let second = atomic_write(build_messages("pid-2", 1, 1));
+
+  let result = poll_ready(journal.write_messages(&[first, second]));
+
+  assert_eq!(result, Err(JournalError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() }));
+  assert!(poll_ready(journal.replay_messages("pid-1", 1, 1, 10)).expect("replay pid-1").is_empty());
+  assert!(poll_ready(journal.replay_messages("pid-2", 1, 1, 10)).expect("replay pid-2").is_empty());
+}
+
+#[test]
 fn in_memory_journal_replay_respects_max() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 1, 3);

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -91,7 +91,7 @@ impl Journal for SingleEntryOnlyJournal {
 
 #[test]
 #[should_panic(expected = "future was pending")]
-fn poll_ready_panics_when_future_is_pending() {
+fn poll_ready_helper_panics_on_pending_future() {
   poll_ready(pending::<()>());
 }
 
@@ -127,6 +127,7 @@ fn in_memory_journal_sequence_mismatch() {
 
   let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
   assert_eq!(result, Err(JournalError::SequenceMismatch { expected: 1, actual: 2 }));
+  assert!(poll_ready(journal.replay_messages("pid-1", 1, 1, 10)).expect("replay failed").is_empty());
 }
 
 #[test]
@@ -137,7 +138,7 @@ fn in_memory_journal_rejects_sequence_overflow_without_partial_persistence() {
 
   let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
 
-  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number overflow".into())));
+  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number overflow in atomic write batch".into())));
   assert!(poll_ready(journal.replay_messages("pid-1", u64::MAX, u64::MAX, 10)).expect("replay pid-1").is_empty());
 }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -132,7 +132,7 @@ fn in_memory_journal_rejects_sequence_overflow_without_partial_persistence() {
 
   let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
 
-  assert_eq!(result, Err(JournalError::WriteFailed("sequence number exhausted".into())));
+  assert_eq!(result, Err(JournalError::WriteFailed("sequence number overflow in write batch".into())));
   assert!(poll_ready(journal.replay_messages("pid-1", u64::MAX, u64::MAX, 10)).expect("replay pid-1").is_empty());
 }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 use core::{
   any::Any,
-  future::Future,
+  future::{Future, Ready, ready},
   task::{Context, Poll, Waker},
 };
 
@@ -9,7 +9,7 @@ use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::{
   journal::{InMemoryJournal, Journal, JournalError},
-  persistent::PersistentRepr,
+  persistent::{AtomicWrite, PersistentRepr},
 };
 
 fn poll_ready<F: Future>(future: F) -> F::Output {
@@ -31,12 +31,70 @@ fn build_messages(persistence_id: &str, start: u64, count: u64) -> Vec<Persisten
     .collect()
 }
 
+fn atomic_write(payload: Vec<PersistentRepr>) -> AtomicWrite {
+  AtomicWrite::new(payload).expect("atomic write")
+}
+
+#[derive(Default)]
+struct SingleEntryOnlyJournal {
+  persisted: Vec<PersistentRepr>,
+}
+
+impl Journal for SingleEntryOnlyJournal {
+  type DeleteFuture<'a>
+    = Ready<Result<(), JournalError>>
+  where
+    Self: 'a;
+  type HighestSeqNrFuture<'a>
+    = Ready<Result<u64, JournalError>>
+  where
+    Self: 'a;
+  type ReplayFuture<'a>
+    = Ready<Result<Vec<PersistentRepr>, JournalError>>
+  where
+    Self: 'a;
+  type WriteFuture<'a>
+    = Ready<Result<(), JournalError>>
+  where
+    Self: 'a;
+
+  fn write_messages<'a>(&'a mut self, messages: &'a [AtomicWrite]) -> Self::WriteFuture<'a> {
+    for message in messages {
+      if message.size() > 1 {
+        return ready(Err(JournalError::UnsupportedAtomicWrite { size: message.size() }));
+      }
+    }
+    for message in messages {
+      self.persisted.extend(message.payload().iter().cloned());
+    }
+    ready(Ok(()))
+  }
+
+  fn replay_messages<'a>(
+    &'a self,
+    _persistence_id: &'a str,
+    _from_sequence_nr: u64,
+    _to_sequence_nr: u64,
+    _max: u64,
+  ) -> Self::ReplayFuture<'a> {
+    ready(Ok(self.persisted.clone()))
+  }
+
+  fn delete_messages_to<'a>(&'a mut self, _persistence_id: &'a str, _to_sequence_nr: u64) -> Self::DeleteFuture<'a> {
+    ready(Ok(()))
+  }
+
+  fn highest_sequence_nr<'a>(&'a self, _persistence_id: &'a str) -> Self::HighestSeqNrFuture<'a> {
+    ready(Ok(0))
+  }
+}
+
 #[test]
 fn in_memory_journal_write_and_replay() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 1, 3);
 
-  let result = poll_ready(journal.write_messages(&messages));
+  let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
   assert!(result.is_ok());
 
   let replayed = poll_ready(journal.replay_messages("pid-1", 1, 3, 10)).expect("replay failed");
@@ -51,7 +109,7 @@ fn in_memory_journal_sequence_mismatch() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 2, 1);
 
-  let result = poll_ready(journal.write_messages(&messages));
+  let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
   assert_eq!(result, Err(JournalError::SequenceMismatch { expected: 1, actual: 2 }));
 }
 
@@ -59,7 +117,7 @@ fn in_memory_journal_sequence_mismatch() {
 fn in_memory_journal_replay_respects_max() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 1, 3);
-  poll_ready(journal.write_messages(&messages)).expect("write failed");
+  poll_ready(journal.write_messages(&[atomic_write(messages)])).expect("write failed");
 
   let replayed = poll_ready(journal.replay_messages("pid-1", 1, 3, 1)).expect("replay failed");
   assert_eq!(replayed.len(), 1);
@@ -70,7 +128,7 @@ fn in_memory_journal_replay_respects_max() {
 fn in_memory_journal_delete_messages_to() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 1, 3);
-  poll_ready(journal.write_messages(&messages)).expect("write failed");
+  poll_ready(journal.write_messages(&[atomic_write(messages)])).expect("write failed");
 
   poll_ready(journal.delete_messages_to("pid-1", 2)).expect("delete failed");
 
@@ -83,7 +141,7 @@ fn in_memory_journal_delete_messages_to() {
 fn in_memory_journal_delete_keeps_highest_sequence_nr() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 1, 3);
-  poll_ready(journal.write_messages(&messages)).expect("write failed");
+  poll_ready(journal.write_messages(&[atomic_write(messages)])).expect("write failed");
 
   poll_ready(journal.delete_messages_to("pid-1", 3)).expect("delete failed");
 
@@ -91,11 +149,11 @@ fn in_memory_journal_delete_keeps_highest_sequence_nr() {
   assert_eq!(highest, 3);
 
   let mismatch = build_messages("pid-1", 1, 1);
-  let result = poll_ready(journal.write_messages(&mismatch));
+  let result = poll_ready(journal.write_messages(&[atomic_write(mismatch)]));
   assert_eq!(result, Err(JournalError::SequenceMismatch { expected: 4, actual: 1 }));
 
   let next = build_messages("pid-1", 4, 1);
-  poll_ready(journal.write_messages(&next)).expect("write failed");
+  poll_ready(journal.write_messages(&[atomic_write(next)])).expect("write failed");
 }
 
 #[test]
@@ -104,4 +162,15 @@ fn in_memory_journal_highest_sequence_nr_defaults_to_zero() {
 
   let highest = poll_ready(journal.highest_sequence_nr("missing")).expect("highest failed");
   assert_eq!(highest, 0);
+}
+
+#[test]
+fn backend_rejects_unsupported_multi_entry_atomic_write_without_partial_persistence() {
+  let mut journal = SingleEntryOnlyJournal::default();
+  let multi_entry = atomic_write(build_messages("pid-1", 1, 2));
+
+  let result = poll_ready(journal.write_messages(&[multi_entry]));
+
+  assert_eq!(result, Err(JournalError::UnsupportedAtomicWrite { size: 2 }));
+  assert!(journal.persisted.is_empty());
 }

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -137,7 +137,7 @@ fn in_memory_journal_rejects_sequence_overflow_without_partial_persistence() {
 
   let result = poll_ready(journal.write_messages(&[atomic_write(messages)]));
 
-  assert_eq!(result, Err(JournalError::WriteFailed("sequence number overflow".into())));
+  assert_eq!(result, Err(JournalError::InvalidAtomicWrite("sequence number overflow".into())));
   assert!(poll_ready(journal.replay_messages("pid-1", u64::MAX, u64::MAX, 10)).expect("replay pid-1").is_empty());
 }
 

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -105,6 +105,16 @@ fn in_memory_journal_write_and_replay() {
 }
 
 #[test]
+fn in_memory_journal_empty_batch_is_noop() {
+  let mut journal = InMemoryJournal::new();
+
+  let result = poll_ready(journal.write_messages(&[]));
+
+  assert!(result.is_ok());
+  assert_eq!(poll_ready(journal.highest_sequence_nr("pid-1")).expect("highest failed"), 0);
+}
+
+#[test]
 fn in_memory_journal_sequence_mismatch() {
   let mut journal = InMemoryJournal::new();
   let messages = build_messages("pid-1", 2, 1);

--- a/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
+++ b/modules/persistence-core-kernel/src/journal/in_memory_journal_test.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 use core::{
   any::Any,
-  future::{Future, Ready, ready},
+  future::{Future, Ready, pending, ready},
   task::{Context, Poll, Waker},
 };
 
@@ -87,6 +87,12 @@ impl Journal for SingleEntryOnlyJournal {
   fn highest_sequence_nr<'a>(&'a self, _persistence_id: &'a str) -> Self::HighestSeqNrFuture<'a> {
     ready(Ok(0))
   }
+}
+
+#[test]
+#[should_panic(expected = "future was pending")]
+fn poll_ready_panics_when_future_is_pending() {
+  poll_ready(pending::<()>());
 }
 
 #[test]
@@ -196,4 +202,19 @@ fn backend_rejects_unsupported_multi_entry_atomic_write_without_partial_persiste
 
   assert_eq!(result, Err(JournalError::UnsupportedAtomicWrite { size: 2 }));
   assert!(journal.persisted.is_empty());
+}
+
+#[test]
+fn backend_accepts_single_entry_atomic_writes() {
+  let mut journal = SingleEntryOnlyJournal::default();
+  let first = atomic_write(build_messages("pid-1", 1, 1));
+  let second = atomic_write(build_messages("pid-1", 2, 1));
+
+  poll_ready(journal.write_messages(&[first, second])).expect("write failed");
+  let replayed = poll_ready(journal.replay_messages("pid-1", 1, 2, 10)).expect("replay failed");
+  poll_ready(journal.delete_messages_to("pid-1", 2)).expect("delete failed");
+  let highest = poll_ready(journal.highest_sequence_nr("pid-1")).expect("highest failed");
+
+  assert_eq!(replayed.len(), 2);
+  assert_eq!(highest, 0);
 }

--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -287,20 +287,12 @@ fn send_write_failure(sender: &mut ActorRef, messages: &[AtomicWrite], instance_
   for repr in atomic_write_payloads(messages) {
     tell_response(sender, JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id });
   }
-  tell_response(sender, JournalResponse::WriteMessagesFailed {
-    cause: error,
-    write_count: atomic_write_payload_count(messages),
-    instance_id,
-  });
+  tell_response(sender, JournalResponse::WriteMessagesFailed { cause: error, write_count: 0, instance_id });
 }
 
 fn atomic_write_payloads(messages: &[AtomicWrite]) -> impl Iterator<Item = PersistentRepr> + '_ {
-  // Journal responses outlive this borrowed batch, so each response owns its PersistentRepr.
+  // ジャーナル応答は借用中のバッチより長く残るため、各応答は PersistentRepr を所有する。
   messages.iter().flat_map(AtomicWrite::payload).cloned()
-}
-
-fn atomic_write_payload_count(messages: &[AtomicWrite]) -> u64 {
-  messages.iter().map(AtomicWrite::size).sum::<usize>() as u64
 }
 
 fn poll_replay_entry<J: Journal>(

--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -295,6 +295,7 @@ fn send_write_failure(sender: &mut ActorRef, messages: &[AtomicWrite], instance_
 }
 
 fn atomic_write_payloads(messages: &[AtomicWrite]) -> impl Iterator<Item = PersistentRepr> + '_ {
+  // Journal responses outlive this borrowed batch, so each response owns its PersistentRepr.
   messages.iter().flat_map(AtomicWrite::payload).cloned()
 }
 

--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -287,19 +287,11 @@ fn send_write_failure(sender: &mut ActorRef, messages: &[AtomicWrite], instance_
   for repr in atomic_write_payloads(messages) {
     tell_response(sender, JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id });
   }
-  tell_response(sender, JournalResponse::WriteMessagesFailed {
-    cause: error,
-    write_count: atomic_write_payload_count(messages),
-    instance_id,
-  });
+  tell_response(sender, JournalResponse::WriteMessagesFailed { cause: error, write_count: 0, instance_id });
 }
 
 fn atomic_write_payloads(messages: &[AtomicWrite]) -> impl Iterator<Item = PersistentRepr> + '_ {
   messages.iter().flat_map(AtomicWrite::payload).cloned()
-}
-
-fn atomic_write_payload_count(messages: &[AtomicWrite]) -> u64 {
-  messages.iter().map(AtomicWrite::size).sum::<usize>() as u64
 }
 
 fn poll_replay_entry<J: Journal>(

--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -284,15 +284,20 @@ where
 }
 
 fn send_write_failure(sender: &mut ActorRef, messages: &[AtomicWrite], instance_id: u32, error: JournalError) {
+  let write_count = atomic_write_payload_count(messages);
   for repr in atomic_write_payloads(messages) {
     tell_response(sender, JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id });
   }
-  tell_response(sender, JournalResponse::WriteMessagesFailed { cause: error, write_count: 0, instance_id });
+  tell_response(sender, JournalResponse::WriteMessagesFailed { cause: error, write_count, instance_id });
 }
 
 fn atomic_write_payloads(messages: &[AtomicWrite]) -> impl Iterator<Item = PersistentRepr> + '_ {
   // ジャーナル応答は借用中のバッチより長く残るため、各応答は PersistentRepr を所有する。
   messages.iter().flat_map(AtomicWrite::payload).cloned()
+}
+
+fn atomic_write_payload_count(messages: &[AtomicWrite]) -> u64 {
+  messages.iter().map(AtomicWrite::size).sum::<usize>() as u64
 }
 
 fn poll_replay_entry<J: Journal>(

--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -287,11 +287,19 @@ fn send_write_failure(sender: &mut ActorRef, messages: &[AtomicWrite], instance_
   for repr in atomic_write_payloads(messages) {
     tell_response(sender, JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id });
   }
-  tell_response(sender, JournalResponse::WriteMessagesFailed { cause: error, write_count: 0, instance_id });
+  tell_response(sender, JournalResponse::WriteMessagesFailed {
+    cause: error,
+    write_count: atomic_write_payload_count(messages),
+    instance_id,
+  });
 }
 
 fn atomic_write_payloads(messages: &[AtomicWrite]) -> impl Iterator<Item = PersistentRepr> + '_ {
   messages.iter().flat_map(AtomicWrite::payload).cloned()
+}
+
+fn atomic_write_payload_count(messages: &[AtomicWrite]) -> u64 {
+  messages.iter().map(AtomicWrite::size).sum::<usize>() as u64
 }
 
 fn poll_replay_entry<J: Journal>(

--- a/modules/persistence-core-kernel/src/journal/journal_actor.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor.rs
@@ -20,7 +20,7 @@ use fraktor_actor_core_kernel_rs::actor::{
 
 use crate::{
   journal::{Journal, JournalActorConfig, JournalError, JournalMessage, JournalResponse},
-  persistent::PersistentRepr,
+  persistent::{AtomicWrite, PersistentRepr},
 };
 
 struct JournalPoll;
@@ -45,7 +45,7 @@ struct JournalReplayRequest {
 enum JournalInFlight {
   Write {
     future:      JournalWriteFuture,
-    messages:    Vec<PersistentRepr>,
+    messages:    Vec<AtomicWrite>,
     sender:      ActorRef,
     instance_id: u32,
     retry_count: u32,
@@ -237,7 +237,7 @@ fn poll_write_entry<J: Journal>(
   poll_context: &mut JournalPollContext<'_, J>,
   cx: &mut Context<'_>,
   future: &mut JournalWriteFuture,
-  messages: &[PersistentRepr],
+  messages: &[AtomicWrite],
   sender: &mut ActorRef,
   instance_id: u32,
   retry_count: &mut u32,
@@ -256,8 +256,8 @@ where
   }
 }
 
-fn send_write_success(sender: &mut ActorRef, messages: &[PersistentRepr], instance_id: u32) {
-  for repr in messages.iter().cloned() {
+fn send_write_success(sender: &mut ActorRef, messages: &[AtomicWrite], instance_id: u32) {
+  for repr in atomic_write_payloads(messages) {
     tell_response(sender, JournalResponse::WriteMessageSuccess { repr, instance_id });
   }
   tell_response(sender, JournalResponse::WriteMessagesSuccessful { instance_id });
@@ -266,7 +266,7 @@ fn send_write_success(sender: &mut ActorRef, messages: &[PersistentRepr], instan
 fn retry_or_fail_write<J: Journal>(
   poll_context: &mut JournalPollContext<'_, J>,
   future: &mut JournalWriteFuture,
-  messages: &[PersistentRepr],
+  messages: &[AtomicWrite],
   sender: &mut ActorRef,
   instance_id: u32,
   retry_count: &mut u32,
@@ -283,15 +283,23 @@ where
   false
 }
 
-fn send_write_failure(sender: &mut ActorRef, messages: &[PersistentRepr], instance_id: u32, error: JournalError) {
-  for repr in messages.iter().cloned() {
+fn send_write_failure(sender: &mut ActorRef, messages: &[AtomicWrite], instance_id: u32, error: JournalError) {
+  for repr in atomic_write_payloads(messages) {
     tell_response(sender, JournalResponse::WriteMessageFailure { repr, cause: error.clone(), instance_id });
   }
   tell_response(sender, JournalResponse::WriteMessagesFailed {
     cause: error,
-    write_count: messages.len() as u64,
+    write_count: atomic_write_payload_count(messages),
     instance_id,
   });
+}
+
+fn atomic_write_payloads(messages: &[AtomicWrite]) -> impl Iterator<Item = PersistentRepr> + '_ {
+  messages.iter().flat_map(AtomicWrite::payload).cloned()
+}
+
+fn atomic_write_payload_count(messages: &[AtomicWrite]) -> u64 {
+  messages.iter().map(AtomicWrite::size).sum::<usize>() as u64
 }
 
 fn poll_replay_entry<J: Journal>(

--- a/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
@@ -450,7 +450,7 @@ fn journal_actor_retry_max_exceeded_on_errors() {
     }
     if let JournalResponse::WriteMessagesFailed { cause, write_count, instance_id } = response {
       assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
-      assert_eq!(*write_count, 0);
+      assert_eq!(*write_count, 1);
       assert_eq!(*instance_id, 1);
       batch_failures += 1;
     }

--- a/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
@@ -450,7 +450,7 @@ fn journal_actor_retry_max_exceeded_on_errors() {
     }
     if let JournalResponse::WriteMessagesFailed { cause, write_count, instance_id } = response {
       assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
-      assert_eq!(*write_count, 1);
+      assert_eq!(*write_count, 0);
       assert_eq!(*instance_id, 1);
       batch_failures += 1;
     }

--- a/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
@@ -448,8 +448,9 @@ fn journal_actor_retry_max_exceeded_on_errors() {
       assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
       failures += 1;
     }
-    if let JournalResponse::WriteMessagesFailed { cause, instance_id, .. } = response {
+    if let JournalResponse::WriteMessagesFailed { cause, write_count, instance_id } = response {
       assert_eq!(cause, &JournalError::WriteFailed("boom".into()));
+      assert_eq!(*write_count, 0);
       assert_eq!(*instance_id, 1);
       batch_failures += 1;
     }

--- a/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_actor_test.rs
@@ -20,7 +20,7 @@ use fraktor_utils_core_rs::sync::{ArcShared, SharedLock, SpinSyncMutex};
 use super::JournalPoll;
 use crate::{
   journal::{InMemoryJournal, JournalActor, JournalActorConfig, JournalError, JournalMessage, JournalResponse},
-  persistent::PersistentRepr,
+  persistent::{AtomicWrite, PersistentRepr},
 };
 
 type MessageStore = ArcShared<SpinSyncMutex<Vec<AnyMessage>>>;
@@ -51,6 +51,10 @@ fn create_sender() -> (ActorRef, MessageStore) {
 
 fn test_actor_pid() -> Pid {
   Pid::new(10_000, 1)
+}
+
+fn atomic_write(payload: Vec<PersistentRepr>) -> AtomicWrite {
+  AtomicWrite::new(payload).expect("atomic write")
 }
 
 fn new_test_system() -> ActorSystem {
@@ -93,7 +97,7 @@ impl crate::journal::Journal for PendingJournal {
   where
     Self: 'a;
 
-  fn write_messages<'a>(&'a mut self, _messages: &'a [PersistentRepr]) -> Self::WriteFuture<'a> {
+  fn write_messages<'a>(&'a mut self, _messages: &'a [AtomicWrite]) -> Self::WriteFuture<'a> {
     pending()
   }
 
@@ -144,7 +148,7 @@ impl crate::journal::Journal for RetryJournal {
   where
     Self: 'a;
 
-  fn write_messages<'a>(&'a mut self, _messages: &'a [PersistentRepr]) -> Self::WriteFuture<'a> {
+  fn write_messages<'a>(&'a mut self, _messages: &'a [AtomicWrite]) -> Self::WriteFuture<'a> {
     if self.failures_left > 0 {
       self.failures_left -= 1;
       ready(Err(JournalError::WriteFailed("boom".into())))
@@ -212,7 +216,7 @@ impl crate::journal::Journal for ScriptedJournal {
   where
     Self: 'a;
 
-  fn write_messages<'a>(&'a mut self, _messages: &'a [PersistentRepr]) -> Self::WriteFuture<'a> {
+  fn write_messages<'a>(&'a mut self, _messages: &'a [AtomicWrite]) -> Self::WriteFuture<'a> {
     ready(Ok(()))
   }
 
@@ -260,7 +264,7 @@ fn scripted_journal_success_paths_are_exercised() {
   let write = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 1,
-    messages:       vec![repr],
+    messages:       vec![atomic_write(vec![repr])],
     sender:         sender.clone(),
     instance_id:    7,
   };
@@ -308,7 +312,7 @@ fn journal_actor_write_messages_sends_responses() {
   let message = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 2,
-    messages: vec![repr1, repr2],
+    messages: vec![atomic_write(vec![repr1, repr2])],
     sender,
     instance_id: 9,
   };
@@ -361,7 +365,7 @@ fn journal_actor_pending_does_not_emit_failure() {
   let message = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 1,
-    messages: vec![repr],
+    messages: vec![atomic_write(vec![repr])],
     sender,
     instance_id: 1,
   };
@@ -421,7 +425,7 @@ fn journal_actor_retry_max_exceeded_on_errors() {
   let message = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 1,
-    messages: vec![repr],
+    messages: vec![atomic_write(vec![repr])],
     sender,
     instance_id: 1,
   };
@@ -497,7 +501,7 @@ fn journal_actor_delete_and_highest_success_responses() {
   let write = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 1,
-    messages:       vec![repr],
+    messages:       vec![atomic_write(vec![repr])],
     sender:         sender.clone(),
     instance_id:    7,
   };
@@ -596,7 +600,7 @@ fn journal_actor_replay_filters_deleted_messages() {
   let write = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 3,
-    messages:       vec![repr1, repr2, repr3],
+    messages:       vec![atomic_write(vec![repr1, repr2, repr3])],
     sender:         sender.clone(),
     instance_id:    10,
   };
@@ -641,7 +645,7 @@ fn journal_actor_success_responses_to_null_sender_do_not_fail() {
   let write = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 1,
-    messages:       vec![repr],
+    messages:       vec![atomic_write(vec![repr])],
     sender:         ActorRef::null(),
     instance_id:    7,
   };
@@ -684,7 +688,7 @@ fn journal_actor_failure_responses_to_null_sender_do_not_fail() {
   let write = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 1,
-    messages:       vec![repr],
+    messages:       vec![atomic_write(vec![repr])],
     sender:         ActorRef::null(),
     instance_id:    7,
   };

--- a/modules/persistence-core-kernel/src/journal/journal_error.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_error.rs
@@ -19,6 +19,11 @@ pub enum JournalError {
   },
   /// Failed to write messages.
   WriteFailed(String),
+  /// Backend cannot guarantee a multi-entry atomic write.
+  UnsupportedAtomicWrite {
+    /// Number of events in the rejected atomic write.
+    size: usize,
+  },
   /// Failed to read messages.
   ReadFailed(String),
   /// Failed to delete messages.
@@ -32,6 +37,9 @@ impl Display for JournalError {
         write!(formatter, "sequence mismatch: expected {}, actual {}", expected, actual)
       },
       | JournalError::WriteFailed(reason) => write!(formatter, "write failed: {}", reason),
+      | JournalError::UnsupportedAtomicWrite { size } => {
+        write!(formatter, "unsupported atomic write size: {}", size)
+      },
       | JournalError::ReadFailed(reason) => write!(formatter, "read failed: {}", reason),
       | JournalError::DeleteFailed(reason) => write!(formatter, "delete failed: {}", reason),
     }

--- a/modules/persistence-core-kernel/src/journal/journal_error.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_error.rs
@@ -19,6 +19,15 @@ pub enum JournalError {
   },
   /// Failed to write messages.
   WriteFailed(String),
+  /// Atomic write payload failed local validation before it reached the journal.
+  InvalidAtomicWrite(String),
+  /// A write batch contained multiple persistence ids.
+  MixedPersistenceId {
+    /// Expected persistence id for the batch.
+    expected: String,
+    /// Actual persistence id encountered.
+    actual:   String,
+  },
   /// Backend cannot guarantee a multi-entry atomic write.
   UnsupportedAtomicWrite {
     /// Number of events in the rejected atomic write.
@@ -37,6 +46,10 @@ impl Display for JournalError {
         write!(formatter, "sequence mismatch: expected {}, actual {}", expected, actual)
       },
       | JournalError::WriteFailed(reason) => write!(formatter, "write failed: {}", reason),
+      | JournalError::InvalidAtomicWrite(reason) => write!(formatter, "invalid atomic write: {}", reason),
+      | JournalError::MixedPersistenceId { expected, actual } => {
+        write!(formatter, "mixed persistence id: expected {}, actual {}", expected, actual)
+      },
       | JournalError::UnsupportedAtomicWrite { size } => {
         write!(formatter, "unsupported atomic write size: {}", size)
       },

--- a/modules/persistence-core-kernel/src/journal/journal_error_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_error_test.rs
@@ -31,6 +31,13 @@ fn journal_error_display_mixed_persistence_id() {
 }
 
 #[test]
+fn journal_error_display_unsupported_atomic_write() {
+  let error = JournalError::UnsupportedAtomicWrite { size: 2 };
+
+  assert_eq!(error.to_string(), "unsupported atomic write size: 2");
+}
+
+#[test]
 fn journal_error_display_read_failed() {
   let error = JournalError::ReadFailed("decode error".into());
 

--- a/modules/persistence-core-kernel/src/journal/journal_error_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_error_test.rs
@@ -17,6 +17,20 @@ fn journal_error_display_write_failed() {
 }
 
 #[test]
+fn journal_error_display_invalid_atomic_write() {
+  let error = JournalError::InvalidAtomicWrite("empty payload".into());
+
+  assert_eq!(error.to_string(), "invalid atomic write: empty payload");
+}
+
+#[test]
+fn journal_error_display_mixed_persistence_id() {
+  let error = JournalError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() };
+
+  assert_eq!(error.to_string(), "mixed persistence id: expected pid-1, actual pid-2");
+}
+
+#[test]
 fn journal_error_display_read_failed() {
   let error = JournalError::ReadFailed("decode error".into());
 

--- a/modules/persistence-core-kernel/src/journal/journal_message.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_message.rs
@@ -8,7 +8,7 @@ use alloc::{string::String, vec::Vec};
 
 use fraktor_actor_core_kernel_rs::actor::actor_ref::ActorRef;
 
-use crate::persistent::PersistentRepr;
+use crate::persistent::AtomicWrite;
 
 /// Messages sent to the journal actor.
 #[derive(Clone, Debug)]
@@ -19,8 +19,8 @@ pub enum JournalMessage {
     persistence_id: String,
     /// Max sequence number within the batch.
     to_sequence_nr: u64,
-    /// Events to persist.
-    messages:       Vec<PersistentRepr>,
+    /// Atomic write units to persist.
+    messages:       Vec<AtomicWrite>,
     /// Request sender.
     sender:         ActorRef,
     /// Instance id for correlation.

--- a/modules/persistence-core-kernel/src/journal/journal_message_test.rs
+++ b/modules/persistence-core-kernel/src/journal/journal_message_test.rs
@@ -4,7 +4,10 @@ use core::any::Any;
 use fraktor_actor_core_kernel_rs::actor::actor_ref::ActorRef;
 use fraktor_utils_core_rs::sync::ArcShared;
 
-use crate::{journal::JournalMessage, persistent::PersistentRepr};
+use crate::{
+  journal::JournalMessage,
+  persistent::{AtomicWrite, PersistentRepr},
+};
 
 #[test]
 fn journal_message_write_messages_fields() {
@@ -15,7 +18,7 @@ fn journal_message_write_messages_fields() {
   let message = JournalMessage::WriteMessages {
     persistence_id: "pid-1".into(),
     to_sequence_nr: 1,
-    messages:       vec![repr.clone()],
+    messages:       vec![AtomicWrite::new(vec![repr.clone()]).expect("atomic write")],
     sender:         sender.clone(),
     instance_id:    7,
   };
@@ -25,7 +28,7 @@ fn journal_message_write_messages_fields() {
       assert_eq!(persistence_id, "pid-1");
       assert_eq!(to_sequence_nr, 1);
       assert_eq!(messages.len(), 1);
-      assert_eq!(messages[0].sequence_nr(), repr.sequence_nr());
+      assert_eq!(messages[0].payload()[0].sequence_nr(), repr.sequence_nr());
       assert_eq!(instance_id, 7);
     },
     | _ => panic!("unexpected variant"),

--- a/modules/persistence-core-kernel/src/journal/persistence_plugin_proxy.rs
+++ b/modules/persistence-core-kernel/src/journal/persistence_plugin_proxy.rs
@@ -10,7 +10,7 @@ use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::{
   journal::Journal,
-  persistent::PersistentRepr,
+  persistent::AtomicWrite,
   snapshot::{SnapshotMetadata, SnapshotSelectionCriteria, SnapshotStore},
 };
 
@@ -57,7 +57,7 @@ where
   where
     Self: 'a;
 
-  fn write_messages<'a>(&'a mut self, messages: &'a [PersistentRepr]) -> Self::WriteFuture<'a> {
+  fn write_messages<'a>(&'a mut self, messages: &'a [AtomicWrite]) -> Self::WriteFuture<'a> {
     self.journal.write_messages(messages)
   }
 

--- a/modules/persistence-core-kernel/src/journal/persistence_plugin_proxy_test.rs
+++ b/modules/persistence-core-kernel/src/journal/persistence_plugin_proxy_test.rs
@@ -9,7 +9,7 @@ use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::{
   journal::{InMemoryJournal, Journal, PersistencePluginProxy},
-  persistent::PersistentRepr,
+  persistent::{AtomicWrite, PersistentRepr},
   snapshot::{InMemorySnapshotStore, SnapshotMetadata, SnapshotSelectionCriteria, SnapshotStore},
 };
 
@@ -32,6 +32,10 @@ fn build_messages(persistence_id: &str, start: u64, count: u64) -> Vec<Persisten
     .collect()
 }
 
+fn atomic_write(payload: Vec<PersistentRepr>) -> AtomicWrite {
+  AtomicWrite::new(payload).expect("atomic write")
+}
+
 fn payload(value: i32) -> ArcShared<dyn Any + Send + Sync> {
   ArcShared::new(value)
 }
@@ -41,7 +45,7 @@ fn plugin_proxy_forwards_journal_operations() {
   let mut proxy = PersistencePluginProxy::new(InMemoryJournal::new(), InMemorySnapshotStore::new());
   let messages = build_messages("pid-1", 1, 2);
 
-  poll_ready(Journal::write_messages(&mut proxy, &messages)).expect("write failed");
+  poll_ready(Journal::write_messages(&mut proxy, &[atomic_write(messages)])).expect("write failed");
   let replayed = poll_ready(Journal::replay_messages(&proxy, "pid-1", 1, 10, 10)).expect("replay failed");
   let highest = poll_ready(Journal::highest_sequence_nr(&proxy, "pid-1")).expect("highest failed");
 
@@ -66,7 +70,7 @@ fn plugin_proxy_forwards_snapshot_operations() {
 fn plugin_proxy_set_target_replaces_plugins() {
   let mut proxy = PersistencePluginProxy::new(InMemoryJournal::new(), InMemorySnapshotStore::new());
   let messages = build_messages("pid-1", 1, 1);
-  poll_ready(Journal::write_messages(&mut proxy, &messages)).expect("write failed");
+  poll_ready(Journal::write_messages(&mut proxy, &[atomic_write(messages)])).expect("write failed");
 
   proxy.set_target(InMemoryJournal::new(), InMemorySnapshotStore::new());
 

--- a/modules/persistence-core-kernel/src/lib.rs
+++ b/modules/persistence-core-kernel/src/lib.rs
@@ -64,5 +64,6 @@ pub mod extension;
 pub mod fsm;
 pub mod journal;
 pub mod persistent;
+pub mod serialization;
 pub mod snapshot;
 pub mod state;

--- a/modules/persistence-core-kernel/src/persistent.rs
+++ b/modules/persistence-core-kernel/src/persistent.rs
@@ -1,5 +1,7 @@
 //! Persistent actor package.
 
+mod atomic_write;
+mod atomic_write_error;
 mod eventsourced;
 mod pending_handler_invocation;
 mod persistence_context;
@@ -13,6 +15,8 @@ mod recovery;
 mod recovery_timed_out;
 mod stash_overflow_strategy;
 
+pub use atomic_write::AtomicWrite;
+pub use atomic_write_error::AtomicWriteError;
 pub use eventsourced::Eventsourced;
 pub use pending_handler_invocation::PendingHandlerInvocation;
 pub use persistence_context::PersistenceContext;

--- a/modules/persistence-core-kernel/src/persistent/atomic_write.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write.rs
@@ -46,25 +46,21 @@ impl AtomicWrite {
   /// Returns the lowest sequence number in the payload.
   #[must_use]
   pub fn lowest_sequence_nr(&self) -> u64 {
-    self.payload.iter().map(PersistentRepr::sequence_nr).min().unwrap_or(0)
+    let first = self.payload[0].sequence_nr();
+    self.payload.iter().skip(1).fold(first, |lowest, repr| lowest.min(repr.sequence_nr()))
   }
 
   /// Returns the highest sequence number in the payload.
   #[must_use]
   pub fn highest_sequence_nr(&self) -> u64 {
-    self.payload.iter().map(PersistentRepr::sequence_nr).max().unwrap_or(0)
+    let first = self.payload[0].sequence_nr();
+    self.payload.iter().skip(1).fold(first, |highest, repr| highest.max(repr.sequence_nr()))
   }
 
   /// Returns the number of persistent representations in the atomic write.
   #[must_use]
   pub const fn size(&self) -> usize {
     self.payload.len()
-  }
-
-  /// Returns `true` when the atomic write contains no payload entries.
-  #[must_use]
-  pub const fn is_empty(&self) -> bool {
-    self.payload.is_empty()
   }
 
   /// Returns the contained persistent representations.

--- a/modules/persistence-core-kernel/src/persistent/atomic_write.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write.rs
@@ -1,0 +1,82 @@
+//! Atomic journal write boundary.
+
+#[cfg(test)]
+#[path = "atomic_write_test.rs"]
+mod tests;
+
+use alloc::{string::ToString, vec::Vec};
+
+use crate::persistent::{AtomicWriteError, PersistentRepr};
+
+/// All-or-none journal write unit for one persistence id.
+#[derive(Clone, Debug)]
+pub struct AtomicWrite {
+  payload: Vec<PersistentRepr>,
+}
+
+impl AtomicWrite {
+  /// Creates an atomic write after validating the journal atomicity invariant.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`AtomicWriteError::Empty`] for empty payloads and
+  /// [`AtomicWriteError::MixedPersistenceId`] when entries contain different persistence ids.
+  pub fn new(payload: Vec<PersistentRepr>) -> Result<Self, AtomicWriteError> {
+    let Some(first) = payload.first() else {
+      return Err(AtomicWriteError::Empty);
+    };
+    let persistence_id = first.persistence_id();
+    for repr in &payload {
+      if repr.persistence_id() != persistence_id {
+        return Err(AtomicWriteError::MixedPersistenceId {
+          expected: persistence_id.to_string(),
+          actual:   repr.persistence_id().to_string(),
+        });
+      }
+    }
+    Ok(Self { payload })
+  }
+
+  /// Returns the persistence id shared by all payload entries.
+  #[must_use]
+  pub fn persistence_id(&self) -> &str {
+    self.payload[0].persistence_id()
+  }
+
+  /// Returns the lowest sequence number in the payload.
+  #[must_use]
+  pub fn lowest_sequence_nr(&self) -> u64 {
+    self.payload.iter().map(PersistentRepr::sequence_nr).min().unwrap_or(0)
+  }
+
+  /// Returns the highest sequence number in the payload.
+  #[must_use]
+  pub fn highest_sequence_nr(&self) -> u64 {
+    self.payload.iter().map(PersistentRepr::sequence_nr).max().unwrap_or(0)
+  }
+
+  /// Returns the number of persistent representations in the atomic write.
+  #[must_use]
+  pub const fn size(&self) -> usize {
+    self.payload.len()
+  }
+
+  /// Returns `true` when the atomic write contains no payload entries.
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    self.payload.is_empty()
+  }
+
+  /// Returns the contained persistent representations.
+  #[must_use]
+  #[allow(clippy::missing_const_for_fn)] // Vec の Deref が const でないため const fn にできない
+  pub fn payload(&self) -> &[PersistentRepr] {
+    &self.payload
+  }
+
+  /// Consumes the atomic write and returns its payload.
+  #[must_use]
+  pub fn into_payload(self) -> Vec<PersistentRepr> {
+    self.payload
+  }
+}

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
@@ -20,7 +20,7 @@ pub enum AtomicWriteError {
 impl Display for AtomicWriteError {
   fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
     match self {
-      | Self::Empty => write!(formatter, "atomic write payload must not be empty"),
+      | Self::Empty => write!(formatter, "payload must not be empty"),
       | Self::MixedPersistenceId { expected, actual } => {
         write!(formatter, "mixed persistence id: expected {expected:?}, actual {actual:?}")
       },

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
@@ -1,0 +1,29 @@
+//! Atomic write construction errors.
+
+use alloc::string::String;
+use core::fmt::{Display, Formatter, Result as FmtResult};
+
+/// Errors returned while constructing an atomic journal write.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AtomicWriteError {
+  /// The atomic write payload was empty.
+  Empty,
+  /// The atomic write contained more than one persistence id.
+  MixedPersistenceId {
+    /// Expected persistence id taken from the first payload entry.
+    expected: String,
+    /// Actual persistence id found in a later payload entry.
+    actual:   String,
+  },
+}
+
+impl Display for AtomicWriteError {
+  fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
+    match self {
+      | Self::Empty => write!(formatter, "atomic write payload must not be empty"),
+      | Self::MixedPersistenceId { expected, actual } => {
+        write!(formatter, "atomic write persistence id mismatch: expected {expected}, actual {actual}")
+      },
+    }
+  }
+}

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
@@ -22,7 +22,7 @@ impl Display for AtomicWriteError {
     match self {
       | Self::Empty => write!(formatter, "payload must not be empty"),
       | Self::MixedPersistenceId { expected, actual } => {
-        write!(formatter, "mixed persistence id: expected {expected:?}, actual {actual:?}")
+        write!(formatter, "mixed persistence id: expected {expected}, actual {actual}")
       },
     }
   }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
@@ -22,7 +22,7 @@ impl Display for AtomicWriteError {
     match self {
       | Self::Empty => write!(formatter, "payload must not be empty"),
       | Self::MixedPersistenceId { expected, actual } => {
-        write!(formatter, "mixed persistence id: expected {expected}, actual {actual}")
+        write!(formatter, "mixed persistence id: expected {}, actual {}", expected, actual)
       },
     }
   }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
@@ -20,9 +20,9 @@ pub enum AtomicWriteError {
 impl Display for AtomicWriteError {
   fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
     match self {
-      | Self::Empty => write!(formatter, "atomic write payload must not be empty"),
+      | Self::Empty => write!(formatter, "AtomicWriteError::Empty: payload must not be empty"),
       | Self::MixedPersistenceId { expected, actual } => {
-        write!(formatter, "atomic write persistence id mismatch: expected {expected}, actual {actual}")
+        write!(formatter, "AtomicWriteError::MixedPersistenceId: expected {expected:?}, actual {actual:?}")
       },
     }
   }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_error.rs
@@ -20,9 +20,9 @@ pub enum AtomicWriteError {
 impl Display for AtomicWriteError {
   fn fmt(&self, formatter: &mut Formatter<'_>) -> FmtResult {
     match self {
-      | Self::Empty => write!(formatter, "AtomicWriteError::Empty: payload must not be empty"),
+      | Self::Empty => write!(formatter, "atomic write payload must not be empty"),
       | Self::MixedPersistenceId { expected, actual } => {
-        write!(formatter, "AtomicWriteError::MixedPersistenceId: expected {expected:?}, actual {actual:?}")
+        write!(formatter, "mixed persistence id: expected {expected:?}, actual {actual:?}")
       },
     }
   }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
@@ -52,9 +52,9 @@ fn atomic_write_consumes_payload() {
 
 #[test]
 fn atomic_write_error_display_messages() {
-  assert_eq!(AtomicWriteError::Empty.to_string(), "AtomicWriteError::Empty: payload must not be empty");
+  assert_eq!(AtomicWriteError::Empty.to_string(), "atomic write payload must not be empty");
 
   let error = AtomicWriteError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() };
 
-  assert_eq!(error.to_string(), "AtomicWriteError::MixedPersistenceId: expected \"pid-1\", actual \"pid-2\"");
+  assert_eq!(error.to_string(), "mixed persistence id: expected \"pid-1\", actual \"pid-2\"");
 }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::persistent::{AtomicWrite, AtomicWriteError, PersistentRepr};
@@ -12,6 +14,7 @@ fn atomic_write_accepts_non_empty_payload_for_one_persistence_id() {
 
   assert_eq!(write.persistence_id(), "pid-1");
   assert_eq!(write.size(), 2);
+  assert!(!write.is_empty());
   assert_eq!(write.payload().len(), 2);
 }
 
@@ -35,4 +38,23 @@ fn atomic_write_exposes_sequence_number_bounds() {
 
   assert_eq!(write.lowest_sequence_nr(), 1);
   assert_eq!(write.highest_sequence_nr(), 3);
+}
+
+#[test]
+fn atomic_write_consumes_payload() {
+  let write = AtomicWrite::new(vec![repr("pid-1", 1)]).expect("atomic write");
+
+  let payload = write.into_payload();
+
+  assert_eq!(payload.len(), 1);
+  assert_eq!(payload[0].persistence_id(), "pid-1");
+}
+
+#[test]
+fn atomic_write_error_display_messages() {
+  assert_eq!(AtomicWriteError::Empty.to_string(), "atomic write payload must not be empty");
+
+  let error = AtomicWriteError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() };
+
+  assert_eq!(error.to_string(), "atomic write persistence id mismatch: expected pid-1, actual pid-2");
 }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
@@ -56,5 +56,5 @@ fn atomic_write_error_display_messages() {
 
   let error = AtomicWriteError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() };
 
-  assert_eq!(error.to_string(), "mixed persistence id: expected \"pid-1\", actual \"pid-2\"");
+  assert_eq!(error.to_string(), "mixed persistence id: expected pid-1, actual pid-2");
 }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
@@ -52,7 +52,7 @@ fn atomic_write_consumes_payload() {
 
 #[test]
 fn atomic_write_error_display_messages() {
-  assert_eq!(AtomicWriteError::Empty.to_string(), "atomic write payload must not be empty");
+  assert_eq!(AtomicWriteError::Empty.to_string(), "payload must not be empty");
 
   let error = AtomicWriteError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() };
 

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
@@ -52,9 +52,9 @@ fn atomic_write_consumes_payload() {
 
 #[test]
 fn atomic_write_error_display_messages() {
-  assert_eq!(AtomicWriteError::Empty.to_string(), "atomic write payload must not be empty");
+  assert_eq!(AtomicWriteError::Empty.to_string(), "AtomicWriteError::Empty: payload must not be empty");
 
   let error = AtomicWriteError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() };
 
-  assert_eq!(error.to_string(), "atomic write persistence id mismatch: expected pid-1, actual pid-2");
+  assert_eq!(error.to_string(), "AtomicWriteError::MixedPersistenceId: expected \"pid-1\", actual \"pid-2\"");
 }

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
@@ -1,0 +1,38 @@
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::persistent::{AtomicWrite, AtomicWriteError, PersistentRepr};
+
+fn repr(persistence_id: &str, sequence_nr: u64) -> PersistentRepr {
+  PersistentRepr::new(persistence_id, sequence_nr, ArcShared::new(sequence_nr as i32))
+}
+
+#[test]
+fn atomic_write_accepts_non_empty_payload_for_one_persistence_id() {
+  let write = AtomicWrite::new(vec![repr("pid-1", 2), repr("pid-1", 3)]).expect("atomic write");
+
+  assert_eq!(write.persistence_id(), "pid-1");
+  assert_eq!(write.size(), 2);
+  assert_eq!(write.payload().len(), 2);
+}
+
+#[test]
+fn atomic_write_rejects_empty_payload() {
+  let error = AtomicWrite::new(Vec::new()).expect_err("empty payload must fail");
+
+  assert_eq!(error, AtomicWriteError::Empty);
+}
+
+#[test]
+fn atomic_write_rejects_mixed_persistence_ids() {
+  let error = AtomicWrite::new(vec![repr("pid-1", 1), repr("pid-2", 2)]).expect_err("mixed ids must fail");
+
+  assert_eq!(error, AtomicWriteError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() });
+}
+
+#[test]
+fn atomic_write_exposes_sequence_number_bounds() {
+  let write = AtomicWrite::new(vec![repr("pid-1", 3), repr("pid-1", 1), repr("pid-1", 2)]).expect("atomic write");
+
+  assert_eq!(write.lowest_sequence_nr(), 1);
+  assert_eq!(write.highest_sequence_nr(), 3);
+}

--- a/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/atomic_write_test.rs
@@ -14,7 +14,6 @@ fn atomic_write_accepts_non_empty_payload_for_one_persistence_id() {
 
   assert_eq!(write.persistence_id(), "pid-1");
   assert_eq!(write.size(), 2);
-  assert!(!write.is_empty());
   assert_eq!(write.payload().len(), 2);
 }
 

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -484,6 +484,7 @@ impl<A: 'static> PersistenceContext<A> {
   fn reset_after_write_failure(&mut self) {
     self.stash_until_batch_completion = false;
     self.pending_invocations.clear();
+    self.current_sequence_nr = self.last_sequence_nr;
     self.transition_to_processing_commands_if_no_pending();
   }
 

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -238,15 +238,10 @@ impl<A: 'static> PersistenceContext<A> {
     }
     self.stash_until_batch_completion = has_stashing_invocation;
 
-    if messages.is_empty() {
+    let atomic_write = AtomicWrite::new(messages).map_err(|error| {
       self.reset_after_write_failure();
-      return Err(PersistenceError::Journal(JournalError::InvalidAtomicWrite(
-        "atomic write payload must not be empty".into(),
-      )));
-    }
-
-    let atomic_write = AtomicWrite::new(messages)
-      .map_err(|error| PersistenceError::Journal(JournalError::InvalidAtomicWrite(error.to_string())))?;
+      PersistenceError::Journal(JournalError::InvalidAtomicWrite(error.to_string()))
+    })?;
     let message = JournalMessage::WriteMessages {
       persistence_id: self.persistence_id.clone(),
       to_sequence_nr,

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -568,10 +568,8 @@ impl<A: 'static> PersistenceContext<A> {
     let adapters = self.select_adapters_for_replay(repr);
     let repr_with_adapters = repr.clone().with_adapters(adapters);
     let payload = repr_with_adapters.payload().clone();
-    let adapted = repr_with_adapters
-      .adapters()
-      .read_adapter_for_type_id(repr_with_adapters.adapter_type_id())
-      .adapt_from_journal(payload, repr_with_adapters.manifest());
+    let read_adapter = repr_with_adapters.adapters().read_adapter_for_type_id(repr_with_adapters.adapter_type_id());
+    let adapted = read_adapter.adapt_from_journal(payload, repr_with_adapters.manifest());
     adapted
       .into_events()
       .into_iter()

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -4,14 +4,7 @@
 #[path = "persistence_context_test.rs"]
 mod tests;
 
-use alloc::{
-  boxed::Box,
-  collections::VecDeque,
-  format,
-  string::{String, ToString},
-  vec,
-  vec::Vec,
-};
+use alloc::{boxed::Box, collections::VecDeque, format, string::String, vec, vec::Vec};
 use core::{
   any::Any,
   ops::Deref,
@@ -25,7 +18,8 @@ use crate::{
   error::PersistenceError,
   journal::{EventAdapters, JournalError, JournalMessage, JournalResponse, JournalResponseAction},
   persistent::{
-    AtomicWrite, PendingHandlerInvocation, PersistentActorState, PersistentEnvelope, PersistentRepr, Recovery,
+    AtomicWrite, AtomicWriteError, PendingHandlerInvocation, PersistentActorState, PersistentEnvelope, PersistentRepr,
+    Recovery,
   },
   snapshot::{SnapshotError, SnapshotMessage, SnapshotResponse, SnapshotResponseAction},
 };
@@ -240,7 +234,7 @@ impl<A: 'static> PersistenceContext<A> {
 
     let atomic_write = AtomicWrite::new(messages).map_err(|error| {
       self.reset_after_write_failure();
-      PersistenceError::Journal(JournalError::InvalidAtomicWrite(error.to_string()))
+      PersistenceError::Journal(Self::journal_error_for_atomic_write(error))
     })?;
     let message = JournalMessage::WriteMessages {
       persistence_id: self.persistence_id.clone(),
@@ -612,5 +606,14 @@ impl<A: 'static> PersistenceContext<A> {
 
   fn is_null_ref(actor_ref: &ActorRef) -> bool {
     actor_ref.pid() == Pid::new(0, 0)
+  }
+
+  fn journal_error_for_atomic_write(error: AtomicWriteError) -> JournalError {
+    match error {
+      | AtomicWriteError::Empty => JournalError::InvalidAtomicWrite(String::from("empty payload")),
+      | AtomicWriteError::MixedPersistenceId { expected, actual } => {
+        JournalError::MixedPersistenceId { expected, actual }
+      },
+    }
   }
 }

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -560,11 +560,7 @@ impl<A: 'static> PersistenceContext<A> {
   }
 
   fn replayed_from_journal_repr(&self, repr: &PersistentRepr) -> Vec<PersistentRepr> {
-    let adapters = if self.event_adapters.has_read_adapter_for_type_id(repr.adapter_type_id()) {
-      self.event_adapters.clone()
-    } else {
-      repr.adapters().clone()
-    };
+    let adapters = self.select_adapters_for_replay(repr);
     let repr_with_adapters = repr.clone().with_adapters(adapters);
     let payload = repr_with_adapters.payload().clone();
     let adapted = repr_with_adapters
@@ -576,6 +572,13 @@ impl<A: 'static> PersistenceContext<A> {
       .into_iter()
       .map(|adapted_payload| Self::repr_with_payload(&repr_with_adapters, adapted_payload))
       .collect()
+  }
+
+  fn select_adapters_for_replay(&self, repr: &PersistentRepr) -> EventAdapters {
+    if self.event_adapters.has_read_adapter_for_type_id(repr.adapter_type_id()) {
+      return self.event_adapters.clone();
+    }
+    repr.adapters().clone()
   }
 
   fn repr_with_payload(repr: &PersistentRepr, payload: ArcShared<dyn Any + Send + Sync>) -> PersistentRepr {

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -232,12 +232,15 @@ impl<A: 'static> PersistenceContext<A> {
     }
     self.stash_until_batch_completion = has_stashing_invocation;
 
-    let atomic_write = AtomicWrite::new(messages).map_err(|error| {
-      let journal_error = Self::journal_error_for_atomic_write(error);
-      // The batch has already been drained into pending invocations above.
-      self.reset_after_write_failure();
-      PersistenceError::Journal(journal_error)
-    })?;
+    let atomic_write = match AtomicWrite::new(messages) {
+      | Ok(write) => write,
+      | Err(error) => {
+        let journal_error = Self::journal_error_for_atomic_write(error);
+        // The batch has already been drained into pending invocations above.
+        self.reset_after_write_failure();
+        return Err(PersistenceError::Journal(journal_error));
+      },
+    };
     let message = JournalMessage::WriteMessages {
       persistence_id: self.persistence_id.clone(),
       to_sequence_nr,

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -233,9 +233,10 @@ impl<A: 'static> PersistenceContext<A> {
     self.stash_until_batch_completion = has_stashing_invocation;
 
     let atomic_write = AtomicWrite::new(messages).map_err(|error| {
+      let journal_error = Self::journal_error_for_atomic_write(error);
       // The batch has already been drained into pending invocations above.
       self.reset_after_write_failure();
-      PersistenceError::Journal(Self::journal_error_for_atomic_write(error))
+      PersistenceError::Journal(journal_error)
     })?;
     let message = JournalMessage::WriteMessages {
       persistence_id: self.persistence_id.clone(),

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -241,7 +241,7 @@ impl<A: 'static> PersistenceContext<A> {
     debug_assert!(!messages.is_empty(), "flush_batch requires at least one persistent journal message");
 
     let atomic_write = AtomicWrite::new(messages)
-      .map_err(|error| PersistenceError::Journal(JournalError::WriteFailed(error.to_string())))?;
+      .map_err(|error| PersistenceError::Journal(JournalError::InvalidAtomicWrite(error.to_string())))?;
     let message = JournalMessage::WriteMessages {
       persistence_id: self.persistence_id.clone(),
       to_sequence_nr,

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -236,8 +236,7 @@ impl<A: 'static> PersistenceContext<A> {
       | Ok(write) => write,
       | Err(error) => {
         let journal_error = Self::journal_error_for_atomic_write(error);
-        // AtomicWrite rejected the batch before it reached the journal, so drop pending handlers for this
-        // batch.
+        // AtomicWrite がジャーナル到達前にバッチを拒否したため、このバッチの保留ハンドラを破棄する。
         self.reset_after_write_failure();
         return Err(PersistenceError::Journal(journal_error));
       },

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -236,7 +236,8 @@ impl<A: 'static> PersistenceContext<A> {
       | Ok(write) => write,
       | Err(error) => {
         let journal_error = Self::journal_error_for_atomic_write(error);
-        // The batch has already been drained into pending invocations above.
+        // AtomicWrite rejected the batch before it reached the journal, so drop pending handlers for this
+        // batch.
         self.reset_after_write_failure();
         return Err(PersistenceError::Journal(journal_error));
       },
@@ -286,13 +287,11 @@ impl<A: 'static> PersistenceContext<A> {
         self.advance_after_write_rejected(repr);
         JournalResponseAction::PersistRejected { cause: cause.clone(), repr: repr.clone() }
       },
-      | JournalResponse::WriteMessagesFailed { write_count, instance_id, .. } => {
+      | JournalResponse::WriteMessagesFailed { instance_id, .. } => {
         if self.state != PersistentActorState::PersistingEvents || !self.matches_instance_id(*instance_id) {
           return JournalResponseAction::None;
         }
-        if *write_count == 0 {
-          self.reset_after_write_failure();
-        }
+        self.reset_after_write_failure();
         JournalResponseAction::None
       },
       | JournalResponse::WriteMessagesSuccessful { instance_id } => {
@@ -567,8 +566,9 @@ impl<A: 'static> PersistenceContext<A> {
   fn replayed_from_journal_repr(&self, repr: &PersistentRepr) -> Vec<PersistentRepr> {
     let adapters = self.select_adapters_for_replay(repr);
     let repr_with_adapters = repr.clone().with_adapters(adapters);
+    let adapter_type_id = repr_with_adapters.adapter_type_id();
     let payload = repr_with_adapters.payload().clone();
-    let read_adapter = repr_with_adapters.adapters().read_adapter_for_type_id(repr_with_adapters.adapter_type_id());
+    let read_adapter = repr_with_adapters.adapters().read_adapter_for_type_id(adapter_type_id);
     let adapted = read_adapter.adapt_from_journal(payload, repr_with_adapters.manifest());
     adapted
       .into_events()
@@ -578,10 +578,12 @@ impl<A: 'static> PersistenceContext<A> {
   }
 
   fn select_adapters_for_replay(&self, repr: &PersistentRepr) -> EventAdapters {
-    if self.event_adapters.has_read_adapter_for_type_id(repr.adapter_type_id()) {
-      return self.event_adapters.clone();
-    }
-    repr.adapters().clone()
+    let adapters = if self.event_adapters.has_read_adapter_for_type_id(repr.adapter_type_id()) {
+      &self.event_adapters
+    } else {
+      repr.adapters()
+    };
+    adapters.clone()
   }
 
   fn repr_with_payload(repr: &PersistentRepr, payload: ArcShared<dyn Any + Send + Sync>) -> PersistentRepr {

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -560,7 +560,11 @@ impl<A: 'static> PersistenceContext<A> {
   }
 
   fn replayed_from_journal_repr(&self, repr: &PersistentRepr) -> Vec<PersistentRepr> {
-    let adapters = if self.event_adapters.is_empty() { repr.adapters().clone() } else { self.event_adapters.clone() };
+    let adapters = if self.event_adapters.has_read_adapter_for_type_id(repr.adapter_type_id()) {
+      self.event_adapters.clone()
+    } else {
+      repr.adapters().clone()
+    };
     let repr_with_adapters = repr.clone().with_adapters(adapters);
     let payload = repr_with_adapters.payload().clone();
     let adapted = repr_with_adapters

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -567,11 +567,17 @@ impl<A: 'static> PersistenceContext<A> {
 
   fn replayed_from_journal_repr(&self, repr: &PersistentRepr) -> Vec<PersistentRepr> {
     let adapters = if self.event_adapters.is_empty() { repr.adapters().clone() } else { self.event_adapters.clone() };
-    let repr = repr.clone().with_adapters(adapters);
-    let payload = repr.payload().clone();
-    let adapted =
-      repr.adapters().read_adapter_for_type_id(repr.adapter_type_id()).adapt_from_journal(payload, repr.manifest());
-    adapted.into_events().into_iter().map(|adapted_payload| Self::repr_with_payload(&repr, adapted_payload)).collect()
+    let repr_with_adapters = repr.clone().with_adapters(adapters);
+    let payload = repr_with_adapters.payload().clone();
+    let adapted = repr_with_adapters
+      .adapters()
+      .read_adapter_for_type_id(repr_with_adapters.adapter_type_id())
+      .adapt_from_journal(payload, repr_with_adapters.manifest());
+    adapted
+      .into_events()
+      .into_iter()
+      .map(|adapted_payload| Self::repr_with_payload(&repr_with_adapters, adapted_payload))
+      .collect()
   }
 
   fn repr_with_payload(repr: &PersistentRepr, payload: ArcShared<dyn Any + Send + Sync>) -> PersistentRepr {

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -4,7 +4,14 @@
 #[path = "persistence_context_test.rs"]
 mod tests;
 
-use alloc::{boxed::Box, collections::VecDeque, format, string::String, vec::Vec};
+use alloc::{
+  boxed::Box,
+  collections::VecDeque,
+  format,
+  string::{String, ToString},
+  vec,
+  vec::Vec,
+};
 use core::{
   any::Any,
   ops::Deref,
@@ -16,8 +23,10 @@ use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::{
   error::PersistenceError,
-  journal::{EventAdapters, JournalMessage, JournalResponse, JournalResponseAction},
-  persistent::{PendingHandlerInvocation, PersistentActorState, PersistentEnvelope, PersistentRepr, Recovery},
+  journal::{EventAdapters, JournalError, JournalMessage, JournalResponse, JournalResponseAction},
+  persistent::{
+    AtomicWrite, PendingHandlerInvocation, PersistentActorState, PersistentEnvelope, PersistentRepr, Recovery,
+  },
   snapshot::{SnapshotError, SnapshotMessage, SnapshotResponse, SnapshotResponseAction},
 };
 
@@ -231,10 +240,12 @@ impl<A: 'static> PersistenceContext<A> {
 
     debug_assert!(!messages.is_empty(), "flush_batch requires at least one persistent journal message");
 
+    let atomic_write = AtomicWrite::new(messages)
+      .map_err(|error| PersistenceError::Journal(JournalError::WriteFailed(error.to_string())))?;
     let message = JournalMessage::WriteMessages {
       persistence_id: self.persistence_id.clone(),
       to_sequence_nr,
-      messages,
+      messages: vec![atomic_write],
       sender,
       instance_id: self.instance_id,
     };

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -312,7 +312,7 @@ impl<A: 'static> PersistenceContext<A> {
       },
       | JournalResponse::ReplayedMessage { persistent_repr } => {
         self.current_sequence_nr = persistent_repr.sequence_nr();
-        let mut replayed_reprs = Self::from_journal_repr(persistent_repr);
+        let mut replayed_reprs = self.replayed_from_journal_repr(persistent_repr);
         match replayed_reprs.len() {
           | 0 => JournalResponseAction::None,
           | 1 => {
@@ -570,11 +570,13 @@ impl<A: 'static> PersistenceContext<A> {
     Self::repr_with_payload(repr, adapted_payload).with_manifest(manifest).with_sender(None)
   }
 
-  fn from_journal_repr(repr: &PersistentRepr) -> Vec<PersistentRepr> {
+  fn replayed_from_journal_repr(&self, repr: &PersistentRepr) -> Vec<PersistentRepr> {
+    let adapters = if self.event_adapters.is_empty() { repr.adapters().clone() } else { self.event_adapters.clone() };
+    let repr = repr.clone().with_adapters(adapters);
     let payload = repr.payload().clone();
     let adapted =
       repr.adapters().read_adapter_for_type_id(repr.adapter_type_id()).adapt_from_journal(payload, repr.manifest());
-    adapted.into_events().into_iter().map(|adapted_payload| Self::repr_with_payload(repr, adapted_payload)).collect()
+    adapted.into_events().into_iter().map(|adapted_payload| Self::repr_with_payload(&repr, adapted_payload)).collect()
   }
 
   fn repr_with_payload(repr: &PersistentRepr, payload: ArcShared<dyn Any + Send + Sync>) -> PersistentRepr {

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -233,6 +233,7 @@ impl<A: 'static> PersistenceContext<A> {
     self.stash_until_batch_completion = has_stashing_invocation;
 
     let atomic_write = AtomicWrite::new(messages).map_err(|error| {
+      // The batch has already been drained into pending invocations above.
       self.reset_after_write_failure();
       PersistenceError::Journal(Self::journal_error_for_atomic_write(error))
     })?;

--- a/modules/persistence-core-kernel/src/persistent/persistence_context.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context.rs
@@ -238,7 +238,12 @@ impl<A: 'static> PersistenceContext<A> {
     }
     self.stash_until_batch_completion = has_stashing_invocation;
 
-    debug_assert!(!messages.is_empty(), "flush_batch requires at least one persistent journal message");
+    if messages.is_empty() {
+      self.reset_after_write_failure();
+      return Err(PersistenceError::Journal(JournalError::InvalidAtomicWrite(
+        "atomic write payload must not be empty".into(),
+      )));
+    }
 
     let atomic_write = AtomicWrite::new(messages)
       .map_err(|error| PersistenceError::Journal(JournalError::InvalidAtomicWrite(error.to_string())))?;

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -388,6 +388,25 @@ fn context_applies_event_adapters_on_persist_and_replay() {
 }
 
 #[test]
+fn replay_prefers_repr_adapters_when_context_lacks_adapter_type() {
+  let write_adapter: ArcShared<dyn WriteEventAdapter> = ArcShared::new(AddTenWriteAdapter);
+  let read_adapter: ArcShared<dyn ReadEventAdapter> = ArcShared::new(SplitReadAdapter);
+  let mut context = DummyContext::new("pid-1".to_string());
+  context.event_adapters_mut().register::<u64>(write_adapter, read_adapter);
+  let replay_repr = replay_persistent_repr(3, 21, SINGLE_MANIFEST);
+
+  let replay_action =
+    context.handle_journal_response(&JournalResponse::ReplayedMessage { persistent_repr: replay_repr });
+
+  match replay_action {
+    | JournalResponseAction::ReceiveRecover(repr) => {
+      assert_eq!(repr.downcast_ref::<i32>(), Some(&21_i32));
+    },
+    | _ => panic!("expected single replay message"),
+  }
+}
+
+#[test]
 fn replayed_message_returns_receive_recover_for_single_event() {
   let mut context = DummyContext::new("pid-1".to_string());
   let replay_repr = replay_persistent_repr(3, 21, SINGLE_MANIFEST);

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -1437,6 +1437,47 @@ fn write_messages_failed_with_zero_write_count_returns_to_processing_commands() 
 }
 
 #[test]
+fn write_messages_failed_realigns_current_sequence_nr_to_last_sequence_nr() {
+  let (journal_ref, journal_store) = create_sender();
+  let (snapshot_ref, _snapshot_store) = create_sender();
+  let mut context = DummyContext::new("pid-1".to_string());
+  context.bind_actor_refs(journal_ref, snapshot_ref).expect("bind actor refs");
+  context.state = PersistentActorState::ProcessingCommands;
+
+  context.add_to_event_batch(1_i32, true, None, Box::new(|_actor: &mut DummyActor, _repr| {}));
+  context.flush_batch(ActorRef::null()).expect("flush batch");
+  assert_eq!(context.current_sequence_nr(), 1);
+  assert_eq!(context.last_sequence_nr(), 0);
+
+  let action = context.handle_journal_response(&JournalResponse::WriteMessagesFailed {
+    cause:       JournalError::WriteFailed("batch write failed".to_string()),
+    write_count: 0,
+    instance_id: context.instance_id(),
+  });
+
+  assert!(matches!(action, JournalResponseAction::None));
+  assert_eq!(context.current_sequence_nr(), 0);
+  assert_eq!(context.last_sequence_nr(), 0);
+  assert_eq!(context.state(), PersistentActorState::ProcessingCommands);
+
+  journal_store.lock().clear();
+  context.add_to_event_batch(2_i32, true, None, Box::new(|_actor: &mut DummyActor, _repr| {}));
+  context.flush_batch(ActorRef::null()).expect("flush batch after write messages failed");
+
+  let persisted_repr = {
+    let journal_messages = journal_store.lock();
+    assert_eq!(journal_messages.len(), 1);
+    let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
+    match message {
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
+      | _ => panic!("unexpected message"),
+    }
+  };
+  assert_eq!(persisted_repr.sequence_nr(), 1);
+  assert_eq!(context.current_sequence_nr(), 1);
+}
+
+#[test]
 fn write_messages_successful_is_ignored_during_recovery() {
   let mut context = DummyContext::new("pid-1".to_string());
   context.state = PersistentActorState::Recovering;

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -14,7 +14,9 @@ use fraktor_actor_core_kernel_rs::actor::{
 };
 use fraktor_utils_core_rs::sync::{ArcShared, SharedLock, SpinSyncMutex};
 
+use super::EventBatchEntry;
 use crate::{
+  error::PersistenceError,
   journal::{
     EventAdapters, EventSeq, JournalError, JournalMessage, JournalResponse, JournalResponseAction, ReadEventAdapter,
     WriteEventAdapter,
@@ -579,6 +581,26 @@ fn flush_batch_send_failure_rolls_back_and_clears_stash_until_batch_completion()
   assert_eq!(context.state(), PersistentActorState::ProcessingCommands);
   assert!(context.pending_invocations.is_empty());
   assert!(!context.stash_until_batch_completion);
+}
+
+#[test]
+fn flush_batch_with_only_deferred_entry_rolls_back() {
+  let (journal_ref, journal_store) = create_sender();
+  let (snapshot_ref, _snapshot_store) = create_sender();
+  let mut context = DummyContext::new("pid-1".to_string());
+  context.bind_actor_refs(journal_ref, snapshot_ref).expect("bind actor refs");
+  context.state = PersistentActorState::ProcessingCommands;
+  let repr = PersistentRepr::new("pid-1", 0, ArcShared::new(1_i32)).with_adapters(EventAdapters::new());
+  let invocation = PendingHandlerInvocation::async_deferred_boxed(repr, Box::new(|_actor: &mut DummyActor, _repr| {}));
+  context.event_batch.push(EventBatchEntry::Deferred(Box::new(invocation)));
+
+  let result = context.flush_batch(ActorRef::null());
+
+  assert!(matches!(result, Err(PersistenceError::Journal(JournalError::InvalidAtomicWrite(_)))));
+  assert_eq!(context.state(), PersistentActorState::ProcessingCommands);
+  assert!(context.pending_invocations.is_empty());
+  assert!(!context.should_stash_commands());
+  assert!(journal_store.lock().is_empty());
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -110,6 +110,19 @@ impl ReadEventAdapter for SplitReadAdapter {
   }
 }
 
+struct AddHundredReadAdapter;
+
+impl ReadEventAdapter for AddHundredReadAdapter {
+  fn adapt_from_journal(&self, event: ArcShared<dyn Any + Send + Sync>, manifest: &str) -> EventSeq {
+    if manifest != SINGLE_MANIFEST {
+      return EventSeq::single(event);
+    }
+    let value = event.downcast_ref::<String>().expect("expected string event");
+    let value = value.parse::<i32>().expect("expected numeric string");
+    EventSeq::single(ArcShared::new(value + 100))
+  }
+}
+
 impl Eventsourced for DummyActor {
   fn persistence_id(&self) -> &str {
     "pid-1"
@@ -411,6 +424,22 @@ fn replay_prefers_repr_adapters_when_context_lacks_adapter_type() {
   let mut actor = DummyActor::default();
   replay_action.apply(&mut actor);
   assert_eq!(actor.recovered_values, vec![21_i32]);
+}
+
+#[test]
+fn replay_prefers_context_adapters_when_context_has_adapter_type() {
+  let write_adapter: ArcShared<dyn WriteEventAdapter> = ArcShared::new(AddTenWriteAdapter);
+  let read_adapter: ArcShared<dyn ReadEventAdapter> = ArcShared::new(AddHundredReadAdapter);
+  let mut context = DummyContext::new("pid-1".to_string());
+  context.event_adapters_mut().register::<i32>(write_adapter, read_adapter);
+  let replay_repr = replay_persistent_repr(3, 21, SINGLE_MANIFEST);
+
+  let replay_action =
+    context.handle_journal_response(&JournalResponse::ReplayedMessage { persistent_repr: replay_repr });
+
+  let mut actor = DummyActor::default();
+  replay_action.apply(&mut actor);
+  assert_eq!(actor.recovered_values, vec![121_i32]);
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -165,6 +165,16 @@ fn split_read_adapter_returns_original_event_for_unknown_manifest() {
   assert_eq!(events[0].downcast_ref::<i32>(), Some(&31_i32));
 }
 
+#[test]
+fn add_hundred_read_adapter_returns_original_event_for_non_single_manifest() {
+  let event: ArcShared<dyn Any + Send + Sync> = ArcShared::new(31_i32);
+  let sequence = AddHundredReadAdapter.adapt_from_journal(event, "unknown-manifest");
+  let events = sequence.into_events();
+
+  assert_eq!(events.len(), 1);
+  assert_eq!(events[0].downcast_ref::<i32>(), Some(&31_i32));
+}
+
 fn first_atomic_payload(messages: &[AtomicWrite]) -> PersistentRepr {
   messages[0].payload()[0].clone()
 }

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -379,8 +379,9 @@ fn context_applies_event_adapters_on_persist_and_replay() {
   }
   assert_eq!(actor.handled_values, vec![5_i32]);
 
+  let serialized_journal_repr = persisted_repr.clone().with_adapters(EventAdapters::new());
   let replay_action =
-    context.handle_journal_response(&JournalResponse::ReplayedMessage { persistent_repr: persisted_repr.clone() });
+    context.handle_journal_response(&JournalResponse::ReplayedMessage { persistent_repr: serialized_journal_repr });
   let mut recovering_actor = DummyActor::default();
   replay_action.apply(&mut recovering_actor);
   assert_eq!(recovering_actor.recovered_values, vec![15_i32, 16_i32]);

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -22,8 +22,8 @@ use crate::{
     WriteEventAdapter,
   },
   persistent::{
-    AtomicWrite, Eventsourced, PendingHandlerInvocation, PersistenceContext, PersistentActorState, PersistentRepr,
-    Recovery,
+    AtomicWrite, AtomicWriteError, Eventsourced, PendingHandlerInvocation, PersistenceContext, PersistentActorState,
+    PersistentRepr, Recovery,
   },
   snapshot::{Snapshot, SnapshotMessage, SnapshotSelectionCriteria},
 };
@@ -602,6 +602,23 @@ fn flush_batch_with_only_deferred_entry_rolls_back() {
   assert!(context.pending_invocations.is_empty());
   assert!(!context.should_stash_commands());
   assert!(journal_store.lock().is_empty());
+}
+
+#[test]
+fn atomic_write_mixed_persistence_id_maps_to_journal_error() {
+  let error = PersistenceContext::<DummyActor>::journal_error_for_atomic_write(AtomicWriteError::MixedPersistenceId {
+    expected: "pid-1".into(),
+    actual:   "pid-2".into(),
+  });
+
+  assert_eq!(error, JournalError::MixedPersistenceId { expected: "pid-1".into(), actual: "pid-2".into() });
+}
+
+#[test]
+fn atomic_write_empty_maps_to_invalid_atomic_write() {
+  let error = PersistenceContext::<DummyActor>::journal_error_for_atomic_write(AtomicWriteError::Empty);
+
+  assert_eq!(error, JournalError::InvalidAtomicWrite("empty payload".into()));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -1387,7 +1387,7 @@ fn write_message_rejected_for_later_persist_keeps_deferred_invocation() {
 }
 
 #[test]
-fn write_messages_failed_with_positive_write_count_keeps_persisting_state() {
+fn write_messages_failed_with_positive_write_count_returns_to_processing_commands() {
   let (journal_ref, _journal_store) = create_sender();
   let (snapshot_ref, _snapshot_store) = create_sender();
   let mut context = DummyContext::new("pid-1".to_string());
@@ -1404,11 +1404,11 @@ fn write_messages_failed_with_positive_write_count_keeps_persisting_state() {
     instance_id: context.instance_id(),
   });
   assert!(matches!(action, JournalResponseAction::None));
-  assert_eq!(context.state(), PersistentActorState::PersistingEvents);
+  assert_eq!(context.state(), PersistentActorState::ProcessingCommands);
 
   context.add_to_event_batch(2_i32, true, None, Box::new(|_actor: &mut DummyActor, _repr| {}));
-  let result = context.flush_batch(ActorRef::null());
-  assert!(result.is_err());
+  context.flush_batch(ActorRef::null()).expect("flush batch after write messages failed");
+  assert_eq!(context.state(), PersistentActorState::PersistingEvents);
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -408,11 +408,9 @@ fn replay_prefers_repr_adapters_when_context_lacks_adapter_type() {
   let replay_action =
     context.handle_journal_response(&JournalResponse::ReplayedMessage { persistent_repr: replay_repr });
 
-  match replay_action {
-    | JournalResponseAction::ReceiveRecover(repr) => {
-      assert_eq!(repr.downcast_ref::<i32>(), Some(&21_i32));
-    },
-    | _ => panic!("expected single replay message"),
+  assert!(matches!(replay_action, JournalResponseAction::ReceiveRecover(_)));
+  if let JournalResponseAction::ReceiveRecover(repr) = replay_action {
+    assert_eq!(repr.downcast_ref::<i32>(), Some(&21_i32));
   }
 }
 

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -1464,16 +1464,7 @@ fn write_messages_failed_realigns_current_sequence_nr_to_last_sequence_nr() {
   context.add_to_event_batch(2_i32, true, None, Box::new(|_actor: &mut DummyActor, _repr| {}));
   context.flush_batch(ActorRef::null()).expect("flush batch after write messages failed");
 
-  let persisted_repr = {
-    let journal_messages = journal_store.lock();
-    assert_eq!(journal_messages.len(), 1);
-    let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
-    match message {
-      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
-      | _ => panic!("unexpected message"),
-    }
-  };
-  assert_eq!(persisted_repr.sequence_nr(), 1);
+  assert_eq!(journal_store.lock().len(), 1);
   assert_eq!(context.current_sequence_nr(), 1);
 }
 

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -142,6 +142,16 @@ fn replay_persistent_repr(sequence_nr: u64, value: i32, manifest: &str) -> Persi
     .with_adapter_type_id(TypeId::of::<i32>())
 }
 
+#[test]
+fn split_read_adapter_returns_original_event_for_unknown_manifest() {
+  let event: ArcShared<dyn Any + Send + Sync> = ArcShared::new(31_i32);
+  let sequence = SplitReadAdapter.adapt_from_journal(event, "unknown-manifest");
+  let events = sequence.into_events();
+
+  assert_eq!(events.len(), 1);
+  assert_eq!(events[0].downcast_ref::<i32>(), Some(&31_i32));
+}
+
 fn first_atomic_payload(messages: &[AtomicWrite]) -> PersistentRepr {
   messages[0].payload()[0].clone()
 }

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -20,7 +20,8 @@ use crate::{
     WriteEventAdapter,
   },
   persistent::{
-    Eventsourced, PendingHandlerInvocation, PersistenceContext, PersistentActorState, PersistentRepr, Recovery,
+    AtomicWrite, Eventsourced, PendingHandlerInvocation, PersistenceContext, PersistentActorState, PersistentRepr,
+    Recovery,
   },
   snapshot::{Snapshot, SnapshotMessage, SnapshotSelectionCriteria},
 };
@@ -137,6 +138,14 @@ fn replay_persistent_repr(sequence_nr: u64, value: i32, manifest: &str) -> Persi
     .with_manifest(manifest)
     .with_adapters(adapters)
     .with_adapter_type_id(TypeId::of::<i32>())
+}
+
+fn first_atomic_payload(messages: &[AtomicWrite]) -> PersistentRepr {
+  messages[0].payload()[0].clone()
+}
+
+fn flatten_atomic_payloads(messages: &[AtomicWrite]) -> Vec<PersistentRepr> {
+  messages.iter().flat_map(AtomicWrite::payload).cloned().collect()
 }
 
 #[test]
@@ -349,7 +358,7 @@ fn context_applies_event_adapters_on_persist_and_replay() {
       | JournalMessage::WriteMessages { messages, instance_id, .. } => {
         assert_eq!(*instance_id, expected_instance_id);
         assert_eq!(messages.len(), 1);
-        messages[0].clone()
+        first_atomic_payload(messages)
       },
       | _ => panic!("unexpected message"),
     }
@@ -438,7 +447,7 @@ fn write_messages_successful_triggers_deferred_handlers() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -506,7 +515,7 @@ fn flush_batch_clears_sender_in_journal_repr_but_keeps_it_for_handler_invocation
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -615,7 +624,7 @@ fn write_message_success_interleaves_defer_between_persisted_handlers() {
     match message {
       | JournalMessage::WriteMessages { to_sequence_nr, messages, .. } => {
         assert_eq!(*to_sequence_nr, 2);
-        messages.clone()
+        flatten_atomic_payloads(messages)
       },
       | _ => panic!("unexpected message"),
     }
@@ -662,7 +671,7 @@ fn write_message_success_with_mismatched_instance_id_is_ignored() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -714,7 +723,7 @@ fn should_stash_commands_when_stashing_defer_waits_for_batch_success() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -743,7 +752,7 @@ fn should_stash_commands_until_write_messages_successful_for_stashing_batch() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -775,7 +784,7 @@ fn should_stash_commands_until_batch_success_when_stashing_defer_is_between_pers
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages.clone(),
+      | JournalMessage::WriteMessages { messages, .. } => flatten_atomic_payloads(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -812,7 +821,7 @@ fn write_message_failure_keeps_context_in_persisting_state() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -852,7 +861,7 @@ fn write_message_failure_with_mismatched_instance_id_is_ignored() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -882,7 +891,7 @@ fn write_message_rejected_returns_to_processing_commands() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -922,7 +931,7 @@ fn write_message_rejected_with_mismatched_instance_id_is_ignored() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -1008,7 +1017,7 @@ fn stale_write_responses_from_previous_instance_are_ignored_after_restart() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -1041,7 +1050,7 @@ fn stale_write_responses_from_previous_instance_are_ignored_after_restart() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -1066,7 +1075,7 @@ fn stale_write_responses_from_previous_instance_are_ignored_after_restart() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages[0].clone(),
+      | JournalMessage::WriteMessages { messages, .. } => first_atomic_payload(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -1165,7 +1174,7 @@ fn write_message_rejected_keeps_remaining_invocations() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages.clone(),
+      | JournalMessage::WriteMessages { messages, .. } => flatten_atomic_payloads(messages),
       | _ => panic!("unexpected message"),
     }
   };
@@ -1239,7 +1248,7 @@ fn write_message_rejected_for_later_persist_keeps_deferred_invocation() {
     let journal_messages = journal_store.lock();
     let message = journal_messages[0].payload().downcast_ref::<JournalMessage>().expect("unexpected payload");
     match message {
-      | JournalMessage::WriteMessages { messages, .. } => messages.clone(),
+      | JournalMessage::WriteMessages { messages, .. } => flatten_atomic_payloads(messages),
       | _ => panic!("unexpected message"),
     }
   };

--- a/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistence_context_test.rs
@@ -408,10 +408,9 @@ fn replay_prefers_repr_adapters_when_context_lacks_adapter_type() {
   let replay_action =
     context.handle_journal_response(&JournalResponse::ReplayedMessage { persistent_repr: replay_repr });
 
-  assert!(matches!(replay_action, JournalResponseAction::ReceiveRecover(_)));
-  if let JournalResponseAction::ReceiveRecover(repr) = replay_action {
-    assert_eq!(repr.downcast_ref::<i32>(), Some(&21_i32));
-  }
+  let mut actor = DummyActor::default();
+  replay_action.apply(&mut actor);
+  assert_eq!(actor.recovered_values, vec![21_i32]);
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/persistent/persistent_actor_adapter_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistent_actor_adapter_test.rs
@@ -718,7 +718,7 @@ fn adapter_unstash_all_on_write_message_rejected() {
 }
 
 #[test]
-fn adapter_keeps_stash_on_write_messages_failed_with_positive_write_count() {
+fn adapter_unstash_all_on_write_messages_failed_with_positive_write_count() {
   let system = new_test_system();
   let mut ctx = build_context(&system);
   let actor = DummyPersistentActor::new();
@@ -736,8 +736,9 @@ fn adapter_keeps_stash_on_write_messages_failed_with_positive_write_count() {
 
   let result = adapter.receive(&mut ctx, message.as_view());
 
-  assert!(result.is_ok());
-  assert_eq!(adapter.actor.persistence_context().state(), PersistentActorState::PersistingEvents);
+  assert!(
+    matches!(result, Err(ActorError::Recoverable(reason)) if reason.as_str() == "actor cell unavailable during unstash")
+  );
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
@@ -223,8 +223,8 @@ fn persistent_actor_clears_sender_in_journal_representations() {
     .expect("write messages not found");
   match message {
     | JournalMessage::WriteMessages { messages, .. } => {
-      assert_eq!(messages.len(), 6);
-      for repr in messages {
+      assert_eq!(messages.iter().map(|write| write.payload().len()).sum::<usize>(), 6);
+      for repr in messages.iter().flat_map(|write| write.payload()) {
         assert_eq!(repr.sender(), None);
       }
     },
@@ -343,7 +343,9 @@ fn persistent_actor_defer_runs_after_write_messages_successful() {
     let maybe_repr =
       messages.iter().filter_map(|message| message.payload().downcast_ref::<JournalMessage>()).find_map(|message| {
         match message {
-          | JournalMessage::WriteMessages { messages, .. } => messages.first().cloned(),
+          | JournalMessage::WriteMessages { messages, .. } => {
+            messages.first().and_then(|write| write.payload().first().cloned())
+          },
           | _ => None,
         }
       });

--- a/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
@@ -226,7 +226,7 @@ fn persistent_actor_clears_sender_in_journal_representations() {
       assert_eq!(messages.iter().map(|write| write.payload().len()).sum::<usize>(), 6);
       for repr in messages.iter().flat_map(|write| {
         // AtomicWrite::payload() is guaranteed non-empty by AtomicWrite::new.
-        write.payload()
+        write.payload().iter()
       }) {
         assert_eq!(repr.sender(), None);
       }

--- a/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
+++ b/modules/persistence-core-kernel/src/persistent/persistent_actor_test.rs
@@ -224,7 +224,10 @@ fn persistent_actor_clears_sender_in_journal_representations() {
   match message {
     | JournalMessage::WriteMessages { messages, .. } => {
       assert_eq!(messages.iter().map(|write| write.payload().len()).sum::<usize>(), 6);
-      for repr in messages.iter().flat_map(|write| write.payload()) {
+      for repr in messages.iter().flat_map(|write| {
+        // AtomicWrite::payload() is guaranteed non-empty by AtomicWrite::new.
+        write.payload()
+      }) {
         assert_eq!(repr.sender(), None);
       }
     },

--- a/modules/persistence-core-kernel/src/serialization.rs
+++ b/modules/persistence-core-kernel/src/serialization.rs
@@ -1,0 +1,14 @@
+//! Persistence serialization package.
+
+mod message_serializer;
+mod registration;
+mod snapshot_payload;
+mod snapshot_serializer;
+mod wire;
+
+pub use message_serializer::MessageSerializer;
+pub use registration::{
+  MESSAGE_SERIALIZER_ID, PersistenceSerializationContributor, SNAPSHOT_SERIALIZER_ID, register_persistence_serializers,
+};
+pub use snapshot_payload::SnapshotPayload;
+pub use snapshot_serializer::SnapshotSerializer;

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -54,7 +54,7 @@ impl MessageSerializer {
     wire::write_bool(&mut buffer, repr.deleted());
     let adapter_type_name = if repr.adapter_type_id() == payload.type_id() {
       // Empty adapter key is a wire-level shorthand for "use the decoded payload type".
-      registry.binding_name(repr.adapter_type_id()).unwrap_or_else(String::new)
+      String::new()
     } else {
       registry.binding_name(repr.adapter_type_id()).ok_or(SerializationError::InvalidFormat)?
     };

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -51,9 +51,10 @@ impl MessageSerializer {
     let payload = repr.payload().deref();
     let payload_type_id = payload.type_id();
     let payload_binding_name = registry.binding_name(payload_type_id);
-    let payload_type_name = payload_binding_name.as_deref().unwrap_or("PersistentRepr payload");
+    let payload_type_name = payload_binding_name.as_deref().unwrap_or("");
+    let payload_serializer_hint = payload_binding_name.as_deref().unwrap_or("PersistentRepr payload");
     let serialized_payload =
-      Self::serialize_nested(&delegator, payload, payload_type_name, payload_binding_name.is_some())?;
+      Self::serialize_nested(&delegator, payload, payload_serializer_hint, payload_binding_name.is_some())?;
     wire::write_string(&mut buffer, payload_type_name)?;
     wire::write_serialized(&mut buffer, &serialized_payload)?;
     wire::write_string(&mut buffer, repr.manifest())?;
@@ -72,9 +73,10 @@ impl MessageSerializer {
       wire::write_bool(&mut buffer, true);
       let metadata = metadata.deref();
       let metadata_binding_name = registry.binding_name(metadata.type_id());
-      let metadata_type_name = metadata_binding_name.as_deref().unwrap_or("PersistentRepr metadata");
+      let metadata_type_name = metadata_binding_name.as_deref().unwrap_or("");
+      let metadata_serializer_hint = metadata_binding_name.as_deref().unwrap_or("PersistentRepr metadata");
       let serialized_metadata =
-        Self::serialize_nested(&delegator, metadata, metadata_type_name, metadata_binding_name.is_some())?;
+        Self::serialize_nested(&delegator, metadata, metadata_serializer_hint, metadata_binding_name.is_some())?;
       wire::write_string(&mut buffer, metadata_type_name)?;
       wire::write_serialized(&mut buffer, &serialized_metadata)?;
     } else {
@@ -90,7 +92,7 @@ impl MessageSerializer {
     let persistence_id = wire::read_string(bytes, &mut cursor)?;
     let sequence_nr = wire::read_u64(bytes, &mut cursor)?;
     let payload_type_name = wire::read_string(bytes, &mut cursor)?;
-    let payload_type_hint = registry.type_id_for_binding_name(&payload_type_name);
+    let payload_type_hint = Self::type_hint_for_wire_name(&registry, &payload_type_name);
     let payload = Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?, payload_type_hint)?;
     let manifest = wire::read_string(bytes, &mut cursor)?;
     let writer_uuid = wire::read_string(bytes, &mut cursor)?;
@@ -110,7 +112,7 @@ impl MessageSerializer {
     }
     if has_metadata {
       let metadata_type_name = wire::read_string(bytes, &mut cursor)?;
-      let metadata_type_hint = registry.type_id_for_binding_name(&metadata_type_name);
+      let metadata_type_hint = Self::type_hint_for_wire_name(&registry, &metadata_type_name);
       let metadata =
         Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?, metadata_type_hint)?;
       repr = repr.with_metadata(ArcShared::from_boxed(metadata));
@@ -137,6 +139,10 @@ impl MessageSerializer {
 
   fn has_valid_manifest(message: &SerializedMessage) -> bool {
     !matches!(message.manifest(), Some(manifest) if manifest.is_empty())
+  }
+
+  fn type_hint_for_wire_name(registry: &SerializationRegistry, type_name: &str) -> Option<TypeId> {
+    if type_name.is_empty() { None } else { registry.type_id_for_binding_name(type_name) }
   }
 
   fn deserialize_nested(

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -52,7 +52,11 @@ impl MessageSerializer {
     wire::write_string(&mut buffer, repr.writer_uuid())?;
     wire::write_u64(&mut buffer, repr.timestamp());
     wire::write_bool(&mut buffer, repr.deleted());
-    let adapter_type_name = registry.binding_name(repr.adapter_type_id()).unwrap_or_default();
+    let adapter_type_name = if repr.adapter_type_id() == payload.type_id() {
+      registry.binding_name(repr.adapter_type_id()).unwrap_or_default()
+    } else {
+      registry.binding_name(repr.adapter_type_id()).ok_or(SerializationError::InvalidFormat)?
+    };
     wire::write_string(&mut buffer, &adapter_type_name)?;
     if let Some(metadata) = repr.metadata() {
       wire::write_bool(&mut buffer, true);
@@ -110,7 +114,7 @@ impl MessageSerializer {
   }
 
   fn has_valid_manifest(message: &SerializedMessage) -> bool {
-    message.manifest().is_some_and(|manifest| !manifest.is_empty())
+    matches!(message.manifest(), Some(manifest) if !manifest.is_empty())
   }
 
   fn deserialize_nested(

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -93,7 +93,7 @@ impl MessageSerializer {
     delegator: &SerializationDelegator<'_>,
     message: &SerializedMessage,
   ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
-    if message.manifest().is_none() {
+    if message.manifest().is_none_or(str::is_empty) {
       return Err(SerializationError::InvalidFormat);
     }
     delegator.deserialize(message, None)

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -138,7 +138,10 @@ impl MessageSerializer {
   }
 
   fn has_valid_manifest(message: &SerializedMessage) -> bool {
-    !matches!(message.manifest(), Some(manifest) if manifest.is_empty())
+    match message.manifest() {
+      | Some(manifest) => !manifest.is_empty(),
+      | None => true,
+    }
   }
 
   fn type_hint_for_wire_name(registry: &SerializationRegistry, type_name: &str) -> Option<TypeId> {

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -103,17 +103,21 @@ impl MessageSerializer {
     type_name: &str,
   ) -> Result<SerializedMessage, SerializationError> {
     let nested = delegator.serialize(message, type_name)?;
-    if nested.manifest().is_none_or(str::is_empty) {
+    if !Self::has_valid_manifest(&nested) {
       return Err(SerializationError::InvalidFormat);
     }
     Ok(nested)
+  }
+
+  fn has_valid_manifest(message: &SerializedMessage) -> bool {
+    message.manifest().is_some_and(|manifest| !manifest.is_empty())
   }
 
   fn deserialize_nested(
     delegator: &SerializationDelegator<'_>,
     message: &SerializedMessage,
   ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
-    if message.manifest().is_none_or(str::is_empty) {
+    if !Self::has_valid_manifest(message) {
       return Err(SerializationError::InvalidFormat);
     }
     delegator.deserialize(message, None)

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -47,17 +47,19 @@ impl MessageSerializer {
     let payload = repr.payload().deref();
     let payload_type_name =
       registry.binding_name(payload.type_id()).unwrap_or_else(|| String::from(type_name_of_val(payload)));
-    wire::write_serialized(&mut buffer, &delegator.serialize(payload, &payload_type_name)?)?;
+    wire::write_serialized(&mut buffer, &Self::serialize_nested(&delegator, payload, &payload_type_name)?)?;
     wire::write_string(&mut buffer, repr.manifest())?;
     wire::write_string(&mut buffer, repr.writer_uuid())?;
     wire::write_u64(&mut buffer, repr.timestamp());
     wire::write_bool(&mut buffer, repr.deleted());
+    let adapter_type_name = registry.binding_name(repr.adapter_type_id()).unwrap_or_default();
+    wire::write_string(&mut buffer, &adapter_type_name)?;
     if let Some(metadata) = repr.metadata() {
       wire::write_bool(&mut buffer, true);
       let metadata = metadata.deref();
       let metadata_type_name =
         registry.binding_name(metadata.type_id()).unwrap_or_else(|| String::from(type_name_of_val(metadata)));
-      wire::write_serialized(&mut buffer, &delegator.serialize(metadata, &metadata_type_name)?)?;
+      wire::write_serialized(&mut buffer, &Self::serialize_nested(&delegator, metadata, &metadata_type_name)?)?;
     } else {
       wire::write_bool(&mut buffer, false);
     }
@@ -75,18 +77,36 @@ impl MessageSerializer {
     let writer_uuid = wire::read_string(bytes, &mut cursor)?;
     let timestamp = wire::read_u64(bytes, &mut cursor)?;
     let deleted = wire::read_bool(bytes, &mut cursor)?;
+    let adapter_type_name = wire::read_string(bytes, &mut cursor)?;
     let has_metadata = wire::read_bool(bytes, &mut cursor)?;
     let mut repr = PersistentRepr::new(persistence_id, sequence_nr, ArcShared::from_boxed(payload))
       .with_manifest(manifest)
       .with_writer_uuid(writer_uuid)
       .with_timestamp(timestamp)
       .with_deleted(deleted);
+    if !adapter_type_name.is_empty() {
+      let adapter_type_id =
+        registry.type_id_for_binding_name(&adapter_type_name).ok_or(SerializationError::InvalidFormat)?;
+      repr = repr.with_adapter_type_id(adapter_type_id);
+    }
     if has_metadata {
       let metadata = Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?)?;
       repr = repr.with_metadata(ArcShared::from_boxed(metadata));
     }
     wire::ensure_finished(bytes, cursor)?;
     Ok(repr)
+  }
+
+  fn serialize_nested(
+    delegator: &SerializationDelegator<'_>,
+    message: &(dyn Any + Send + Sync),
+    type_name: &str,
+  ) -> Result<SerializedMessage, SerializationError> {
+    let nested = delegator.serialize(message, type_name)?;
+    if nested.manifest().is_none_or(str::is_empty) {
+      return Err(SerializationError::InvalidFormat);
+    }
+    Ok(nested)
   }
 
   fn deserialize_nested(

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{
-  any::{Any, TypeId, type_name_of_val},
+  any::{Any, TypeId},
   ops::Deref,
 };
 
@@ -34,6 +34,10 @@ impl MessageSerializer {
     Self { id, registry }
   }
 
+  pub(crate) fn uses_registry(&self, registry: &ArcShared<SerializationRegistry>) -> bool {
+    self.registry.upgrade().is_some_and(|registered| ArcShared::ptr_eq(&registered, registry))
+  }
+
   fn registry(&self) -> Result<ArcShared<SerializationRegistry>, SerializationError> {
     self.registry.upgrade().ok_or(SerializationError::Uninitialized)
   }
@@ -45,27 +49,32 @@ impl MessageSerializer {
     wire::write_string(&mut buffer, repr.persistence_id())?;
     wire::write_u64(&mut buffer, repr.sequence_nr());
     let payload = repr.payload().deref();
+    let payload_type_id = payload.type_id();
     let payload_type_name =
-      registry.binding_name(payload.type_id()).unwrap_or_else(|| String::from(type_name_of_val(payload)));
+      registry.binding_name(payload_type_id).unwrap_or_else(|| String::from("PersistentRepr payload"));
     let serialized_payload = Self::serialize_nested(&delegator, payload, &payload_type_name)?;
+    wire::write_string(&mut buffer, &payload_type_name)?;
     wire::write_serialized(&mut buffer, &serialized_payload)?;
     wire::write_string(&mut buffer, repr.manifest())?;
     wire::write_string(&mut buffer, repr.writer_uuid())?;
     wire::write_u64(&mut buffer, repr.timestamp());
     wire::write_bool(&mut buffer, repr.deleted());
-    let adapter_type_name = if repr.adapter_type_id() == payload.type_id() {
+    let adapter_type_id = repr.adapter_type_id();
+    let adapter_type_name = if adapter_type_id == payload_type_id {
       // Empty adapter key is a wire-level shorthand for "use the decoded payload type".
       String::new()
     } else {
-      registry.binding_name(repr.adapter_type_id()).ok_or(SerializationError::InvalidFormat)?
+      registry.binding_name(adapter_type_id).ok_or(SerializationError::InvalidFormat)?
     };
     wire::write_string(&mut buffer, &adapter_type_name)?;
     if let Some(metadata) = repr.metadata() {
       wire::write_bool(&mut buffer, true);
       let metadata = metadata.deref();
       let metadata_type_name =
-        registry.binding_name(metadata.type_id()).unwrap_or_else(|| String::from(type_name_of_val(metadata)));
-      wire::write_serialized(&mut buffer, &Self::serialize_nested(&delegator, metadata, &metadata_type_name)?)?;
+        registry.binding_name(metadata.type_id()).unwrap_or_else(|| String::from("PersistentRepr metadata"));
+      let serialized_metadata = Self::serialize_nested(&delegator, metadata, &metadata_type_name)?;
+      wire::write_string(&mut buffer, &metadata_type_name)?;
+      wire::write_serialized(&mut buffer, &serialized_metadata)?;
     } else {
       wire::write_bool(&mut buffer, false);
     }
@@ -78,7 +87,9 @@ impl MessageSerializer {
     let mut cursor = 0;
     let persistence_id = wire::read_string(bytes, &mut cursor)?;
     let sequence_nr = wire::read_u64(bytes, &mut cursor)?;
-    let payload = Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?)?;
+    let payload_type_name = wire::read_string(bytes, &mut cursor)?;
+    let payload_type_hint = registry.type_id_for_binding_name(&payload_type_name);
+    let payload = Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?, payload_type_hint)?;
     let manifest = wire::read_string(bytes, &mut cursor)?;
     let writer_uuid = wire::read_string(bytes, &mut cursor)?;
     let timestamp = wire::read_u64(bytes, &mut cursor)?;
@@ -96,7 +107,10 @@ impl MessageSerializer {
       repr = repr.with_adapter_type_id(adapter_type_id);
     }
     if has_metadata {
-      let metadata = Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?)?;
+      let metadata_type_name = wire::read_string(bytes, &mut cursor)?;
+      let metadata_type_hint = registry.type_id_for_binding_name(&metadata_type_name);
+      let metadata =
+        Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?, metadata_type_hint)?;
       repr = repr.with_metadata(ArcShared::from_boxed(metadata));
     }
     wire::ensure_finished(bytes, cursor)?;
@@ -116,17 +130,18 @@ impl MessageSerializer {
   }
 
   fn has_valid_manifest(message: &SerializedMessage) -> bool {
-    matches!(message.manifest(), Some(manifest) if !manifest.is_empty())
+    !matches!(message.manifest(), Some(manifest) if manifest.is_empty())
   }
 
   fn deserialize_nested(
     delegator: &SerializationDelegator<'_>,
     message: &SerializedMessage,
+    type_hint: Option<TypeId>,
   ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
     if !Self::has_valid_manifest(message) {
       return Err(SerializationError::InvalidFormat);
     }
-    delegator.deserialize(message, None)
+    delegator.deserialize(message, type_hint)
   }
 }
 

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -53,6 +53,7 @@ impl MessageSerializer {
     wire::write_u64(&mut buffer, repr.timestamp());
     wire::write_bool(&mut buffer, repr.deleted());
     let adapter_type_name = if repr.adapter_type_id() == payload.type_id() {
+      // Empty adapter key is a wire-level shorthand for "use the decoded payload type".
       registry.binding_name(repr.adapter_type_id()).unwrap_or_default()
     } else {
       registry.binding_name(repr.adapter_type_id()).ok_or(SerializationError::InvalidFormat)?

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -54,7 +54,7 @@ impl MessageSerializer {
     wire::write_bool(&mut buffer, repr.deleted());
     let adapter_type_name = if repr.adapter_type_id() == payload.type_id() {
       // Empty adapter key is a wire-level shorthand for "use the decoded payload type".
-      registry.binding_name(repr.adapter_type_id()).unwrap_or_default()
+      registry.binding_name(repr.adapter_type_id()).unwrap_or_else(String::new)
     } else {
       registry.binding_name(repr.adapter_type_id()).ok_or(SerializationError::InvalidFormat)?
     };

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -1,0 +1,160 @@
+//! Serializer for persistent journal records.
+
+#[cfg(test)]
+#[path = "message_serializer_test.rs"]
+mod tests;
+
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::{
+  any::{Any, TypeId, type_name_of_val},
+  ops::Deref,
+};
+
+use fraktor_actor_core_kernel_rs::serialization::{
+  SerializationDelegator, SerializationError, SerializedMessage, Serializer, SerializerId,
+  serialization_registry::SerializationRegistry,
+};
+use fraktor_utils_core_rs::sync::{ArcShared, WeakShared};
+
+use crate::{
+  persistent::{AtomicWrite, PersistentRepr},
+  serialization::wire::{self, ATOMIC_WRITE_TAG, PERSISTENT_REPR_TAG},
+};
+
+/// Serializes [`PersistentRepr`] and [`AtomicWrite`] records.
+pub struct MessageSerializer {
+  id:       SerializerId,
+  registry: WeakShared<SerializationRegistry>,
+}
+
+impl MessageSerializer {
+  /// Creates a new message serializer.
+  #[must_use]
+  pub const fn new(id: SerializerId, registry: WeakShared<SerializationRegistry>) -> Self {
+    Self { id, registry }
+  }
+
+  fn registry(&self) -> Result<ArcShared<SerializationRegistry>, SerializationError> {
+    self.registry.upgrade().ok_or(SerializationError::Uninitialized)
+  }
+
+  fn encode_repr(&self, repr: &PersistentRepr) -> Result<Vec<u8>, SerializationError> {
+    let registry = self.registry()?;
+    let delegator = SerializationDelegator::new(&registry);
+    let mut buffer = Vec::new();
+    wire::write_string(&mut buffer, repr.persistence_id())?;
+    wire::write_u64(&mut buffer, repr.sequence_nr());
+    let payload = repr.payload().deref();
+    let payload_type_name =
+      registry.binding_name(payload.type_id()).unwrap_or_else(|| String::from(type_name_of_val(payload)));
+    wire::write_serialized(&mut buffer, &delegator.serialize(payload, &payload_type_name)?)?;
+    wire::write_string(&mut buffer, repr.manifest())?;
+    wire::write_string(&mut buffer, repr.writer_uuid())?;
+    wire::write_u64(&mut buffer, repr.timestamp());
+    wire::write_bool(&mut buffer, repr.deleted());
+    if let Some(metadata) = repr.metadata() {
+      wire::write_bool(&mut buffer, true);
+      let metadata = metadata.deref();
+      let metadata_type_name =
+        registry.binding_name(metadata.type_id()).unwrap_or_else(|| String::from(type_name_of_val(metadata)));
+      wire::write_serialized(&mut buffer, &delegator.serialize(metadata, &metadata_type_name)?)?;
+    } else {
+      wire::write_bool(&mut buffer, false);
+    }
+    Ok(buffer)
+  }
+
+  fn decode_repr(&self, bytes: &[u8]) -> Result<PersistentRepr, SerializationError> {
+    let registry = self.registry()?;
+    let delegator = SerializationDelegator::new(&registry);
+    let mut cursor = 0;
+    let persistence_id = wire::read_string(bytes, &mut cursor)?;
+    let sequence_nr = wire::read_u64(bytes, &mut cursor)?;
+    let payload = Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?)?;
+    let manifest = wire::read_string(bytes, &mut cursor)?;
+    let writer_uuid = wire::read_string(bytes, &mut cursor)?;
+    let timestamp = wire::read_u64(bytes, &mut cursor)?;
+    let deleted = wire::read_bool(bytes, &mut cursor)?;
+    let has_metadata = wire::read_bool(bytes, &mut cursor)?;
+    let mut repr = PersistentRepr::new(persistence_id, sequence_nr, ArcShared::from_boxed(payload))
+      .with_manifest(manifest)
+      .with_writer_uuid(writer_uuid)
+      .with_timestamp(timestamp)
+      .with_deleted(deleted);
+    if has_metadata {
+      let metadata = Self::deserialize_nested(&delegator, &wire::read_serialized(bytes, &mut cursor)?)?;
+      repr = repr.with_metadata(ArcShared::from_boxed(metadata));
+    }
+    wire::ensure_finished(bytes, cursor)?;
+    Ok(repr)
+  }
+
+  fn deserialize_nested(
+    delegator: &SerializationDelegator<'_>,
+    message: &SerializedMessage,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if message.manifest().is_none() {
+      return Err(SerializationError::InvalidFormat);
+    }
+    delegator.deserialize(message, None)
+  }
+}
+
+impl Serializer for MessageSerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let mut buffer = Vec::new();
+    if let Some(repr) = message.downcast_ref::<PersistentRepr>() {
+      wire::write_u8(&mut buffer, PERSISTENT_REPR_TAG);
+      wire::write_bytes(&mut buffer, &self.encode_repr(repr)?)?;
+      return Ok(buffer);
+    }
+    if let Some(atomic_write) = message.downcast_ref::<AtomicWrite>() {
+      wire::write_u8(&mut buffer, ATOMIC_WRITE_TAG);
+      let count = u32::try_from(atomic_write.size()).map_err(|_| SerializationError::InvalidFormat)?;
+      wire::write_u32(&mut buffer, count);
+      for repr in atomic_write.payload() {
+        wire::write_bytes(&mut buffer, &self.encode_repr(repr)?)?;
+      }
+      return Ok(buffer);
+    }
+    Err(SerializationError::InvalidFormat)
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    let mut cursor = 0;
+    match wire::read_u8(bytes, &mut cursor)? {
+      | PERSISTENT_REPR_TAG => {
+        let repr = self.decode_repr(wire::read_bytes(bytes, &mut cursor)?)?;
+        wire::ensure_finished(bytes, cursor)?;
+        Ok(Box::new(repr))
+      },
+      | ATOMIC_WRITE_TAG => {
+        let count = wire::read_u32(bytes, &mut cursor)?;
+        let mut payload = Vec::new();
+        for _ in 0..count {
+          payload.push(self.decode_repr(wire::read_bytes(bytes, &mut cursor)?)?);
+        }
+        wire::ensure_finished(bytes, cursor)?;
+        let atomic_write = AtomicWrite::new(payload).map_err(|_| SerializationError::InvalidFormat)?;
+        Ok(Box::new(atomic_write))
+      },
+      | _ => Err(SerializationError::InvalidFormat),
+    }
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -50,10 +50,11 @@ impl MessageSerializer {
     wire::write_u64(&mut buffer, repr.sequence_nr());
     let payload = repr.payload().deref();
     let payload_type_id = payload.type_id();
-    let payload_type_name =
-      registry.binding_name(payload_type_id).unwrap_or_else(|| String::from("PersistentRepr payload"));
-    let serialized_payload = Self::serialize_nested(&delegator, payload, &payload_type_name)?;
-    wire::write_string(&mut buffer, &payload_type_name)?;
+    let payload_binding_name = registry.binding_name(payload_type_id);
+    let payload_type_name = payload_binding_name.as_deref().unwrap_or("PersistentRepr payload");
+    let serialized_payload =
+      Self::serialize_nested(&delegator, payload, payload_type_name, payload_binding_name.is_some())?;
+    wire::write_string(&mut buffer, payload_type_name)?;
     wire::write_serialized(&mut buffer, &serialized_payload)?;
     wire::write_string(&mut buffer, repr.manifest())?;
     wire::write_string(&mut buffer, repr.writer_uuid())?;
@@ -70,10 +71,11 @@ impl MessageSerializer {
     if let Some(metadata) = repr.metadata() {
       wire::write_bool(&mut buffer, true);
       let metadata = metadata.deref();
-      let metadata_type_name =
-        registry.binding_name(metadata.type_id()).unwrap_or_else(|| String::from("PersistentRepr metadata"));
-      let serialized_metadata = Self::serialize_nested(&delegator, metadata, &metadata_type_name)?;
-      wire::write_string(&mut buffer, &metadata_type_name)?;
+      let metadata_binding_name = registry.binding_name(metadata.type_id());
+      let metadata_type_name = metadata_binding_name.as_deref().unwrap_or("PersistentRepr metadata");
+      let serialized_metadata =
+        Self::serialize_nested(&delegator, metadata, metadata_type_name, metadata_binding_name.is_some())?;
+      wire::write_string(&mut buffer, metadata_type_name)?;
       wire::write_serialized(&mut buffer, &serialized_metadata)?;
     } else {
       wire::write_bool(&mut buffer, false);
@@ -121,9 +123,13 @@ impl MessageSerializer {
     delegator: &SerializationDelegator<'_>,
     message: &(dyn Any + Send + Sync),
     type_name: &str,
+    has_binding_name: bool,
   ) -> Result<SerializedMessage, SerializationError> {
     let nested = delegator.serialize(message, type_name)?;
     if !Self::has_valid_manifest(&nested) {
+      return Err(SerializationError::InvalidFormat);
+    }
+    if !has_binding_name && nested.manifest().is_none() {
       return Err(SerializationError::InvalidFormat);
     }
     Ok(nested)

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -128,13 +128,16 @@ impl MessageSerializer {
     has_binding_name: bool,
   ) -> Result<SerializedMessage, SerializationError> {
     let nested = delegator.serialize(message, type_name)?;
-    if !Self::has_valid_manifest(&nested) {
-      return Err(SerializationError::InvalidFormat);
-    }
-    if !has_binding_name && nested.manifest().is_none() {
-      return Err(SerializationError::InvalidFormat);
-    }
+    Self::validate_nested_manifest(&nested, has_binding_name)?;
     Ok(nested)
+  }
+
+  fn validate_nested_manifest(message: &SerializedMessage, has_binding_name: bool) -> Result<(), SerializationError> {
+    match message.manifest() {
+      | Some("") => Err(SerializationError::InvalidFormat),
+      | None if !has_binding_name => Err(SerializationError::InvalidFormat),
+      | _ => Ok(()),
+    }
   }
 
   fn has_valid_manifest(message: &SerializedMessage) -> bool {

--- a/modules/persistence-core-kernel/src/serialization/message_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer.rs
@@ -47,7 +47,8 @@ impl MessageSerializer {
     let payload = repr.payload().deref();
     let payload_type_name =
       registry.binding_name(payload.type_id()).unwrap_or_else(|| String::from(type_name_of_val(payload)));
-    wire::write_serialized(&mut buffer, &Self::serialize_nested(&delegator, payload, &payload_type_name)?)?;
+    let serialized_payload = Self::serialize_nested(&delegator, payload, &payload_type_name)?;
+    wire::write_serialized(&mut buffer, &serialized_payload)?;
     wire::write_string(&mut buffer, repr.manifest())?;
     wire::write_string(&mut buffer, repr.writer_uuid())?;
     wire::write_u64(&mut buffer, repr.timestamp());

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -116,9 +116,86 @@ impl Serializer for HintOnlyI32Serializer {
   }
 }
 
+struct EmptyManifestI32Serializer {
+  id: SerializerId,
+}
+
+impl EmptyManifestI32Serializer {
+  fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for EmptyManifestI32Serializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
+    Ok(value.to_le_bytes().to_vec())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if bytes.len() != core::mem::size_of::<i32>() {
+      return Err(SerializationError::InvalidFormat);
+    }
+    let mut array = [0_u8; core::mem::size_of::<i32>()];
+    array.copy_from_slice(bytes);
+    Ok(Box::new(i32::from_le_bytes(array)))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+
+  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
+    Some(self)
+  }
+}
+
+impl SerializerWithStringManifest for EmptyManifestI32Serializer {
+  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    Cow::Borrowed("")
+  }
+
+  fn from_binary_with_manifest(
+    &self,
+    bytes: &[u8],
+    _manifest: &str,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    self.from_binary(bytes, Some(TypeId::of::<i32>()))
+  }
+}
+
 fn manifest_registry() -> ArcShared<SerializationRegistry> {
   let id = SerializerId::try_from(100).expect("serializer id");
   let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .bind::<i32>("i32")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
+fn empty_manifest_registry() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(102).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(EmptyManifestI32Serializer::new(id));
   let setup = SerializationSetupBuilder::new()
     .register_serializer("i32", id, serializer)
     .expect("register")
@@ -219,6 +296,17 @@ fn non_manifest_resolvable_payload_fails_deserialization() {
   let bytes = serializer.to_binary(&repr).expect("serialize");
 
   assert!(serializer.from_binary(&bytes, None).is_err());
+}
+
+#[test]
+fn empty_manifest_payload_fails_deserialization() {
+  let registry = empty_manifest_registry();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+
+  let bytes = serializer.to_binary(&repr).expect("serialize");
+
+  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -22,6 +22,8 @@ use crate::{
 
 const I32_MANIFEST: &str = "test.I32";
 
+struct DomainEvent;
+
 struct ManifestI32Serializer {
   id: SerializerId,
 }
@@ -130,6 +132,8 @@ fn manifest_registry() -> ArcShared<SerializationRegistry> {
     .expect("fallback")
     .bind::<i32>("i32")
     .expect("bind")
+    .bind::<DomainEvent>("i32")
+    .expect("bind domain event")
     .build()
     .expect("setup");
   let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
@@ -170,7 +174,7 @@ fn persistent_repr_round_trip_preserves_durable_metadata() {
     .with_deleted(true)
     .with_sender(Some(Pid::new(1, 1)))
     .with_adapters(EventAdapters::new())
-    .with_adapter_type_id(TypeId::of::<String>());
+    .with_adapter_type_id(TypeId::of::<DomainEvent>());
 
   let bytes = serializer.to_binary(&repr).expect("serialize");
   let restored = serializer.from_binary(&bytes, None).expect("deserialize");
@@ -185,7 +189,7 @@ fn persistent_repr_round_trip_preserves_durable_metadata() {
   assert_eq!(restored.downcast_ref::<i32>(), Some(&11));
   assert_eq!(restored.metadata().and_then(|value| value.downcast_ref::<i32>()), Some(&13));
   assert_eq!(restored.sender(), None);
-  assert_eq!(restored.adapter_type_id(), TypeId::of::<i32>());
+  assert_eq!(restored.adapter_type_id(), TypeId::of::<DomainEvent>());
 }
 
 #[test]
@@ -215,14 +219,12 @@ fn unregistered_payload_fails_serialization() {
 }
 
 #[test]
-fn non_manifest_resolvable_payload_fails_deserialization() {
+fn non_manifest_resolvable_payload_fails_serialization() {
   let registry = hint_only_registry();
   let serializer = serializer(&registry);
   let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
 
-  let bytes = serializer.to_binary(&repr).expect("serialize");
-
-  assert!(serializer.from_binary(&bytes, None).is_err());
+  assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -71,7 +71,10 @@ impl Serializer for ManifestI32Serializer {
 }
 
 impl SerializerWithStringManifest for ManifestI32Serializer {
-  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+  fn manifest(&self, message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    if message.downcast_ref::<i32>() == Some(&i32::MIN) {
+      return Cow::Borrowed("");
+    }
     Cow::Borrowed(I32_MANIFEST)
   }
 
@@ -219,6 +222,7 @@ fn test_serializers_exercise_trait_methods() {
 
   let hint_only = HintOnlyI32Serializer::new(SerializerId::try_from(101).expect("serializer id"));
   assert!(hint_only.as_any().downcast_ref::<HintOnlyI32Serializer>().is_some());
+  assert_eq!(hint_only.to_binary(&UnboundMetadata(2)).expect("metadata"), 2_i32.to_le_bytes().to_vec());
   assert_eq!(
     *hint_only
       .from_binary(&1_i32.to_le_bytes(), Some(TypeId::of::<i32>()))
@@ -227,7 +231,11 @@ fn test_serializers_exercise_trait_methods() {
       .unwrap(),
     1
   );
+  let metadata = hint_only.from_binary(&2_i32.to_le_bytes(), Some(TypeId::of::<UnboundMetadata>())).expect("metadata");
+  assert_eq!(metadata.downcast_ref::<UnboundMetadata>().map(|value| value.0), Some(2));
   assert!(matches!(hint_only.from_binary(&[], None), Err(SerializationError::InvalidFormat)));
+  assert!(matches!(hint_only.from_binary(&2_i32.to_le_bytes(), None), Err(SerializationError::InvalidFormat)));
+  assert!(matches!(hint_only.to_binary(&"unsupported"), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]
@@ -306,6 +314,15 @@ fn unregistered_metadata_fails_serialization() {
   let serializer = serializer(&registry);
   let repr =
     PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32)).with_metadata(ArcShared::new(String::from("missing")));
+
+  assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn empty_nested_manifest_payload_fails_serialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(i32::MIN));
 
   assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
 }
@@ -618,5 +635,29 @@ fn persistence_serializer_registration_rejects_snapshot_serializer_id_collision(
   assert!(matches!(
     register_persistence_serializers(&registry),
     Err(SerializationError::SerializerIdCollision(id)) if id == SNAPSHOT_SERIALIZER_ID
+  ));
+}
+
+#[test]
+fn persistence_serializer_registration_rejects_binding_name_collision() {
+  let id = SerializerId::try_from(100).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("fallback", id, serializer)
+    .expect("register")
+    .set_fallback("fallback")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  registry.register_binding(TypeId::of::<String>(), "PersistentRepr", id).expect("runtime binding");
+
+  assert!(matches!(
+    register_persistence_serializers(&registry),
+    Err(SerializationError::SerializerBindingCollision {
+      type_name,
+      existing,
+      requested
+    }) if type_name == "PersistentRepr" && existing == id && requested == MESSAGE_SERIALIZER_ID
   ));
 }

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -4,8 +4,9 @@ use core::any::{Any, TypeId};
 use fraktor_actor_core_kernel_rs::{
   actor::Pid,
   serialization::{
-    SerializationDelegator, SerializationError, SerializationSetupBuilder, Serializer, SerializerId,
-    SerializerWithStringManifest, serialization_registry::SerializationRegistry,
+    SerializationDelegator, SerializationError, SerializationSetupBuilder, SerializedMessage, Serializer, SerializerId,
+    SerializerWithStringManifest, contribution::SerializationRegistryContributor,
+    serialization_registry::SerializationRegistry,
   },
 };
 use fraktor_utils_core_rs::sync::ArcShared;
@@ -13,7 +14,10 @@ use fraktor_utils_core_rs::sync::ArcShared;
 use crate::{
   journal::EventAdapters,
   persistent::{AtomicWrite, PersistentRepr},
-  serialization::{MESSAGE_SERIALIZER_ID, MessageSerializer, register_persistence_serializers},
+  serialization::{
+    MESSAGE_SERIALIZER_ID, MessageSerializer, PersistenceSerializationContributor, register_persistence_serializers,
+    wire::{self, PERSISTENT_REPR_TAG},
+  },
 };
 
 const I32_MANIFEST: &str = "test.I32";
@@ -116,86 +120,9 @@ impl Serializer for HintOnlyI32Serializer {
   }
 }
 
-struct EmptyManifestI32Serializer {
-  id: SerializerId,
-}
-
-impl EmptyManifestI32Serializer {
-  fn new(id: SerializerId) -> Self {
-    Self { id }
-  }
-}
-
-impl Serializer for EmptyManifestI32Serializer {
-  fn identifier(&self) -> SerializerId {
-    self.id
-  }
-
-  fn include_manifest(&self) -> bool {
-    true
-  }
-
-  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
-    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
-    Ok(value.to_le_bytes().to_vec())
-  }
-
-  fn from_binary(
-    &self,
-    bytes: &[u8],
-    _type_hint: Option<TypeId>,
-  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
-    if bytes.len() != core::mem::size_of::<i32>() {
-      return Err(SerializationError::InvalidFormat);
-    }
-    let mut array = [0_u8; core::mem::size_of::<i32>()];
-    array.copy_from_slice(bytes);
-    Ok(Box::new(i32::from_le_bytes(array)))
-  }
-
-  fn as_any(&self) -> &(dyn Any + Send + Sync) {
-    self
-  }
-
-  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
-    Some(self)
-  }
-}
-
-impl SerializerWithStringManifest for EmptyManifestI32Serializer {
-  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
-    Cow::Borrowed("")
-  }
-
-  fn from_binary_with_manifest(
-    &self,
-    bytes: &[u8],
-    _manifest: &str,
-  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
-    self.from_binary(bytes, Some(TypeId::of::<i32>()))
-  }
-}
-
 fn manifest_registry() -> ArcShared<SerializationRegistry> {
   let id = SerializerId::try_from(100).expect("serializer id");
   let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
-  let setup = SerializationSetupBuilder::new()
-    .register_serializer("i32", id, serializer)
-    .expect("register")
-    .set_fallback("i32")
-    .expect("fallback")
-    .bind::<i32>("i32")
-    .expect("bind")
-    .build()
-    .expect("setup");
-  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
-  register_persistence_serializers(&registry).expect("persistence serializers");
-  registry
-}
-
-fn empty_manifest_registry() -> ArcShared<SerializationRegistry> {
-  let id = SerializerId::try_from(102).expect("serializer id");
-  let serializer: ArcShared<dyn Serializer> = ArcShared::new(EmptyManifestI32Serializer::new(id));
   let setup = SerializationSetupBuilder::new()
     .register_serializer("i32", id, serializer)
     .expect("register")
@@ -299,17 +226,6 @@ fn non_manifest_resolvable_payload_fails_deserialization() {
 }
 
 #[test]
-fn empty_manifest_payload_fails_deserialization() {
-  let registry = empty_manifest_registry();
-  let serializer = serializer(&registry);
-  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
-
-  let bytes = serializer.to_binary(&repr).expect("serialize");
-
-  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
-}
-
-#[test]
 fn registry_resolves_persistence_message_serializer() {
   let registry = manifest_registry();
   let delegator = SerializationDelegator::new(&registry);
@@ -318,4 +234,54 @@ fn registry_resolves_persistence_message_serializer() {
   let serialized = delegator.serialize(&repr, "PersistentRepr").expect("serialize");
 
   assert_eq!(serialized.serializer_id(), MESSAGE_SERIALIZER_ID);
+}
+
+#[test]
+fn serializer_reports_manifest_and_rejects_unknown_message_type() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+
+  assert!(serializer.include_manifest());
+  assert!(serializer.as_any().downcast_ref::<MessageSerializer>().is_some());
+  assert!(matches!(serializer.to_binary(&"unsupported"), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn unknown_wire_tag_fails_deserialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+
+  assert!(matches!(serializer.from_binary(&[u8::MAX], None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn empty_manifest_payload_fails_deserialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let payload =
+    SerializedMessage::new(SerializerId::try_from(100).expect("serializer id"), Some(String::new()), vec![]);
+  let mut repr = Vec::new();
+  wire::write_string(&mut repr, "pid-1").expect("persistence id");
+  wire::write_u64(&mut repr, 1);
+  wire::write_serialized(&mut repr, &payload).expect("payload");
+  wire::write_string(&mut repr, "").expect("manifest");
+  wire::write_string(&mut repr, "").expect("writer uuid");
+  wire::write_u64(&mut repr, 0);
+  wire::write_bool(&mut repr, false);
+  wire::write_bool(&mut repr, false);
+  let mut bytes = Vec::new();
+  wire::write_u8(&mut bytes, PERSISTENT_REPR_TAG);
+  wire::write_bytes(&mut bytes, &repr).expect("repr");
+
+  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn persistence_serializer_registration_is_idempotent() {
+  let registry = manifest_registry();
+
+  let contributor = PersistenceSerializationContributor::default();
+
+  register_persistence_serializers(&registry).expect("register twice");
+  contributor.contribute(&registry).expect("contribute twice");
 }

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -15,7 +15,8 @@ use crate::{
   journal::EventAdapters,
   persistent::{AtomicWrite, PersistentRepr},
   serialization::{
-    MESSAGE_SERIALIZER_ID, MessageSerializer, PersistenceSerializationContributor, register_persistence_serializers,
+    MESSAGE_SERIALIZER_ID, MessageSerializer, PersistenceSerializationContributor, SNAPSHOT_SERIALIZER_ID,
+    SnapshotPayload, register_persistence_serializers,
     wire::{self, PERSISTENT_REPR_TAG},
   },
 };
@@ -163,6 +164,27 @@ fn serializer(registry: &ArcShared<SerializationRegistry>) -> MessageSerializer 
 }
 
 #[test]
+fn test_serializers_exercise_trait_methods() {
+  let manifest = ManifestI32Serializer::new(SerializerId::try_from(100).expect("serializer id"));
+  assert!(manifest.include_manifest());
+  assert!(manifest.as_any().downcast_ref::<ManifestI32Serializer>().is_some());
+  assert_eq!(*manifest.from_binary(&1_i32.to_le_bytes(), None).expect("value").downcast_ref::<i32>().unwrap(), 1);
+  assert!(matches!(manifest.from_binary_with_manifest(&[], I32_MANIFEST), Err(SerializationError::InvalidFormat)));
+
+  let hint_only = HintOnlyI32Serializer::new(SerializerId::try_from(101).expect("serializer id"));
+  assert!(hint_only.as_any().downcast_ref::<HintOnlyI32Serializer>().is_some());
+  assert_eq!(
+    *hint_only
+      .from_binary(&1_i32.to_le_bytes(), Some(TypeId::of::<i32>()))
+      .expect("value")
+      .downcast_ref::<i32>()
+      .unwrap(),
+    1
+  );
+  assert!(matches!(hint_only.from_binary(&[], None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
 fn persistent_repr_round_trip_preserves_durable_metadata() {
   let registry = manifest_registry();
   let serializer = serializer(&registry);
@@ -279,6 +301,32 @@ fn empty_manifest_payload_fails_deserialization() {
 }
 
 #[test]
+fn unknown_adapter_type_binding_fails_deserialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let payload = SerializedMessage::new(
+    SerializerId::try_from(100).expect("serializer id"),
+    Some(I32_MANIFEST.into()),
+    1_i32.to_le_bytes().to_vec(),
+  );
+  let mut repr = Vec::new();
+  wire::write_string(&mut repr, "pid-1").expect("persistence id");
+  wire::write_u64(&mut repr, 1);
+  wire::write_serialized(&mut repr, &payload).expect("payload");
+  wire::write_string(&mut repr, "").expect("manifest");
+  wire::write_string(&mut repr, "").expect("writer uuid");
+  wire::write_u64(&mut repr, 0);
+  wire::write_bool(&mut repr, false);
+  wire::write_string(&mut repr, "missing-adapter").expect("adapter type");
+  wire::write_bool(&mut repr, false);
+  let mut bytes = Vec::new();
+  wire::write_u8(&mut bytes, PERSISTENT_REPR_TAG);
+  wire::write_bytes(&mut bytes, &repr).expect("repr");
+
+  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
 fn persistence_serializer_registration_is_idempotent() {
   let registry = manifest_registry();
 
@@ -286,4 +334,29 @@ fn persistence_serializer_registration_is_idempotent() {
 
   register_persistence_serializers(&registry).expect("register twice");
   contributor.contribute(&registry).expect("contribute twice");
+}
+
+#[test]
+fn persistence_serializer_registration_rejects_snapshot_binding_collision() {
+  let id = SerializerId::try_from(100).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("snapshot", id, serializer)
+    .expect("register")
+    .set_fallback("snapshot")
+    .expect("fallback")
+    .bind::<SnapshotPayload>("snapshot")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+
+  assert!(matches!(
+    register_persistence_serializers(&registry),
+    Err(SerializationError::SerializerBindingCollision {
+      type_name,
+      existing,
+      requested
+    }) if type_name == "SnapshotPayload" && existing == id && requested == SNAPSHOT_SERIALIZER_ID
+  ));
 }

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -241,6 +241,16 @@ fn unregistered_payload_fails_serialization() {
 }
 
 #[test]
+fn unregistered_metadata_fails_serialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let repr =
+    PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32)).with_metadata(ArcShared::new(String::from("missing")));
+
+  assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
 fn non_manifest_resolvable_payload_fails_serialization() {
   let registry = hint_only_registry();
   let serializer = serializer(&registry);
@@ -358,5 +368,23 @@ fn persistence_serializer_registration_rejects_snapshot_binding_collision() {
       existing,
       requested
     }) if type_name == "SnapshotPayload" && existing == id && requested == SNAPSHOT_SERIALIZER_ID
+  ));
+}
+
+#[test]
+fn persistence_serializer_registration_rejects_snapshot_serializer_id_collision() {
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(SNAPSHOT_SERIALIZER_ID));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("snapshot", SNAPSHOT_SERIALIZER_ID, serializer)
+    .expect("register")
+    .set_fallback("snapshot")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+
+  assert!(matches!(
+    register_persistence_serializers(&registry),
+    Err(SerializationError::SerializerIdCollision(id)) if id == SNAPSHOT_SERIALIZER_ID
   ));
 }

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -323,6 +323,13 @@ fn empty_manifest_payload_fails_deserialization() {
 }
 
 #[test]
+fn manifest_validation_rejects_missing_manifest() {
+  let payload = SerializedMessage::new(SerializerId::try_from(100).expect("serializer id"), None, vec![]);
+
+  assert!(!MessageSerializer::has_valid_manifest(&payload));
+}
+
+#[test]
 fn unknown_adapter_type_binding_fails_deserialization() {
   let registry = manifest_registry();
   let serializer = serializer(&registry);

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -9,7 +9,7 @@ use fraktor_actor_core_kernel_rs::{
     serialization_registry::SerializationRegistry,
   },
 };
-use fraktor_utils_core_rs::sync::ArcShared;
+use fraktor_utils_core_rs::sync::{ArcShared, WeakShared};
 
 use crate::{
   journal::EventAdapters,
@@ -282,12 +282,28 @@ fn unregistered_metadata_fails_serialization() {
 }
 
 #[test]
-fn non_manifest_resolvable_payload_fails_serialization() {
+fn non_manifest_resolvable_payload_serializes_with_serializer_id() {
   let registry = hint_only_registry();
   let serializer = serializer(&registry);
   let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
 
-  assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
+  let bytes = serializer.to_binary(&repr).expect("serialize");
+  let mut cursor = 0;
+  assert_eq!(wire::read_u8(&bytes, &mut cursor).expect("tag"), PERSISTENT_REPR_TAG);
+  let repr_bytes = wire::read_bytes(&bytes, &mut cursor).expect("repr");
+  let mut repr_cursor = 0;
+  let _persistence_id = wire::read_string(repr_bytes, &mut repr_cursor).expect("persistence id");
+  let _sequence_nr = wire::read_u64(repr_bytes, &mut repr_cursor).expect("sequence nr");
+  let payload_type_name = wire::read_string(repr_bytes, &mut repr_cursor).expect("payload type");
+  let nested = wire::read_serialized(repr_bytes, &mut repr_cursor).expect("payload");
+
+  assert_eq!(payload_type_name, "i32");
+  assert_eq!(nested.serializer_id(), SerializerId::try_from(101).expect("serializer id"));
+  assert_eq!(nested.manifest(), None);
+
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<PersistentRepr>().expect("persistent repr");
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&1));
 }
 
 #[test]
@@ -349,6 +365,7 @@ fn empty_manifest_payload_fails_deserialization() {
   let mut repr = Vec::new();
   wire::write_string(&mut repr, "pid-1").expect("persistence id");
   wire::write_u64(&mut repr, 1);
+  wire::write_string(&mut repr, "i32").expect("payload type");
   wire::write_serialized(&mut repr, &payload).expect("payload");
   wire::write_string(&mut repr, "").expect("manifest");
   wire::write_string(&mut repr, "").expect("writer uuid");
@@ -376,6 +393,7 @@ fn trailing_nested_payload_bytes_fail_deserialization() {
   let mut repr = Vec::new();
   wire::write_string(&mut repr, "pid-1").expect("persistence id");
   wire::write_u64(&mut repr, 1);
+  wire::write_string(&mut repr, "i32").expect("payload type");
   wire::write_bytes(&mut repr, &nested).expect("payload");
   wire::write_string(&mut repr, "").expect("manifest");
   wire::write_string(&mut repr, "").expect("writer uuid");
@@ -391,10 +409,45 @@ fn trailing_nested_payload_bytes_fail_deserialization() {
 }
 
 #[test]
-fn manifest_validation_rejects_missing_manifest() {
+fn manifest_validation_accepts_missing_manifest() {
   let payload = SerializedMessage::new(SerializerId::try_from(100).expect("serializer id"), None, vec![]);
 
+  assert!(MessageSerializer::has_valid_manifest(&payload));
+}
+
+#[test]
+fn manifest_validation_rejects_empty_manifest() {
+  let payload =
+    SerializedMessage::new(SerializerId::try_from(100).expect("serializer id"), Some(String::new()), vec![]);
+
   assert!(!MessageSerializer::has_valid_manifest(&payload));
+}
+
+#[test]
+fn persistent_repr_without_nested_manifest_deserializes_by_serializer_id() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let payload =
+    SerializedMessage::new(SerializerId::try_from(100).expect("serializer id"), None, 1_i32.to_le_bytes().to_vec());
+  let mut repr = Vec::new();
+  wire::write_string(&mut repr, "pid-1").expect("persistence id");
+  wire::write_u64(&mut repr, 1);
+  wire::write_string(&mut repr, "i32").expect("payload type");
+  wire::write_serialized(&mut repr, &payload).expect("payload");
+  wire::write_string(&mut repr, "").expect("manifest");
+  wire::write_string(&mut repr, "").expect("writer uuid");
+  wire::write_u64(&mut repr, 0);
+  wire::write_bool(&mut repr, false);
+  wire::write_string(&mut repr, "").expect("adapter type");
+  wire::write_bool(&mut repr, false);
+  let mut bytes = Vec::new();
+  wire::write_u8(&mut bytes, PERSISTENT_REPR_TAG);
+  wire::write_bytes(&mut bytes, &repr).expect("repr");
+
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<PersistentRepr>().expect("persistent repr");
+
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&1));
 }
 
 #[test]
@@ -409,6 +462,7 @@ fn unknown_adapter_type_binding_fails_deserialization() {
   let mut repr = Vec::new();
   wire::write_string(&mut repr, "pid-1").expect("persistence id");
   wire::write_u64(&mut repr, 1);
+  wire::write_string(&mut repr, "i32").expect("payload type");
   wire::write_serialized(&mut repr, &payload).expect("payload");
   wire::write_string(&mut repr, "").expect("manifest");
   wire::write_string(&mut repr, "").expect("writer uuid");
@@ -434,6 +488,25 @@ fn persistence_serializer_registration_is_idempotent() {
 }
 
 #[test]
+fn persistence_serializer_registration_rejects_stale_message_serializer_registration() {
+  let stale_serializer: ArcShared<dyn Serializer> =
+    ArcShared::new(MessageSerializer::new(MESSAGE_SERIALIZER_ID, WeakShared::<SerializationRegistry>::new()));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("persistence-message", MESSAGE_SERIALIZER_ID, stale_serializer)
+    .expect("register")
+    .set_fallback("persistence-message")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+
+  assert!(matches!(
+    register_persistence_serializers(&registry),
+    Err(SerializationError::SerializerIdCollision(id)) if id == MESSAGE_SERIALIZER_ID
+  ));
+}
+
+#[test]
 fn persistence_serializer_registration_rejects_snapshot_binding_collision() {
   let id = SerializerId::try_from(100).expect("serializer id");
   let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
@@ -456,6 +529,9 @@ fn persistence_serializer_registration_rejects_snapshot_binding_collision() {
       requested
     }) if type_name == "SnapshotPayload" && existing == id && requested == SNAPSHOT_SERIALIZER_ID
   ));
+  assert!(registry.registered_serializer(MESSAGE_SERIALIZER_ID).is_none());
+  assert!(registry.binding_for(TypeId::of::<PersistentRepr>()).is_none());
+  assert!(registry.binding_for(TypeId::of::<AtomicWrite>()).is_none());
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -1,0 +1,233 @@
+use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
+use core::any::{Any, TypeId};
+
+use fraktor_actor_core_kernel_rs::{
+  actor::Pid,
+  serialization::{
+    SerializationDelegator, SerializationError, SerializationSetupBuilder, Serializer, SerializerId,
+    SerializerWithStringManifest, serialization_registry::SerializationRegistry,
+  },
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::{
+  journal::EventAdapters,
+  persistent::{AtomicWrite, PersistentRepr},
+  serialization::{MESSAGE_SERIALIZER_ID, MessageSerializer, register_persistence_serializers},
+};
+
+const I32_MANIFEST: &str = "test.I32";
+
+struct ManifestI32Serializer {
+  id: SerializerId,
+}
+
+impl ManifestI32Serializer {
+  fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for ManifestI32Serializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
+    Ok(value.to_le_bytes().to_vec())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    self.from_binary_with_manifest(bytes, I32_MANIFEST)
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+
+  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
+    Some(self)
+  }
+}
+
+impl SerializerWithStringManifest for ManifestI32Serializer {
+  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    Cow::Borrowed(I32_MANIFEST)
+  }
+
+  fn from_binary_with_manifest(
+    &self,
+    bytes: &[u8],
+    manifest: &str,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if manifest != I32_MANIFEST || bytes.len() != core::mem::size_of::<i32>() {
+      return Err(SerializationError::InvalidFormat);
+    }
+    let mut array = [0_u8; core::mem::size_of::<i32>()];
+    array.copy_from_slice(bytes);
+    Ok(Box::new(i32::from_le_bytes(array)))
+  }
+}
+
+struct HintOnlyI32Serializer {
+  id: SerializerId,
+}
+
+impl HintOnlyI32Serializer {
+  fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for HintOnlyI32Serializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
+    Ok(value.to_le_bytes().to_vec())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if type_hint != Some(TypeId::of::<i32>()) || bytes.len() != core::mem::size_of::<i32>() {
+      return Err(SerializationError::InvalidFormat);
+    }
+    let mut array = [0_u8; core::mem::size_of::<i32>()];
+    array.copy_from_slice(bytes);
+    Ok(Box::new(i32::from_le_bytes(array)))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}
+
+fn manifest_registry() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(100).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .bind::<i32>("i32")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
+fn hint_only_registry() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(101).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(HintOnlyI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .bind::<i32>("i32")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
+fn serializer(registry: &ArcShared<SerializationRegistry>) -> MessageSerializer {
+  MessageSerializer::new(MESSAGE_SERIALIZER_ID, registry.downgrade())
+}
+
+#[test]
+fn persistent_repr_round_trip_preserves_durable_metadata() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 7, ArcShared::new(11_i32))
+    .with_metadata(ArcShared::new(13_i32))
+    .with_manifest("event-manifest")
+    .with_writer_uuid("writer")
+    .with_timestamp(123)
+    .with_deleted(true)
+    .with_sender(Some(Pid::new(1, 1)))
+    .with_adapters(EventAdapters::new())
+    .with_adapter_type_id(TypeId::of::<String>());
+
+  let bytes = serializer.to_binary(&repr).expect("serialize");
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<PersistentRepr>().expect("persistent repr");
+
+  assert_eq!(restored.persistence_id(), "pid-1");
+  assert_eq!(restored.sequence_nr(), 7);
+  assert_eq!(restored.manifest(), "event-manifest");
+  assert_eq!(restored.writer_uuid(), "writer");
+  assert_eq!(restored.timestamp(), 123);
+  assert!(restored.deleted());
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&11));
+  assert_eq!(restored.metadata().and_then(|value| value.downcast_ref::<i32>()), Some(&13));
+  assert_eq!(restored.sender(), None);
+  assert_eq!(restored.adapter_type_id(), TypeId::of::<i32>());
+}
+
+#[test]
+fn atomic_write_round_trip_restores_payloads() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let repr1 = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+  let repr2 = PersistentRepr::new("pid-1", 2, ArcShared::new(2_i32));
+  let atomic_write = AtomicWrite::new(vec![repr1, repr2]).expect("atomic write");
+
+  let bytes = serializer.to_binary(&atomic_write).expect("serialize");
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<AtomicWrite>().expect("atomic write");
+
+  assert_eq!(restored.persistence_id(), "pid-1");
+  assert_eq!(restored.size(), 2);
+  assert_eq!(restored.payload()[1].downcast_ref::<i32>(), Some(&2));
+}
+
+#[test]
+fn unregistered_payload_fails_serialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(String::from("missing")));
+
+  assert!(serializer.to_binary(&repr).is_err());
+}
+
+#[test]
+fn non_manifest_resolvable_payload_fails_deserialization() {
+  let registry = hint_only_registry();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+
+  let bytes = serializer.to_binary(&repr).expect("serialize");
+
+  assert!(serializer.from_binary(&bytes, None).is_err());
+}
+
+#[test]
+fn registry_resolves_persistence_message_serializer() {
+  let registry = manifest_registry();
+  let delegator = SerializationDelegator::new(&registry);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+
+  let serialized = delegator.serialize(&repr, "PersistentRepr").expect("serialize");
+
+  assert_eq!(serialized.serializer_id(), MESSAGE_SERIALIZER_ID);
+}

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -17,7 +17,7 @@ use crate::{
   serialization::{
     MESSAGE_SERIALIZER_ID, MessageSerializer, PersistenceSerializationContributor, SNAPSHOT_SERIALIZER_ID,
     SnapshotPayload, register_persistence_serializers,
-    wire::{self, PERSISTENT_REPR_TAG},
+    wire::{self, ATOMIC_WRITE_TAG, PERSISTENT_REPR_TAG},
   },
 };
 
@@ -298,6 +298,17 @@ fn unknown_wire_tag_fails_deserialization() {
   let serializer = serializer(&registry);
 
   assert!(matches!(serializer.from_binary(&[u8::MAX], None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn empty_atomic_write_payload_fails_deserialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let mut bytes = Vec::new();
+  wire::write_u8(&mut bytes, ATOMIC_WRITE_TAG);
+  wire::write_u32(&mut bytes, 0);
+
+  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -161,6 +161,21 @@ fn hint_only_registry() -> ArcShared<SerializationRegistry> {
   registry
 }
 
+fn fallback_registry_without_payload_binding() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(100).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
 fn serializer(registry: &ArcShared<SerializationRegistry>) -> MessageSerializer {
   MessageSerializer::new(MESSAGE_SERIALIZER_ID, registry.downgrade())
 }
@@ -214,6 +229,20 @@ fn persistent_repr_round_trip_preserves_durable_metadata() {
   assert_eq!(restored.metadata().and_then(|value| value.downcast_ref::<i32>()), Some(&13));
   assert_eq!(restored.sender(), None);
   assert_eq!(restored.adapter_type_id(), TypeId::of::<DomainEvent>());
+}
+
+#[test]
+fn persistent_repr_round_trip_uses_payload_type_when_adapter_binding_is_absent() {
+  let registry = fallback_registry_without_payload_binding();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 7, ArcShared::new(11_i32));
+
+  let bytes = serializer.to_binary(&repr).expect("serialize");
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<PersistentRepr>().expect("persistent repr");
+
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&11));
+  assert_eq!(restored.adapter_type_id(), TypeId::of::<i32>());
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -27,6 +27,8 @@ struct DomainEvent;
 
 struct UnboundDomainEvent;
 
+struct UnboundMetadata(i32);
+
 struct ManifestI32Serializer {
   id: SerializerId,
 }
@@ -103,8 +105,13 @@ impl Serializer for HintOnlyI32Serializer {
   }
 
   fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
-    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
-    Ok(value.to_le_bytes().to_vec())
+    if let Some(value) = message.downcast_ref::<i32>() {
+      return Ok(value.to_le_bytes().to_vec());
+    }
+    if let Some(value) = message.downcast_ref::<UnboundMetadata>() {
+      return Ok(value.0.to_le_bytes().to_vec());
+    }
+    Err(SerializationError::InvalidFormat)
   }
 
   fn from_binary(
@@ -112,12 +119,19 @@ impl Serializer for HintOnlyI32Serializer {
     bytes: &[u8],
     type_hint: Option<TypeId>,
   ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
-    if type_hint != Some(TypeId::of::<i32>()) || bytes.len() != core::mem::size_of::<i32>() {
+    if bytes.len() != core::mem::size_of::<i32>() {
       return Err(SerializationError::InvalidFormat);
     }
     let mut array = [0_u8; core::mem::size_of::<i32>()];
     array.copy_from_slice(bytes);
-    Ok(Box::new(i32::from_le_bytes(array)))
+    let value = i32::from_le_bytes(array);
+    if type_hint == Some(TypeId::of::<i32>()) {
+      return Ok(Box::new(value));
+    }
+    if type_hint == Some(TypeId::of::<UnboundMetadata>()) {
+      return Ok(Box::new(UnboundMetadata(value)));
+    }
+    Err(SerializationError::InvalidFormat)
   }
 
   fn as_any(&self) -> &(dyn Any + Send + Sync) {
@@ -154,6 +168,21 @@ fn hint_only_registry() -> ArcShared<SerializationRegistry> {
     .expect("fallback")
     .bind::<i32>("i32")
     .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
+fn hint_only_registry_without_payload_binding() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(101).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(HintOnlyI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
     .build()
     .expect("setup");
   let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
@@ -277,6 +306,24 @@ fn unregistered_metadata_fails_serialization() {
   let serializer = serializer(&registry);
   let repr =
     PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32)).with_metadata(ArcShared::new(String::from("missing")));
+
+  assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn non_manifest_unbound_payload_fails_serialization() {
+  let registry = hint_only_registry_without_payload_binding();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+
+  assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn non_manifest_unbound_metadata_fails_serialization() {
+  let registry = hint_only_registry();
+  let serializer = serializer(&registry);
+  let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32)).with_metadata(ArcShared::new(UnboundMetadata(2)));
 
   assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
 }
@@ -500,6 +547,28 @@ fn persistence_serializer_registration_rejects_stale_message_serializer_registra
     .expect("setup");
   let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
 
+  assert!(matches!(
+    register_persistence_serializers(&registry),
+    Err(SerializationError::SerializerIdCollision(id)) if id == MESSAGE_SERIALIZER_ID
+  ));
+}
+
+#[test]
+fn persistence_serializer_registration_rejects_message_serializer_with_wrong_internal_id() {
+  let fallback_id = SerializerId::try_from(100).expect("serializer id");
+  let fallback: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(fallback_id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("fallback", fallback_id, fallback)
+    .expect("register")
+    .set_fallback("fallback")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  let wrong_id = SerializerId::try_from(999).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(MessageSerializer::new(wrong_id, registry.downgrade()));
+
+  assert!(registry.register_serializer(MESSAGE_SERIALIZER_ID, serializer));
   assert!(matches!(
     register_persistence_serializers(&registry),
     Err(SerializationError::SerializerIdCollision(id)) if id == MESSAGE_SERIALIZER_ID

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -334,6 +334,34 @@ fn empty_manifest_payload_fails_deserialization() {
 }
 
 #[test]
+fn trailing_nested_payload_bytes_fail_deserialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let payload = SerializedMessage::new(
+    SerializerId::try_from(100).expect("serializer id"),
+    Some(I32_MANIFEST.into()),
+    1_i32.to_le_bytes().to_vec(),
+  );
+  let mut nested = payload.encode();
+  nested.push(0);
+  let mut repr = Vec::new();
+  wire::write_string(&mut repr, "pid-1").expect("persistence id");
+  wire::write_u64(&mut repr, 1);
+  wire::write_bytes(&mut repr, &nested).expect("payload");
+  wire::write_string(&mut repr, "").expect("manifest");
+  wire::write_string(&mut repr, "").expect("writer uuid");
+  wire::write_u64(&mut repr, 0);
+  wire::write_bool(&mut repr, false);
+  wire::write_string(&mut repr, "").expect("adapter type");
+  wire::write_bool(&mut repr, false);
+  let mut bytes = Vec::new();
+  wire::write_u8(&mut bytes, PERSISTENT_REPR_TAG);
+  wire::write_bytes(&mut bytes, &repr).expect("repr");
+
+  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
 fn manifest_validation_rejects_missing_manifest() {
   let payload = SerializedMessage::new(SerializerId::try_from(100).expect("serializer id"), None, vec![]);
 

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -275,6 +275,14 @@ fn persistent_repr_round_trip_uses_payload_type_when_adapter_binding_is_absent()
   let repr = PersistentRepr::new("pid-1", 7, ArcShared::new(11_i32));
 
   let bytes = serializer.to_binary(&repr).expect("serialize");
+  let mut cursor = 0;
+  assert_eq!(wire::read_u8(&bytes, &mut cursor).expect("tag"), PERSISTENT_REPR_TAG);
+  let repr_bytes = wire::read_bytes(&bytes, &mut cursor).expect("repr");
+  let mut repr_cursor = 0;
+  let _persistence_id = wire::read_string(repr_bytes, &mut repr_cursor).expect("persistence id");
+  let _sequence_nr = wire::read_u64(repr_bytes, &mut repr_cursor).expect("sequence nr");
+  assert_eq!(wire::read_string(repr_bytes, &mut repr_cursor).expect("payload type"), "");
+
   let restored = serializer.from_binary(&bytes, None).expect("deserialize");
   let restored = restored.downcast_ref::<PersistentRepr>().expect("persistent repr");
 

--- a/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/message_serializer_test.rs
@@ -25,6 +25,8 @@ const I32_MANIFEST: &str = "test.I32";
 
 struct DomainEvent;
 
+struct UnboundDomainEvent;
+
 struct ManifestI32Serializer {
   id: SerializerId,
 }
@@ -255,6 +257,16 @@ fn non_manifest_resolvable_payload_fails_serialization() {
   let registry = hint_only_registry();
   let serializer = serializer(&registry);
   let repr = PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32));
+
+  assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn unbound_adapter_type_fails_serialization() {
+  let registry = manifest_registry();
+  let serializer = serializer(&registry);
+  let repr =
+    PersistentRepr::new("pid-1", 1, ArcShared::new(1_i32)).with_adapter_type_id(TypeId::of::<UnboundDomainEvent>());
 
   assert!(matches!(serializer.to_binary(&repr), Err(SerializationError::InvalidFormat)));
 }

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -113,7 +113,7 @@ fn register_serializer<F>(
 where
   F: FnOnce(&dyn Serializer) -> bool, {
   if let Some(existing) = registry.registered_serializer(id) {
-    if existing.identifier() == id && is_same_registration(&*existing) {
+    if is_same_registration(&*existing) {
       return Ok(());
     }
     return Err(SerializationError::SerializerIdCollision(id));

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -1,0 +1,93 @@
+//! Persistence serializer registration.
+
+use core::any::TypeId;
+
+use fraktor_actor_core_kernel_rs::serialization::{
+  SerializationError, Serializer, SerializerId, contribution::SerializationRegistryContributor,
+  serialization_registry::SerializationRegistry,
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::{
+  persistent::{AtomicWrite, PersistentRepr},
+  serialization::{MessageSerializer, SnapshotPayload, SnapshotSerializer},
+};
+
+/// Serializer id for persistence journal messages.
+pub const MESSAGE_SERIALIZER_ID: SerializerId = SerializerId::from_raw(41);
+
+/// Serializer id for persistence snapshot payloads.
+pub const SNAPSHOT_SERIALIZER_ID: SerializerId = SerializerId::from_raw(42);
+
+/// Contributes persistence serializers to a serialization registry.
+pub struct PersistenceSerializationContributor;
+
+impl PersistenceSerializationContributor {
+  /// Creates a new persistence serialization contributor.
+  #[must_use]
+  pub const fn new() -> Self {
+    Self
+  }
+}
+
+impl Default for PersistenceSerializationContributor {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl SerializationRegistryContributor for PersistenceSerializationContributor {
+  fn contribute(&self, registry: &ArcShared<SerializationRegistry>) -> Result<(), SerializationError> {
+    register_persistence_serializers(registry)
+  }
+}
+
+/// Registers persistence serializers and type bindings.
+///
+/// # Errors
+///
+/// Returns [`SerializationError`] when an id or binding collision is detected.
+pub fn register_persistence_serializers(registry: &ArcShared<SerializationRegistry>) -> Result<(), SerializationError> {
+  register_serializer(
+    registry,
+    MESSAGE_SERIALIZER_ID,
+    ArcShared::new(MessageSerializer::new(MESSAGE_SERIALIZER_ID, registry.downgrade())),
+  )?;
+  register_serializer(
+    registry,
+    SNAPSHOT_SERIALIZER_ID,
+    ArcShared::new(SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade())),
+  )?;
+  register_binding::<PersistentRepr>(registry, "PersistentRepr", MESSAGE_SERIALIZER_ID)?;
+  register_binding::<AtomicWrite>(registry, "AtomicWrite", MESSAGE_SERIALIZER_ID)?;
+  register_binding::<SnapshotPayload>(registry, "SnapshotPayload", SNAPSHOT_SERIALIZER_ID)
+}
+
+fn register_serializer(
+  registry: &SerializationRegistry,
+  id: SerializerId,
+  serializer: ArcShared<dyn Serializer>,
+) -> Result<(), SerializationError> {
+  if let Some(existing) = registry.registered_serializer(id) {
+    if existing.as_any().type_id() == serializer.as_any().type_id() {
+      return Ok(());
+    }
+    return Err(SerializationError::UnknownSerializer(id));
+  }
+  if registry.register_serializer(id, serializer) { Ok(()) } else { Err(SerializationError::UnknownSerializer(id)) }
+}
+
+fn register_binding<T: 'static>(
+  registry: &SerializationRegistry,
+  type_name: &'static str,
+  serializer_id: SerializerId,
+) -> Result<(), SerializationError> {
+  let type_id = TypeId::of::<T>();
+  if let Some(existing) = registry.binding_for(type_id) {
+    if existing == serializer_id {
+      return Ok(());
+    }
+    return Err(SerializationError::UnknownSerializer(existing));
+  }
+  registry.register_binding(type_id, type_name, serializer_id)
+}

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -69,12 +69,13 @@ fn register_serializer(
   serializer: ArcShared<dyn Serializer>,
 ) -> Result<(), SerializationError> {
   if let Some(existing) = registry.registered_serializer(id) {
-    if existing.as_any().type_id() == serializer.as_any().type_id() {
+    if existing.identifier() == serializer.identifier() && existing.as_any().type_id() == serializer.as_any().type_id()
+    {
       return Ok(());
     }
-    return Err(SerializationError::UnknownSerializer(id));
+    return Err(SerializationError::SerializerIdCollision(id));
   }
-  if registry.register_serializer(id, serializer) { Ok(()) } else { Err(SerializationError::UnknownSerializer(id)) }
+  if registry.register_serializer(id, serializer) { Ok(()) } else { Err(SerializationError::SerializerIdCollision(id)) }
 }
 
 fn register_binding<T: 'static>(
@@ -87,7 +88,7 @@ fn register_binding<T: 'static>(
     if existing == serializer_id {
       return Ok(());
     }
-    return Err(SerializationError::UnknownSerializer(existing));
+    return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
   }
   registry.register_binding(type_id, type_name, serializer_id)
 }

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 /// Serializer id for persistence journal messages.
-pub const MESSAGE_SERIALIZER_ID: SerializerId = SerializerId::from_raw(41);
+pub const MESSAGE_SERIALIZER_ID: SerializerId = SerializerId::from_raw(43);
 
 /// Serializer id for persistence snapshot payloads.
 pub const SNAPSHOT_SERIALIZER_ID: SerializerId = SerializerId::from_raw(42);

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -113,10 +113,8 @@ fn register_serializer<F>(
 where
   F: FnOnce(&dyn Serializer) -> bool, {
   if let Some(existing) = registry.registered_serializer(id) {
-    if is_same_registration(&*existing) {
-      return Ok(());
-    }
-    return Err(SerializationError::SerializerIdCollision(id));
+    debug_assert!(is_same_registration(&*existing));
+    return Ok(());
   }
   if registry.register_serializer(id, serializer) { Ok(()) } else { Err(SerializationError::SerializerIdCollision(id)) }
 }
@@ -147,12 +145,5 @@ fn register_binding<T: 'static>(
   type_name: &'static str,
   serializer_id: SerializerId,
 ) -> Result<(), SerializationError> {
-  let type_id = TypeId::of::<T>();
-  if let Some(existing) = registry.binding_for(type_id) {
-    if existing == serializer_id {
-      return Ok(());
-    }
-    return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
-  }
-  registry.register_binding(type_id, type_name, serializer_id)
+  registry.register_binding(TypeId::of::<T>(), type_name, serializer_id)
 }

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -80,7 +80,7 @@ fn validate_serializer<F>(
 where
   F: FnOnce(&dyn Serializer) -> bool, {
   if let Some(existing) = registry.registered_serializer(id) {
-    if is_same_registration(&*existing) {
+    if existing.identifier() == id && is_same_registration(&*existing) {
       return Ok(());
     }
     return Err(SerializationError::SerializerIdCollision(id));
@@ -113,7 +113,7 @@ fn register_serializer<F>(
 where
   F: FnOnce(&dyn Serializer) -> bool, {
   if let Some(existing) = registry.registered_serializer(id) {
-    if is_same_registration(&*existing) {
+    if existing.identifier() == id && is_same_registration(&*existing) {
       return Ok(());
     }
     return Err(SerializationError::SerializerIdCollision(id));

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -44,6 +44,10 @@ impl SerializationRegistryContributor for PersistenceSerializationContributor {
 
 /// Registers persistence serializers and type bindings.
 ///
+/// Re-registering the same persistence serializers is idempotent. Occupied ids or bindings that
+/// point to different serializers are reported as collision errors so actor-system setup can fail
+/// fast instead of silently replacing user configuration.
+///
 /// # Errors
 ///
 /// Returns [`SerializationError`] when an id or binding collision is detected.

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -52,34 +52,94 @@ impl SerializationRegistryContributor for PersistenceSerializationContributor {
 ///
 /// Returns [`SerializationError`] when an id or binding collision is detected.
 pub fn register_persistence_serializers(registry: &ArcShared<SerializationRegistry>) -> Result<(), SerializationError> {
-  register_serializer(
-    registry,
-    MESSAGE_SERIALIZER_ID,
-    ArcShared::new(MessageSerializer::new(MESSAGE_SERIALIZER_ID, registry.downgrade())),
-  )?;
-  register_serializer(
-    registry,
-    SNAPSHOT_SERIALIZER_ID,
-    ArcShared::new(SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade())),
-  )?;
+  validate_persistence_registration(registry)?;
+  register_message_serializer(registry)?;
+  register_snapshot_serializer(registry)?;
   register_binding::<PersistentRepr>(registry, "PersistentRepr", MESSAGE_SERIALIZER_ID)?;
   register_binding::<AtomicWrite>(registry, "AtomicWrite", MESSAGE_SERIALIZER_ID)?;
   register_binding::<SnapshotPayload>(registry, "SnapshotPayload", SNAPSHOT_SERIALIZER_ID)
 }
 
-fn register_serializer(
+fn validate_persistence_registration(registry: &ArcShared<SerializationRegistry>) -> Result<(), SerializationError> {
+  validate_serializer(registry, MESSAGE_SERIALIZER_ID, |existing| {
+    existing.as_any().downcast_ref::<MessageSerializer>().is_some_and(|serializer| serializer.uses_registry(registry))
+  })?;
+  validate_serializer(registry, SNAPSHOT_SERIALIZER_ID, |existing| {
+    existing.as_any().downcast_ref::<SnapshotSerializer>().is_some_and(|serializer| serializer.uses_registry(registry))
+  })?;
+  validate_binding::<PersistentRepr>(registry, "PersistentRepr", MESSAGE_SERIALIZER_ID)?;
+  validate_binding::<AtomicWrite>(registry, "AtomicWrite", MESSAGE_SERIALIZER_ID)?;
+  validate_binding::<SnapshotPayload>(registry, "SnapshotPayload", SNAPSHOT_SERIALIZER_ID)
+}
+
+fn validate_serializer<F>(
+  registry: &SerializationRegistry,
+  id: SerializerId,
+  is_same_registration: F,
+) -> Result<(), SerializationError>
+where
+  F: FnOnce(&dyn Serializer) -> bool, {
+  if let Some(existing) = registry.registered_serializer(id) {
+    if is_same_registration(&*existing) {
+      return Ok(());
+    }
+    return Err(SerializationError::SerializerIdCollision(id));
+  }
+  Ok(())
+}
+
+fn register_message_serializer(registry: &ArcShared<SerializationRegistry>) -> Result<(), SerializationError> {
+  let serializer: ArcShared<dyn Serializer> =
+    ArcShared::new(MessageSerializer::new(MESSAGE_SERIALIZER_ID, registry.downgrade()));
+  register_serializer(registry, MESSAGE_SERIALIZER_ID, serializer, |existing| {
+    existing.as_any().downcast_ref::<MessageSerializer>().is_some_and(|serializer| serializer.uses_registry(registry))
+  })
+}
+
+fn register_snapshot_serializer(registry: &ArcShared<SerializationRegistry>) -> Result<(), SerializationError> {
+  let serializer: ArcShared<dyn Serializer> =
+    ArcShared::new(SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade()));
+  register_serializer(registry, SNAPSHOT_SERIALIZER_ID, serializer, |existing| {
+    existing.as_any().downcast_ref::<SnapshotSerializer>().is_some_and(|serializer| serializer.uses_registry(registry))
+  })
+}
+
+fn register_serializer<F>(
   registry: &SerializationRegistry,
   id: SerializerId,
   serializer: ArcShared<dyn Serializer>,
-) -> Result<(), SerializationError> {
+  is_same_registration: F,
+) -> Result<(), SerializationError>
+where
+  F: FnOnce(&dyn Serializer) -> bool, {
   if let Some(existing) = registry.registered_serializer(id) {
-    if existing.identifier() == serializer.identifier() && existing.as_any().type_id() == serializer.as_any().type_id()
-    {
+    if is_same_registration(&*existing) {
       return Ok(());
     }
     return Err(SerializationError::SerializerIdCollision(id));
   }
   if registry.register_serializer(id, serializer) { Ok(()) } else { Err(SerializationError::SerializerIdCollision(id)) }
+}
+
+fn validate_binding<T: 'static>(
+  registry: &SerializationRegistry,
+  type_name: &'static str,
+  serializer_id: SerializerId,
+) -> Result<(), SerializationError> {
+  let type_id = TypeId::of::<T>();
+  if let Some(existing) = registry.binding_for(type_id) {
+    if existing == serializer_id {
+      return Ok(());
+    }
+    return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
+  }
+  if let Some(existing_type_id) = registry.type_id_for_binding_name(type_name)
+    && existing_type_id != type_id
+  {
+    let existing = registry.binding_for(existing_type_id).ok_or(SerializationError::InvalidFormat)?;
+    return Err(SerializationError::serializer_binding_collision(type_name, existing, serializer_id));
+  }
+  Ok(())
 }
 
 fn register_binding<T: 'static>(

--- a/modules/persistence-core-kernel/src/serialization/registration.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration.rs
@@ -1,5 +1,9 @@
 //! Persistence serializer registration.
 
+#[cfg(test)]
+#[path = "registration_test.rs"]
+mod tests;
+
 use core::any::TypeId;
 
 use fraktor_actor_core_kernel_rs::serialization::{
@@ -113,8 +117,10 @@ fn register_serializer<F>(
 where
   F: FnOnce(&dyn Serializer) -> bool, {
   if let Some(existing) = registry.registered_serializer(id) {
-    debug_assert!(is_same_registration(&*existing));
-    return Ok(());
+    if is_same_registration(&*existing) {
+      return Ok(());
+    }
+    return Err(SerializationError::SerializerIdCollision(id));
   }
   if registry.register_serializer(id, serializer) { Ok(()) } else { Err(SerializationError::SerializerIdCollision(id)) }
 }

--- a/modules/persistence-core-kernel/src/serialization/registration_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/registration_test.rs
@@ -1,0 +1,85 @@
+use alloc::{boxed::Box, vec::Vec};
+use core::any::{Any, TypeId};
+
+use fraktor_actor_core_kernel_rs::serialization::{
+  SerializationError, SerializationSetupBuilder, Serializer, SerializerId,
+  serialization_registry::SerializationRegistry,
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use super::{MESSAGE_SERIALIZER_ID, register_serializer};
+
+struct DummySerializer {
+  id: SerializerId,
+}
+
+impl DummySerializer {
+  const fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for DummySerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn to_binary(&self, _message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    Ok(Vec::new())
+  }
+
+  fn from_binary(
+    &self,
+    _bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    Ok(Box::new(()))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}
+
+fn registry_with_serializer(slot_id: SerializerId, serializer_id: SerializerId) -> SerializationRegistry {
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(DummySerializer::new(serializer_id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("dummy", slot_id, serializer)
+    .expect("register")
+    .set_fallback("dummy")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  SerializationRegistry::from_setup(&setup)
+}
+
+#[test]
+fn register_serializer_accepts_existing_same_registration() {
+  let registry = registry_with_serializer(MESSAGE_SERIALIZER_ID, MESSAGE_SERIALIZER_ID);
+  let serializer: ArcShared<dyn Serializer> =
+    ArcShared::new(DummySerializer::new(SerializerId::try_from(101).expect("serializer id")));
+
+  let result = register_serializer(&registry, MESSAGE_SERIALIZER_ID, serializer, |existing| {
+    existing.identifier() == MESSAGE_SERIALIZER_ID
+  });
+
+  assert!(result.is_ok());
+  let existing = registry.registered_serializer(MESSAGE_SERIALIZER_ID).expect("serializer");
+  assert_eq!(existing.identifier(), MESSAGE_SERIALIZER_ID);
+  assert_eq!(existing.to_binary(&()).expect("binary"), Vec::<u8>::new());
+  assert!(existing.from_binary(&[], None).expect("value").downcast_ref::<()>().is_some());
+  assert!(existing.as_any().downcast_ref::<DummySerializer>().is_some());
+}
+
+#[test]
+fn register_serializer_rejects_existing_conflicting_registration() {
+  let wrong_id = SerializerId::try_from(101).expect("serializer id");
+  let registry = registry_with_serializer(MESSAGE_SERIALIZER_ID, wrong_id);
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(DummySerializer::new(MESSAGE_SERIALIZER_ID));
+
+  let result = register_serializer(&registry, MESSAGE_SERIALIZER_ID, serializer, |existing| {
+    existing.identifier() == MESSAGE_SERIALIZER_ID
+  });
+
+  assert!(matches!(result, Err(SerializationError::SerializerIdCollision(id)) if id == MESSAGE_SERIALIZER_ID));
+}

--- a/modules/persistence-core-kernel/src/serialization/snapshot_payload.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_payload.rs
@@ -1,0 +1,31 @@
+//! Snapshot payload wrapper for persistence serialization.
+
+use core::any::Any;
+
+use fraktor_utils_core_rs::sync::ArcShared;
+
+/// Serializable wrapper around snapshot data.
+#[derive(Clone, Debug)]
+pub struct SnapshotPayload {
+  data: ArcShared<dyn Any + Send + Sync>,
+}
+
+impl SnapshotPayload {
+  /// Creates a new snapshot payload wrapper.
+  #[must_use]
+  pub const fn new(data: ArcShared<dyn Any + Send + Sync>) -> Self {
+    Self { data }
+  }
+
+  /// Returns the wrapped snapshot data.
+  #[must_use]
+  pub const fn data(&self) -> &ArcShared<dyn Any + Send + Sync> {
+    &self.data
+  }
+
+  /// Attempts to downcast the snapshot data.
+  #[must_use]
+  pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+    self.data.downcast_ref::<T>()
+  }
+}

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use alloc::{boxed::Box, string::String, vec::Vec};
 use core::{
-  any::{Any, TypeId, type_name_of_val},
+  any::{Any, TypeId},
   ops::Deref,
 };
 
@@ -16,7 +16,7 @@ use fraktor_actor_core_kernel_rs::serialization::{
 };
 use fraktor_utils_core_rs::sync::{ArcShared, WeakShared};
 
-use crate::serialization::SnapshotPayload;
+use crate::serialization::{SnapshotPayload, wire};
 
 /// Serializes snapshot payload wrappers.
 pub struct SnapshotSerializer {
@@ -31,12 +31,16 @@ impl SnapshotSerializer {
     Self { id, registry }
   }
 
+  pub(crate) fn uses_registry(&self, registry: &ArcShared<SerializationRegistry>) -> bool {
+    self.registry.upgrade().is_some_and(|registered| ArcShared::ptr_eq(&registered, registry))
+  }
+
   fn registry(&self) -> Result<ArcShared<SerializationRegistry>, SerializationError> {
     self.registry.upgrade().ok_or(SerializationError::Uninitialized)
   }
 
   fn has_valid_manifest(message: &SerializedMessage) -> bool {
-    matches!(message.manifest(), Some(manifest) if !manifest.is_empty())
+    !matches!(message.manifest(), Some(manifest) if manifest.is_empty())
   }
 }
 
@@ -54,12 +58,15 @@ impl Serializer for SnapshotSerializer {
     let registry = self.registry()?;
     let delegator = SerializationDelegator::new(&registry);
     let data = payload.data().deref();
-    let type_name = registry.binding_name(data.type_id()).unwrap_or_else(|| String::from(type_name_of_val(data)));
+    let type_name = registry.binding_name(data.type_id()).unwrap_or_else(|| String::from("SnapshotPayload data"));
     let nested = delegator.serialize(data, &type_name)?;
     if !Self::has_valid_manifest(&nested) {
       return Err(SerializationError::InvalidFormat);
     }
-    Ok(nested.encode())
+    let mut buffer = Vec::new();
+    wire::write_string(&mut buffer, &type_name)?;
+    wire::write_serialized(&mut buffer, &nested)?;
+    Ok(buffer)
   }
 
   fn from_binary(
@@ -69,11 +76,15 @@ impl Serializer for SnapshotSerializer {
   ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
     let registry = self.registry()?;
     let delegator = SerializationDelegator::new(&registry);
-    let nested = SerializedMessage::decode(bytes)?;
+    let mut cursor = 0;
+    let type_name = wire::read_string(bytes, &mut cursor)?;
+    let type_hint = registry.type_id_for_binding_name(&type_name);
+    let nested = wire::read_serialized(bytes, &mut cursor)?;
+    wire::ensure_finished(bytes, cursor)?;
     if !Self::has_valid_manifest(&nested) {
       return Err(SerializationError::InvalidFormat);
     }
-    let data = delegator.deserialize(&nested, None)?;
+    let data = delegator.deserialize(&nested, type_hint)?;
     Ok(Box::new(SnapshotPayload::new(ArcShared::from_boxed(data))))
   }
 

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -34,6 +34,10 @@ impl SnapshotSerializer {
   fn registry(&self) -> Result<ArcShared<SerializationRegistry>, SerializationError> {
     self.registry.upgrade().ok_or(SerializationError::Uninitialized)
   }
+
+  fn has_valid_manifest(message: &SerializedMessage) -> bool {
+    matches!(message.manifest(), Some(manifest) if !manifest.is_empty())
+  }
 }
 
 impl Serializer for SnapshotSerializer {
@@ -52,7 +56,7 @@ impl Serializer for SnapshotSerializer {
     let data = payload.data().deref();
     let type_name = registry.binding_name(data.type_id()).unwrap_or_else(|| String::from(type_name_of_val(data)));
     let nested = delegator.serialize(data, &type_name)?;
-    if nested.manifest().is_none_or(str::is_empty) {
+    if !Self::has_valid_manifest(&nested) {
       return Err(SerializationError::InvalidFormat);
     }
     Ok(nested.encode())
@@ -66,7 +70,7 @@ impl Serializer for SnapshotSerializer {
     let registry = self.registry()?;
     let delegator = SerializationDelegator::new(&registry);
     let nested = SerializedMessage::decode(bytes)?;
-    if nested.manifest().is_none() {
+    if !Self::has_valid_manifest(&nested) {
       return Err(SerializationError::InvalidFormat);
     }
     let data = delegator.deserialize(&nested, None)?;

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -1,0 +1,76 @@
+//! Serializer for persistence snapshot payloads.
+
+#[cfg(test)]
+#[path = "snapshot_serializer_test.rs"]
+mod tests;
+
+use alloc::{boxed::Box, string::String, vec::Vec};
+use core::{
+  any::{Any, TypeId, type_name_of_val},
+  ops::Deref,
+};
+
+use fraktor_actor_core_kernel_rs::serialization::{
+  SerializationDelegator, SerializationError, SerializedMessage, Serializer, SerializerId,
+  serialization_registry::SerializationRegistry,
+};
+use fraktor_utils_core_rs::sync::{ArcShared, WeakShared};
+
+use crate::serialization::SnapshotPayload;
+
+/// Serializes snapshot payload wrappers.
+pub struct SnapshotSerializer {
+  id:       SerializerId,
+  registry: WeakShared<SerializationRegistry>,
+}
+
+impl SnapshotSerializer {
+  /// Creates a new snapshot serializer.
+  #[must_use]
+  pub const fn new(id: SerializerId, registry: WeakShared<SerializationRegistry>) -> Self {
+    Self { id, registry }
+  }
+
+  fn registry(&self) -> Result<ArcShared<SerializationRegistry>, SerializationError> {
+    self.registry.upgrade().ok_or(SerializationError::Uninitialized)
+  }
+}
+
+impl Serializer for SnapshotSerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let payload = message.downcast_ref::<SnapshotPayload>().ok_or(SerializationError::InvalidFormat)?;
+    let registry = self.registry()?;
+    let delegator = SerializationDelegator::new(&registry);
+    let data = payload.data().deref();
+    let type_name = registry.binding_name(data.type_id()).unwrap_or_else(|| String::from(type_name_of_val(data)));
+    let nested = delegator.serialize(data, &type_name)?;
+    Ok(nested.encode())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    let registry = self.registry()?;
+    let delegator = SerializationDelegator::new(&registry);
+    let nested = SerializedMessage::decode(bytes)?;
+    if nested.manifest().is_none() {
+      return Err(SerializationError::InvalidFormat);
+    }
+    let data = delegator.deserialize(&nested, None)?;
+    Ok(Box::new(SnapshotPayload::new(ArcShared::from_boxed(data))))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -39,6 +39,14 @@ impl SnapshotSerializer {
     self.registry.upgrade().ok_or(SerializationError::Uninitialized)
   }
 
+  fn validate_nested_manifest(message: &SerializedMessage, has_binding_name: bool) -> Result<(), SerializationError> {
+    match message.manifest() {
+      | Some("") => Err(SerializationError::InvalidFormat),
+      | None if !has_binding_name => Err(SerializationError::InvalidFormat),
+      | _ => Ok(()),
+    }
+  }
+
   fn has_valid_manifest(message: &SerializedMessage) -> bool {
     match message.manifest() {
       | Some(manifest) => !manifest.is_empty(),
@@ -65,12 +73,7 @@ impl Serializer for SnapshotSerializer {
     let type_name = binding_name.as_deref().unwrap_or("");
     let serializer_hint = binding_name.as_deref().unwrap_or("SnapshotPayload data");
     let nested = delegator.serialize(data, serializer_hint)?;
-    if !Self::has_valid_manifest(&nested) {
-      return Err(SerializationError::InvalidFormat);
-    }
-    if binding_name.is_none() && nested.manifest().is_none() {
-      return Err(SerializationError::InvalidFormat);
-    }
+    Self::validate_nested_manifest(&nested, binding_name.is_some())?;
     let mut buffer = Vec::new();
     wire::write_string(&mut buffer, type_name)?;
     wire::write_serialized(&mut buffer, &nested)?;

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -52,6 +52,9 @@ impl Serializer for SnapshotSerializer {
     let data = payload.data().deref();
     let type_name = registry.binding_name(data.type_id()).unwrap_or_else(|| String::from(type_name_of_val(data)));
     let nested = delegator.serialize(data, &type_name)?;
+    if nested.manifest().is_none_or(str::is_empty) {
+      return Err(SerializationError::InvalidFormat);
+    }
     Ok(nested.encode())
   }
 

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -59,8 +59,9 @@ impl Serializer for SnapshotSerializer {
     let delegator = SerializationDelegator::new(&registry);
     let data = payload.data().deref();
     let binding_name = registry.binding_name(data.type_id());
-    let type_name = binding_name.as_deref().unwrap_or("SnapshotPayload data");
-    let nested = delegator.serialize(data, type_name)?;
+    let type_name = binding_name.as_deref().unwrap_or("");
+    let serializer_hint = binding_name.as_deref().unwrap_or("SnapshotPayload data");
+    let nested = delegator.serialize(data, serializer_hint)?;
     if !Self::has_valid_manifest(&nested) {
       return Err(SerializationError::InvalidFormat);
     }
@@ -82,7 +83,7 @@ impl Serializer for SnapshotSerializer {
     let delegator = SerializationDelegator::new(&registry);
     let mut cursor = 0;
     let type_name = wire::read_string(bytes, &mut cursor)?;
-    let type_hint = registry.type_id_for_binding_name(&type_name);
+    let type_hint = if type_name.is_empty() { None } else { registry.type_id_for_binding_name(&type_name) };
     let nested = wire::read_serialized(bytes, &mut cursor)?;
     wire::ensure_finished(bytes, cursor)?;
     if !Self::has_valid_manifest(&nested) {

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -40,7 +40,10 @@ impl SnapshotSerializer {
   }
 
   fn has_valid_manifest(message: &SerializedMessage) -> bool {
-    !matches!(message.manifest(), Some(manifest) if manifest.is_empty())
+    match message.manifest() {
+      | Some(manifest) => !manifest.is_empty(),
+      | None => true,
+    }
   }
 }
 

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer.rs
@@ -4,7 +4,7 @@
 #[path = "snapshot_serializer_test.rs"]
 mod tests;
 
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{boxed::Box, vec::Vec};
 use core::{
   any::{Any, TypeId},
   ops::Deref,
@@ -58,13 +58,17 @@ impl Serializer for SnapshotSerializer {
     let registry = self.registry()?;
     let delegator = SerializationDelegator::new(&registry);
     let data = payload.data().deref();
-    let type_name = registry.binding_name(data.type_id()).unwrap_or_else(|| String::from("SnapshotPayload data"));
-    let nested = delegator.serialize(data, &type_name)?;
+    let binding_name = registry.binding_name(data.type_id());
+    let type_name = binding_name.as_deref().unwrap_or("SnapshotPayload data");
+    let nested = delegator.serialize(data, type_name)?;
     if !Self::has_valid_manifest(&nested) {
       return Err(SerializationError::InvalidFormat);
     }
+    if binding_name.is_none() && nested.manifest().is_none() {
+      return Err(SerializationError::InvalidFormat);
+    }
     let mut buffer = Vec::new();
-    wire::write_string(&mut buffer, &type_name)?;
+    wire::write_string(&mut buffer, type_name)?;
     wire::write_serialized(&mut buffer, &nested)?;
     Ok(buffer)
   }

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -8,7 +8,7 @@ use fraktor_actor_core_kernel_rs::serialization::{
 use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::serialization::{
-  SNAPSHOT_SERIALIZER_ID, SnapshotPayload, SnapshotSerializer, register_persistence_serializers,
+  SNAPSHOT_SERIALIZER_ID, SnapshotPayload, SnapshotSerializer, register_persistence_serializers, wire,
 };
 
 const I32_MANIFEST: &str = "test.I32";
@@ -66,6 +66,57 @@ impl SerializerWithStringManifest for ManifestI32Serializer {
     let mut array = [0_u8; core::mem::size_of::<i32>()];
     array.copy_from_slice(bytes);
     Ok(Box::new(i32::from_le_bytes(array)))
+  }
+}
+
+struct EmptyManifestI32Serializer {
+  id: SerializerId,
+}
+
+impl EmptyManifestI32Serializer {
+  fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for EmptyManifestI32Serializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
+    Ok(value.to_le_bytes().to_vec())
+  }
+
+  fn from_binary(
+    &self,
+    _bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    Err(SerializationError::InvalidFormat)
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+
+  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
+    Some(self)
+  }
+}
+
+impl SerializerWithStringManifest for EmptyManifestI32Serializer {
+  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    Cow::Borrowed("")
+  }
+
+  fn from_binary_with_manifest(
+    &self,
+    _bytes: &[u8],
+    _manifest: &str,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    Err(SerializationError::InvalidFormat)
   }
 }
 
@@ -141,6 +192,23 @@ fn hint_only_registry() -> ArcShared<SerializationRegistry> {
   registry
 }
 
+fn empty_manifest_registry() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(112).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(EmptyManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .bind::<i32>("i32")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
 #[test]
 fn test_serializers_exercise_trait_methods() {
   let manifest = ManifestI32Serializer::new(SerializerId::try_from(110).expect("serializer id"));
@@ -186,12 +254,19 @@ fn snapshot_serializer_reports_manifest_and_rejects_unknown_message_type() {
 }
 
 #[test]
-fn snapshot_payload_without_manifest_fails_deserialization() {
+fn snapshot_payload_without_manifest_deserializes_by_serializer_id() {
   let registry = registry();
   let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
-  let nested = SerializedMessage::new(SerializerId::try_from(110).expect("serializer id"), None, Vec::new());
+  let nested =
+    SerializedMessage::new(SerializerId::try_from(110).expect("serializer id"), None, 1_i32.to_le_bytes().to_vec());
+  let mut bytes = Vec::new();
+  wire::write_string(&mut bytes, "i32").expect("payload type");
+  wire::write_serialized(&mut bytes, &nested).expect("payload");
 
-  assert!(matches!(serializer.from_binary(&nested.encode(), None), Err(SerializationError::InvalidFormat)));
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<SnapshotPayload>().expect("snapshot payload");
+
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&1));
 }
 
 #[test]
@@ -200,8 +275,11 @@ fn snapshot_payload_with_empty_manifest_fails_deserialization() {
   let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
   let nested =
     SerializedMessage::new(SerializerId::try_from(110).expect("serializer id"), Some(String::new()), Vec::new());
+  let mut bytes = Vec::new();
+  wire::write_string(&mut bytes, "i32").expect("payload type");
+  wire::write_serialized(&mut bytes, &nested).expect("payload");
 
-  assert!(matches!(serializer.from_binary(&nested.encode(), None), Err(SerializationError::InvalidFormat)));
+  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]
@@ -213,15 +291,38 @@ fn snapshot_payload_with_trailing_nested_bytes_fails_deserialization() {
     Some(I32_MANIFEST.into()),
     1_i32.to_le_bytes().to_vec(),
   );
-  let mut bytes = nested.encode();
-  bytes.push(0);
+  let mut encoded = nested.encode();
+  encoded.push(0);
+  let mut bytes = Vec::new();
+  wire::write_string(&mut bytes, "i32").expect("payload type");
+  wire::write_bytes(&mut bytes, &encoded).expect("payload");
 
   assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]
-fn snapshot_payload_without_manifest_fails_serialization() {
+fn snapshot_payload_without_manifest_serializes_with_serializer_id() {
   let registry = hint_only_registry();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let payload = SnapshotPayload::new(ArcShared::new(99_i32));
+
+  let bytes = serializer.to_binary(&payload).expect("serialize");
+  let mut cursor = 0;
+  let payload_type_name = wire::read_string(&bytes, &mut cursor).expect("payload type");
+  let nested = wire::read_serialized(&bytes, &mut cursor).expect("decode");
+
+  assert_eq!(payload_type_name, "i32");
+  assert_eq!(nested.serializer_id(), SerializerId::try_from(111).expect("serializer id"));
+  assert_eq!(nested.manifest(), None);
+
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<SnapshotPayload>().expect("snapshot payload");
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&99));
+}
+
+#[test]
+fn snapshot_payload_with_empty_nested_manifest_fails_serialization() {
+  let registry = empty_manifest_registry();
   let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
   let payload = SnapshotPayload::new(ArcShared::new(99_i32));
 

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -142,6 +142,26 @@ fn hint_only_registry() -> ArcShared<SerializationRegistry> {
 }
 
 #[test]
+fn test_serializers_exercise_trait_methods() {
+  let manifest = ManifestI32Serializer::new(SerializerId::try_from(110).expect("serializer id"));
+  assert!(manifest.as_any().downcast_ref::<ManifestI32Serializer>().is_some());
+  assert_eq!(*manifest.from_binary(&1_i32.to_le_bytes(), None).expect("value").downcast_ref::<i32>().unwrap(), 1);
+  assert!(matches!(manifest.from_binary_with_manifest(&[], I32_MANIFEST), Err(SerializationError::InvalidFormat)));
+
+  let hint_only = HintOnlyI32Serializer::new(SerializerId::try_from(111).expect("serializer id"));
+  assert!(hint_only.as_any().downcast_ref::<HintOnlyI32Serializer>().is_some());
+  assert_eq!(
+    *hint_only
+      .from_binary(&1_i32.to_le_bytes(), Some(TypeId::of::<i32>()))
+      .expect("value")
+      .downcast_ref::<i32>()
+      .unwrap(),
+    1
+  );
+  assert!(matches!(hint_only.from_binary(&[], None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
 fn snapshot_payload_round_trip_restores_data() {
   let registry = registry();
   let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -205,6 +205,21 @@ fn snapshot_payload_with_empty_manifest_fails_deserialization() {
 }
 
 #[test]
+fn snapshot_payload_with_trailing_nested_bytes_fails_deserialization() {
+  let registry = registry();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let nested = SerializedMessage::new(
+    SerializerId::try_from(110).expect("serializer id"),
+    Some(I32_MANIFEST.into()),
+    1_i32.to_le_bytes().to_vec(),
+  );
+  let mut bytes = nested.encode();
+  bytes.push(0);
+
+  assert!(matches!(serializer.from_binary(&bytes, None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
 fn snapshot_payload_without_manifest_fails_serialization() {
   let registry = hint_only_registry();
   let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -69,9 +69,64 @@ impl SerializerWithStringManifest for ManifestI32Serializer {
   }
 }
 
+struct HintOnlyI32Serializer {
+  id: SerializerId,
+}
+
+impl HintOnlyI32Serializer {
+  fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for HintOnlyI32Serializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
+    Ok(value.to_le_bytes().to_vec())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if type_hint != Some(TypeId::of::<i32>()) || bytes.len() != core::mem::size_of::<i32>() {
+      return Err(SerializationError::InvalidFormat);
+    }
+    let mut array = [0_u8; core::mem::size_of::<i32>()];
+    array.copy_from_slice(bytes);
+    Ok(Box::new(i32::from_le_bytes(array)))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}
+
 fn registry() -> ArcShared<SerializationRegistry> {
   let id = SerializerId::try_from(110).expect("serializer id");
   let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .bind::<i32>("i32")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
+fn hint_only_registry() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(111).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(HintOnlyI32Serializer::new(id));
   let setup = SerializationSetupBuilder::new()
     .register_serializer("i32", id, serializer)
     .expect("register")
@@ -117,4 +172,13 @@ fn snapshot_payload_without_manifest_fails_deserialization() {
   let nested = SerializedMessage::new(SerializerId::try_from(110).expect("serializer id"), None, Vec::new());
 
   assert!(matches!(serializer.from_binary(&nested.encode(), None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn snapshot_payload_without_manifest_fails_serialization() {
+  let registry = hint_only_registry();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let payload = SnapshotPayload::new(ArcShared::new(99_i32));
+
+  assert!(matches!(serializer.to_binary(&payload), Err(SerializationError::InvalidFormat)));
 }

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -1,0 +1,100 @@
+use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use core::any::{Any, TypeId};
+
+use fraktor_actor_core_kernel_rs::serialization::{
+  SerializationError, SerializationSetupBuilder, Serializer, SerializerId, SerializerWithStringManifest,
+  serialization_registry::SerializationRegistry,
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use crate::serialization::{
+  SNAPSHOT_SERIALIZER_ID, SnapshotPayload, SnapshotSerializer, register_persistence_serializers,
+};
+
+const I32_MANIFEST: &str = "test.I32";
+
+struct ManifestI32Serializer {
+  id: SerializerId,
+}
+
+impl ManifestI32Serializer {
+  fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for ManifestI32Serializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let value = message.downcast_ref::<i32>().ok_or(SerializationError::InvalidFormat)?;
+    Ok(value.to_le_bytes().to_vec())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    self.from_binary_with_manifest(bytes, I32_MANIFEST)
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+
+  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
+    Some(self)
+  }
+}
+
+impl SerializerWithStringManifest for ManifestI32Serializer {
+  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    Cow::Borrowed(I32_MANIFEST)
+  }
+
+  fn from_binary_with_manifest(
+    &self,
+    bytes: &[u8],
+    manifest: &str,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if manifest != I32_MANIFEST || bytes.len() != core::mem::size_of::<i32>() {
+      return Err(SerializationError::InvalidFormat);
+    }
+    let mut array = [0_u8; core::mem::size_of::<i32>()];
+    array.copy_from_slice(bytes);
+    Ok(Box::new(i32::from_le_bytes(array)))
+  }
+}
+
+fn registry() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(110).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .bind::<i32>("i32")
+    .expect("bind")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
+#[test]
+fn snapshot_payload_round_trip_restores_data() {
+  let registry = registry();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let payload = SnapshotPayload::new(ArcShared::new(99_i32));
+
+  let bytes = serializer.to_binary(&payload).expect("serialize");
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<SnapshotPayload>().expect("snapshot payload");
+
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&99));
+}

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -1,4 +1,4 @@
-use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 use core::any::{Any, TypeId};
 
 use fraktor_actor_core_kernel_rs::serialization::{
@@ -190,6 +190,16 @@ fn snapshot_payload_without_manifest_fails_deserialization() {
   let registry = registry();
   let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
   let nested = SerializedMessage::new(SerializerId::try_from(110).expect("serializer id"), None, Vec::new());
+
+  assert!(matches!(serializer.from_binary(&nested.encode(), None), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn snapshot_payload_with_empty_manifest_fails_deserialization() {
+  let registry = registry();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let nested =
+    SerializedMessage::new(SerializerId::try_from(110).expect("serializer id"), Some(String::new()), Vec::new());
 
   assert!(matches!(serializer.from_binary(&nested.encode(), None), Err(SerializationError::InvalidFormat)));
 }

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -242,6 +242,11 @@ fn test_serializers_exercise_trait_methods() {
     1
   );
   assert!(matches!(hint_only.from_binary(&[], None), Err(SerializationError::InvalidFormat)));
+
+  let empty_manifest = EmptyManifestI32Serializer::new(SerializerId::try_from(112).expect("serializer id"));
+  assert!(empty_manifest.as_any().downcast_ref::<EmptyManifestI32Serializer>().is_some());
+  assert!(matches!(empty_manifest.from_binary(&[], None), Err(SerializationError::InvalidFormat)));
+  assert!(matches!(empty_manifest.from_binary_with_manifest(&[], ""), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -192,6 +192,21 @@ fn hint_only_registry() -> ArcShared<SerializationRegistry> {
   registry
 }
 
+fn hint_only_registry_without_payload_binding() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(111).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(HintOnlyI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
 fn empty_manifest_registry() -> ArcShared<SerializationRegistry> {
   let id = SerializerId::try_from(112).expect("serializer id");
   let serializer: ArcShared<dyn Serializer> = ArcShared::new(EmptyManifestI32Serializer::new(id));
@@ -318,6 +333,15 @@ fn snapshot_payload_without_manifest_serializes_with_serializer_id() {
   let restored = serializer.from_binary(&bytes, None).expect("deserialize");
   let restored = restored.downcast_ref::<SnapshotPayload>().expect("snapshot payload");
   assert_eq!(restored.downcast_ref::<i32>(), Some(&99));
+}
+
+#[test]
+fn non_manifest_unbound_snapshot_payload_fails_serialization() {
+  let registry = hint_only_registry_without_payload_binding();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let payload = SnapshotPayload::new(ArcShared::new(99_i32));
+
+  assert!(matches!(serializer.to_binary(&payload), Err(SerializationError::InvalidFormat)));
 }
 
 #[test]

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -2,8 +2,8 @@ use alloc::{borrow::Cow, boxed::Box, vec::Vec};
 use core::any::{Any, TypeId};
 
 use fraktor_actor_core_kernel_rs::serialization::{
-  SerializationError, SerializationSetupBuilder, Serializer, SerializerId, SerializerWithStringManifest,
-  serialization_registry::SerializationRegistry,
+  SerializationError, SerializationSetupBuilder, SerializedMessage, Serializer, SerializerId,
+  SerializerWithStringManifest, serialization_registry::SerializationRegistry,
 };
 use fraktor_utils_core_rs::sync::ArcShared;
 
@@ -97,4 +97,24 @@ fn snapshot_payload_round_trip_restores_data() {
   let restored = restored.downcast_ref::<SnapshotPayload>().expect("snapshot payload");
 
   assert_eq!(restored.downcast_ref::<i32>(), Some(&99));
+}
+
+#[test]
+fn snapshot_serializer_reports_manifest_and_rejects_unknown_message_type() {
+  let registry = registry();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+
+  assert_eq!(serializer.identifier(), SNAPSHOT_SERIALIZER_ID);
+  assert!(serializer.include_manifest());
+  assert!(serializer.as_any().downcast_ref::<SnapshotSerializer>().is_some());
+  assert!(matches!(serializer.to_binary(&"unsupported"), Err(SerializationError::InvalidFormat)));
+}
+
+#[test]
+fn snapshot_payload_without_manifest_fails_deserialization() {
+  let registry = registry();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let nested = SerializedMessage::new(SerializerId::try_from(110).expect("serializer id"), None, Vec::new());
+
+  assert!(matches!(serializer.from_binary(&nested.encode(), None), Err(SerializationError::InvalidFormat)));
 }

--- a/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/snapshot_serializer_test.rs
@@ -175,6 +175,21 @@ fn registry() -> ArcShared<SerializationRegistry> {
   registry
 }
 
+fn manifest_registry_without_payload_binding() -> ArcShared<SerializationRegistry> {
+  let id = SerializerId::try_from(110).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(ManifestI32Serializer::new(id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("i32", id, serializer)
+    .expect("register")
+    .set_fallback("i32")
+    .expect("fallback")
+    .build()
+    .expect("setup");
+  let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
+  register_persistence_serializers(&registry).expect("persistence serializers");
+  registry
+}
+
 fn hint_only_registry() -> ArcShared<SerializationRegistry> {
   let id = SerializerId::try_from(111).expect("serializer id");
   let serializer: ArcShared<dyn Serializer> = ArcShared::new(HintOnlyI32Serializer::new(id));
@@ -334,6 +349,21 @@ fn snapshot_payload_without_manifest_serializes_with_serializer_id() {
   assert_eq!(payload_type_name, "i32");
   assert_eq!(nested.serializer_id(), SerializerId::try_from(111).expect("serializer id"));
   assert_eq!(nested.manifest(), None);
+
+  let restored = serializer.from_binary(&bytes, None).expect("deserialize");
+  let restored = restored.downcast_ref::<SnapshotPayload>().expect("snapshot payload");
+  assert_eq!(restored.downcast_ref::<i32>(), Some(&99));
+}
+
+#[test]
+fn manifest_backed_unbound_snapshot_payload_round_trips_without_type_hint() {
+  let registry = manifest_registry_without_payload_binding();
+  let serializer = SnapshotSerializer::new(SNAPSHOT_SERIALIZER_ID, registry.downgrade());
+  let payload = SnapshotPayload::new(ArcShared::new(99_i32));
+
+  let bytes = serializer.to_binary(&payload).expect("serialize");
+  let mut cursor = 0;
+  assert_eq!(wire::read_string(&bytes, &mut cursor).expect("payload type"), "");
 
   let restored = serializer.from_binary(&bytes, None).expect("deserialize");
   let restored = restored.downcast_ref::<SnapshotPayload>().expect("snapshot payload");

--- a/modules/persistence-core-kernel/src/serialization/wire.rs
+++ b/modules/persistence-core-kernel/src/serialization/wire.rs
@@ -46,11 +46,12 @@ pub(crate) fn write_serialized(buffer: &mut Vec<u8>, value: &SerializedMessage) 
 }
 
 pub(crate) fn read_u8(bytes: &[u8], cursor: &mut usize) -> Result<u8, SerializationError> {
-  if bytes.len() < cursor.saturating_add(1) {
+  let end = cursor.checked_add(1).ok_or(SerializationError::InvalidFormat)?;
+  if bytes.len() < end {
     return Err(SerializationError::InvalidFormat);
   }
   let value = bytes[*cursor];
-  *cursor = cursor.saturating_add(1);
+  *cursor = end;
   Ok(value)
 }
 
@@ -63,22 +64,24 @@ pub(crate) fn read_bool(bytes: &[u8], cursor: &mut usize) -> Result<bool, Serial
 }
 
 pub(crate) fn read_u32(bytes: &[u8], cursor: &mut usize) -> Result<u32, SerializationError> {
-  if bytes.len() < cursor.saturating_add(4) {
+  let end = cursor.checked_add(4).ok_or(SerializationError::InvalidFormat)?;
+  if bytes.len() < end {
     return Err(SerializationError::InvalidFormat);
   }
   let mut array = [0_u8; 4];
-  array.copy_from_slice(&bytes[*cursor..*cursor + 4]);
-  *cursor = cursor.saturating_add(4);
+  array.copy_from_slice(&bytes[*cursor..end]);
+  *cursor = end;
   Ok(u32::from_le_bytes(array))
 }
 
 pub(crate) fn read_u64(bytes: &[u8], cursor: &mut usize) -> Result<u64, SerializationError> {
-  if bytes.len() < cursor.saturating_add(8) {
+  let end = cursor.checked_add(8).ok_or(SerializationError::InvalidFormat)?;
+  if bytes.len() < end {
     return Err(SerializationError::InvalidFormat);
   }
   let mut array = [0_u8; 8];
-  array.copy_from_slice(&bytes[*cursor..*cursor + 8]);
-  *cursor = cursor.saturating_add(8);
+  array.copy_from_slice(&bytes[*cursor..end]);
+  *cursor = end;
   Ok(u64::from_le_bytes(array))
 }
 

--- a/modules/persistence-core-kernel/src/serialization/wire.rs
+++ b/modules/persistence-core-kernel/src/serialization/wire.rs
@@ -1,0 +1,103 @@
+//! Internal persistence serialization wire helpers.
+
+use alloc::{
+  string::{String, ToString},
+  vec::Vec,
+};
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializationError, SerializedMessage};
+
+pub(crate) const PERSISTENT_REPR_TAG: u8 = 1;
+pub(crate) const ATOMIC_WRITE_TAG: u8 = 2;
+
+pub(crate) fn write_u8(buffer: &mut Vec<u8>, value: u8) {
+  buffer.push(value);
+}
+
+pub(crate) fn write_bool(buffer: &mut Vec<u8>, value: bool) {
+  buffer.push(u8::from(value));
+}
+
+pub(crate) fn write_u32(buffer: &mut Vec<u8>, value: u32) {
+  buffer.extend_from_slice(&value.to_le_bytes());
+}
+
+pub(crate) fn write_u64(buffer: &mut Vec<u8>, value: u64) {
+  buffer.extend_from_slice(&value.to_le_bytes());
+}
+
+pub(crate) fn write_bytes(buffer: &mut Vec<u8>, bytes: &[u8]) -> Result<(), SerializationError> {
+  let len = u32::try_from(bytes.len()).map_err(|_| SerializationError::InvalidFormat)?;
+  write_u32(buffer, len);
+  buffer.extend_from_slice(bytes);
+  Ok(())
+}
+
+pub(crate) fn write_string(buffer: &mut Vec<u8>, value: &str) -> Result<(), SerializationError> {
+  write_bytes(buffer, value.as_bytes())
+}
+
+pub(crate) fn write_serialized(buffer: &mut Vec<u8>, value: &SerializedMessage) -> Result<(), SerializationError> {
+  write_bytes(buffer, &value.encode())
+}
+
+pub(crate) fn read_u8(bytes: &[u8], cursor: &mut usize) -> Result<u8, SerializationError> {
+  if bytes.len() < cursor.saturating_add(1) {
+    return Err(SerializationError::InvalidFormat);
+  }
+  let value = bytes[*cursor];
+  *cursor = cursor.saturating_add(1);
+  Ok(value)
+}
+
+pub(crate) fn read_bool(bytes: &[u8], cursor: &mut usize) -> Result<bool, SerializationError> {
+  match read_u8(bytes, cursor)? {
+    | 0 => Ok(false),
+    | 1 => Ok(true),
+    | _ => Err(SerializationError::InvalidFormat),
+  }
+}
+
+pub(crate) fn read_u32(bytes: &[u8], cursor: &mut usize) -> Result<u32, SerializationError> {
+  if bytes.len() < cursor.saturating_add(4) {
+    return Err(SerializationError::InvalidFormat);
+  }
+  let mut array = [0_u8; 4];
+  array.copy_from_slice(&bytes[*cursor..*cursor + 4]);
+  *cursor = cursor.saturating_add(4);
+  Ok(u32::from_le_bytes(array))
+}
+
+pub(crate) fn read_u64(bytes: &[u8], cursor: &mut usize) -> Result<u64, SerializationError> {
+  if bytes.len() < cursor.saturating_add(8) {
+    return Err(SerializationError::InvalidFormat);
+  }
+  let mut array = [0_u8; 8];
+  array.copy_from_slice(&bytes[*cursor..*cursor + 8]);
+  *cursor = cursor.saturating_add(8);
+  Ok(u64::from_le_bytes(array))
+}
+
+pub(crate) fn read_bytes<'a>(bytes: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], SerializationError> {
+  let len = read_u32(bytes, cursor)? as usize;
+  if bytes.len() < cursor.saturating_add(len) {
+    return Err(SerializationError::InvalidFormat);
+  }
+  let result = &bytes[*cursor..*cursor + len];
+  *cursor = cursor.saturating_add(len);
+  Ok(result)
+}
+
+pub(crate) fn read_string(bytes: &[u8], cursor: &mut usize) -> Result<String, SerializationError> {
+  let bytes = read_bytes(bytes, cursor)?;
+  let value = core::str::from_utf8(bytes).map_err(|_| SerializationError::InvalidFormat)?;
+  Ok(value.to_string())
+}
+
+pub(crate) fn read_serialized(bytes: &[u8], cursor: &mut usize) -> Result<SerializedMessage, SerializationError> {
+  SerializedMessage::decode(read_bytes(bytes, cursor)?)
+}
+
+pub(crate) const fn ensure_finished(bytes: &[u8], cursor: usize) -> Result<(), SerializationError> {
+  if cursor == bytes.len() { Ok(()) } else { Err(SerializationError::InvalidFormat) }
+}

--- a/modules/persistence-core-kernel/src/serialization/wire.rs
+++ b/modules/persistence-core-kernel/src/serialization/wire.rs
@@ -1,5 +1,9 @@
 //! Internal persistence serialization wire helpers.
 
+#[cfg(test)]
+#[path = "wire_test.rs"]
+mod tests;
+
 use alloc::{
   string::{String, ToString},
   vec::Vec,
@@ -80,11 +84,12 @@ pub(crate) fn read_u64(bytes: &[u8], cursor: &mut usize) -> Result<u64, Serializ
 
 pub(crate) fn read_bytes<'a>(bytes: &'a [u8], cursor: &mut usize) -> Result<&'a [u8], SerializationError> {
   let len = read_u32(bytes, cursor)? as usize;
-  if bytes.len() < cursor.saturating_add(len) {
+  let end = cursor.checked_add(len).ok_or(SerializationError::InvalidFormat)?;
+  if end > bytes.len() {
     return Err(SerializationError::InvalidFormat);
   }
-  let result = &bytes[*cursor..*cursor + len];
-  *cursor = cursor.saturating_add(len);
+  let result = &bytes[*cursor..end];
+  *cursor = end;
   Ok(result)
 }
 

--- a/modules/persistence-core-kernel/src/serialization/wire_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/wire_test.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use fraktor_actor_core_kernel_rs::serialization::SerializationError;
 
-use super::{read_bytes, write_u32};
+use super::{ensure_finished, read_bool, read_bytes, read_string, read_u8, read_u32, read_u64, write_bytes, write_u32};
 
 #[test]
 fn read_bytes_rejects_declared_length_beyond_remaining_bytes() {
@@ -14,4 +14,37 @@ fn read_bytes_rejects_declared_length_beyond_remaining_bytes() {
   let result = read_bytes(&bytes, &mut cursor);
 
   assert_eq!(result, Err(SerializationError::InvalidFormat));
+}
+
+#[test]
+fn primitive_reads_reject_truncated_input() {
+  let mut cursor = 0;
+  assert_eq!(read_u8(&[], &mut cursor), Err(SerializationError::InvalidFormat));
+
+  let mut cursor = 0;
+  assert_eq!(read_u32(&[1, 2, 3], &mut cursor), Err(SerializationError::InvalidFormat));
+
+  let mut cursor = 0;
+  assert_eq!(read_u64(&[1, 2, 3, 4, 5, 6, 7], &mut cursor), Err(SerializationError::InvalidFormat));
+}
+
+#[test]
+fn read_bool_rejects_unknown_discriminant() {
+  let mut cursor = 0;
+
+  assert_eq!(read_bool(&[2], &mut cursor), Err(SerializationError::InvalidFormat));
+}
+
+#[test]
+fn read_string_rejects_invalid_utf8() {
+  let mut bytes = Vec::new();
+  write_bytes(&mut bytes, &[0xff]).expect("bytes");
+  let mut cursor = 0;
+
+  assert_eq!(read_string(&bytes, &mut cursor), Err(SerializationError::InvalidFormat));
+}
+
+#[test]
+fn ensure_finished_rejects_trailing_bytes() {
+  assert_eq!(ensure_finished(&[1, 2], 1), Err(SerializationError::InvalidFormat));
 }

--- a/modules/persistence-core-kernel/src/serialization/wire_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/wire_test.rs
@@ -29,6 +29,18 @@ fn primitive_reads_reject_truncated_input() {
 }
 
 #[test]
+fn primitive_reads_reject_cursor_overflow() {
+  let mut cursor = usize::MAX;
+  assert_eq!(read_u8(&[1], &mut cursor), Err(SerializationError::InvalidFormat));
+
+  let mut cursor = usize::MAX;
+  assert_eq!(read_u32(&[1, 2, 3, 4], &mut cursor), Err(SerializationError::InvalidFormat));
+
+  let mut cursor = usize::MAX;
+  assert_eq!(read_u64(&[1, 2, 3, 4, 5, 6, 7, 8], &mut cursor), Err(SerializationError::InvalidFormat));
+}
+
+#[test]
 fn read_bool_rejects_unknown_discriminant() {
   let mut cursor = 0;
 

--- a/modules/persistence-core-kernel/src/serialization/wire_test.rs
+++ b/modules/persistence-core-kernel/src/serialization/wire_test.rs
@@ -1,0 +1,17 @@
+use alloc::vec::Vec;
+
+use fraktor_actor_core_kernel_rs::serialization::SerializationError;
+
+use super::{read_bytes, write_u32};
+
+#[test]
+fn read_bytes_rejects_declared_length_beyond_remaining_bytes() {
+  let mut bytes = Vec::new();
+  write_u32(&mut bytes, 4);
+  bytes.extend_from_slice(&[1, 2]);
+  let mut cursor = 0;
+
+  let result = read_bytes(&bytes, &mut cursor);
+
+  assert_eq!(result, Err(SerializationError::InvalidFormat));
+}

--- a/modules/persistence-core-kernel/tests/persistence_flow.rs
+++ b/modules/persistence-core-kernel/tests/persistence_flow.rs
@@ -32,7 +32,9 @@ use fraktor_actor_core_kernel_rs::{
 use fraktor_persistence_core_kernel_rs::{
   extension::PersistenceExtensionInstaller,
   journal::{InMemoryJournal, Journal},
-  persistent::{Eventsourced, PersistenceContext, PersistentActor, PersistentRepr, persistent_props, spawn_persistent},
+  persistent::{
+    AtomicWrite, Eventsourced, PersistenceContext, PersistentActor, PersistentRepr, persistent_props, spawn_persistent,
+  },
   snapshot::{InMemorySnapshotStore, Snapshot, SnapshotMetadata, SnapshotStore},
 };
 use fraktor_utils_core_rs::sync::{ArcShared, SpinSyncMutex};
@@ -176,7 +178,8 @@ fn recovery_flow_snapshot_then_replay() {
   let repr1 = PersistentRepr::new("pid-1", 2, ArcShared::new(Event::Incremented(6)));
   let repr2 = PersistentRepr::new("pid-1", 3, ArcShared::new(Event::Incremented(2)));
   let repr3 = PersistentRepr::new("pid-1", 4, ArcShared::new(Event::Incremented(3)));
-  drive_ready(journal.write_messages(&[repr0, repr1, repr2, repr3])).expect("seed journal");
+  let atomic_write = AtomicWrite::new(vec![repr0, repr1, repr2, repr3]).expect("atomic write");
+  drive_ready(journal.write_messages(&[atomic_write])).expect("seed journal");
 
   let mut snapshot_store = InMemorySnapshotStore::new();
   let snapshot_metadata = SnapshotMetadata::new("pid-1", 2, 0);

--- a/modules/persistence-core-typed/tests/persistence_effector_flow.rs
+++ b/modules/persistence-core-typed/tests/persistence_effector_flow.rs
@@ -27,7 +27,7 @@ use fraktor_actor_core_typed_rs::{
 use fraktor_persistence_core_kernel_rs::{
   extension::PersistenceExtensionInstaller,
   journal::{InMemoryJournal, Journal},
-  persistent::PersistentRepr,
+  persistent::{AtomicWrite, PersistentRepr},
   snapshot::{InMemorySnapshotStore, SnapshotMetadata, SnapshotStore},
 };
 use fraktor_persistence_core_typed_rs::{
@@ -277,7 +277,8 @@ fn persisted_mode_recovers_snapshot_replays_events_and_persists_new_events() {
   let repr0 = PersistentRepr::new(PERSISTENCE_ID, 1, ArcShared::new(CounterEvent::Added(4)));
   let repr1 = PersistentRepr::new(PERSISTENCE_ID, 2, ArcShared::new(CounterEvent::Added(6)));
   let repr2 = PersistentRepr::new(PERSISTENCE_ID, 3, ArcShared::new(CounterEvent::Added(2)));
-  drive_ready(journal.write_messages(&[repr0, repr1, repr2])).expect("seed journal");
+  let atomic_write = AtomicWrite::new(vec![repr0, repr1, repr2]).expect("atomic write");
+  drive_ready(journal.write_messages(&[atomic_write])).expect("seed journal");
 
   let mut snapshot_store = InMemorySnapshotStore::new();
   let snapshot_metadata = SnapshotMetadata::new(PERSISTENCE_ID, 2, 0);
@@ -313,7 +314,8 @@ fn persisted_mode_runs_recovery_and_on_ready_during_startup() {
 
   let mut journal = InMemoryJournal::new();
   let repr = PersistentRepr::new(PERSISTENCE_ID, 1, ArcShared::new(CounterEvent::Added(3)));
-  drive_ready(journal.write_messages(&[repr])).expect("seed journal");
+  let atomic_write = AtomicWrite::new(vec![repr]).expect("atomic write");
+  drive_ready(journal.write_messages(&[atomic_write])).expect("seed journal");
 
   let snapshot_store = InMemorySnapshotStore::new();
   let command_log = ArcShared::new(SpinSyncMutex::new(Vec::new()));

--- a/openspec/changes/add-pekko-persistence-serialization/tasks.md
+++ b/openspec/changes/add-pekko-persistence-serialization/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Atomic Write Contract
 
-- [ ] 1.1 Add `AtomicWrite` as a public persistence type with non-empty and single-persistence-id construction checks.
-- [ ] 1.2 Add focused unit tests for valid creation, empty payload rejection, mixed persistence id rejection, and sequence accessors.
-- [ ] 1.3 Update `Journal` to accept `&[AtomicWrite]` for write operations.
-- [ ] 1.4 Update `JournalMessage::WriteMessages`, `JournalActor`, and journal response paths to iterate atomic write payloads for per-event responses.
-- [ ] 1.5 Update `InMemoryJournal` and persistence tests/examples to use `AtomicWrite`.
-- [ ] 1.6 Add tests for backends that reject unsupported multi-entry atomic writes without partial persistence.
+- [x] 1.1 Add `AtomicWrite` as a public persistence type with non-empty and single-persistence-id construction checks.
+- [x] 1.2 Add focused unit tests for valid creation, empty payload rejection, mixed persistence id rejection, and sequence accessors.
+- [x] 1.3 Update `Journal` to accept `&[AtomicWrite]` for write operations.
+- [x] 1.4 Update `JournalMessage::WriteMessages`, `JournalActor`, and journal response paths to iterate atomic write payloads for per-event responses.
+- [x] 1.5 Update `InMemoryJournal` and persistence tests/examples to use `AtomicWrite`.
+- [x] 1.6 Add tests for backends that reject unsupported multi-entry atomic writes without partial persistence.
 
 ## 2. Persistence Serializer Types
 
-- [ ] 2.1 Add a `serialization` module under `persistence-core-kernel` with public `MessageSerializer` and `SnapshotSerializer` exports.
-- [ ] 2.2 Add any required persistence serialization wrapper type for snapshot data without conflicting with the existing `snapshot::Snapshot` container.
-- [ ] 2.3 Implement internal no_std encoding/decoding helpers for nested `SerializedMessage` records and persistence metadata fields.
-- [ ] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator` while preserving durable metadata and excluding runtime-only sender, `EventAdapters`, and Rust `TypeId` adapter keys from durable bytes.
-- [ ] 2.5 Implement `SnapshotSerializer` for snapshot payload wrappers, delegating data through `SerializationDelegator`.
-- [ ] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, runtime replay context exclusion, unregistered payload failure, and non-manifest-resolvable payload failure.
+- [x] 2.1 Add a `serialization` module under `persistence-core-kernel` with public `MessageSerializer` and `SnapshotSerializer` exports.
+- [x] 2.2 Add any required persistence serialization wrapper type for snapshot data without conflicting with the existing `snapshot::Snapshot` container.
+- [x] 2.3 Implement internal no_std encoding/decoding helpers for nested `SerializedMessage` records and persistence metadata fields.
+- [x] 2.4 Implement `MessageSerializer` for `PersistentRepr` and `AtomicWrite`, delegating payload and metadata through `SerializationDelegator` while preserving durable metadata and excluding runtime-only sender, `EventAdapters`, and Rust `TypeId` adapter keys from durable bytes.
+- [x] 2.5 Implement `SnapshotSerializer` for snapshot payload wrappers, delegating data through `SerializationDelegator`.
+- [x] 2.6 Add serializer round-trip tests for `PersistentRepr`, `AtomicWrite`, snapshot data, metadata, runtime replay context exclusion, unregistered payload failure, and non-manifest-resolvable payload failure.
 
 ## 3. Automatic Registration
 
-- [ ] 3.1 Add persistence serializer ids and a registration helper that registers serializers and type bindings against `SerializationRegistry`.
-- [ ] 3.2 Define fail-fast collision handling for occupied persistence serializer ids and conflicting persistence type bindings.
-- [ ] 3.3 Expose the minimal actor serialization bootstrap API needed to compose persistence serializers with default and custom serialization setup before `SerializationExtension` instantiation.
-- [ ] 3.4 Update `PersistenceExtensionInstaller` to contribute persistence serializers without installing a default serialization extension that can shadow later custom setup.
-- [ ] 3.5 Add installer tests for default serialization extension creation, custom setup installed before persistence, custom setup installed after persistence, serializer id collision failure, and persistence type binding collision failure.
+- [x] 3.1 Add persistence serializer ids and a registration helper that registers serializers and type bindings against `SerializationRegistry`.
+- [x] 3.2 Define fail-fast collision handling for occupied persistence serializer ids and conflicting persistence type bindings.
+- [x] 3.3 Expose the minimal actor serialization bootstrap API needed to compose persistence serializers with default and custom serialization setup before `SerializationExtension` instantiation.
+- [x] 3.4 Update `PersistenceExtensionInstaller` to contribute persistence serializers without installing a default serialization extension that can shadow later custom setup.
+- [x] 3.5 Add installer tests for default serialization extension creation, custom setup installed before persistence, custom setup installed after persistence, serializer id collision failure, and persistence type binding collision failure.
 
 ## 4. Documentation and Validation
 
-- [ ] 4.1 Update persistence gap analysis to mark `AtomicWrite`, `MessageSerializer`, and `SnapshotSerializer` according to the implemented scope.
-- [ ] 4.2 Run targeted persistence-core-kernel tests.
-- [ ] 4.3 Run serialization-related actor-core-kernel tests touched by runtime registration changes.
-- [ ] 4.4 Run `cargo fmt --check`.
-- [ ] 4.5 Run the relevant `./scripts/ci-check.sh ai ...` checks for persistence, no_std, and dylint coverage.
+- [x] 4.1 Update persistence gap analysis to mark `AtomicWrite`, `MessageSerializer`, and `SnapshotSerializer` according to the implemented scope.
+- [x] 4.2 Run targeted persistence-core-kernel tests.
+- [x] 4.3 Run serialization-related actor-core-kernel tests touched by runtime registration changes.
+- [x] 4.4 Run `cargo fmt --check`.
+- [x] 4.5 Run the relevant `./scripts/ci-check.sh ai ...` checks for persistence, no_std, and dylint coverage.


### PR DESCRIPTION
### **User description**
## Summary
- Add AtomicWrite and update journal write paths to use atomic batches
- Add persistence MessageSerializer and SnapshotSerializer with actor serialization contributor registration
- Update persistence gap analysis and OpenSpec task status

## Verification
- MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- cargo test -p fraktor-persistence-core-kernel-rs --lib
- MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- cargo test -p fraktor-actor-core-kernel-rs serialization --lib
- MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- cargo fmt --check
- ./scripts/ci-check.sh ai clippy
- ./scripts/ci-check.sh ai dylint
- ./scripts/ci-check.sh ai no-std
- MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- openspec validate add-pekko-persistence-serialization --strict

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core persistence write-paths and actor serialization registry behavior, so regressions could affect journal consistency or system startup (via new collision checks/panics). Risk is mitigated by extensive new unit tests around atomic writes, wire decoding, and registration/collision scenarios.
> 
> **Overview**
> Adds Pekko-style persistence serialization by introducing `MessageSerializer` (for `PersistentRepr`/`AtomicWrite`) and `SnapshotSerializer` (via new `SnapshotPayload` wrapper), plus a wire-format layer and registration helpers that bind these types to fixed serializer IDs.
> 
> Updates the journal write API to operate on validated `AtomicWrite` batches end-to-end (journal trait, messages, actor, in-memory journal, plugin proxy), adds new `JournalError` cases for atomic-write validation/mixed IDs/unsupported atomicity, and adjusts persistence batching/recovery to handle atomic-write failures and choose replay adapters more predictably.
> 
> Extends the actor-core serialization runtime with a contributor mechanism to register serializers/bindings before/after the serialization extension is installed, including collision detection, improved `SerializationError` reporting/`Display`, stricter `SerializedMessage` decoding, and broader test coverage; documentation gap analysis is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27492c3154e8690292a6a00cf148d03ae504858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add Pekko-style persistence serialization with `MessageSerializer` and `SnapshotSerializer`

- Introduce `AtomicWrite` batches for validated journal write operations end-to-end

- Implement serialization registry contributor mechanism with collision detection

- Extend journal error handling for atomic write validation and mixed persistence IDs

- Update replay adapter selection to prefer context adapters when available


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PersistentRepr<br/>AtomicWrite"] -->|MessageSerializer| B["Wire Format<br/>Serialization"]
  C["SnapshotPayload"] -->|SnapshotSerializer| B
  B -->|Registry| D["Serialization<br/>Extension"]
  E["AtomicWrite<br/>Validation"] -->|Journal API| F["InMemoryJournal<br/>JournalActor"]
  G["EventAdapters"] -->|Replay Selection| H["PersistenceContext<br/>Recovery"]
  D -->|Contributor| I["Actor System<br/>Setup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>23 files</summary><table>
<tr>
  <td><strong>message_serializer.rs</strong><dd><code>New serializer for persistent journal records</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-33f33bb50c9f37b8bb50022e53066eae42b369c9b7d178fdf6b287c18ddeb8f7">+223/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>snapshot_serializer.rs</strong><dd><code>New serializer for snapshot payloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-8412ca2194decfcd3b31d1ab9735600d6079d9882416681f9c3af8f6d51c1894">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>snapshot_payload.rs</strong><dd><code>Wrapper type for snapshot serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-1d69a4b0e6288c055167f9dc78b9301027a2a54b6e4d79d78e9d51ea45017877">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registration.rs</strong><dd><code>Persistence serializer registration with collision detection</code></dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-e58b7b1bc634e77d228ae50b0b0db28327e9960967c8538ada8ce5b58e18cf8e">+155/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>wire.rs</strong><dd><code>Wire format helpers for serialization encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-94f635d9369ce1d9a98d6b9ff27a58527d79af761c15e51091fee9d40d85d864">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>serialization.rs</strong><dd><code>Export serialization types and registration functions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-f3ae21bfc0e408003a33395fe0bfe67836f23752af3a540364a669bd8978f0ed">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>atomic_write.rs</strong><dd><code>Validated atomic write batch container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-b013be156d4dfc30f656f3eb6232ba9efc5dd6d80d907cf2b5e28aba9d21d78a">+78/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>atomic_write_error.rs</strong><dd><code>Error types for atomic write validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-f5af91f86e30c40849cf1ce0edd0fac82d6e80ec2ccac3b89fec350a124f03c7">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_context.rs</strong><dd><code>Update journal write API and replay adapter selection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-71e128bdac0ea6ab74803d2fd3306a7c3ccddf72ab3d215bf6d51ca032b0de80">+50/-16</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>journal_error.rs</strong><dd><code>Add atomic write validation error variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-d4be70a11c52715b22f87bc57fdf377b3ce5e137dc865141e87dd780a28b678f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>journal_message.rs</strong><dd><code>Update journal message to use atomic write batches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-a99207ebe7581ee2ffa09966aae2d26759a798d6c5a9e2e6add2e8324d299270">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>base.rs</strong><dd><code>Update journal trait to accept atomic write batches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-d438e7bed1dbcd3a29ed15e2a7b76561b0887659ec82a83d48dcd678d9b4f879">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>in_memory_journal.rs</strong><dd><code>Implement atomic write batch handling in journal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-af0a3ecb291db10c569cd974512fb2327f5b4bd74e5da90180fdc847c0f61a22">+28/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>journal_actor.rs</strong><dd><code>Update journal actor to handle atomic write batches</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-49cf4c84a936d803f9b31d3b44c2ba07989b8cdca255361697b756604632b07c">+19/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_extension_installer.rs</strong><dd><code>Register persistence serializers during extension install</code></dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-01ba12144d642f0e6388afaa64bc6c52faf1f01ddfe5e7472b5803d5a43c4aa7">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>contribution.rs</strong><dd><code>New serialization registry contributor mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-73f099d2c25f1845636dc46840e65902ad5bbd5cb7ddd42c0be0614f7eae9d06">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serialization_registry_contributor.rs</strong><dd><code>Trait for contributing serializers to registry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-21cae32cedfd921a921ba1686fc6705d8e5154cd54ac7bb78dd9e35d869bca65">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serialization_registry_contributors.rs</strong><dd><code>Registry and helpers for serialization contributors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-09a3b35c41cdb647cf236e04c7081a7fd6f6c0c82d1626ad6ceac7ebc1097e60">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serialization_registry_contribution_error.rs</strong><dd><code>Error type for serialization contribution failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-4c627d4297167b6737480e62a1e81490e7ca9d37e5c26ffd4e1cf03365462180">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error.rs</strong><dd><code>Add serializer collision error variants and display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-d90b8bd2c65e036d9755faa82a7cb0070b83e9b30b2320296a5b7290b31efa75">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry.rs</strong><dd><code>Add binding name and type ID lookup methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-da920e988b0155883cc39f05fa28fe9ed7cb9ed141f8d74a14724f9b19e7a11d">+34/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serialized_message.rs</strong><dd><code>Add encode/decode methods for wire format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-add3688d0d539eef8ca675abb8069570663645aa9d2859ab1bff2604cc6eec9c">+30/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>extension.rs</strong><dd><code>Update extension to support contributor registration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-0c56e0eeb234bd44086db67834bfb60e6a09e5da5c29ca74129160dc516a1db4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>20 files</summary><table>
<tr>
  <td><strong>message_serializer_test.rs</strong><dd><code>Comprehensive tests for message serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-17fc3d20591425cbf13fab7371c4f09936f4152c830075d54370a775846c54d4">+671/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>snapshot_serializer_test.rs</strong><dd><code>Comprehensive tests for snapshot serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-4779c121ac9d57e4c094d593490d289b3ff31706d107252e1c6de7fea6b59aa4">+389/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>registration_test.rs</strong><dd><code>Tests for serializer registration and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-05ecf750685d754bb9a2cae9e22b67335df19e9f89c4151f6986dd4af381eb98">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wire_test.rs</strong><dd><code>Tests for wire format encoding and decoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-a54718e7f9f1b93c4dc1b9b04faa45f1925b627b65526e89420bc53b92552d4e">+62/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>atomic_write_test.rs</strong><dd><code>Tests for atomic write validation and batching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-75102811e90aaa3a508290975a0357db31b639b0f973c4d6639df75ec5f1b3ac">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_context_test.rs</strong><dd><code>Tests for atomic write handling and adapter selection</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-57ebf64a9db6ad09c3f5534b0c19e7bd88f35f6e7ea3fb8bf6def1fd7578e314">+169/-23</a></td>

</tr>

<tr>
  <td><strong>journal_error_test.rs</strong><dd><code>Tests for new journal error variants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-7038a1b4cd38e168f47106bb43b24183744c12eeb6290a1b2cb091e125752285">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>journal_message_test.rs</strong><dd><code>Tests for atomic write journal messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-0ce472236db7c74cc35c6cb636b66474875cd31d957506b55ccd74b9dd0c968e">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>in_memory_journal_test.rs</strong><dd><code>Tests for atomic write batch processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-b9370bb6b6a4716ced04a9d3dfc0720da77e3eca1bf5c4fb941254227e9a7757">+129/-9</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>journal_actor_test.rs</strong><dd><code>Tests for journal actor atomic write handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-0f5393f5d522534d880aea13312b5d13ece0a3fd7ae4fb20e7ac4d6e5f537282">+18/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_plugin_proxy_test.rs</strong><dd><code>Tests for plugin proxy with atomic writes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-decfd00d0d08873d73e9847781ae1607d54196ec358f528d78a0a2f0e8e57446">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_extension_installer_test.rs</strong><dd><code>Tests for serializer registration in extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-271cedaee6d9da90431ec5c014905ceb11c059b4d5073219c50a95dec8b7a694">+157/-20</a></td>

</tr>

<tr>
  <td><strong>serialization_registry_contribution_error_test.rs</strong><dd><code>Tests for contribution error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-62f2c98ac53bf6a9f242d4de3e0884579900a78fb502feff955cea444cc2c81d">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error_test.rs</strong><dd><code>Tests for serialization error display formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-2c6947b0b5f29f2e8de22be58c087d01bb9ae39a5c0c5ec27ae058abdc21729a">+66/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serialization_registry_test.rs</strong><dd><code>Tests for registry binding lookups</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-780a10574a2a149f30c536ea0938dd896d3c939bc809be9dd088bf3c132d84e4">+27/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>serialized_message_test.rs</strong><dd><code>Tests for serialized message encoding</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-0aad6928801209c11b405c322f6fae9facdfbc425f2326ea507f9dba09bfe814">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_flow.rs</strong><dd><code>Integration tests for persistence serialization flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-5d562b52a78d32d9ab61fad7412d3f2032dfea11a3d99ee400b36b7f5b00212a">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_effector_flow.rs</strong><dd><code>Integration tests for typed persistence flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-d933e2320afbfdd52d0f2b2374e18daa1f005c3537656a283a5f8c810ce93934">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistent_actor_test.rs</strong><dd><code>Tests for persistent actor with serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-4c766898d15527302add2d725685e42d52c65ec82f86627c93c82388c7509198">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistent_actor_adapter_test.rs</strong><dd><code>Tests for adapter handling in serialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-2fc766ba1ec6147ca4c361681bf71dbf50e4a13e5e4b56829c1664d661a8d016">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>persistence-gap-analysis.md</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-be1d865d66730a569a01413e768071cc84cc4224a45d577dd3a0847a0279d511">+10/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>serialization.rs</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-781081dd2bdfd6b31aaddf9f92394661d557eb515058c2ca38f90bc37a891452">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistent_fsm_test.rs</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-d18f79978f116ee685b7182045d80c739a2329ff9542610e78dde9d9ee061268">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>event_adapters.rs</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-efb12119aaea05822f4f550553417db2a767bcca2d12019a23c3609c83ec0de8">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistence_plugin_proxy.rs</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-2102316b543db6f8964a3ad9013f902bfc6ae47c34b9c6ca456ccd14bb4e9028">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lib.rs</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-01dc2e09991635f26e47b8c44594e63fc5f9ac49de59cf706964adc583f885a1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>persistent.rs</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-212702bacf3e8f28a63fec3e3bfa681bd652fb068a9b1688589496ca59493d7c">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>tasks.md</strong></td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1865/files#diff-da424871970d4312fd5bdc22e8c3eaa7271165a03e82e517154c5f327beffdaf">+22/-22</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

