### PR TITLE
[codex] Allow Codex connector acknowledgements

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -407,6 +407,7 @@ jobs:
                             url
                             createdAt
                             updatedAt
+                            body
                             authorAssociation
                             author {
                               login
@@ -448,27 +449,39 @@ jobs:
           done
 
           unacknowledged_top_level="$(
-            jq -c --arg pr_author "$pr_author" --arg pr_author_type "$pr_author_type" '
+            jq -c \
+              --arg pr_author "$pr_author" \
+              --arg pr_author_type "$pr_author_type" \
+              --argjson trusted_acknowledger_logins '["chatgpt-codex-connector", "chatgpt-codex-connector[bot]"]' '
+              def is_trusted_acknowledger:
+                (.author.login // "") as $login
+                | ($trusted_acknowledger_logins | index($login)) != null;
+              def is_acknowledgement_text:
+                (.body // "") | test("(?i)^\\s*(acknowledged|addressed|確認しました|承知しました|了解しました|対応済み|対応しました|対処しました)");
+              def is_trusted_acknowledgement:
+                is_trusted_acknowledger and is_acknowledgement_text;
+              def is_maintainer:
+                .authorAssociation == "OWNER"
+                or .authorAssociation == "MEMBER"
+                or .authorAssociation == "COLLABORATOR";
+              def is_acknowledger:
+                (.author.login // "") == $pr_author
+                or is_trusted_acknowledgement
+                or ($pr_author_type == "Bot" and is_maintainer);
+              def requires_acknowledgement:
+                (.author.login // "") != $pr_author
+                and (is_trusted_acknowledgement | not);
               . as $comments
               | [
                   $comments[]
-                  | select((.author.login // "") != $pr_author)
+                  | select(requires_acknowledgement)
                   | . as $comment
                   | select([
                       $comments[]
                       # Human-authored PRs require the PR author to acknowledge.
                       # Bot-authored PRs allow maintainers to acknowledge on behalf of the bot.
-                      | select(
-                          (.author.login // "") == $pr_author
-                          or (
-                            $pr_author_type == "Bot"
-                            and (
-                              .authorAssociation == "OWNER"
-                              or .authorAssociation == "MEMBER"
-                              or .authorAssociation == "COLLABORATOR"
-                            )
-                          )
-                        )
+                      # Explicit Codex connector acknowledgement comments can also acknowledge on behalf of the PR author.
+                      | select(is_acknowledger)
                       | select(.createdAt > ($comment.updatedAt // $comment.createdAt))
                     ] | length == 0)
                 ]


### PR DESCRIPTION
## Summary

- Allow `chatgpt-codex-connector` and `chatgpt-codex-connector[bot]` top-level PR comments to acknowledge prior top-level comments.
- Exclude those connector acknowledgement comments from becoming new acknowledgement targets themselves.
- Keep the existing PR-author and bot-PR maintainer acknowledgement behavior intact.

## Why

Top-level PR comments can be posted by the ChatGPT Codex connector on behalf of the author. The previous workflow only accepted the PR author as the acknowledger for human-authored PRs, so connector acknowledgements could leave the review-thread check red.

## Validation

- Extracted workflow shell and ran `bash -n`.
- Ran `git diff --check origin/main...HEAD`.
- Verified a sample top-level comment list where `chatgpt-codex-connector[bot]` acknowledges a prior bot comment returns zero unacknowledged comments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the GitHub Actions workflow logic that determines whether top-level PR comments are considered acknowledged, which can affect merge gating and may cause false passes/failures if the heuristics misclassify comments.
> 
> **Overview**
> Updates the `Review Thread Resolution` workflow to treat top-level comments from `chatgpt-codex-connector` / `chatgpt-codex-connector[bot]` as valid acknowledgements when their body matches an acknowledgement phrase.
> 
> The workflow now fetches comment `body`, excludes these trusted acknowledgement comments from becoming acknowledgement *targets*, and refactors the jq filter into explicit helper predicates while keeping existing PR-author and maintainer-on-bot-PR acknowledgement behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 737df08421093a92d2ee528b52cff8622db4ef58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->