### PR TITLE
fix(ci): limit maintainer acknowledgement to bot PRs

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -84,7 +84,10 @@ jobs:
           max_attempts=60
           sleep_seconds=30
           for attempt in $(seq 1 "$max_attempts"); do
-            status_response="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid,statusCheckRollup)"
+            status_response="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid,statusCheckRollup)" || {
+              echo "::error::Failed to fetch PR status on attempt $attempt."
+              exit 1
+            }
             current_head_ref_oid="$(jq -r '.headRefOid' <<< "$status_response")"
             if [[ "$current_head_ref_oid" != "$head_ref_oid" ]]; then
               echo "::error::PR head changed from $head_ref_oid to $current_head_ref_oid while waiting for checks."
@@ -106,9 +109,9 @@ jobs:
                     end
                   )
                 | if .__typename == "CheckRun" then
-                    "\(.workflowName // "unknown") / \(.name)"
+                    "\(.workflowName // "unknown") / \(.name // "unknown")"
                   else
-                    "\(.context)"
+                    "\(.context // "unknown")"
                   end
               ' <<< "$status_response"
             )"

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -90,8 +90,19 @@ jobs:
           while [[ "$attempt" -lt "$max_attempts" ]]; do
             attempt=$((attempt + 1))
             status_response="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid,statusCheckRollup)" || {
-              echo "::error::Failed to fetch PR status on attempt $attempt."
-              exit 1
+              if [[ "$attempt" -eq "$max_attempts" ]]; then
+                echo "::error::Failed to fetch PR status after $max_attempts attempts."
+                exit 1
+              fi
+              echo "::warning::Failed to fetch PR status on attempt $attempt; retrying."
+              sleep "$sleep_seconds"
+              if [[ "$sleep_seconds" -lt "$max_sleep_seconds" ]]; then
+                sleep_seconds=$((sleep_seconds * 2))
+                if [[ "$sleep_seconds" -gt "$max_sleep_seconds" ]]; then
+                  sleep_seconds="$max_sleep_seconds"
+                fi
+              fi
+              continue
             }
             current_head_ref_oid="$(jq -r '.headRefOid' <<< "$status_response")"
             if [[ "$current_head_ref_oid" != "$head_ref_oid" ]]; then
@@ -302,6 +313,8 @@ jobs:
                   | . as $comment
                   | select([
                       $comments[]
+                      # Human-authored PRs require the PR author to acknowledge.
+                      # Bot-authored PRs allow maintainers to acknowledge on behalf of the bot.
                       | select(
                           (.author.login // "") == $pr_author
                           or (

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -41,6 +41,7 @@ jobs:
                   repository(owner: $owner, name: $name) {
                     pullRequest(number: $number) {
                       author {
+                        __typename
                         login
                       }
                       baseRefName
@@ -65,6 +66,7 @@ jobs:
           fi
 
           pr_author="$(jq -r '.data.repository.pullRequest.author.login' <<< "$pr_response")"
+          pr_author_type="$(jq -r '.data.repository.pullRequest.author.__typename' <<< "$pr_response")"
           base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
 
           if [[ "$base_ref" != "main" ]]; then
@@ -222,7 +224,7 @@ jobs:
           done
 
           unacknowledged_top_level="$(
-            jq -c --arg pr_author "$pr_author" '
+            jq -c --arg pr_author "$pr_author" --arg pr_author_type "$pr_author_type" '
               . as $comments
               | [
                   $comments[]
@@ -232,9 +234,14 @@ jobs:
                       $comments[]
                       | select(
                           (.author.login // "") == $pr_author
-                          or .authorAssociation == "OWNER"
-                          or .authorAssociation == "MEMBER"
-                          or .authorAssociation == "COLLABORATOR"
+                          or (
+                            $pr_author_type == "Bot"
+                            and (
+                              .authorAssociation == "OWNER"
+                              or .authorAssociation == "MEMBER"
+                              or .authorAssociation == "COLLABORATOR"
+                            )
+                          )
                         )
                       | select(.createdAt > $comment.createdAt)
                     ] | length == 0)

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -16,11 +16,16 @@ permissions:
   issues: read
   pull-requests: read
 
+concurrency:
+  group: review-thread-resolution-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   unresolved-comments:
     name: Check unresolved comments
     if: ${{ github.event.pull_request != null || github.event.issue.pull_request != null }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Check unresolved comments
         env:
@@ -45,6 +50,7 @@ jobs:
                         login
                       }
                       baseRefName
+                      headRefOid
                     }
                   }
                 }
@@ -68,11 +74,60 @@ jobs:
           pr_author="$(jq -r '.data.repository.pullRequest.author.login' <<< "$pr_response")"
           pr_author_type="$(jq -r '.data.repository.pullRequest.author.__typename' <<< "$pr_response")"
           base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
+          head_ref_oid="$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_response")"
 
           if [[ "$base_ref" != "main" ]]; then
             echo "Skipping PR #$PR_NUMBER because base branch is $base_ref, not main."
             exit 0
           fi
+
+          max_attempts=60
+          sleep_seconds=30
+          for attempt in $(seq 1 "$max_attempts"); do
+            status_response="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid,statusCheckRollup)"
+            current_head_ref_oid="$(jq -r '.headRefOid' <<< "$status_response")"
+            if [[ "$current_head_ref_oid" != "$head_ref_oid" ]]; then
+              echo "::error::PR head changed from $head_ref_oid to $current_head_ref_oid while waiting for checks."
+              exit 1
+            fi
+
+            pending_checks="$(
+              jq -r '
+                .statusCheckRollup[]
+                | select(
+                    if .__typename == "CheckRun" then
+                      (.name != "Check unresolved comments"
+                        and .workflowName != "Review Thread Resolution"
+                        and (.status != "COMPLETED"))
+                    elif .__typename == "StatusContext" then
+                      (.state == "PENDING" or .state == "EXPECTED")
+                    else
+                      false
+                    end
+                  )
+                | if .__typename == "CheckRun" then
+                    "\(.workflowName // "unknown") / \(.name)"
+                  else
+                    "\(.context)"
+                  end
+              ' <<< "$status_response"
+            )"
+
+            if [[ -z "$pending_checks" ]]; then
+              echo "All other PR checks have reached a terminal state."
+              break
+            fi
+
+            if [[ "$attempt" -eq "$max_attempts" ]]; then
+              echo "::error::Timed out waiting for other PR checks to finish before evaluating review comments."
+              echo "$pending_checks" >&2
+              exit 1
+            fi
+
+            echo "Waiting for other PR checks to finish before evaluating review comments:"
+            echo "$pending_checks"
+            sleep "$sleep_seconds"
+          done
 
           unresolved='[]'
           cursor=''

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -238,6 +238,7 @@ jobs:
                           nodes {
                             url
                             createdAt
+                            updatedAt
                             authorAssociation
                             author {
                               login
@@ -298,7 +299,7 @@ jobs:
                             )
                           )
                         )
-                      | select(.createdAt > $comment.createdAt)
+                      | select(.createdAt > ($comment.updatedAt // $comment.createdAt))
                     ] | length == 0)
                 ]
             ' <<< "$top_level_comments"
@@ -320,7 +321,7 @@ jobs:
             if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
               echo "### Unacknowledged top-level PR comments"
               echo
-              jq -r '.[] | "- by \(.author.login // "unknown") at \(.createdAt): \(.url // "no comment URL")"' \
+              jq -r '.[] | "- by \(.author.login // "unknown") updated at \((.updatedAt // .createdAt)): \(.url // "no comment URL")"' \
                 <<< "$unacknowledged_top_level"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -82,7 +82,9 @@ jobs:
           fi
 
           max_attempts=60
-          sleep_seconds=30
+          initial_sleep_seconds=5
+          max_sleep_seconds=30
+          sleep_seconds="$initial_sleep_seconds"
           for attempt in $(seq 1 "$max_attempts"); do
             status_response="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid,statusCheckRollup)" || {
               echo "::error::Failed to fetch PR status on attempt $attempt."
@@ -130,6 +132,12 @@ jobs:
             echo "Waiting for other PR checks to finish before evaluating review comments:"
             echo "$pending_checks"
             sleep "$sleep_seconds"
+            if [[ "$sleep_seconds" -lt "$max_sleep_seconds" ]]; then
+              sleep_seconds=$((sleep_seconds * 2))
+              if [[ "$sleep_seconds" -gt "$max_sleep_seconds" ]]; then
+                sleep_seconds="$max_sleep_seconds"
+              fi
+            fi
           done
 
           unresolved='[]'

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -85,7 +85,9 @@ jobs:
           initial_sleep_seconds=5
           max_sleep_seconds=30
           sleep_seconds="$initial_sleep_seconds"
-          for attempt in $(seq 1 "$max_attempts"); do
+          attempt=0
+          while [[ "$attempt" -lt "$max_attempts" ]]; do
+            attempt=$((attempt + 1))
             status_response="$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json headRefOid,statusCheckRollup)" || {
               echo "::error::Failed to fetch PR status on attempt $attempt."
               exit 1

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -12,6 +12,7 @@ on:
     types: [created, edited, deleted]
 
 permissions:
+  checks: read
   contents: read
   issues: read
   pull-requests: read


### PR DESCRIPTION
### **User description**
## Summary
- Follow up PR #1867 with the final Cursor Bugbot fix that was pushed after #1867 had already merged.
- Keep PR-author replies required for human-authored PRs.
- Allow maintainer acknowledgements only when the PR author is a GitHub `Bot`, such as Renovate.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-thread-resolution.yml`
- `git diff --check HEAD~1..HEAD`

## Context
PR #1867 merged at commit `1e23fc179`, while this fix was originally pushed afterward and therefore was not included in the merge commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the merge-gating GitHub Action that enforces resolved/acknowledged review conversations; mistakes could incorrectly block or allow merges. Adds polling/retry behavior and bot-only acknowledgement logic that may affect when the check reports success/failure.
> 
> **Overview**
> Updates the `Review Thread Resolution` workflow to be more reliable and less noisy by adding **per-PR concurrency cancellation**, a **45-minute job timeout**, and explicit `checks: read` permission.
> 
> Before evaluating review threads/comments, it now **polls PR status checks with exponential backoff** (and aborts if the PR `headRefOid` changes) so the unresolved-comment evaluation runs against a stable set of checks.
> 
> Tightens acknowledgement rules for top-level PR comments by **allowing maintainer acknowledgements only for bot-authored PRs** and by treating comment edits as new activity via `updatedAt` (also reflected in the job summary output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37b55b4b7f596fcc7c1ec971473f829265c6af9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add PR status polling with exponential backoff before evaluating comments

- Limit maintainer acknowledgements to bot-authored PRs only

- Track comment edits via `updatedAt` field in acknowledgement logic

- Add concurrency control and 45-minute timeout for workflow reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PR Events"] -->|triggers| B["Review Thread Resolution"]
  B -->|polls with backoff| C["PR Status Checks"]
  C -->|stable state| D["Fetch Review Threads"]
  D -->|filter unresolved| E["Unresolved Items"]
  B -->|fetch top-level comments| F["Top-level Comments"]
  F -->|filter unacknowledged| G["Unacknowledged Comments"]
  G -->|bot PR only| H["Maintainer Acknowledgement"]
  E -->|report| I["Workflow Summary"]
  G -->|report| I
  I -->|fail if issues| J["Job Result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>review-thread-resolution.yml</strong><dd><code>Add polling, bot detection, and improved acknowledgement logic</code></dd></summary>
<hr>

.github/workflows/review-thread-resolution.yml

<ul><li>Add <code>checks: read</code> permission and concurrency control with job timeout<br> <li> Implement PR status polling with exponential backoff (5-30s) to wait <br>for other checks before evaluating comments<br> <li> Detect PR head changes during polling and abort if <code>headRefOid</code> changes<br> <li> Fetch <code>__typename</code> to identify bot-authored PRs and restrict maintainer <br>acknowledgements accordingly<br> <li> Track comment <code>updatedAt</code> field to treat edits as new activity in <br>acknowledgement logic<br> <li> Refine acknowledgement rules: human PRs require author reply, bot PRs <br>allow maintainer replies</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1868/files#diff-f4df2572955ee3a7bf2e9a4fba9c4200d03cc100acc603e5fda498333715ef6f">+96/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

