### PR TITLE
review-thread check で bot の初期レポートを除外する

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -503,10 +503,14 @@ jobs:
                   (.body // "") | test("(?i)^\\s*(acknowledged|addressed|確認しました|承知しました|了解しました|対応済み|対応しました|対処しました)");
                 def is_trusted_acknowledgement:
                   is_trusted_acknowledger and is_acknowledgement_text;
+                def author_login:
+                  .author.login // "";
+                def is_author($login):
+                  author_login == $login or author_login == ($login + "[bot]");
                 def comment_body:
                   .body // "";
                 def is_coderabbit_report_comment:
-                  ((.author.login // "") == "coderabbitai")
+                  is_author("coderabbitai")
                   and (
                     (comment_body | contains("<!-- This is an auto-generated comment: summarize by coderabbit.ai -->"))
                     or (comment_body | contains("<!-- walkthrough_start -->"))
@@ -515,7 +519,7 @@ jobs:
                     or (comment_body | contains("## Walkthrough"))
                   );
                 def is_codecov_report_comment:
-                  ((.author.login // "") == "codecov")
+                  is_author("codecov")
                   and (
                     (comment_body | test("(?m)^\\s*## \\[Codecov\\]\\([^\\n]+\\) Report\\s*$"))
                     or (comment_body | test("(?im)^\\s*##\\s+Codecov\\s+Report\\s*$"))
@@ -523,7 +527,7 @@ jobs:
                 def is_automated_status_comment:
                   is_coderabbit_report_comment
                   or is_codecov_report_comment
-                  or ((.author.login // "") == "renovate"
+                  or (is_author("renovate")
                     and ((.body // "") | startswith("### Edited/Blocked Notification")));
                 def is_maintainer:
                   .authorAssociation == "OWNER"

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -503,11 +503,26 @@ jobs:
                   (.body // "") | test("(?i)^\\s*(acknowledged|addressed|確認しました|承知しました|了解しました|対応済み|対応しました|対処しました)");
                 def is_trusted_acknowledgement:
                   is_trusted_acknowledger and is_acknowledgement_text;
+                def comment_body:
+                  .body // "";
+                def is_coderabbit_report_comment:
+                  ((.author.login // "") == "coderabbitai")
+                  and (
+                    (comment_body | contains("<!-- This is an auto-generated comment: summarize by coderabbit.ai -->"))
+                    or (comment_body | contains("<!-- walkthrough_start -->"))
+                    or (comment_body | contains("<!-- pre_merge_checks_walkthrough_start -->"))
+                    or (comment_body | contains("## Review limit reached"))
+                    or (comment_body | contains("## Walkthrough"))
+                  );
+                def is_codecov_report_comment:
+                  ((.author.login // "") == "codecov")
+                  and (
+                    (comment_body | test("(?m)^\\s*## \\[Codecov\\]\\([^\\n]+\\) Report\\s*$"))
+                    or (comment_body | test("(?im)^\\s*##\\s+Codecov\\s+Report\\s*$"))
+                  );
                 def is_automated_status_comment:
-                  ((.author.login // "") == "coderabbitai"
-                    and ((.body // "") | startswith("<!-- This is an auto-generated comment: summarize by coderabbit.ai -->")))
-                  or ((.author.login // "") == "codecov"
-                    and ((.body // "") | startswith("## [Codecov](")))
+                  is_coderabbit_report_comment
+                  or is_codecov_report_comment
                   or ((.author.login // "") == "renovate"
                     and ((.body // "") | startswith("### Edited/Blocked Notification")));
                 def is_maintainer:


### PR DESCRIPTION
## 概要

- CodeRabbit の初期レポート系コメントを top-level comment acknowledgement の対象外にしました
  - `Review limit reached`
  - `Walkthrough`
  - pre-merge checks walkthrough
  - 既存の CodeRabbit 自動 summary marker
- Codecov の `Codecov Report` コメントを acknowledgement 対象外として明示しました
- `coderabbitai[bot]` / `codecov[bot]` のような GitHub App の `[bot]` サフィックス付きログイン名も許容しました

## 背景

`Check unresolved comments` は top-level PR comments も確認しますが、CodeRabbit の初期レポートや Codecov の coverage report は別の review/check 経路で扱われるため、人間の acknowledgement を要求するとノイズになります。

## 確認

- `git diff --check`
- `yq -r '.jobs."unresolved-comments".steps[0].run' .github/workflows/review-thread-resolution.yml | bash -n`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-thread-resolution.yml`
- jq predicate のローカル確認
  - `coderabbitai[bot]` の `Review limit reached` が自動レポート扱いになる
  - `codecov[bot]` の `Codecov Report` が自動レポート扱いになる
  - `renovate[bot]` の edited/blocked notification が自動レポート扱いになる
- 実 PR コメントで以下が自動レポート扱いになることを確認
  - PR #1882: CodeRabbit `Review limit reached` / Codecov Report
  - PR #1865: CodeRabbit `Walkthrough` / Codecov Report
  - PR #1869: CodeRabbit pre-merge checks walkthrough / Codecov Report