### PR TITLE
Implement durable state revision and tag contract

### DIFF
--- a/docs/gap-analysis/persistence-gap-analysis.md
+++ b/docs/gap-analysis/persistence-gap-analysis.md
@@ -1,6 +1,6 @@
 # persistence モジュール ギャップ分析
 
-更新日: 2026-05-21 JST (current main 再検証)
+更新日: 2026-05-23 JST (durable state revision / tag contract 更新)
 
 ## 比較スコープ定義
 
@@ -44,11 +44,11 @@ fraktor-rs 側は `modules/persistence-core-kernel/src/` と `modules/persistenc
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象概念 | 80 |
-| fraktor-rs 固定スコープ対応概念 | 61 |
-| 固定スコープ概念カバレッジ | 61/80 (76%) |
+| fraktor-rs 固定スコープ対応概念 | 62 |
+| 固定スコープ概念カバレッジ | 62/80 (78%) |
 | raw public type declarations | 79（kernel: 59, typed: 20） |
 | raw public method declarations | 277（kernel: 202, typed: 75） |
-| hard / medium / easy / trivial gap | 4 / 10 / 3 / 6 |
+| hard / medium / easy / trivial gap | 4 / 9 / 3 / 6 |
 | panic 系スタブ | 0 件 |
 | 機能 placeholder / TODO | 0 件 |
 
@@ -62,7 +62,7 @@ classic write-side persistence は、persistent actor、journal、snapshot、eve
 
 | 層 | Pekko 対応範囲 | fraktor-rs 現状 | 評価 |
 |----|----------------|-----------------|------|
-| core / classic write-side | `PersistentActor`, `Eventsourced`, `Recovery`, journal, snapshot, adapter, delivery, durable state store | `Eventsourced`, `PersistentActor`, `Journal`, `AtomicWrite`, `SnapshotStore`, `EventAdapters`, `AtLeastOnceDelivery`, `DurableStateStore` が存在 | 主要契約は中程度以上に対応。revision、std serializer backend、設定型が不足 |
+| core / classic write-side | `PersistentActor`, `Eventsourced`, `Recovery`, journal, snapshot, adapter, delivery, durable state store | `Eventsourced`, `PersistentActor`, `Journal`, `AtomicWrite`, `SnapshotStore`, `EventAdapters`, `AtLeastOnceDelivery`, `DurableStateStore` が存在 | 主要契約は中程度以上に対応。std serializer backend、設定型が不足 |
 | core / typed write-side | `EventSourcedBehavior`, `Effect`, signal, typed recovery / retention, `DurableStateBehavior` | `fraktor-persistence-core-typed-rs` が `PersistenceEffector`, `PersistenceEffectorConfig`, `PersistenceEffectorSignal`, `PersistenceMode`, `SnapshotCriteria`, `RetentionCriteria`, `BackoffConfig`, `PersistenceEffectorMessageAdapter`, `Recovery`, `SnapshotSelectionCriteria`, `EventAdapter`, `EventSeq`, `SnapshotAdapter`, `DurableStateSignal` を提供 | effector-first と Phase 1 typed parity surface は実装済み。Pekko 互換の behavior DSL と typed durable state behavior は未実装 |
 | std / adaptor | local snapshot store、runtime plugin adapter | 対応 crate なし。in-memory store は kernel に存在 | ファイル IO / runtime adapter は未対応 |
 
@@ -109,14 +109,14 @@ fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventso
 |------------------|------------|-----------------|----------|--------|------|
 | `MaxUnconfirmedMessagesExceededException` 相当 | `AtLeastOnceDelivery.scala:80`, `AtLeastOnceDelivery.scala:126` | 実装済み | core/delivery | done | `PersistenceError::MaxUnconfirmedMessagesExceeded` を返す |
 
-### 5. Durable State store contract　✅ 実装済み 5/8 (63%)
+### 5. Durable State store contract　✅ 実装済み 6/8 (75%)
 
-`DurableStateStore`、`DurableStateUpdateStore`、`DurableStateStoreProvider`、`DurableStateStoreRegistry`、`DurableStateError` は存在する。ただし Pekko の revision / tag を含む durable state write-side contract とはまだ差がある。根拠は `modules/persistence-core-kernel/src/state/durable_state_store.rs:12`、`modules/persistence-core-kernel/src/state/durable_state_update_store.rs:6`、`modules/persistence-core-kernel/src/state/durable_state_store_registry.rs:18`。
+`DurableStateStore`、`DurableStateUpdateStore`、`DurableStateStoreProvider`、`DurableStateStoreRegistry`、`DurableStateError` は存在する。`DurableStateStore` は expected revision を受け取り、`DurableStateUpdateStore::changes` は tag と offset から `DurableStateChange` を返す。typed `DurableStateBehavior` との実行統合は別カテゴリの未達として残る。根拠は `modules/persistence-core-kernel/src/state/durable_state_store.rs:12`、`modules/persistence-core-kernel/src/state/durable_state_update_store.rs:6`、`modules/persistence-core-kernel/src/state/durable_state_change.rs:7`、`modules/persistence-core-kernel/src/state/durable_state_store_registry.rs:18`。
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
 | `GetObjectResult[A]` | `state/scaladsl/DurableStateStore.scala:31`, `state/scaladsl/DurableStateStore.scala:35` | 実装済み | core/durable_state | done | `GetObjectResult<A>` が value と revision を保持し、`DurableStateStore::get_object` が返す |
-| revision / tag aware update store | `state/scaladsl/DurableStateUpdateStore.scala:37`, `state/scaladsl/DurableStateUpdateStore.scala:63` | 部分実装 | core/durable_state | medium | `upsert_object` と `delete_object` に revision / tag がない |
+| revision / tag aware update store | `state/scaladsl/DurableStateUpdateStore.scala:37`, `state/scaladsl/DurableStateUpdateStore.scala:63` | 実装済み | core/durable_state | done | `upsert_object` / `delete_object` が expected revision を受け取り、tagged upsert は offset、persistence id、revision、tag、value を持つ `DurableStateChange` として取得できる |
 | `DeleteRevisionException` | `state/exception/DurableStateException.scala:41` | 実装済み | core/durable_state | done | `DurableStateError::DeleteRevision` を追加 |
 
 ### 6. Plugin / extension / in-memory stores　✅ 実装済み 5/7 (71%)
@@ -202,7 +202,6 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 |------|----------|------|
 | `LocalSnapshotStore` | std/snapshot | カテゴリ2 |
 | adapter manifest と serializer manifest の接続 | core/serialization | カテゴリ3 |
-| revision / tag aware update store | core/durable_state | カテゴリ5 |
 | plugin target location / proxy extension semantics | core/plugin + std/runtime | カテゴリ6 |
 | `EventSourcedSignal` family | core/typed | カテゴリ8 |
 | `PublishedEvent` / `EventRejectedException` | core/typed | カテゴリ8 |
@@ -218,7 +217,7 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 
 ## 内部モジュール構造ギャップ
 
-今回は API ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 61/80 (76%) で、特に typed `EventSourcedBehavior` direct DSL、typed `DurableStateBehavior`、std durable serializer backend、durable state revision model が未達である。責務分割の細部比較より先に、behavior DSL と storage backend contract の境界を決める段階である。
+今回は API ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 62/80 (78%) で、特に typed `EventSourcedBehavior` direct DSL、typed `DurableStateBehavior`、std durable serializer backend が未達である。責務分割の細部比較より先に、behavior DSL と storage backend contract の境界を決める段階である。
 
 次版で構造分析へ進む場合の観点は以下になる。
 
@@ -226,7 +225,7 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 |----------|------|----------------|
 | classic と typed の境界 | `persistence-core-kernel` が classic runtime、`persistence-core-typed` が effector-first typed API を担当 | typed `DurableStateBehavior` を同じ typed crate に追加するか別 change に分けるか |
 | journal / serializer の境界 | `Journal` は `AtomicWrite` を受け、persistence serializers は actor-core serialization registry に contributor として登録される | std durable journal / local snapshot store がこの contract をどう呼び出すか |
-| durable state revision model | store trait は value 中心で revision / tag を持たない | revision を store API に入れるか typed DurableStateBehavior 側に閉じるか |
+| durable state revision model | store trait は expected revision と optional tag を受け、tagged update metadata を返す | typed DurableStateBehavior がこの contract をどう実行するか |
 | plugin adapter 境界 | core extension は generic journal / snapshot を直接受ける | std runtime で plugin selection / local snapshot store をどう表すか |
 | typed effector と Pekko typed DSL の境界 | `PersistenceEffector` は通常 `Behavior` に統合されるが、Pekko の `EffectBuilder` / signal / adapter をそのまま露出しない | parity 目標を effector-first で固定するか、Pekko direct DSL を追加するか |
 
@@ -236,4 +235,4 @@ persistence は classic write-side の基礎部品はかなり揃っている。
 
 Phase 1 の kernel 側低コスト項目は `SnapshotOffer`、`PersistenceSettings`、`NoSnapshotStore`、snapshot retry settings、`MaxUnconfirmedMessagesExceededException` 相当、`GetObjectResult[A]`、`DeleteRevisionException` まで実装済みである。`RecoveryCompleted` の classic 同名公開型と `RuntimePluginConfig` / plugin settings は現設計では non-goal とした。
 
-主要ギャップは、std durable journal / local snapshot store、revision / tag-aware durable state update、typed `EventSourcedBehavior` / `EffectBuilder`、typed `DurableStateBehavior` である。typed write-side は effector-first API として前進し、Phase 1 typed parity surface は閉じたが、Pekko parity の観点では behavior-level failure supervision と durable state behavior execution がまだ閉じていない。内部構造比較は、revision model と typed durable state behavior の実行契約を決めた後に進めるのが妥当である。
+主要ギャップは、std durable journal / local snapshot store、typed `EventSourcedBehavior` / `EffectBuilder`、typed `DurableStateBehavior` である。typed write-side は effector-first API として前進し、Phase 1 typed parity surface は閉じたが、Pekko parity の観点では behavior-level failure supervision と durable state behavior execution がまだ閉じていない。内部構造比較は、typed durable state behavior の実行契約を決めた後に進めるのが妥当である。

--- a/modules/persistence-core-kernel/src/state.rs
+++ b/modules/persistence-core-kernel/src/state.rs
@@ -1,5 +1,6 @@
 //! Durable state package.
 
+mod durable_state_change;
 mod durable_state_error;
 mod durable_state_store;
 mod durable_state_store_provider;
@@ -7,6 +8,7 @@ mod durable_state_store_registry;
 mod durable_state_update_store;
 mod get_object_result;
 
+pub use durable_state_change::DurableStateChange;
 pub use durable_state_error::DurableStateError;
 pub use durable_state_store::DurableStateStore;
 pub(crate) use durable_state_store::DurableStateStoreFuture;

--- a/modules/persistence-core-kernel/src/state/durable_state_change.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_change.rs
@@ -1,0 +1,61 @@
+//! Durable state update record.
+
+#[cfg(test)]
+#[path = "durable_state_change_test.rs"]
+mod tests;
+
+use alloc::string::String;
+
+/// Durable state change returned by update queries.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DurableStateChange<A> {
+  offset:         usize,
+  persistence_id: String,
+  revision:       u64,
+  tag:            String,
+  value:          A,
+}
+
+impl<A> DurableStateChange<A> {
+  /// Creates a durable state change record.
+  #[must_use]
+  pub const fn new(offset: usize, persistence_id: String, revision: u64, tag: String, value: A) -> Self {
+    Self { offset, persistence_id, revision, tag, value }
+  }
+
+  /// Returns the change offset.
+  #[must_use]
+  pub const fn offset(&self) -> usize {
+    self.offset
+  }
+
+  /// Returns the persistence identifier.
+  #[must_use]
+  pub fn persistence_id(&self) -> &str {
+    &self.persistence_id
+  }
+
+  /// Returns the stored revision after the change.
+  #[must_use]
+  pub const fn revision(&self) -> u64 {
+    self.revision
+  }
+
+  /// Returns the durable state tag.
+  #[must_use]
+  pub fn tag(&self) -> &str {
+    &self.tag
+  }
+
+  /// Returns the changed value.
+  #[must_use]
+  pub const fn value(&self) -> &A {
+    &self.value
+  }
+
+  /// Consumes the change and returns the changed value.
+  #[must_use]
+  pub fn into_value(self) -> A {
+    self.value
+  }
+}

--- a/modules/persistence-core-kernel/src/state/durable_state_change_test.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_change_test.rs
@@ -1,0 +1,15 @@
+use alloc::string::ToString;
+
+use crate::state::DurableStateChange;
+
+#[test]
+fn durable_state_change_exposes_metadata_and_value() {
+  let change = DurableStateChange::new(3, "pid-1".to_string(), 7, "orders".to_string(), 42);
+
+  assert_eq!(change.offset(), 3);
+  assert_eq!(change.persistence_id(), "pid-1");
+  assert_eq!(change.revision(), 7);
+  assert_eq!(change.tag(), "orders");
+  assert_eq!(change.value(), &42);
+  assert_eq!(change.into_value(), 42);
+}

--- a/modules/persistence-core-kernel/src/state/durable_state_error.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_error.rs
@@ -14,6 +14,15 @@ pub enum DurableStateError {
   GetObjectFailed(String),
   /// Failed to persist a durable state object.
   UpsertObjectFailed(String),
+  /// Failed to persist a durable state object because the revision did not match.
+  UpsertRevision {
+    /// Persistence identifier for the object.
+    persistence_id:    String,
+    /// Revision requested by the caller.
+    expected_revision: u64,
+    /// Revision stored by the durable state backend.
+    actual_revision:   u64,
+  },
   /// Failed to delete a durable state object.
   DeleteObjectFailed(String),
   /// Failed to delete a durable state object because the revision did not match.
@@ -51,6 +60,12 @@ impl DurableStateError {
   pub fn delete_revision(persistence_id: impl Into<String>, expected_revision: u64, actual_revision: u64) -> Self {
     Self::DeleteRevision { persistence_id: persistence_id.into(), expected_revision, actual_revision }
   }
+
+  /// Creates an upsert revision mismatch error.
+  #[must_use]
+  pub fn upsert_revision(persistence_id: impl Into<String>, expected_revision: u64, actual_revision: u64) -> Self {
+    Self::UpsertRevision { persistence_id: persistence_id.into(), expected_revision, actual_revision }
+  }
 }
 
 impl Display for DurableStateError {
@@ -58,6 +73,11 @@ impl Display for DurableStateError {
     match self {
       | Self::GetObjectFailed(reason) => write!(formatter, "get durable state object failed: {}", reason),
       | Self::UpsertObjectFailed(reason) => write!(formatter, "upsert durable state object failed: {}", reason),
+      | Self::UpsertRevision { persistence_id, expected_revision, actual_revision } => write!(
+        formatter,
+        "upsert durable state object failed for '{}': expected revision {}, actual revision {}",
+        persistence_id, expected_revision, actual_revision
+      ),
       | Self::DeleteObjectFailed(reason) => write!(formatter, "delete durable state object failed: {}", reason),
       | Self::DeleteRevision { persistence_id, expected_revision, actual_revision } => write!(
         formatter,

--- a/modules/persistence-core-kernel/src/state/durable_state_error_test.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_error_test.rs
@@ -34,6 +34,16 @@ fn durable_state_error_display_delete_revision() {
 }
 
 #[test]
+fn durable_state_error_display_upsert_revision() {
+  let error = DurableStateError::upsert_revision("pid-1", 3, 2);
+
+  assert_eq!(
+    error.to_string(),
+    "upsert durable state object failed for 'pid-1': expected revision 3, actual revision 2"
+  );
+}
+
+#[test]
 fn durable_state_error_display_changes_failed() {
   let error = DurableStateError::ChangesFailed("stream closed".into());
 

--- a/modules/persistence-core-kernel/src/state/durable_state_store.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_store.rs
@@ -14,8 +14,18 @@ pub trait DurableStateStore<A: Send>: Send + Sync + 'static {
   fn get_object<'a>(&'a self, persistence_id: &'a str) -> DurableStateStoreFuture<'a, GetObjectResult<A>>;
 
   /// Inserts or updates the durable state object for the persistence identifier.
-  fn upsert_object<'a>(&'a mut self, persistence_id: &'a str, object: A) -> DurableStateStoreFuture<'a, ()>;
+  fn upsert_object<'a>(
+    &'a mut self,
+    persistence_id: &'a str,
+    expected_revision: u64,
+    object: A,
+    tag: Option<&'a str>,
+  ) -> DurableStateStoreFuture<'a, ()>;
 
   /// Deletes the durable state object for the persistence identifier.
-  fn delete_object<'a>(&'a mut self, persistence_id: &'a str) -> DurableStateStoreFuture<'a, ()>;
+  fn delete_object<'a>(
+    &'a mut self,
+    persistence_id: &'a str,
+    expected_revision: u64,
+  ) -> DurableStateStoreFuture<'a, ()>;
 }

--- a/modules/persistence-core-kernel/src/state/durable_state_store_registry_test.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_store_registry_test.rs
@@ -13,8 +13,8 @@ use core::{
 use fraktor_utils_core_rs::sync::ArcShared;
 
 use crate::state::{
-  DurableStateError, DurableStateStore, DurableStateStoreProvider, DurableStateStoreRegistry, DurableStateUpdateStore,
-  GetObjectResult,
+  DurableStateChange, DurableStateError, DurableStateStore, DurableStateStoreProvider, DurableStateStoreRegistry,
+  DurableStateUpdateStore, GetObjectResult,
 };
 
 const TEST_PROVIDER_ID: &str = "in-memory";
@@ -27,7 +27,7 @@ type DurableStateFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, DurableSt
 struct TestDurableStateStore {
   objects:   BTreeMap<String, i32>,
   revisions: BTreeMap<String, u64>,
-  updates:   BTreeMap<String, Vec<i32>>,
+  updates:   BTreeMap<String, Vec<DurableStateChange<i32>>>,
 }
 
 impl TestDurableStateStore {
@@ -45,15 +45,45 @@ impl DurableStateStore<i32> for TestDurableStateStore {
     Box::pin(ready(Ok(result)))
   }
 
-  fn upsert_object<'a>(&'a mut self, persistence_id: &'a str, object: i32) -> DurableStateFuture<'a, ()> {
+  fn upsert_object<'a>(
+    &'a mut self,
+    persistence_id: &'a str,
+    expected_revision: u64,
+    object: i32,
+    tag: Option<&'a str>,
+  ) -> DurableStateFuture<'a, ()> {
+    let actual_revision = self.revisions.get(persistence_id).copied().unwrap_or(0);
+    if actual_revision != expected_revision {
+      return Box::pin(ready(Err(DurableStateError::upsert_revision(
+        persistence_id,
+        expected_revision,
+        actual_revision,
+      ))));
+    }
+
     self.objects.insert(persistence_id.to_string(), object);
-    let revision = self.revisions.get(persistence_id).copied().unwrap_or(0).saturating_add(1);
+    let revision = actual_revision.saturating_add(1);
     self.revisions.insert(persistence_id.to_string(), revision);
-    self.updates.entry(persistence_id.to_string()).or_default().push(object);
+
+    if let Some(tag) = tag {
+      let updates = self.updates.entry(tag.to_string()).or_default();
+      let offset = updates.len().saturating_add(1);
+      updates.push(DurableStateChange::new(offset, persistence_id.to_string(), revision, tag.to_string(), object));
+    }
+
     Box::pin(ready(Ok(())))
   }
 
-  fn delete_object<'a>(&'a mut self, persistence_id: &'a str) -> DurableStateFuture<'a, ()> {
+  fn delete_object<'a>(&'a mut self, persistence_id: &'a str, expected_revision: u64) -> DurableStateFuture<'a, ()> {
+    let actual_revision = self.revisions.get(persistence_id).copied().unwrap_or(0);
+    if actual_revision != expected_revision {
+      return Box::pin(ready(Err(DurableStateError::delete_revision(
+        persistence_id,
+        expected_revision,
+        actual_revision,
+      ))));
+    }
+
     self.objects.remove(persistence_id);
     self.revisions.remove(persistence_id);
     Box::pin(ready(Ok(())))
@@ -63,15 +93,10 @@ impl DurableStateStore<i32> for TestDurableStateStore {
 impl DurableStateUpdateStore<i32> for TestDurableStateStore {
   fn changes<'a>(
     &'a self,
-    persistence_id: &'a str,
+    tag: &'a str,
     from_offset: usize,
-  ) -> DurableStateFuture<'a, Option<(usize, i32)>> {
-    let next_change = self
-      .updates
-      .get(persistence_id)
-      .and_then(|updates| updates.get(from_offset))
-      .copied()
-      .map(|state| (from_offset.saturating_add(1), state));
+  ) -> DurableStateFuture<'a, Option<DurableStateChange<i32>>> {
+    let next_change = self.updates.get(tag).and_then(|updates| updates.get(from_offset)).cloned();
     Box::pin(ready(Ok(next_change)))
   }
 }
@@ -108,15 +133,49 @@ fn register_and_resolve_provider_for_crud_operations() {
 
   let mut store = registry.resolve(TEST_PROVIDER_ID).expect("resolve provider");
 
-  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 42)).expect("upsert durable state");
+  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 0, 42, None)).expect("upsert durable state");
   let loaded = poll_ready(store.get_object(TEST_PERSISTENCE_ID)).expect("get durable state");
   assert_eq!(loaded.value(), Some(&42));
   assert_eq!(loaded.revision(), 1);
 
-  poll_ready(store.delete_object(TEST_PERSISTENCE_ID)).expect("delete durable state");
+  poll_ready(store.delete_object(TEST_PERSISTENCE_ID, 1)).expect("delete durable state");
   let loaded_after_delete = poll_ready(store.get_object(TEST_PERSISTENCE_ID)).expect("get durable state after delete");
   assert!(loaded_after_delete.is_empty());
   assert_eq!(loaded_after_delete.revision(), 0);
+}
+
+#[test]
+fn revision_mismatch_rejects_upsert_without_mutation() {
+  let mut store = TestDurableStateStore::new();
+
+  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 0, 10, Some("orders"))).expect("upsert initial state");
+
+  let result = poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 0, 20, Some("orders")));
+  assert_eq!(result, Err(DurableStateError::upsert_revision(TEST_PERSISTENCE_ID, 0, 1)));
+
+  let loaded = poll_ready(store.get_object(TEST_PERSISTENCE_ID)).expect("get durable state after failed upsert");
+  assert_eq!(loaded.value(), Some(&10));
+  assert_eq!(loaded.revision(), 1);
+
+  let first_change = poll_ready(store.changes("orders", 0)).expect("load first change");
+  assert_eq!(first_change.map(|change| (change.offset(), *change.value())), Some((1, 10)));
+
+  let no_second_change = poll_ready(store.changes("orders", 1)).expect("load missing second change");
+  assert_eq!(no_second_change, None);
+}
+
+#[test]
+fn revision_mismatch_rejects_delete_without_mutation() {
+  let mut store = TestDurableStateStore::new();
+
+  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 0, 10, None)).expect("upsert initial state");
+
+  let result = poll_ready(store.delete_object(TEST_PERSISTENCE_ID, 0));
+  assert_eq!(result, Err(DurableStateError::delete_revision(TEST_PERSISTENCE_ID, 0, 1)));
+
+  let loaded = poll_ready(store.get_object(TEST_PERSISTENCE_ID)).expect("get durable state after failed delete");
+  assert_eq!(loaded.value(), Some(&10));
+  assert_eq!(loaded.revision(), 1);
 }
 
 #[test]
@@ -142,25 +201,70 @@ fn resolve_unknown_provider_fails() {
 fn durable_state_update_store_reports_changes() {
   let mut store = TestDurableStateStore::new();
 
-  // changes(id, seq) は指定 seq より大きいシーケンス番号の変更を返す
-  let no_change = poll_ready(store.changes(TEST_PERSISTENCE_ID, 0)).expect("load changes before first upsert");
+  // changes(tag, offset) は指定 offset より大きい tagged change を返す
+  let no_change = poll_ready(store.changes("orders", 0)).expect("load changes before first upsert");
   assert_eq!(no_change, None);
 
-  // 最初の upsert → seq=1, value=10
-  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 10)).expect("upsert first state");
-  let first_change = poll_ready(store.changes(TEST_PERSISTENCE_ID, 0)).expect("load first change");
-  assert_eq!(first_change, Some((1, 10)));
+  // 最初の tagged upsert -> offset=1, revision=1, value=10
+  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 0, 10, Some("orders"))).expect("upsert first state");
+  let first_change = poll_ready(store.changes("orders", 0)).expect("load first change");
+  assert_eq!(
+    first_change.as_ref().map(|change| (
+      change.offset(),
+      change.persistence_id(),
+      change.revision(),
+      change.tag(),
+      *change.value()
+    )),
+    Some((1, TEST_PERSISTENCE_ID, 1, "orders", 10))
+  );
 
-  // seq=1 以降は未更新なので None
-  let no_second_change = poll_ready(store.changes(TEST_PERSISTENCE_ID, 1)).expect("load second change before upsert");
+  // offset=1 以降は未更新なので None
+  let no_second_change = poll_ready(store.changes("orders", 1)).expect("load second change before upsert");
   assert_eq!(no_second_change, None);
 
-  // 2回目の upsert → seq=2, value=20
-  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 20)).expect("upsert second state");
-  let second_change = poll_ready(store.changes(TEST_PERSISTENCE_ID, 1)).expect("load second change");
-  assert_eq!(second_change, Some((2, 20)));
+  // 2回目の tagged upsert -> offset=2, revision=2, value=20
+  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 1, 20, Some("orders"))).expect("upsert second state");
+  let second_change = poll_ready(store.changes("orders", 1)).expect("load second change");
+  assert_eq!(
+    second_change.as_ref().map(|change| (change.offset(), change.revision(), change.tag(), *change.value())),
+    Some((2, 2, "orders", 20))
+  );
 
-  // seq=2 以降は未更新なので None
-  let no_third_change = poll_ready(store.changes(TEST_PERSISTENCE_ID, 2)).expect("load third change");
+  // offset=2 以降は未更新なので None
+  let no_third_change = poll_ready(store.changes("orders", 2)).expect("load third change");
   assert_eq!(no_third_change, None);
+}
+
+#[test]
+fn untagged_update_is_not_returned_by_tag_query() {
+  let mut store = TestDurableStateStore::new();
+
+  poll_ready(store.upsert_object(TEST_PERSISTENCE_ID, 0, 10, None)).expect("upsert untagged state");
+
+  let no_change = poll_ready(store.changes("orders", 0)).expect("load tagged changes");
+  assert_eq!(no_change, None);
+}
+
+#[test]
+fn durable_state_update_store_isolates_tags() {
+  let mut store = TestDurableStateStore::new();
+
+  poll_ready(store.upsert_object("order-1", 0, 10, Some("orders"))).expect("upsert order state");
+  poll_ready(store.upsert_object("payment-1", 0, 20, Some("payments"))).expect("upsert payment state");
+
+  let order_change = poll_ready(store.changes("orders", 0)).expect("load order change");
+  assert_eq!(
+    order_change.as_ref().map(|change| (
+      change.offset(),
+      change.persistence_id(),
+      change.revision(),
+      change.tag(),
+      *change.value()
+    )),
+    Some((1, "order-1", 1, "orders", 10))
+  );
+
+  let no_second_order_change = poll_ready(store.changes("orders", 1)).expect("load missing order change");
+  assert_eq!(no_second_order_change, None);
 }

--- a/modules/persistence-core-kernel/src/state/durable_state_update_store.rs
+++ b/modules/persistence-core-kernel/src/state/durable_state_update_store.rs
@@ -1,15 +1,15 @@
 //! Durable state update store abstraction.
 
-use crate::state::{DurableStateStore, DurableStateStoreFuture};
+use crate::state::{DurableStateChange, DurableStateStore, DurableStateStoreFuture};
 
 /// Durable state store extension that exposes update notifications.
 pub trait DurableStateUpdateStore<A: Send>: DurableStateStore<A> {
-  /// Loads the next update after `from_offset` for the persistence identifier.
+  /// Loads the next tagged update after `from_offset`.
   ///
-  /// Returns `Some((next_offset, value))` when a new update exists, otherwise `None`.
+  /// Returns `Some(change)` when a new tagged update exists, otherwise `None`.
   fn changes<'a>(
     &'a self,
-    persistence_id: &'a str,
+    tag: &'a str,
     from_offset: usize,
-  ) -> DurableStateStoreFuture<'a, Option<(usize, A)>>;
+  ) -> DurableStateStoreFuture<'a, Option<DurableStateChange<A>>>;
 }

--- a/openspec/changes/add-durable-state-revision-tags/tasks.md
+++ b/openspec/changes/add-durable-state-revision-tags/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Durable State Write Contract
 
-- [ ] 1.1 Add focused tests for revision-aware upsert success, upsert revision mismatch, delete success, and delete revision mismatch.
-- [ ] 1.2 Update `DurableStateStore` to require expected revision parameters for upsert and delete operations.
-- [ ] 1.3 Add a deterministic upsert revision mismatch error if the existing error surface is not specific enough.
-- [ ] 1.4 Update all in-repo durable state store test implementations to enforce no-mutation-on-mismatch semantics.
+- [x] 1.1 Add focused tests for revision-aware upsert success, upsert revision mismatch, delete success, and delete revision mismatch.
+- [x] 1.2 Update `DurableStateStore` to require expected revision parameters for upsert and delete operations.
+- [x] 1.3 Add a deterministic upsert revision mismatch error if the existing error surface is not specific enough.
+- [x] 1.4 Update all in-repo durable state store test implementations to enforce no-mutation-on-mismatch semantics.
 
 ## 2. Tagged Change Metadata
 
-- [ ] 2.1 Add a durable state change record type that carries offset, persistence id, revision, tag, and value.
-- [ ] 2.2 Update `DurableStateUpdateStore::changes` to query by tag and offset instead of persistence id and offset.
-- [ ] 2.3 Add tests for tagged update lookup, untagged update exclusion, and tag isolation.
+- [x] 2.1 Add a durable state change record type that carries offset, persistence id, revision, tag, and value.
+- [x] 2.2 Update `DurableStateUpdateStore::changes` to query by tag and offset instead of persistence id and offset.
+- [x] 2.3 Add tests for tagged update lookup, untagged update exclusion, and tag isolation.
 
 ## 3. Documentation and Validation
 
-- [ ] 3.1 Update persistence gap analysis and issue #521 status notes to reflect the remaining/resolved durable state revision and tag scope.
-- [ ] 3.2 Run targeted `persistence-core-kernel` state tests.
-- [ ] 3.3 Run `cargo fmt --check`.
-- [ ] 3.4 Run relevant `./scripts/ci-check.sh ai ...` checks for persistence-core-kernel and no_std/dylint coverage touched by this change.
+- [x] 3.1 Update persistence gap analysis and issue #521 status notes to reflect the remaining/resolved durable state revision and tag scope.
+- [x] 3.2 Run targeted `persistence-core-kernel` state tests.
+- [x] 3.3 Run `cargo fmt --check`.
+- [x] 3.4 Run relevant `./scripts/ci-check.sh ai ...` checks for persistence-core-kernel and no_std/dylint coverage touched by this change.


### PR DESCRIPTION
## Summary

- add expected-revision parameters to durable state upsert/delete APIs
- add deterministic upsert revision mismatch errors and no-mutation mismatch tests
- return tagged durable state change metadata from update queries
- update the persistence gap analysis and complete the OpenSpec task checklist

## Motivation

This implements OpenSpec change `add-durable-state-revision-tags` and closes the issue #521 durable state write-side gap. Loads already exposed revisions, but writes could not validate optimistic concurrency and update queries were keyed by persistence id instead of tag.

Closes #521

## Validation

- `cargo test -p fraktor-persistence-core-kernel-rs state::durable_state --lib`
- `cargo fmt --check`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/j5ik2o/.codex/worktrees/99fa/fraktor-rs/mise.toml mise exec -- openspec validate add-durable-state-revision-tags --strict`
- `./scripts/ci-check.sh ai lint dylint:type-per-file-lint,module-wiring-lint,rustdoc-lint,tests-location-lint no-std`
- `cargo check -p fraktor-persistence-core-kernel-rs --no-default-features`

Note: the ci-check no-std phase skipped `thumbv8m.main-none-eabi` because that target is not installed locally; host no-std checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public durable-state store traits (`DurableStateStore`/`DurableStateUpdateStore`) by adding optimistic-concurrency parameters and altering the update-query return type, which is a breaking API change for store implementers and callers.
> 
> **Overview**
> Implements the *durable state revision + tag contract* by making durable-state writes revision-aware: `DurableStateStore::upsert_object`/`delete_object` now require an `expected_revision` (and `upsert_object` optionally accepts a `tag`), with a new deterministic `DurableStateError::UpsertRevision` for mismatch handling.
> 
> Update queries are reworked to be tag-based: a new `DurableStateChange` record (offset, persistence id, revision, tag, value) is introduced and `DurableStateUpdateStore::changes` now takes `(tag, from_offset)` and returns `Option<DurableStateChange<_>>`; tests are expanded to cover mismatch no-mutation semantics, tagged-change lookup, untagged exclusion, and tag isolation. Docs/OpenSpec checklists are updated to reflect the closed durable-state gap and revised coverage numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 106680c394ddfa87c4f6fba533c0bcd3f69a9de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 永続状態の更新時に期待リビジョンとタグによる制御が可能になりました。

* **バグ修正**
  * リビジョンの不一致を検出し、適切なエラーハンドリングを実装しました。

* **テスト**
  * リビジョン・タグ機能と状態変更追跡の検証テストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->