### PR TITLE
Propose durable state revision and tag contract

### DIFF
--- a/openspec/changes/add-durable-state-revision-tags/.openspec.yaml
+++ b/openspec/changes/add-durable-state-revision-tags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/add-durable-state-revision-tags/design.md
+++ b/openspec/changes/add-durable-state-revision-tags/design.md
@@ -1,0 +1,46 @@
+## Context
+
+`DurableStateStore::get_object` already returns `GetObjectResult<A>` with a revision, and `DurableStateError::DeleteRevision` already represents delete revision mismatch. The remaining gap from issue #521 is that writes are still value-only: `upsert_object(persistence_id, object)` and `delete_object(persistence_id)` cannot enforce optimistic concurrency, and `DurableStateUpdateStore::changes` is keyed by persistence id instead of tags.
+
+The current persistence gap analysis identifies revision/tag-aware durable state updates as the remaining medium-sized durable state store gap.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make durable state upsert and delete revision-aware.
+- Preserve all-or-nothing write semantics when the expected revision does not match the stored revision.
+- Add tag-aware durable state update metadata so future change streams can query updates by tag.
+- Keep the contract in `persistence-core-kernel` and maintain no_std compatibility.
+
+**Non-Goals:**
+
+- Do not implement typed `DurableStateBehavior`.
+- Do not add a durable state effect DSL.
+- Do not introduce std-backed durable state storage.
+- Do not keep legacy value-only write methods as compatibility shims.
+
+## Decisions
+
+1. Use explicit expected revision parameters on write methods.
+
+   `upsert_object` and `delete_object` should require the caller's expected revision. This keeps optimistic concurrency at the durable store boundary instead of leaving it to typed behavior code. The alternative was to keep store writes value-only and enforce revision in future typed APIs, but that would let backend implementations bypass the invariant.
+
+2. Treat revision mismatch as a failed write with no partial mutation.
+
+   On mismatch, the store must leave object value, revision, and change log untouched. This makes retry behavior deterministic and matches the existing `DeleteRevision` error direction. If upsert needs its own first-class error variant, it should be added rather than overloading a generic string error.
+
+3. Attach tags to upserted updates, not to the durable state identity.
+
+   A tag classifies a change event for update-stream queries. It should not become part of the persistence id or object key. Untagged updates remain valid, but they must not appear in a tag query.
+
+4. Replace `changes(persistence_id, offset)` with tag-oriented update lookup.
+
+   The existing method shape reports updates for one persistence id. Pekko's durable state changes are classified by tag, so the contract should move to `changes(tag, offset)` and return change metadata including persistence id, revision, and value. A compact record type is preferable to tuple growth because the offset, persistence id, revision, value, and tag have different meanings.
+
+## Risks / Trade-offs
+
+- Breaking trait implementations could touch several tests at once -> update all local test stores in the same change and avoid compatibility wrappers.
+- Adding change metadata can invite over-designed stream APIs -> keep this change to a single-step query contract and defer streaming adapters.
+- Revision numbering for missing objects can be ambiguous -> define empty/missing revision as `0`, so first successful upsert expects `0` and produces revision `1`.
+- Delete change classification is unclear without a delete tag parameter -> keep delete revision-aware in this change; do not require tagged delete notifications unless a future durable state behavior change needs them.

--- a/openspec/changes/add-durable-state-revision-tags/proposal.md
+++ b/openspec/changes/add-durable-state-revision-tags/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Issue #521 still has an unresolved durable state write-side gap: loads expose revisions, but updates and deletes cannot validate an expected revision or attach tags for downstream change classification. Without this contract, future typed `DurableStateBehavior` work has no optimistic concurrency boundary to build on.
+
+## What Changes
+
+- **BREAKING**: Change durable state write APIs to carry expected revision information for upsert and delete operations.
+- Add tag-aware durable state update metadata so stores can classify changes for future change streams.
+- Keep `GetObjectResult` and `DurableStateError::DeleteRevision` as existing prerequisites instead of reintroducing them in this change.
+- Keep full typed `DurableStateBehavior` and durable state effect DSL out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `persistence-durable-state-store`: durable state store contracts for revision-aware writes, deletes, and tagged change metadata.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected crates: `modules/persistence-core-kernel`, and tests under the same crate.
+- Affected APIs: `DurableStateStore`, `DurableStateUpdateStore`, in-memory/test store implementations, durable state errors if an upsert revision mismatch needs a first-class error.
+- Affected docs: persistence gap analysis and issue #521 status.
+- Compatibility: breaking API change is acceptable because fraktor-rs is pre-release and should not keep legacy value-only write paths.

--- a/openspec/changes/add-durable-state-revision-tags/specs/persistence-durable-state-store/spec.md
+++ b/openspec/changes/add-durable-state-revision-tags/specs/persistence-durable-state-store/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Revision-aware durable state writes
+The durable state store contract SHALL require callers to provide an expected revision for upsert and delete operations. The store MUST compare the expected revision with the currently stored revision before mutating durable state.
+
+#### Scenario: First upsert creates revision one
+- **WHEN** a durable state store receives an upsert for a missing persistence id with expected revision `0`
+- **THEN** the store persists the value and subsequent load returns revision `1`
+
+#### Scenario: Upsert revision mismatch is rejected
+- **WHEN** a durable state store receives an upsert whose expected revision does not match the currently stored revision
+- **THEN** the store returns a deterministic revision mismatch error
+- **AND** the previous value, previous revision, and update log are not changed
+
+#### Scenario: Delete revision mismatch is rejected
+- **WHEN** a durable state store receives a delete whose expected revision does not match the currently stored revision
+- **THEN** the store returns a delete revision mismatch error
+- **AND** the object remains loadable at the previous revision
+
+#### Scenario: Delete removes matching revision
+- **WHEN** a durable state store receives a delete whose expected revision matches the currently stored revision
+- **THEN** the store removes the object
+- **AND** subsequent load returns an empty result with revision `0`
+
+### Requirement: Tagged durable state update lookup
+The durable state update store contract SHALL expose tag-oriented change lookup. Successful tagged upserts MUST record change metadata containing offset, persistence id, new revision, tag, and value.
+
+#### Scenario: Tagged upsert is visible by tag
+- **WHEN** a successful upsert stores a value with tag `orders`
+- **THEN** querying changes for tag `orders` after the previous offset returns that update with its persistence id, new revision, tag, value, and next offset
+
+#### Scenario: Untagged upsert is not returned by tag query
+- **WHEN** a successful upsert stores a value without a tag
+- **THEN** querying changes for any tag does not return that untagged update
+
+#### Scenario: Different tag is isolated
+- **WHEN** updates are stored under tags `orders` and `payments`
+- **THEN** querying changes for tag `orders` returns only `orders` updates
+
+### Requirement: Legacy value-only durable state writes are removed
+The durable state public traits MUST NOT expose value-only upsert or delete methods that bypass revision checks.
+
+#### Scenario: Store implementations implement revision-aware signatures
+- **WHEN** a durable state store implements the public durable state traits
+- **THEN** it implements upsert and delete methods with expected revision parameters
+- **AND** no public value-only upsert or delete path remains on those traits

--- a/openspec/changes/add-durable-state-revision-tags/tasks.md
+++ b/openspec/changes/add-durable-state-revision-tags/tasks.md
@@ -1,0 +1,19 @@
+## 1. Durable State Write Contract
+
+- [ ] 1.1 Add focused tests for revision-aware upsert success, upsert revision mismatch, delete success, and delete revision mismatch.
+- [ ] 1.2 Update `DurableStateStore` to require expected revision parameters for upsert and delete operations.
+- [ ] 1.3 Add a deterministic upsert revision mismatch error if the existing error surface is not specific enough.
+- [ ] 1.4 Update all in-repo durable state store test implementations to enforce no-mutation-on-mismatch semantics.
+
+## 2. Tagged Change Metadata
+
+- [ ] 2.1 Add a durable state change record type that carries offset, persistence id, revision, tag, and value.
+- [ ] 2.2 Update `DurableStateUpdateStore::changes` to query by tag and offset instead of persistence id and offset.
+- [ ] 2.3 Add tests for tagged update lookup, untagged update exclusion, and tag isolation.
+
+## 3. Documentation and Validation
+
+- [ ] 3.1 Update persistence gap analysis and issue #521 status notes to reflect the remaining/resolved durable state revision and tag scope.
+- [ ] 3.2 Run targeted `persistence-core-kernel` state tests.
+- [ ] 3.3 Run `cargo fmt --check`.
+- [ ] 3.4 Run relevant `./scripts/ci-check.sh ai ...` checks for persistence-core-kernel and no_std/dylint coverage touched by this change.


### PR DESCRIPTION
## Summary
- add OpenSpec change add-durable-state-revision-tags for issue #521
- scope the change to expected revision writes/deletes and tag-aware durable state changes
- keep typed DurableStateBehavior and durable state effect DSL out of scope

## Verification
- MISE_TRUSTED_CONFIG_PATHS=/Users/j5ik2o/.codex/worktrees/99fa/fraktor-rs/mise.toml mise exec -- openspec validate add-durable-state-revision-tags --strict
- git diff --check

Related: #521

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new OpenSpec proposal/spec for a breaking durable-state contract; no runtime code is modified.
> 
> **Overview**
> Adds a new OpenSpec change set (`add-durable-state-revision-tags`) that **proposes a breaking durable state store contract**: upsert/delete must take an expected revision (with no-mutation-on-mismatch semantics and `0 -> 1` revision bootstrapping), and `DurableStateUpdateStore::changes` becomes **tag-oriented** with richer change metadata (offset, persistence id, revision, tag, value).
> 
> Includes design rationale, requirements/spec scenarios, and an implementation task checklist; this PR does not implement the API changes in `persistence-core-kernel` yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7463bde1a87d5953b85cca4fb04e35c1caa023f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->