### PR TITLE
ci: add PR comment resolution check

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -181,6 +181,7 @@ jobs:
                           nodes {
                             url
                             createdAt
+                            authorAssociation
                             author {
                               login
                             }
@@ -229,7 +230,12 @@ jobs:
                   | . as $comment
                   | select([
                       $comments[]
-                      | select((.author.login // "") == $pr_author)
+                      | select(
+                          (.author.login // "") == $pr_author
+                          or .authorAssociation == "OWNER"
+                          or .authorAssociation == "MEMBER"
+                          or .authorAssociation == "COLLABORATOR"
+                        )
                       | select(.createdAt > $comment.createdAt)
                     ] | length == 0)
                 ]

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -1,0 +1,265 @@
+name: Review Thread Resolution
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  unresolved-comments:
+    name: Check unresolved comments
+    if: ${{ github.event.pull_request != null || github.event.issue.pull_request != null }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check unresolved comments
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          pr_response="$(
+            gh api graphql \
+              -F owner="$OWNER" \
+              -F name="$REPO" \
+              -F number="$PR_NUMBER" \
+              -f query='
+                query($owner: String!, $name: String!, $number: Int!) {
+                  repository(owner: $owner, name: $name) {
+                    pullRequest(number: $number) {
+                      author {
+                        login
+                      }
+                      baseRefName
+                    }
+                  }
+                }
+              '
+          )"
+
+          if jq -e '.errors? | length > 0' <<< "$pr_response" > /dev/null; then
+            echo "::error::GitHub GraphQL returned errors while fetching PR metadata."
+            jq -r '.errors[]?.message' <<< "$pr_response" >&2
+            exit 1
+          fi
+
+          if ! jq -e '.data.repository.pullRequest.author.login
+            and .data.repository.pullRequest.baseRefName' \
+            <<< "$pr_response" > /dev/null; then
+            echo "::error::GitHub GraphQL response did not include PR metadata."
+            jq -c '.' <<< "$pr_response" >&2
+            exit 1
+          fi
+
+          pr_author="$(jq -r '.data.repository.pullRequest.author.login' <<< "$pr_response")"
+          base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
+
+          if [[ "$base_ref" != "main" ]]; then
+            echo "Skipping PR #$PR_NUMBER because base branch is $base_ref, not main."
+            exit 0
+          fi
+
+          unresolved='[]'
+          cursor=''
+          page=1
+
+          while :; do
+            cursor_args=()
+            if [[ -n "$cursor" ]]; then
+              cursor_args=(-F cursor="$cursor")
+            fi
+
+            response="$(
+              gh api graphql \
+                -F owner="$OWNER" \
+                -F name="$REPO" \
+                -F number="$PR_NUMBER" \
+                "${cursor_args[@]}" \
+                -f query='
+                  query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $name) {
+                      pullRequest(number: $number) {
+                        reviewThreads(first: 100, after: $cursor) {
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                          nodes {
+                            isResolved
+                            path
+                            line
+                            comments(first: 1) {
+                              nodes {
+                                url
+                                author {
+                                  login
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                '
+            )"
+
+            if jq -e '.errors? | length > 0' <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL returned errors while fetching PR review threads on page $page."
+              jq -r '.errors[]?.message' <<< "$response" >&2
+              exit 1
+            fi
+
+            if ! jq -e '.data.repository.pullRequest.reviewThreads.nodes
+              and .data.repository.pullRequest.reviewThreads.pageInfo' \
+              <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL response did not include PR review thread data on page $page."
+              jq -c '.' <<< "$response" >&2
+              exit 1
+            fi
+
+            page_unresolved="$(
+              jq -c '.data.repository.pullRequest.reviewThreads.nodes
+                | map(select(.isResolved == false))' <<< "$response"
+            )"
+            unresolved="$(
+              jq -c -n --argjson current "$unresolved" --argjson page "$page_unresolved" \
+                '$current + $page'
+            )"
+
+            has_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<< "$response")"
+            if [[ "$has_next" != "true" ]]; then
+              break
+            fi
+            cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor' <<< "$response")"
+            page=$((page + 1))
+          done
+
+          unresolved_count="$(jq 'length' <<< "$unresolved")"
+          if [[ "$unresolved_count" -eq 0 ]]; then
+            echo "No unresolved PR review threads."
+          fi
+
+          top_level_comments='[]'
+          cursor=''
+          page=1
+
+          while :; do
+            cursor_args=()
+            if [[ -n "$cursor" ]]; then
+              cursor_args=(-F cursor="$cursor")
+            fi
+
+            response="$(
+              gh api graphql \
+                -F owner="$OWNER" \
+                -F name="$REPO" \
+                -F number="$PR_NUMBER" \
+                "${cursor_args[@]}" \
+                -f query='
+                  query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+                    repository(owner: $owner, name: $name) {
+                      pullRequest(number: $number) {
+                        comments(first: 100, after: $cursor) {
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                          nodes {
+                            url
+                            createdAt
+                            author {
+                              login
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                '
+            )"
+
+            if jq -e '.errors? | length > 0' <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL returned errors while fetching top-level PR comments on page $page."
+              jq -r '.errors[]?.message' <<< "$response" >&2
+              exit 1
+            fi
+
+            if ! jq -e '.data.repository.pullRequest.comments.nodes
+              and .data.repository.pullRequest.comments.pageInfo' \
+              <<< "$response" > /dev/null; then
+              echo "::error::GitHub GraphQL response did not include top-level PR comments on page $page."
+              jq -c '.' <<< "$response" >&2
+              exit 1
+            fi
+
+            page_comments="$(jq -c '.data.repository.pullRequest.comments.nodes' <<< "$response")"
+            top_level_comments="$(
+              jq -c -n --argjson current "$top_level_comments" --argjson page "$page_comments" \
+                '$current + $page'
+            )"
+
+            has_next="$(jq -r '.data.repository.pullRequest.comments.pageInfo.hasNextPage' <<< "$response")"
+            if [[ "$has_next" != "true" ]]; then
+              break
+            fi
+            cursor="$(jq -r '.data.repository.pullRequest.comments.pageInfo.endCursor' <<< "$response")"
+            page=$((page + 1))
+          done
+
+          unacknowledged_top_level="$(
+            jq -c --arg pr_author "$pr_author" '
+              . as $comments
+              | [
+                  $comments[]
+                  | select((.author.login // "") != $pr_author)
+                  | . as $comment
+                  | select([
+                      $comments[]
+                      | select((.author.login // "") == $pr_author)
+                      | select(.createdAt > $comment.createdAt)
+                    ] | length == 0)
+                ]
+            ' <<< "$top_level_comments"
+          )"
+
+          unacknowledged_top_level_count="$(jq 'length' <<< "$unacknowledged_top_level")"
+          if [[ "$unacknowledged_top_level_count" -eq 0 ]]; then
+            echo "No unacknowledged top-level PR comments."
+          fi
+
+          {
+            if [[ "$unresolved_count" -gt 0 ]]; then
+              echo "### Unresolved PR review threads"
+              echo
+              jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
+                <<< "$unresolved"
+              echo
+            fi
+            if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
+              echo "### Unacknowledged top-level PR comments"
+              echo
+              jq -r '.[] | "- by \(.author.login // "unknown") at \(.createdAt): \(.url // "no comment URL")"' \
+                <<< "$unacknowledged_top_level"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
+            exit 0
+          fi
+
+          echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain. Resolve or acknowledge all review conversations before merging."
+          exit 1


### PR DESCRIPTION
### **User description**
## Summary
- Add a GitHub Actions check that fails when unresolved PR review threads remain.
- Include top-level PR comments by treating non-author top-level comments as acknowledged only after a later top-level reply from the PR author.
- Trigger on PR, review, review comment, and PR top-level comment activity.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-thread-resolution.yml`
- `git diff --check -- .github/workflows/review-thread-resolution.yml`
- Verified the GraphQL fields against PR #1865 in `j5ik2o/fraktor-rs`.

## Notes
GitHub review threads have native `isResolved` state. Top-level PR comments do not, so this workflow uses a reply-based acknowledgement rule: a top-level comment from someone other than the PR author remains unacknowledged until the PR author posts a later top-level reply.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add GitHub Actions workflow to enforce PR review thread resolution

- Check unresolved review threads and unacknowledged top-level comments

- Allow maintainers to acknowledge comments via replies

- Skip validation for non-main branch PRs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub PR Events"] -->|triggers| B["Review Thread Resolution Workflow"]
  B -->|queries| C["GraphQL API"]
  C -->|fetches| D["Review Threads"]
  C -->|fetches| E["Top-level Comments"]
  D -->|filters| F["Unresolved Threads"]
  E -->|filters| G["Unacknowledged Comments"]
  F -->|reports| H["Workflow Summary"]
  G -->|reports| H
  H -->|fails if| I["Issues Found"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>review-thread-resolution.yml</strong><dd><code>GitHub Actions workflow for review thread resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/review-thread-resolution.yml

<ul><li>New GitHub Actions workflow that enforces PR review thread resolution<br> <li> Queries GraphQL API to fetch unresolved review threads and top-level <br>comments<br> <li> Implements acknowledgement logic: non-author comments require later <br>author/maintainer reply<br> <li> Skips validation for PRs targeting non-main branches<br> <li> Reports findings in workflow summary and fails job if unresolved items <br>remain</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1867/files#diff-f4df2572955ee3a7bf2e9a4fba9c4200d03cc100acc603e5fda498333715ef6f">+271/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

