### PR TITLE
[codex] Publish review comment check status on PR head

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -116,6 +116,12 @@ jobs:
                   --input -
             )"
 
+            if ! jq -e '.id and .html_url' <<< "$check_run_response" > /dev/null; then
+              echo "::error::GitHub API response did not include check-run metadata."
+              jq -c '.' <<< "$check_run_response" >&2
+              return 1
+            fi
+
             check_run_url="$(jq -r '.html_url // .url // "unknown"' <<< "$check_run_response")"
             echo "Published check run: $check_run_url"
           }

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -86,31 +86,60 @@ jobs:
           publish_head_check() {
             local conclusion="$1"
             local summary="$2"
+            local check_run_response
+            local check_run_url
 
-            jq -n \
-              --arg name "Check unresolved comments" \
-              --arg head_sha "$head_ref_oid" \
-              --arg conclusion "$conclusion" \
-              --arg details_url "$RUN_URL" \
-              --arg title "Review Thread Resolution" \
-              --arg summary "$summary" \
-              '{
-                name: $name,
-                head_sha: $head_sha,
-                status: "completed",
-                conclusion: $conclusion,
-                details_url: $details_url,
-                output: {
-                  title: $title,
-                  summary: $summary
-                }
-              }' \
-              | gh api \
-                --method POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "repos/$OWNER/$REPO/check-runs" \
-                --input - > /dev/null
+            check_run_response="$(
+              jq -n \
+                --arg name "Check unresolved comments" \
+                --arg head_sha "$head_ref_oid" \
+                --arg conclusion "$conclusion" \
+                --arg details_url "$RUN_URL" \
+                --arg title "Review Thread Resolution" \
+                --arg summary "$summary" \
+                '{
+                  name: $name,
+                  head_sha: $head_sha,
+                  status: "completed",
+                  conclusion: $conclusion,
+                  details_url: $details_url,
+                  output: {
+                    title: $title,
+                    summary: $summary
+                  }
+                }' \
+                | gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "X-GitHub-Api-Version: 2022-11-28" \
+                  "repos/$OWNER/$REPO/check-runs" \
+                  --input -
+            )"
+
+            check_run_url="$(jq -r '.html_url // .url // "unknown"' <<< "$check_run_response")"
+            echo "Published check run: $check_run_url"
+          }
+
+          build_summary() {
+            {
+              echo "PR: $pr_url"
+              echo
+              echo "$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain."
+              echo
+              if [[ "$unresolved_count" -gt 0 ]]; then
+                echo "### Unresolved PR review threads"
+                echo
+                jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
+                  <<< "$unresolved"
+                echo
+              fi
+              if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
+                echo "### Unacknowledged top-level PR comments"
+                echo
+                jq -r '.[] | "- by \(.author.login // "unknown") updated at \((.updatedAt // .createdAt)): \(.url // "no comment URL")"' \
+                  <<< "$unacknowledged_top_level"
+              fi
+            }
           }
 
           if [[ "$base_ref" != "main" ]]; then
@@ -373,43 +402,8 @@ jobs:
             echo "No unacknowledged top-level PR comments."
           fi
 
-          summary="$(
-            {
-              echo "PR: $pr_url"
-              echo
-              echo "$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain."
-              echo
-              if [[ "$unresolved_count" -gt 0 ]]; then
-                echo "### Unresolved PR review threads"
-                echo
-                jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
-                  <<< "$unresolved"
-                echo
-              fi
-              if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
-                echo "### Unacknowledged top-level PR comments"
-                echo
-                jq -r '.[] | "- by \(.author.login // "unknown") at \(.createdAt): \(.url // "no comment URL")"' \
-                  <<< "$unacknowledged_top_level"
-              fi
-            }
-          )"
-
-          {
-            if [[ "$unresolved_count" -gt 0 ]]; then
-              echo "### Unresolved PR review threads"
-              echo
-              jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
-                <<< "$unresolved"
-              echo
-            fi
-            if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
-              echo "### Unacknowledged top-level PR comments"
-              echo
-              jq -r '.[] | "- by \(.author.login // "unknown") updated at \((.updatedAt // .createdAt)): \(.url // "no comment URL")"' \
-                <<< "$unacknowledged_top_level"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+          summary="$(build_summary)"
+          printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
             if [[ "$EVENT_NAME" == "issue_comment" ]]; then

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -98,7 +98,7 @@ jobs:
             fi
 
             if [[ "$head_repository" != "$OWNER/$REPO" ]]; then
-              echo "::warning::Skipping synthetic check-run publication for cross-repository PR head $head_repository."
+              echo "::notice::Skipping synthetic check-run publication for fork PR head ($head_repository)."
               return 1
             fi
 
@@ -125,6 +125,9 @@ jobs:
             if (( ${#check_summary} > max_summary_chars )); then
               truncation_suffix=$'\n\n... truncated for GitHub Checks API summary limit ...'
               available_chars=$(( max_summary_chars - ${#truncation_suffix} ))
+              if (( available_chars < 1 )); then
+                available_chars=1
+              fi
               check_summary="${check_summary:0:available_chars}${truncation_suffix}"
             fi
 
@@ -163,6 +166,9 @@ jobs:
               cat "$check_run_error" >&2
               rm -f "$check_run_error"
               return 1
+            fi
+            if [[ -s "$check_run_error" ]]; then
+              cat "$check_run_error" >&2
             fi
             rm -f "$check_run_error"
 

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -72,7 +72,6 @@ jobs:
 
           if ! jq -e '.data.repository.pullRequest.author.login
             and .data.repository.pullRequest.baseRefName
-            and .data.repository.pullRequest.headRepository.nameWithOwner
             and .data.repository.pullRequest.headRefOid
             and .data.repository.pullRequest.url' \
             <<< "$pr_response" > /dev/null; then
@@ -84,12 +83,17 @@ jobs:
           pr_author="$(jq -r '.data.repository.pullRequest.author.login' <<< "$pr_response")"
           pr_author_type="$(jq -r '.data.repository.pullRequest.author.__typename' <<< "$pr_response")"
           base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
-          head_repository="$(jq -r '.data.repository.pullRequest.headRepository.nameWithOwner' <<< "$pr_response")"
+          head_repository="$(jq -r '.data.repository.pullRequest.headRepository.nameWithOwner // ""' <<< "$pr_response")"
           head_ref_oid="$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_response")"
           pr_url="$(jq -r '.data.repository.pullRequest.url' <<< "$pr_response")"
 
           should_publish_head_check() {
             if [[ "$EVENT_NAME" != "issue_comment" ]]; then
+              return 1
+            fi
+
+            if [[ -z "$head_repository" ]]; then
+              echo "::warning::Skipping synthetic check-run publication because PR head repository metadata is unavailable."
               return 1
             fi
 
@@ -111,12 +115,17 @@ jobs:
             local summary="$2"
             local check_summary="$summary"
             local max_summary_chars=60000
+            local truncation_suffix
+            local available_chars
             local request_payload
             local check_run_response
+            local check_run_error
             local check_run_url
 
             if (( ${#check_summary} > max_summary_chars )); then
-              check_summary="${check_summary:0:max_summary_chars}"$'\n\n... truncated for GitHub Checks API summary limit ...'
+              truncation_suffix=$'\n\n... truncated for GitHub Checks API summary limit ...'
+              available_chars=$(( max_summary_chars - ${#truncation_suffix} ))
+              check_summary="${check_summary:0:available_chars}${truncation_suffix}"
             fi
 
             request_payload="$(
@@ -140,17 +149,22 @@ jobs:
                 }'
             )"
 
+            check_run_error="$(mktemp)"
             if ! check_run_response="$(
               gh api \
                 --method POST \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 "repos/$OWNER/$REPO/check-runs" \
-                --input - <<< "$request_payload"
+                --input - \
+                2> "$check_run_error" <<< "$request_payload"
             )"; then
               echo "::error::Failed to create check run via GitHub API."
+              cat "$check_run_error" >&2
+              rm -f "$check_run_error"
               return 1
             fi
+            rm -f "$check_run_error"
 
             if ! jq -e '.id and .html_url' <<< "$check_run_response" > /dev/null; then
               echo "::error::GitHub API response did not include check-run metadata."

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -53,6 +53,9 @@ jobs:
                         login
                       }
                       baseRefName
+                      headRepository {
+                        nameWithOwner
+                      }
                       headRefOid
                       url
                     }
@@ -69,6 +72,7 @@ jobs:
 
           if ! jq -e '.data.repository.pullRequest.author.login
             and .data.repository.pullRequest.baseRefName
+            and .data.repository.pullRequest.headRepository.nameWithOwner
             and .data.repository.pullRequest.headRefOid
             and .data.repository.pullRequest.url' \
             <<< "$pr_response" > /dev/null; then
@@ -80,23 +84,49 @@ jobs:
           pr_author="$(jq -r '.data.repository.pullRequest.author.login' <<< "$pr_response")"
           pr_author_type="$(jq -r '.data.repository.pullRequest.author.__typename' <<< "$pr_response")"
           base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
+          head_repository="$(jq -r '.data.repository.pullRequest.headRepository.nameWithOwner' <<< "$pr_response")"
           head_ref_oid="$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_response")"
           pr_url="$(jq -r '.data.repository.pullRequest.url' <<< "$pr_response")"
+
+          should_publish_head_check() {
+            if [[ "$EVENT_NAME" != "issue_comment" ]]; then
+              return 1
+            fi
+
+            if [[ "$head_repository" != "$OWNER/$REPO" ]]; then
+              echo "::warning::Skipping synthetic check-run publication for cross-repository PR head $head_repository."
+              return 1
+            fi
+
+            if [[ "$pr_author" == "dependabot[bot]" ]]; then
+              echo "::warning::Skipping synthetic check-run publication for Dependabot PR author."
+              return 1
+            fi
+
+            return 0
+          }
 
           publish_head_check() {
             local conclusion="$1"
             local summary="$2"
+            local check_summary="$summary"
+            local max_summary_chars=60000
+            local request_payload
             local check_run_response
             local check_run_url
 
-            check_run_response="$(
+            if (( ${#check_summary} > max_summary_chars )); then
+              check_summary="${check_summary:0:max_summary_chars}"$'\n\n... truncated for GitHub Checks API summary limit ...'
+            fi
+
+            request_payload="$(
               jq -n \
                 --arg name "Check unresolved comments" \
                 --arg head_sha "$head_ref_oid" \
                 --arg conclusion "$conclusion" \
                 --arg details_url "$RUN_URL" \
                 --arg title "Review Thread Resolution" \
-                --arg summary "$summary" \
+                --arg summary "$check_summary" \
                 '{
                   name: $name,
                   head_sha: $head_sha,
@@ -107,14 +137,20 @@ jobs:
                     title: $title,
                     summary: $summary
                   }
-                }' \
-                | gh api \
-                  --method POST \
-                  -H "Accept: application/vnd.github+json" \
-                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                  "repos/$OWNER/$REPO/check-runs" \
-                  --input -
+                }'
             )"
+
+            if ! check_run_response="$(
+              gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "repos/$OWNER/$REPO/check-runs" \
+                --input - <<< "$request_payload"
+            )"; then
+              echo "::error::Failed to create check run via GitHub API."
+              return 1
+            fi
 
             if ! jq -e '.id and .html_url' <<< "$check_run_response" > /dev/null; then
               echo "::error::GitHub API response did not include check-run metadata."
@@ -127,6 +163,12 @@ jobs:
           }
 
           build_summary() {
+            local unresolved_count="$1"
+            local unacknowledged_top_level_count="$2"
+            local unresolved="$3"
+            local unacknowledged_top_level="$4"
+            local pr_url="$5"
+
             {
               echo "PR: $pr_url"
               echo
@@ -408,17 +450,25 @@ jobs:
             echo "No unacknowledged top-level PR comments."
           fi
 
-          summary="$(build_summary)"
+          summary="$(build_summary \
+            "$unresolved_count" \
+            "$unacknowledged_top_level_count" \
+            "$unresolved" \
+            "$unacknowledged_top_level" \
+            "$pr_url")"
           printf '%s\n' "$summary" >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
-            if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            # Top-level PR comments arrive as issue_comment and need a synthetic
+            # head check because that event is not naturally attached to the PR head.
+            if should_publish_head_check; then
               publish_head_check "success" "$summary"
             fi
             exit 0
           fi
 
-          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+          # Other review events already create their own PR-head workflow check.
+          if should_publish_head_check; then
             publish_head_check "failure" "$summary"
           fi
 

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -177,7 +177,7 @@ jobs:
               return 1
             fi
 
-            check_run_url="$(jq -r '.html_url // .url // "unknown"' <<< "$check_run_response")"
+            check_run_url="$(jq -r '.html_url // .url' <<< "$check_run_response")"
             echo "Published check run: $check_run_url"
           }
 

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -12,8 +12,8 @@ on:
     types: [created, edited, deleted]
 
 permissions:
-  checks: read
   contents: read
+  checks: write
   issues: read
   pull-requests: read
 
@@ -34,6 +34,8 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -52,6 +54,7 @@ jobs:
                       }
                       baseRefName
                       headRefOid
+                      url
                     }
                   }
                 }
@@ -65,7 +68,9 @@ jobs:
           fi
 
           if ! jq -e '.data.repository.pullRequest.author.login
-            and .data.repository.pullRequest.baseRefName' \
+            and .data.repository.pullRequest.baseRefName
+            and .data.repository.pullRequest.headRefOid
+            and .data.repository.pullRequest.url' \
             <<< "$pr_response" > /dev/null; then
             echo "::error::GitHub GraphQL response did not include PR metadata."
             jq -c '.' <<< "$pr_response" >&2
@@ -76,6 +81,37 @@ jobs:
           pr_author_type="$(jq -r '.data.repository.pullRequest.author.__typename' <<< "$pr_response")"
           base_ref="$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_response")"
           head_ref_oid="$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_response")"
+          pr_url="$(jq -r '.data.repository.pullRequest.url' <<< "$pr_response")"
+
+          publish_head_check() {
+            local conclusion="$1"
+            local summary="$2"
+
+            jq -n \
+              --arg name "Check unresolved comments" \
+              --arg head_sha "$head_ref_oid" \
+              --arg conclusion "$conclusion" \
+              --arg details_url "$RUN_URL" \
+              --arg title "Review Thread Resolution" \
+              --arg summary "$summary" \
+              '{
+                name: $name,
+                head_sha: $head_sha,
+                status: "completed",
+                conclusion: $conclusion,
+                details_url: $details_url,
+                output: {
+                  title: $title,
+                  summary: $summary
+                }
+              }' \
+              | gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "repos/$OWNER/$REPO/check-runs" \
+                --input - > /dev/null
+          }
 
           if [[ "$base_ref" != "main" ]]; then
             echo "Skipping PR #$PR_NUMBER because base branch is $base_ref, not main."
@@ -337,6 +373,28 @@ jobs:
             echo "No unacknowledged top-level PR comments."
           fi
 
+          summary="$(
+            {
+              echo "PR: $pr_url"
+              echo
+              echo "$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain."
+              echo
+              if [[ "$unresolved_count" -gt 0 ]]; then
+                echo "### Unresolved PR review threads"
+                echo
+                jq -r '.[] | "- \(.path):\(.line // "n/a") by \(.comments.nodes[0]?.author.login // "unknown"): \(.comments.nodes[0]?.url // "no comment URL")"' \
+                  <<< "$unresolved"
+                echo
+              fi
+              if [[ "$unacknowledged_top_level_count" -gt 0 ]]; then
+                echo "### Unacknowledged top-level PR comments"
+                echo
+                jq -r '.[] | "- by \(.author.login // "unknown") at \(.createdAt): \(.url // "no comment URL")"' \
+                  <<< "$unacknowledged_top_level"
+              fi
+            }
+          )"
+
           {
             if [[ "$unresolved_count" -gt 0 ]]; then
               echo "### Unresolved PR review threads"
@@ -354,7 +412,14 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$unresolved_count" -eq 0 && "$unacknowledged_top_level_count" -eq 0 ]]; then
+            if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+              publish_head_check "success" "$summary"
+            fi
             exit 0
+          fi
+
+          if [[ "$EVENT_NAME" == "issue_comment" ]]; then
+            publish_head_check "failure" "$summary"
           fi
 
           echo "::error::$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain. Resolve or acknowledge all review conversations before merging."

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -126,9 +126,10 @@ jobs:
               truncation_suffix=$'\n\n... truncated for GitHub Checks API summary limit ...'
               available_chars=$(( max_summary_chars - ${#truncation_suffix} ))
               if (( available_chars < 1 )); then
-                available_chars=1
+                check_summary="${truncation_suffix:0:max_summary_chars}"
+              else
+                check_summary="${check_summary:0:available_chars}${truncation_suffix}"
               fi
-              check_summary="${check_summary:0:available_chars}${truncation_suffix}"
             fi
 
             request_payload="$(
@@ -171,6 +172,16 @@ jobs:
               cat "$check_run_error" >&2
             fi
 
+            if jq -e '(.errors? // []) | length > 0' <<< "$check_run_response" > /dev/null; then
+              echo "::error::GitHub API returned errors while creating check run."
+              jq -r '.errors[]?.message // empty' <<< "$check_run_response" >&2
+              return 1
+            fi
+            if jq -e '.message? // empty' <<< "$check_run_response" > /dev/null; then
+              echo "::error::GitHub API returned an error message while creating check run."
+              jq -r '.message' <<< "$check_run_response" >&2
+              return 1
+            fi
             if ! jq -e '.id and (.html_url // .url)' <<< "$check_run_response" > /dev/null; then
               echo "::error::GitHub API response did not include check-run metadata."
               jq -c '.' <<< "$check_run_response" >&2

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -186,10 +186,10 @@ jobs:
             local unacknowledged_top_level_count="$2"
             local unresolved="$3"
             local unacknowledged_top_level="$4"
-            local pr_url="$5"
+            local summary_pr_url="$5"
 
             {
-              echo "PR: $pr_url"
+              echo "PR: $summary_pr_url"
               echo
               echo "$unresolved_count unresolved PR review thread(s) and $unacknowledged_top_level_count unacknowledged top-level PR comment(s) remain."
               echo

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -93,17 +93,17 @@ jobs:
             fi
 
             if [[ -z "$head_repository" ]]; then
-              echo "::warning::Skipping synthetic check-run publication because PR head repository metadata is unavailable."
+              echo "::warning::Skipping synthetic check-run publication because PR head repository metadata is unavailable." >&2
               return 1
             fi
 
             if [[ "$head_repository" != "$OWNER/$REPO" ]]; then
-              echo "::notice::Skipping synthetic check-run publication for fork PR head ($head_repository)."
+              echo "::notice::Skipping synthetic check-run publication for fork PR head ($head_repository)." >&2
               return 1
             fi
 
             if [[ "$pr_author" == "dependabot[bot]" ]]; then
-              echo "::warning::Skipping synthetic check-run publication for Dependabot PR author."
+              echo "::warning::Skipping synthetic check-run publication for Dependabot PR author." >&2
               return 1
             fi
 
@@ -153,6 +153,7 @@ jobs:
             )"
 
             check_run_error="$(mktemp)"
+            trap 'rm -f "$check_run_error"; trap - RETURN' RETURN
             if ! check_run_response="$(
               gh api \
                 --method POST \
@@ -164,15 +165,13 @@ jobs:
             )"; then
               echo "::error::Failed to create check run via GitHub API."
               cat "$check_run_error" >&2
-              rm -f "$check_run_error"
               return 1
             fi
             if [[ -s "$check_run_error" ]]; then
               cat "$check_run_error" >&2
             fi
-            rm -f "$check_run_error"
 
-            if ! jq -e '.id and .html_url' <<< "$check_run_response" > /dev/null; then
+            if ! jq -e '.id and (.html_url // .url)' <<< "$check_run_response" > /dev/null; then
               echo "::error::GitHub API response did not include check-run metadata."
               jq -c '.' <<< "$check_run_response" >&2
               return 1


### PR DESCRIPTION
### **User description**
## Summary

- Publish a synthetic `Check unresolved comments` check run on the PR head SHA for `issue_comment` events.
- Include the PR URL and unresolved-comment summary in the synthetic check output.
- Keep the existing workflow job behavior for pull request and review-thread events.

## Why

Top-level PR comments trigger `issue_comment` workflow runs, but those runs are not reliably associated with the PR head status checks. That can leave the required check red until someone manually reruns the workflow. Publishing the result directly to the PR head SHA lets the next top-level comment event update the visible check state.

## Validation

- `yq` parsed `.github/workflows/review-thread-resolution.yml`.
- `bash -n` passed for the embedded workflow script.
- `git diff --check --cached` passed.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Publish synthetic check run on PR head SHA for `issue_comment` events

- Extract PR metadata including head repository and URL from GraphQL

- Add conditional logic to publish checks only for eligible PRs

- Refactor summary generation into reusable `build_summary` function

- Upgrade permissions from `checks: read` to `checks: write`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["issue_comment event"] --> B["Fetch PR metadata<br/>including head repo & URL"]
  B --> C["Validate eligibility<br/>not fork, not dependabot"]
  C --> D["Build summary with<br/>unresolved comments"]
  D --> E["Publish synthetic<br/>check run to head SHA"]
  E --> F["Update PR status<br/>checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>review-thread-resolution.yml</strong><dd><code>Add synthetic check run publication for issue_comment events</code></dd></summary>
<hr>

.github/workflows/review-thread-resolution.yml

<ul><li>Changed permissions from <code>checks: read</code> to <code>checks: write</code> to enable check <br>run creation<br> <li> Added <code>EVENT_NAME</code> and <code>RUN_URL</code> environment variables for check <br>publication<br> <li> Extended GraphQL query to fetch <code>headRepository.nameWithOwner</code>, <br><code>headRefOid</code>, and PR <code>url</code><br> <li> Added validation for required PR metadata fields including <code>headRefOid</code> <br>and <code>url</code><br> <li> Extracted <code>head_repository</code> and <code>pr_url</code> from GraphQL response<br> <li> Implemented <code>should_publish_head_check()</code> function with guards for fork <br>PRs, dependabot, and non-issue_comment events<br> <li> Implemented <code>publish_head_check()</code> function to create synthetic check <br>runs via GitHub API with error handling and summary truncation<br> <li> Implemented <code>build_summary()</code> function to generate formatted summary <br>with PR URL and unresolved/unacknowledged comment details<br> <li> Refactored summary output to use <code>build_summary()</code> function and write to <br>both step summary and check run<br> <li> Added conditional check publication for both success and failure cases <br>based on comment resolution status</ul>


</details>


  </td>
  <td><a href="https://github.com/j5ik2o/fraktor-rs/pull/1869/files#diff-f4df2572955ee3a7bf2e9a4fba9c4200d03cc100acc603e5fda498333715ef6f">+162/-17</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

