### PR TITLE
Review Thread Resolution の check 表示名を分離

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -31,12 +31,12 @@ concurrency:
 
 jobs:
   unresolved-comments:
-    name: Check unresolved comments
+    name: Evaluate unresolved comments
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event.pull_request != null || github.event.issue.pull_request != null }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Check unresolved comments
+      - name: Evaluate review-thread gate
         env:
           GH_TOKEN: ${{ github.token }}
           OWNER: ${{ github.repository_owner }}


### PR DESCRIPTION
## 概要

- Actions job 名を `Evaluate unresolved comments` に変更
- workflow step 名を `Evaluate review-thread gate` に変更
- synthetic check-run 名 `Check unresolved comments` は required check 互換性のため維持

## 背景

Actions job と synthetic check-run が同じ `Check unresolved comments` 名で表示され、cancelled workflow run と current synthetic gate の区別がつきにくかったため、表示上の役割を分離します。

Closes #1881

## 確認

- `git diff --check`
- `/usr/bin/ruby -e 'require "yaml"; YAML.load_file(".github/workflows/review-thread-resolution.yml")'`
- synthetic check-run 名が `Check unresolved comments` のまま残っていることを確認

`actionlint` はローカルに未導入のため未実行です。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only renames in the workflow YAML; no changes to gates, scripts, or the synthetic check-run identifier.
> 
> **Overview**
> Renames the **Review Thread Resolution** workflow’s GitHub Actions **job** to `Evaluate unresolved comments` and the main **step** to `Evaluate review-thread gate`, so cancelled workflow runs are easier to tell apart from the branch-protection gate.
> 
> The **synthetic** Checks API run published on the PR head still uses the name `Check unresolved comments` (required-check compatibility). Evaluation logic, API calls, and branch-protection behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78a4204eecc3cfbc5ec295ca83c59ef63e7dd005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->