### PR TITLE
persistence ギャップ分析を現行構成に合わせて整理する

### DIFF
--- a/docs/gap-analysis/persistence-gap-analysis.md
+++ b/docs/gap-analysis/persistence-gap-analysis.md
@@ -1,30 +1,28 @@
 # persistence モジュール ギャップ分析
 
-更新日: 2026-05-23 JST (durable state revision / tag contract 更新)
+更新日: 2026-05-24 JST
 
 ## 比較スコープ定義
 
-この調査は Apache Pekko persistence 配下の raw API 数をそのまま移植対象にするものではない。fraktor-rs の `persistence` では write-side persistence runtime を対象にし、`persistence-query`、testkit / TCK、Java / Scala DSL convenience、JVM 固有の plugin loading は parity 分母から除外する。
+この分析は Apache Pekko persistence の raw API 数をそのまま移植対象にしない。fraktor-rs の persistence では write-side persistence runtime を対象にし、`persistence-query`、testkit / TCK、Java / Scala DSL convenience、JVM 固有の plugin loading は parity 分母から除外する。
 
-現行 fraktor-rs の persistence は、スキル定義に残っている旧 `modules/persistence-core/src/core/` ではなく、`modules/persistence-core-kernel/src/` と `modules/persistence-core-typed/src/` に分割済みである。`persistence-adaptor-std` はまだ存在しないため、ファイル IO や std runtime adapter は未実装ギャップとして扱うが、adaptor crate が未作成であること自体は減点しない。
-
-### 対象に含めるもの
+現行 fraktor-rs の persistence は、旧スコープに残っている `modules/persistence-core/src/core/` ではなく、`modules/persistence-core-kernel/src/` と `modules/persistence-core-typed/src/` に分割済みである。`persistence-adaptor-std` は存在しないため、ファイル IO や std runtime adapter は未実装ギャップとして扱うが、adaptor crate が未作成であること自体は減点しない。
 
 | 領域 | fraktor-rs | Pekko 参照 |
 |------|------------|------------|
-| classic persistent actor | `modules/persistence-core-kernel/src/persistent/persistent_actor.rs`, `modules/persistence-core-kernel/src/persistent/eventsourced.rs`, `modules/persistence-core-kernel/src/persistent/persistence_context.rs` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala`, `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Eventsourced.scala` |
-| recovery / journal / snapshot | `modules/persistence-core-kernel/src/journal/`, `modules/persistence-core-kernel/src/snapshot/`, `modules/persistence-core-kernel/src/persistent/recovery.rs` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/`, `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/`, `JournalProtocol.scala`, `SnapshotProtocol.scala` |
-| persistent representation / adapter | `modules/persistence-core-kernel/src/persistent/persistent_repr.rs`, `modules/persistence-core-kernel/src/persistent/persistent_envelope.rs`, `modules/persistence-core-kernel/src/journal/event_adapters.rs`, `modules/persistence-core-kernel/src/journal/read_event_adapter.rs`, `modules/persistence-core-kernel/src/journal/write_event_adapter.rs`, `modules/persistence-core-kernel/src/journal/tagged.rs` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Persistent.scala`, `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapter.scala`, `Tagged.scala` |
-| durable state store contract | `modules/persistence-core-kernel/src/state/` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/state/scaladsl/`, `state/DurableStateStoreRegistry.scala`, `state/exception/DurableStateException.scala` |
-| delivery / FSM compatibility | `modules/persistence-core-kernel/src/delivery/`, `modules/persistence-core-kernel/src/fsm/persistent_fsm.rs` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala`, `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala` |
+| classic persistent actor | `modules/persistence-core-kernel/src/persistent/` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala`, `Eventsourced.scala` |
+| recovery / journal / snapshot | `modules/persistence-core-kernel/src/journal/`, `modules/persistence-core-kernel/src/snapshot/`, `modules/persistence-core-kernel/src/persistent/recovery.rs` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/`, `snapshot/`, `JournalProtocol.scala`, `SnapshotProtocol.scala` |
+| persistent representation / adapters / serialization | `modules/persistence-core-kernel/src/persistent/persistent_repr.rs`, `modules/persistence-core-kernel/src/journal/`, `modules/persistence-core-kernel/src/serialization/` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Persistent.scala`, `journal/EventAdapter.scala`, `serialization/` |
+| durable state store contract | `modules/persistence-core-kernel/src/state/` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/state/` |
+| delivery / FSM compatibility | `modules/persistence-core-kernel/src/delivery/`, `modules/persistence-core-kernel/src/fsm/` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala`, `fsm/PersistentFSM.scala` |
 | plugin / extension / in-memory stores | `modules/persistence-core-kernel/src/extension/`, `modules/persistence-core-kernel/src/journal/persistence_plugin_proxy.rs`, `modules/persistence-core-kernel/src/journal/in_memory_journal.rs`, `modules/persistence-core-kernel/src/snapshot/in_memory_snapshot_store.rs` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala`, `journal/PersistencePluginProxy.scala`, `journal/inmem/InmemJournal.scala` |
-| typed write-side API | `modules/persistence-core-typed/src/` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/`, `references/pekko-persistence-effector/library/src/main/scala/` |
+| typed write-side API | `modules/persistence-core-typed/src/` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/` |
 
-### 対象から除外するもの
+### 対象外
 
 | 除外項目 | 理由 |
 |----------|------|
-| `persistence-query` | 固定スコープでは write-side runtime と別スコープ。ユーザーが query 調査を明示した場合だけ対象 |
+| `persistence-query` | write-side runtime とは別スコープ。ユーザーが query 調査を明示した場合だけ対象 |
 | `persistence-testkit`, `persistence-tck`, `persistence-typed-tests` | runtime API ではない |
 | `persistence-shared` の `src/test` 配下 | 現在の参照ツリーでは main runtime API がなく、shared LevelDB / serializer spec は test scope |
 | JDBC / Cassandra / LevelDB など特定 storage plugin 完全互換 | storage backend 実装技術ごとの互換は別スコープ |
@@ -33,178 +31,155 @@
 | HOCON plugin loading / JVM reflection / classloader | JVM 固有 |
 | replicated event sourcing / CRDT / typed reliable delivery queue | `persistence-typed` 内にあるが、現 persistence 固定スコープの列挙対象外。必要なら replication / delivery として別調査 |
 
-### raw 抽出値の扱い
+Pekko 側 raw 抽出は `references/pekko/persistence/src/main/scala` と `references/pekko/persistence-typed/src/main/scala` を対象にした。raw public type declarations は 352 件、主要 `def` declarations は 1405 件である。これには private / internal / Java DSL / JVM 固有 / scope 外の replication 系 API が含まれるため、parity カバレッジ分母には使わない。
 
-Pekko 側の固定スコープ候補ディレクトリを raw 抽出すると、型宣言 352 件、主要 `def` 1405 件が見つかる。これには private / internal / Java DSL / JVM 固有 / scope 外の replication 系 API が含まれるため、parity カバレッジ分母には使わない。
-
-fraktor-rs 側は `modules/persistence-core-kernel/src/` と `modules/persistence-core-typed/src/` の `*_test.rs` / `lib_test.rs` を除外して raw 抽出した。raw public type declarations は 79 件（kernel: 59、typed: 20）、raw public method declarations は 277 件（kernel: 202、typed: 75）である。このうち外部到達可能な `pub` type declarations は 65 件（kernel: 55、typed: 10）で、`pub(crate)` の内部型は raw 参考値にのみ含める。
+fraktor-rs 側 raw 抽出は `modules/persistence-core-kernel/src/` と `modules/persistence-core-typed/src/` から `*_test.rs` / `lib_test.rs` を除外して実施した。raw public type declarations は 88 件（kernel: 66、typed: 22）、raw public method declarations は 321 件（kernel: 242、typed: 79）である。このうち `pub(crate)` を除いた外部到達可能な `pub` type declarations は 79 件（kernel: 62、typed: 17）、`pub` method declarations は 282 件（kernel: 214、typed: 68）である。
 
 ## サマリー
 
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象概念 | 80 |
-| fraktor-rs 固定スコープ対応概念 | 62 |
-| 固定スコープ概念カバレッジ | 62/80 (78%) |
-| raw public type declarations | 79（kernel: 59, typed: 20） |
-| raw public method declarations | 277（kernel: 202, typed: 75） |
-| hard / medium / easy / trivial gap | 4 / 9 / 3 / 6 |
+| fraktor-rs 固定スコープ対応概念 | 63 |
+| 固定スコープ概念カバレッジ | 63/80 (79%) |
+| raw public type declarations | 88（kernel: 66, typed: 22） |
+| raw public method declarations | 321（kernel: 242, typed: 79） |
+| externally reachable `pub` type declarations | 79（kernel: 62, typed: 17） |
+| externally reachable `pub` method declarations | 282（kernel: 214, typed: 68） |
+| hard / medium / easy / trivial gap | 4 / 6 / 0 / 0 |
 | panic 系スタブ | 0 件 |
 | 機能 placeholder / TODO | 0 件 |
 
 raw declaration count は参考値であり、parity 分母に使わない。
 
-classic write-side persistence は、persistent actor、journal、snapshot、event adapter、at-least-once delivery、durable state store の基本契約が揃っている。typed write-side は Pekko typed `EventSourcedBehavior` / `Effect` の直移植ではなく、`pekko-persistence-effector` と同じく通常の typed `Behavior` を保ったまま hidden child store actor に永続化を委譲する effector-first API として実装されている。
+classic write-side persistence は、persistent actor、journal、snapshot、event adapter、at-least-once delivery、durable state store の基本契約が揃っている。typed write-side は Pekko typed `EventSourcedBehavior` / `Effect` の直移植ではなく、通常の typed `Behavior` を保ったまま hidden child store actor に永続化を委譲する effector-first API として実装されている。
 
-2026-05-21 時点の再検証では、現行 crate 境界が引き続き `persistence-core-kernel` / `persistence-core-typed` であり、`persistence-adaptor-std` は存在しないことを確認した。typed effector は backoff 中の store command stashing、wait-state recovery signal handling、typed recovery selection、typed adapter contract、durable state signal surface まで進んでいるが、Pekko の typed behavior-level `onPersistFailure`、direct `EventSourcedBehavior` DSL、typed `DurableStateBehavior` はまだ parity ギャップとして残る。
+2026-05-24 の再検証では、現行 crate 境界が `persistence-core-kernel` / `persistence-core-typed` であり、`persistence-adaptor-std` は存在しないことを確認した。前回「部分実装」として残っていた adapter manifest と serializer manifest の接続は、`PersistenceContext::to_journal_repr`、`PersistentRepr::adapter_type_id`、`MessageSerializer` の wire encoding で接続済みと判定する。
 
 ## 層別カバレッジ
 
 | 層 | Pekko 対応範囲 | fraktor-rs 現状 | 評価 |
 |----|----------------|-----------------|------|
-| core / classic write-side | `PersistentActor`, `Eventsourced`, `Recovery`, journal, snapshot, adapter, delivery, durable state store | `Eventsourced`, `PersistentActor`, `Journal`, `AtomicWrite`, `SnapshotStore`, `EventAdapters`, `AtLeastOnceDelivery`, `DurableStateStore` が存在 | 主要契約は中程度以上に対応。std serializer backend、設定型が不足 |
-| core / typed write-side | `EventSourcedBehavior`, `Effect`, signal, typed recovery / retention, `DurableStateBehavior` | `fraktor-persistence-core-typed-rs` が `PersistenceEffector`, `PersistenceEffectorConfig`, `PersistenceEffectorSignal`, `PersistenceMode`, `SnapshotCriteria`, `RetentionCriteria`, `BackoffConfig`, `PersistenceEffectorMessageAdapter`, `Recovery`, `SnapshotSelectionCriteria`, `EventAdapter`, `EventSeq`, `SnapshotAdapter`, `DurableStateSignal` を提供 | effector-first と Phase 1 typed parity surface は実装済み。Pekko 互換の behavior DSL と typed durable state behavior は未実装 |
+| core / kernel | `PersistentActor`, `Eventsourced`, `Recovery`, journal, snapshot, adapter, delivery, durable state store | `Eventsourced`, `PersistentActor`, `Journal`, `AtomicWrite`, `SnapshotStore`, `EventAdapters`, `AtLeastOnceDelivery`, `DurableStateStore` が存在 | classic write-side の主要契約は中程度以上に対応。std local snapshot store と plugin proxy runtime semantics が不足 |
+| core / typed | `EventSourcedBehavior`, `Effect`, signal, typed recovery / retention, `DurableStateBehavior` | `PersistenceEffector`, `PersistenceEffectorConfig`, `PersistenceEffectorSignal`, `PersistenceMode`, `SnapshotCriteria`, `RetentionCriteria`, `BackoffConfig`, typed `Recovery`, typed `EventAdapter`, `SnapshotAdapter`, `DurableStateSignal` を提供 | effector-first API は進んでいるが、Pekko 互換の behavior DSL と typed durable state behavior は未実装 |
 | std / adaptor | local snapshot store、runtime plugin adapter | 対応 crate なし。in-memory store は kernel に存在 | ファイル IO / runtime adapter は未対応 |
 
 ## カテゴリ別ギャップ
 
-ギャップ（未対応・部分実装・方針差あり）のみテーブルに列挙する。実装済みはカテゴリの件数カウントに含めるが、テーブル行には追加しない。
+ギャップ（未対応・部分実装・n/a）のみテーブルに列挙する。実装済みはカテゴリの件数カウントに含めるが、テーブル行には追加しない。
 
-### 1. Persistent actor / recovery / lifecycle　✅ 実装済み 11/15 (73%)
+### 1. Persistent actor / recovery / lifecycle ✅ 実装済み 11/15 (73%)
 
-fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventsourced` と `PersistentActor` に統合している。`persist` / `persist_async` / `persist_all` / `defer` / snapshot / delete / recovery callbacks は存在する。根拠は `modules/persistence-core-kernel/src/persistent/persistent_actor.rs:23`、`modules/persistence-core-kernel/src/persistent/eventsourced.rs:21`、`modules/persistence-core-kernel/src/persistent/eventsourced.rs:48`。
+fraktor-rs は Pekko の `PersistentActor` と複数 mix-in trait を、`Eventsourced` と `PersistentActor` に統合している。`persist` / `persist_async` / `persist_all` / `defer` / snapshot / delete / recovery callbacks は存在する。根拠は `modules/persistence-core-kernel/src/persistent/persistent_actor.rs:23`、`modules/persistence-core-kernel/src/persistent/eventsourced.rs:19`、`modules/persistence-core-kernel/src/persistent/eventsourced.rs:52`。
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| `RecoveryCompleted` signal type | `PersistentActor.scala:29`, `PersistentActor.scala:35` | 実装済み / non-goal | core | n/a | classic は `on_recovery_completed` callback と internal `JournalResponseAction::RecoveryCompleted` で表現済み。typed は `PersistenceEffectorSignal::RecoveryCompleted` を公開済み。Pekko 同名の classic 公開型追加は現設計では不要 |
-| `SnapshotOffer` | `SnapshotProtocol.scala:157` | 実装済み | core | done | `SnapshotOffer` と `receive_snapshot_offer` を追加し、既存 `receive_snapshot` callback と互換 |
-| `PersistenceSettings` | `Persistence.scala:40` | 実装済み | core/config | done | `PersistenceSettings` が `JournalActorConfig` / `SnapshotActorConfig` を束ね、store actor retry 設定を公開 |
-| `AtomicWrite` | `Persistent.scala:45`, `Persistent.scala:49` | 実装済み | core/journal | done | `AtomicWrite` が非空・単一 persistence id を検証し、`Journal` / `JournalMessage::WriteMessages` は atomic write 単位を受ける |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `RecoveryCompleted` classic public signal type | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala:29` | 実装済み / non-goal | core | n/a | classic は `on_recovery_completed` callback と internal `JournalResponseAction::RecoveryCompleted` で表現済み。typed は `PersistenceEffectorSignal::RecoveryCompleted` を公開済み |
+| HOCON `StashOverflowStrategyConfigurator` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/PersistentActor.scala:160` | 対象外 | core | n/a | JVM / HOCON configurator facade。Rust 側は `PersistentActor::stash_overflow_strategy` と `stash_capacity` で方針を直接返す |
 
-### 2. Journal / snapshot store protocol　✅ 実装済み 13/16 (81%)
+### 2. Journal / snapshot store protocol ✅ 実装済み 13/16 (81%)
 
-`Journal` は Pekko の `AsyncWriteJournal` と `AsyncRecovery` を統合した trait として存在し、`JournalActor` / `JournalMessage` / `JournalResponse` もある。`SnapshotStore`、`SnapshotActor`、`SnapshotMessage`、`SnapshotResponse`、`SnapshotMetadata`、`SnapshotSelectionCriteria` も実装済み。根拠は `modules/persistence-core-kernel/src/journal/base.rs:9`、`modules/persistence-core-kernel/src/journal/journal_message.rs:15`、`modules/persistence-core-kernel/src/snapshot/snapshot_store.rs:10`、`modules/persistence-core-kernel/src/snapshot/snapshot_message.rs:17`。
+`Journal` は Pekko の `AsyncWriteJournal` と `AsyncRecovery` を no_std GAT future で統合した trait として存在し、`JournalActor` / `JournalMessage` / `JournalResponse` もある。`SnapshotStore`、`SnapshotActor`、`SnapshotMessage`、`SnapshotResponse`、`SnapshotMetadata`、`SnapshotSelectionCriteria` も実装済み。根拠は `modules/persistence-core-kernel/src/journal/base.rs:12`、`modules/persistence-core-kernel/src/snapshot/snapshot_store.rs:10`。
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| `NoSnapshotStore` | `snapshot/NoSnapshotStore.scala:28` | 実装済み | core/snapshot | done | 何もしない `SnapshotStore` 実装 |
-| `LocalSnapshotStore` | `snapshot/local/LocalSnapshotStore.scala:40` | 未対応 | std/snapshot | medium | ファイルシステム依存。core ではなく std adapter が妥当 |
-| snapshot retry settings の公開契約 | `Persistence.scala:40`, `SnapshotProtocol.scala:235` | 実装済み | core/config | done | `SnapshotActorConfig` を `PersistenceSettings` から渡せる。plugin settings は fraktor-rs の trait 実装注入モデルでは non-goal |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `LocalSnapshotStore` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/local/LocalSnapshotStore.scala:40` | 未対応 | std/snapshot | medium | ファイルシステム依存。core ではなく将来の `persistence-adaptor-std` が妥当 |
+| `receivePluginInternal` for advanced journal / snapshot plugins | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/AsyncWriteJournal.scala:311`, `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/snapshot/local/LocalSnapshotStore.scala:100` | 部分実装 | core/plugin + std/runtime | medium | Rust 側の `Journal` / `SnapshotStore` trait は storage contract を持つが、plugin actor が追加内部メッセージを扱う拡張口はない |
 
-### 3. Persistent representation / adapters / serialization　✅ 実装済み 13/14 (93%)
+### 3. Persistent representation / adapters / serialization ✅ 実装済み 14/14 (100%)
 
-`PersistentRepr` は persistence id、sequence number、manifest、writer uuid、timestamp、deleted、sender、metadata を保持する。`WriteEventAdapter`、`ReadEventAdapter`、`IdentityEventAdapter`、`EventSeq`、`EventAdapters`、`Tagged` も存在する。根拠は `modules/persistence-core-kernel/src/persistent/persistent_repr.rs:20`、`modules/persistence-core-kernel/src/journal/write_event_adapter.rs:13`、`modules/persistence-core-kernel/src/journal/read_event_adapter.rs:14`、`modules/persistence-core-kernel/src/journal/event_adapters.rs:20`、`modules/persistence-core-kernel/src/journal/tagged.rs:16`。
+`PersistentRepr` は persistence id、sequence number、manifest、writer uuid、timestamp、deleted、sender、metadata、adapter resolution key を保持する。`WriteEventAdapter`、`ReadEventAdapter`、`IdentityEventAdapter`、`EventSeq`、`EventAdapters`、`Tagged` も存在する。`MessageSerializer` は `PersistentRepr` / `AtomicWrite` を actor serialization registry 経由で payload / metadata へ委譲し、manifest と adapter type binding を wire に保持する。根拠は `modules/persistence-core-kernel/src/persistent/persistent_repr.rs:20`、`modules/persistence-core-kernel/src/journal/event_adapters.rs:20`、`modules/persistence-core-kernel/src/serialization/message_serializer.rs:45`、`modules/persistence-core-kernel/src/serialization/message_serializer.rs:60`、`modules/persistence-core-kernel/src/serialization/message_serializer.rs:64`。
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `MessageSerializer` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/serialization/MessageSerializer.scala:43` | 実装済み | kernel/serialization | done | `PersistentRepr` / `AtomicWrite` を actor serialization registry 経由で payload / metadata へ委譲する。Pekko protobuf byte 互換は non-goal |
-| `SnapshotSerializer` | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/serialization/SnapshotSerializer.scala:56` | 実装済み | kernel/serialization | done | `SnapshotPayload` wrapper を追加し、snapshot data を actor serialization registry 経由で委譲する。local snapshot store は未対応 |
-| adapter manifest と serializer manifest の接続 | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/EventAdapter.scala:42` | 部分実装 | kernel/serialization | medium | `WriteEventAdapter::manifest` 相当は `modules/persistence-core-kernel/src/journal/write_event_adapter.rs:17` にあるが、永続化 serializer registry との接続点がない |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| Pekko protobuf byte compatibility | `references/pekko/persistence/src/main/protobuf/MessageFormats.proto` | 対象外 | core/serialization | n/a | fraktor-rs は actor serialization registry への委譲で同等契約を満たす。Pekko protobuf の byte-level 互換は non-goal |
 
-### 4. At-least-once delivery / unconfirmed delivery　✅ 実装済み 6/7 (86%)
+### 4. At-least-once delivery / unconfirmed delivery ✅ 実装済み 6/7 (86%)
 
-`AtLeastOnceDelivery`、`AtLeastOnceDeliveryConfig`、`AtLeastOnceDeliverySnapshot`、`UnconfirmedDelivery`、`UnconfirmedWarning`、`RedeliveryTick` は存在する。未確認配送の snapshot / restore、redelivery、confirm も実装済み。根拠は `modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:21`、`modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:72`、`modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:103`。
+`AtLeastOnceDelivery`、`AtLeastOnceDeliveryConfig`、`AtLeastOnceDeliverySnapshot`、`UnconfirmedDelivery`、`UnconfirmedWarning`、`RedeliveryTick` は存在する。未確認配送の snapshot / restore、redelivery、confirm も実装済み。根拠は `modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:21`、`modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:103`、`modules/persistence-core-kernel/src/delivery/at_least_once_delivery.rs:204`。
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| `MaxUnconfirmedMessagesExceededException` 相当 | `AtLeastOnceDelivery.scala:80`, `AtLeastOnceDelivery.scala:126` | 実装済み | core/delivery | done | `PersistenceError::MaxUnconfirmedMessagesExceeded` を返す |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| Java abstract wrapper | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/AtLeastOnceDelivery.scala:426` | 対象外 | core | n/a | Java interop 専用 |
 
-### 5. Durable State store contract　✅ 実装済み 6/8 (75%)
+### 5. Durable State store contract ✅ 実装済み 6/8 (75%)
 
-`DurableStateStore`、`DurableStateUpdateStore`、`DurableStateStoreProvider`、`DurableStateStoreRegistry`、`DurableStateError` は存在する。`DurableStateStore` は expected revision を受け取り、`DurableStateUpdateStore::changes` は tag と offset から `DurableStateChange` を返す。typed `DurableStateBehavior` との実行統合は別カテゴリの未達として残る。根拠は `modules/persistence-core-kernel/src/state/durable_state_store.rs:12`、`modules/persistence-core-kernel/src/state/durable_state_update_store.rs:6`、`modules/persistence-core-kernel/src/state/durable_state_change.rs:7`、`modules/persistence-core-kernel/src/state/durable_state_store_registry.rs:18`。
+`DurableStateStore`、`DurableStateUpdateStore`、`DurableStateStoreProvider`、`DurableStateStoreRegistry`、`DurableStateError` は存在する。`DurableStateStore` は expected revision を受け取り、`DurableStateUpdateStore::changes` は tag と offset から `DurableStateChange` を返す。typed `DurableStateBehavior` との実行統合は別カテゴリの未達として残る。根拠は `modules/persistence-core-kernel/src/state/durable_state_store.rs:12`、`modules/persistence-core-kernel/src/state/durable_state_update_store.rs:6`、`modules/persistence-core-kernel/src/state/durable_state_change.rs:11`。
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| `GetObjectResult[A]` | `state/scaladsl/DurableStateStore.scala:31`, `state/scaladsl/DurableStateStore.scala:35` | 実装済み | core/durable_state | done | `GetObjectResult<A>` が value と revision を保持し、`DurableStateStore::get_object` が返す |
-| revision / tag aware update store | `state/scaladsl/DurableStateUpdateStore.scala:37`, `state/scaladsl/DurableStateUpdateStore.scala:63` | 実装済み | core/durable_state | done | `upsert_object` / `delete_object` が expected revision を受け取り、tagged upsert は offset、persistence id、revision、tag、value を持つ `DurableStateChange` として取得できる |
-| `DeleteRevisionException` | `state/exception/DurableStateException.scala:41` | 実装済み | core/durable_state | done | `DurableStateError::DeleteRevision` を追加 |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| HOCON provider loading | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/state/DurableStateStoreProvider.scala:24` | 対象外 | std/runtime | n/a | Rust 側は provider / store trait を直接登録するモデル。HOCON loading は JVM 固有 |
 
-### 6. Plugin / extension / in-memory stores　✅ 実装済み 5/7 (71%)
+### 6. Plugin / extension / in-memory stores ✅ 実装済み 5/7 (71%)
 
 `PersistenceExtension`、`PersistenceExtensionId`、`PersistenceExtensionInstaller`、`PersistencePluginProxy`、`InMemoryJournal`、`InMemorySnapshotStore` は存在する。HOCON loading と runtime plugin id selection は対象外であり、Rust 側は `Journal` / `SnapshotStore` trait 実装を注入するモデルを採用する。
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| `RuntimePluginConfig` | `Persistence.scala:127` | non-goal | core/config | n/a | Pekko には存在するが、fraktor-rs は plugin 形式ではなく `Journal` / `SnapshotStore` trait 実装注入に留めるため不要 |
-| plugin target location / proxy extension semantics | `journal/PersistencePluginProxy.scala:38`, `journal/PersistencePluginProxy.scala:85` | 部分実装 | core/plugin + std/runtime | medium | `PersistencePluginProxy<J, S>` は forwarding object だが、Pekko の target location / extension actor semantics まではない |
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| plugin target location / proxy extension semantics | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/PersistencePluginProxy.scala:38`, `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/journal/PersistencePluginProxy.scala:85` | 部分実装 | core/plugin + std/runtime | medium | `PersistencePluginProxy<J, S>` は forwarding object だが、Pekko の target location / extension actor semantics まではない |
+| `RuntimePluginConfig` / config based plugin selection | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/Persistence.scala:40` | 対象外 | core/config | n/a | trait 実装注入モデルでは HOCON plugin selection を再現しない |
 
-### 7. Persistent FSM compatibility　✅ 実装済み 1/1 (100%)
+### 7. Persistent FSM compatibility ✅ 実装済み 1/1 (100%)
 
 Pekko の `PersistentFSM` family は deprecated だが、固定スコープでは compatibility marker として確認した。fraktor-rs には最小契約の `PersistentFsm` trait が存在し、state transition event の persist / apply を `PersistentActor` 上で表現できる。根拠は `modules/persistence-core-kernel/src/fsm/persistent_fsm.rs:17`。
 
-完全な FSM DSL、`FSMState`、`StateChangeEvent`、migration helper は Pekko 側でも legacy API であり、今回の parity 分母には含めない。
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| full FSM DSL / migration helper | `references/pekko/persistence/src/main/scala/org/apache/pekko/persistence/fsm/PersistentFSM.scala` | 対象外 | core | n/a | Pekko 側でも legacy / deprecated。fraktor-rs は最小 `PersistentFsm` 契約を持つ |
 
-### 8. Typed write-side effector / EventSourcedBehavior / signal　✅ 実装済みまたは代替 5/9 (56%)
+### 8. Typed write-side effector / EventSourcedBehavior / signal ✅ 実装済みまたは代替 5/9 (56%)
 
-Pekko persistence の現行推奨 write-side API は typed `EventSourcedBehavior` と `Effect` 体系である。一方、fraktor-rs では本カテゴリを `EventSourcedBehavior` の 1:1 直移植ではなく、`pekko-persistence-effector` 由来の effector-first API として実装している。ユーザー actor は通常の typed `Behavior` のまま、内部 store actor が `PersistentActor` / `PersistenceContext` を使って recovery / persist / snapshot / retention を実行する。
+Pekko persistence の現行推奨 write-side API は typed `EventSourcedBehavior` と `Effect` 体系である。一方、fraktor-rs は専用 DSL ではなく、`PersistenceEffector` で通常の typed `Behavior` に永続化 side effect を注入する。`PersistenceId`、effector 経由の persist/snapshot 操作、`RetentionCriteria`、typed recovery selection、typed event/snapshot adapter contract は実装済みまたは明確な代替とみなせる。Pekko 互換 DSL としての `EventSourcedBehavior` / `EffectBuilder`、published event、behavior-level persist failure supervision は未達である。
 
-実装済みまたは明確な代替とみなせるのは、`PersistenceId`、effector 経由の persist/snapshot 操作、`RetentionCriteria`、typed recovery selection、typed event/snapshot adapter contract である。Pekko 互換 DSL としての `EventSourcedBehavior` / `EffectBuilder`、published event、behavior-level persist failure supervision は未達である。根拠は `modules/persistence-core-typed/src/persistence_id.rs:7`、`modules/persistence-core-typed/src/persistence_effector.rs:31`、`modules/persistence-core-typed/src/persistence_effector.rs:205`、`modules/persistence-core-typed/src/retention_criteria.rs:5`、`modules/persistence-core-typed/src/recovery.rs`、`modules/persistence-core-typed/src/event_adapter.rs`、`modules/persistence-core-typed/src/snapshot_adapter.rs`。
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `EventSourcedBehavior[C,E,S]` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala:36`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala:138` | 方針差あり | core/typed | hard | 専用 DSL は導入せず、`modules/persistence-core-typed/src/persistence_effector.rs:52` の `PersistenceEffector::props(config, on_ready)` で通常 `Behavior` と統合 |
+| `Effect` / `EffectBuilder` / `ReplyEffect` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/Effect.scala:132`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/Effect.scala:144`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/Effect.scala:196` | effector API で一部代替 | core/typed | hard | `persist_event` / `persist_events` / `persist_snapshot` はあるが、reply/stash/unhandled/stop の effect model はない |
+| `EventSourcedSignal` family | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventSourcedSignal.scala:27`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventSourcedSignal.scala:58`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventSourcedSignal.scala:131` | 部分実装 | core/typed | medium | `modules/persistence-core-typed/src/persistence_effector_signal.rs:11` は recovery / persisted / snapshot / delete / failure を private message 経由で表すが、Pekko の公開 signal family と一致しない |
+| `PublishedEvent` / `EventRejectedException` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/PublishedEvent.scala:28`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventRejectedException.scala:19` | 未対応 | core/typed | medium | event publication と rejection signal / error の公開契約がない |
+| behavior-level `onPersistFailure` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala:230` | 部分実装 | core/typed | medium | `BackoffConfig` と hidden store actor の `BackoffSupervisor` wiring はあるが、Pekko の behavior-level supervision hook としては未統合 |
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `EventSourcedBehavior[C,E,S]` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala:36`, `EventSourcedBehavior.scala:138` | 方針差あり | typed | hard | 専用 DSL は導入せず、`modules/persistence-core-typed/src/persistence_effector.rs:53` の `PersistenceEffector::props(config, on_ready)` で通常 `Behavior` と統合 |
-| `Effect` / `EffectBuilder` / `ReplyEffect` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/Effect.scala:132`, `Effect.scala:144`, `Effect.scala:196` | effector API で一部代替 | typed | hard | `modules/persistence-core-typed/src/persistence_effector.rs:205`、`persistence_effector.rs:233`、`persistence_effector.rs:258`、`persistence_effector.rs:287`、`persistence_effector.rs:327` で persist / snapshot callback を表現するが、reply/stash/unhandled/stop の effect model はない |
-| `EventSourcedSignal` family | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventSourcedSignal.scala:27`, `EventSourcedSignal.scala:30`, `EventSourcedSignal.scala:139` | 部分実装 | typed | medium | `modules/persistence-core-typed/src/persistence_effector_signal.rs:11` が recovery / persisted / snapshot / delete / failure を actor-private message に包むが、Pekko の公開 signal family と一致しない |
-| typed `Recovery` / typed `SnapshotSelectionCriteria` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/Recovery.scala:24`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/SnapshotSelectionCriteria.scala:21` | 実装済み | typed | done | `modules/persistence-core-typed/src/recovery.rs` と `modules/persistence-core-typed/src/snapshot_selection_criteria.rs` が crate root から re-export され、`PersistenceStoreActor::recovery()` で kernel `persistent::Recovery` へ変換される |
-| typed `EventAdapter` / `EventSeq` / `SnapshotAdapter` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventAdapter.scala:35`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/SnapshotAdapter.scala:23` | 実装済み / snapshot runtime integration は non-goal | typed | done | `modules/persistence-core-typed/src/event_adapter.rs`、`event_seq.rs`、`snapshot_adapter.rs` を追加。event adapter は `PersistenceEffectorConfig::with_event_adapter` から kernel adapter registry へ接続し、snapshot adapter は public conversion contract に留める |
-| `PublishedEvent` / `EventRejectedException` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/PublishedEvent.scala:28`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/EventRejectedException.scala:19` | 未対応 | typed | medium | event publication と rejection signal / error の公開契約がない |
-| behavior-level `onPersistFailure` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/scaladsl/EventSourcedBehavior.scala:230` | 部分実装 | typed | medium | `modules/persistence-core-typed/src/backoff_config.rs:7`、`PersistenceEffectorConfig::with_backoff_config`、hidden store actor の `BackoffSupervisor` wiring はあるが、Pekko の behavior-level supervision hook としては未統合 |
+### 9. Typed DurableStateBehavior ✅ 実装済み 1/3 (33%)
 
-### 9. Typed DurableStateBehavior　✅ 実装済み 1/3 (33%)
+Durable state store contract は kernel に存在するが、Pekko typed の write-side behavior API は未実装である。`DurableStateSignal` は先行して公開されている。根拠は `modules/persistence-core-typed/src/durable_state_signal.rs:13`。
 
-Durable state store contract は kernel に存在するが、Pekko typed の write-side behavior API は未実装である。
+| Pekko API | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
+|-----------|-----------|-------------|----------|--------|------|
+| `DurableStateBehavior[C,S]` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehavior.scala:36`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehavior.scala:127` | 未対応 | core/typed | hard | typed `Behavior` と durable state store の統合が必要。`withTag` / `onPersistFailure` / `snapshotAdapter` も含む |
+| durable state `Effect` / `EffectBuilder` / `ReplyEffect` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/Effect.scala:124`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/Effect.scala:136`, `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/Effect.scala:188` | 未対応 | core/typed | hard | persist / delete / none / unhandled / stop / stash / reply の effect model が必要 |
 
-| Pekko API / 契約 | Pekko参照 | fraktor対応 | 実装先層 | 難易度 | 備考 |
-|------------------|-----------|-------------|----------|--------|------|
-| `DurableStateBehavior[C,S]` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/DurableStateBehavior.scala:36`, `DurableStateBehavior.scala:127` | 未対応 | typed | hard | typed `Behavior` と durable state store の統合が必要。`withTag` / `onPersistFailure` も含む |
-| durable state `Effect` / `EffectBuilder` / `ReplyEffect` | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/scaladsl/Effect.scala:124`, `Effect.scala:136`, `Effect.scala:188` | 未対応 | typed | hard | persist / delete / none / unhandled / stop / stash / reply の effect model が必要 |
-| `DurableStateSignal` family | `references/pekko/persistence-typed/src/main/scala/org/apache/pekko/persistence/typed/state/DurableStateSignal.scala:26`, `DurableStateSignal.scala:29`, `DurableStateSignal.scala:33` | 実装済み | typed | done | `modules/persistence-core-typed/src/durable_state_signal.rs` が recovery completed / failed、state persisted / deleted、persistence failed を公開し、behavior implementation は non-goal |
+## 内部モジュール構造ギャップ
 
-## 対象外 (n/a / 固定スコープ外)
+今回は API ギャップが支配的なため省略する。固定スコープ概念カバレッジは 63/80 (79%) で 80% に届かず、hard / medium の未実装ギャップも 10 件ある。特に typed `EventSourcedBehavior` direct DSL、typed `DurableStateBehavior`、std local snapshot store、plugin runtime extension semantics が未達である。責務分割の細部比較より先に、behavior DSL と std adapter contract の境界を決める段階である。
 
-| Pekko API / 領域 | 判定理由 |
-|------------------|----------|
-| `persistence-query` | write-side runtime とは別スコープ |
-| Java DSL wrapper / `javadsl/*` | Rust API として再現不要 |
-| Scala syntax sugar / implicit ops | Rust API として再現不要 |
-| HOCON dynamic loading / JVM reflection / classloader | JVM 固有 |
-| `persistence-testkit`, `persistence-tck`, typed tests | runtime API ではない |
-| JDBC / Cassandra / LevelDB plugin 完全互換 | storage backend 実装技術ごとの互換は別スコープ |
-| full `PersistentFSM` DSL / migration helper | Pekko 側で legacy / deprecated。fraktor-rs は最小 `PersistentFsm` 契約を持つ |
-| replicated event sourcing / CRDT / typed reliable delivery queue | 現 persistence 固定スコープ外。必要なら別スコープとして調査 |
+次版で構造分析へ進む場合の観点は以下になる。
 
-## スタブ / placeholder
-
-`modules/persistence-core-kernel/src` と `modules/persistence-core-typed/src` に対して `todo!()`、`unimplemented!()`、`panic!("not implemented")`、`TODO`、`FIXME`、`placeholder`、`stub` を検索した範囲では、公開 API 直下の未完成スタブは見つからなかった。
-
-`PersistentActor::defer` / `defer_async` は recovery 中に panic するが、これは Pekko 互換の不正利用検出であり、未実装スタブではない。
+| 構造観点 | 現状 | 次に見るべき点 |
+|----------|------|----------------|
+| classic と typed の境界 | `persistence-core-kernel` が classic runtime、`persistence-core-typed` が effector-first typed API を担当 | typed `DurableStateBehavior` を同じ typed crate に追加するか、別 change に分けるか |
+| journal / serializer の境界 | `Journal` は `AtomicWrite` を受け、persistence serializers は actor-core serialization registry に contributor として登録される | std local snapshot store がこの contract をどう呼び出すか |
+| durable state revision model | store trait は expected revision と optional tag を受け、tagged update metadata を返す | typed DurableStateBehavior がこの contract をどう実行するか |
+| plugin adapter 境界 | core extension は generic journal / snapshot を直接受ける | std runtime で plugin target location / local snapshot store をどう表すか |
+| typed effector と Pekko typed DSL の境界 | `PersistenceEffector` は通常 `Behavior` に統合されるが、Pekko の `EffectBuilder` / signal / adapter をそのまま露出しない | parity 目標を effector-first で固定するか、Pekko direct DSL を追加するか |
 
 ## 実装優先度
 
+ここで出す優先度は「今の要求で実装すべきか」ではなく、「Pekko parity ギャップをどの順で埋めるか」を示す。YAGNI は適用しない。以下は直前のカテゴリ別ギャップに列挙済みの項目だけを再配置する。
+
 ### Phase 1: trivial / easy
 
-| 項目 | 実装先層 | 根拠 | 状態 |
-|------|----------|------|------|
-| `SnapshotOffer` | core | カテゴリ1 | 実装済み |
-| `PersistenceSettings` | core/config | カテゴリ1 | 実装済み |
-| `NoSnapshotStore` | core/snapshot | カテゴリ2 | 実装済み |
-| snapshot retry settings の公開契約 | core/config | カテゴリ2 | 実装済み |
-| `MaxUnconfirmedMessagesExceededException` 相当 | core/delivery | カテゴリ4 | 実装済み |
-| `GetObjectResult[A]` | core/durable_state | カテゴリ5 | 実装済み |
-| `DeleteRevisionException` | core/durable_state | カテゴリ5 | 実装済み |
-| typed `Recovery` / typed `SnapshotSelectionCriteria` | core/typed | カテゴリ8 | 実装済み |
-| typed `EventAdapter` / `EventSeq` / `SnapshotAdapter` | core/typed | カテゴリ8 | 実装済み |
-| `DurableStateSignal` family | core/typed | カテゴリ9 | 実装済み |
+現時点で未実装の trivial / easy gap はない。
 
 ### Phase 2: medium
 
 | 項目 | 実装先層 | 根拠 |
 |------|----------|------|
 | `LocalSnapshotStore` | std/snapshot | カテゴリ2 |
-| adapter manifest と serializer manifest の接続 | core/serialization | カテゴリ3 |
+| `receivePluginInternal` for advanced journal / snapshot plugins | core/plugin + std/runtime | カテゴリ2 |
 | plugin target location / proxy extension semantics | core/plugin + std/runtime | カテゴリ6 |
 | `EventSourcedSignal` family | core/typed | カテゴリ8 |
 | `PublishedEvent` / `EventRejectedException` | core/typed | カテゴリ8 |
+| behavior-level `onPersistFailure` | core/typed | カテゴリ8 |
 
 ### Phase 3: hard
 
@@ -215,24 +190,23 @@ Durable state store contract は kernel に存在するが、Pekko typed の wri
 | `DurableStateBehavior[C,S]` | core/typed | カテゴリ9 |
 | durable state `Effect` / `EffectBuilder` / `ReplyEffect` | core/typed | カテゴリ9 |
 
-## 内部モジュール構造ギャップ
+### 対象外 (n/a)
 
-今回は API ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 62/80 (78%) で、特に typed `EventSourcedBehavior` direct DSL、typed `DurableStateBehavior`、std durable serializer backend が未達である。責務分割の細部比較より先に、behavior DSL と storage backend contract の境界を決める段階である。
-
-次版で構造分析へ進む場合の観点は以下になる。
-
-| 構造観点 | 現状 | 次に見るべき点 |
-|----------|------|----------------|
-| classic と typed の境界 | `persistence-core-kernel` が classic runtime、`persistence-core-typed` が effector-first typed API を担当 | typed `DurableStateBehavior` を同じ typed crate に追加するか別 change に分けるか |
-| journal / serializer の境界 | `Journal` は `AtomicWrite` を受け、persistence serializers は actor-core serialization registry に contributor として登録される | std durable journal / local snapshot store がこの contract をどう呼び出すか |
-| durable state revision model | store trait は expected revision と optional tag を受け、tagged update metadata を返す | typed DurableStateBehavior がこの contract をどう実行するか |
-| plugin adapter 境界 | core extension は generic journal / snapshot を直接受ける | std runtime で plugin selection / local snapshot store をどう表すか |
-| typed effector と Pekko typed DSL の境界 | `PersistenceEffector` は通常 `Behavior` に統合されるが、Pekko の `EffectBuilder` / signal / adapter をそのまま露出しない | parity 目標を effector-first で固定するか、Pekko direct DSL を追加するか |
+| 項目 | 理由 |
+|------|------|
+| `persistence-query` | write-side runtime とは別スコープ |
+| Java DSL wrapper / `javadsl/*` | Rust API として再現不要 |
+| Scala syntax sugar / implicit ops | Rust API として再現不要 |
+| HOCON dynamic loading / JVM reflection / classloader | JVM 固有 |
+| `persistence-testkit`, `persistence-tck`, typed tests | runtime API ではない |
+| JDBC / Cassandra / LevelDB plugin 完全互換 | storage backend 実装技術ごとの互換は別スコープ |
+| full `PersistentFSM` DSL / migration helper | Pekko 側で legacy / deprecated。fraktor-rs は最小 `PersistentFsm` 契約を持つ |
+| replicated event sourcing / CRDT / typed reliable delivery queue | 現 persistence 固定スコープ外。必要なら別スコープとして調査 |
 
 ## まとめ
 
-persistence は classic write-side の基礎部品はかなり揃っている。`PersistentActor`、journal、snapshot、event adapter、at-least-once delivery、durable state store registry、in-memory store は存在し、panic 系スタブも見つからない。
+persistence は classic write-side の基礎部品がかなり揃っている。`PersistentActor`、journal、snapshot、event adapter、serializer、at-least-once delivery、durable state store registry、in-memory store は存在し、panic 系スタブも見つからない。今回の再検証で adapter manifest と serializer manifest の接続は実装済みに更新した。
 
-Phase 1 の kernel 側低コスト項目は `SnapshotOffer`、`PersistenceSettings`、`NoSnapshotStore`、snapshot retry settings、`MaxUnconfirmedMessagesExceededException` 相当、`GetObjectResult[A]`、`DeleteRevisionException` まで実装済みである。`RecoveryCompleted` の classic 同名公開型と `RuntimePluginConfig` / plugin settings は現設計では non-goal とした。
+parity を低コストで前進させる未実装機能は、`LocalSnapshotStore`、plugin target location / proxy extension semantics、typed `EventSourcedSignal` family、`PublishedEvent` / `EventRejectedException`、behavior-level `onPersistFailure` である。いずれも Phase 2 に置けるが、std adapter crate がないため `LocalSnapshotStore` は crate 境界設計も同時に必要になる。
 
-主要ギャップは、std durable journal / local snapshot store、typed `EventSourcedBehavior` / `EffectBuilder`、typed `DurableStateBehavior` である。typed write-side は effector-first API として前進し、Phase 1 typed parity surface は閉じたが、Pekko parity の観点では behavior-level failure supervision と durable state behavior execution がまだ閉じていない。内部構造比較は、typed durable state behavior の実行契約を決めた後に進めるのが妥当である。
+parity 上の主要ギャップは、typed `EventSourcedBehavior` / `EffectBuilder` と typed `DurableStateBehavior` / durable state `EffectBuilder` である。typed write-side は effector-first API として前進しているが、Pekko parity の観点では behavior-level DSL と durable state behavior execution がまだ閉じていない。API ギャップが支配的なため、内部構造比較は後続フェーズで扱うのが妥当である。

--- a/openspec/changes/stabilize-grain-runtime-operational-contract/.openspec.yaml
+++ b/openspec/changes/stabilize-grain-runtime-operational-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/stabilize-grain-runtime-operational-contract/design.md
+++ b/openspec/changes/stabilize-grain-runtime-operational-contract/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`cluster-*` は Virtual Actor / Grain runtime を主軸にする。現在の実装は `PartitionIdentityLookup`、`PlacementCoordinatorCore`、`VirtualActorRegistry`、`PidCache` により、Grain key から authority と PID を決定し、topology update、member departure、passivation に応じて activation / cache を無効化できる。
+
+一方で、これらは個別 unit test として存在しており、運用時に守る contract としてはまだまとまっていない。次の実装では、新しい大規模機能を追加する前に、identity resolution、placement cache、topology update、rolling update 時の期待値を contract test と仕様で固定する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Grain identity resolution の normal / pending / no authority / cache hit を仕様化し、contract test で固定する。
+- topology update と member departure が absent authority の activation / PID cache を無効化することを仕様化する。
+- passivation 後の再解決と cache invalidation event の観測点を固定する。
+- rolling update を join -> topology update -> leave/down -> invalidation -> re-resolution の contract として説明できる状態にする。
+- `no_std` core の `identity` / `placement` / `grain` を中心に閉じ、std adaptor は必要な観測境界だけを扱う。
+
+**Non-Goals:**
+
+- Split Brain Resolver の本実装。
+- reachability matrix の導入。
+- shard rebalance strategy の導入。
+- remembered entities と persistence integration。
+- Pekko typed Cluster API、Cluster Singleton、ShardCoordinator、DistributedData parity。
+- provider-specific discovery backend の拡張。
+
+## Decisions
+
+### Decision 1: Operational contract を core-first で固定する
+
+`PartitionIdentityLookup` と `PlacementCoordinatorCore` の contract test を優先する。これにより、std adaptor や provider ごとの差異に引きずられず、Grain runtime の中核 contract を `no_std` core で検証できる。
+
+Alternative: `cluster-adaptor-std` の end-to-end test から始める。これは実運用に近いが、transport、executor、provider lifecycle の失敗と placement contract の失敗が混ざるため、最初の change としては範囲が広すぎる。
+
+### Decision 2: topology change は cache invalidation contract として扱う
+
+authority set が変わった場合、absent authority の activation / PID cache は再利用してはならない。Rendezvous hashing の movement 最適化や rebalance はこの change では扱わず、「消えた authority を指す解決結果を返さない」ことを先に固定する。
+
+Alternative: rebalance semantics まで同時に設計する。これは大規模運用には重要だが、movement 量、drain、remembered entities の判断が必要になり、直近の contract 固定から逸れる。
+
+### Decision 3: rolling update は minimum guarantee だけ定義する
+
+rolling update 時の保証は、departed authority の stale PID を再利用しないこと、新しい topology に基づいて再解決すること、passivated activation を cache hit として返さないことに限定する。in-flight request の完全 drain、remembered activation 復元、zero-movement rebalance は明示的に非対象とする。
+
+Alternative: rolling update 全体の orchestration を provider lifecycle として定義する。これは後続 change で扱うべきであり、今回の scope では provider-specific な差異が大きい。
+
+### Decision 4: failure detector / downing は入力境界として残す
+
+この change では、failure detector や `DowningProvider` が最終的に topology update / member departure を発生させる前提だけを置く。downing decision model 自体は次の change に分ける。
+
+Alternative: SBR の最小 decision model を同時に導入する。これは `Reachability` 表現の選択に依存するため、Grain runtime contract 固定後に切る方がよい。
+
+## Risks / Trade-offs
+
+- [Risk] core contract だけでは provider lifecycle の抜けが残る -> Mitigation: std adaptor の task は smoke / boundary test に限定し、provider lifecycle hardening は別 change に分ける。
+- [Risk] 既存 test と重複する -> Mitigation: 既存 unit test は部品検証として残し、新規 contract test は join / leave / down / rolling update のシナリオ名で意図を固定する。
+- [Risk] topology update の semantics が rebalance 期待と混同される -> Mitigation: spec で rebalance / remembered entities を非対象として明記する。
+- [Risk] pending resolution の非同期 activation flow が曖昧になる -> Mitigation: distributed activation enabled 時の `Pending` と command result 後の resolution を同じ requirement に含める。

--- a/openspec/changes/stabilize-grain-runtime-operational-contract/proposal.md
+++ b/openspec/changes/stabilize-grain-runtime-operational-contract/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`cluster-*` の主軸を Proto.Actor-Go 型 Virtual Actor / Grain runtime として再定義したため、直近の実装は Pekko parity ではなく Grain runtime の運用 contract を固定する必要がある。identity lookup、topology update、placement cache、join / leave / down の期待値が曖昧なまま failure detector、downing、rebalance に進むと、何を守るための機能なのかが不明確になる。
+
+## What Changes
+
+- Grain identity resolution の成功 / pending / no authority / cache hit の contract を仕様化する。
+- topology update と member departure によって absent authority の activation / PID cache が無効化されることを仕様化する。
+- join / leave / down / passivation と placement resolution の関係を contract test で固定する。
+- rolling update 時に保証することと、rebalance / remembered entities へ先送りすることを明示する。
+- Provider lifecycle、failure detector、downing は今回の contract の観測対象に留め、SBR や reachability matrix の本実装は含めない。
+
+## Capabilities
+
+### New Capabilities
+
+- `cluster-grain-runtime-operational-contract`: Grain runtime の identity lookup、placement cache、topology update、member departure、passivation、rolling update 時の運用 contract を定義する。
+
+### Modified Capabilities
+
+- なし
+
+## Impact
+
+- `modules/cluster-core/src/identity/`
+- `modules/cluster-core/src/placement/`
+- `modules/cluster-core/src/grain/`
+- `modules/cluster-core/src/membership/`
+- `modules/cluster-core/tests/`
+- `modules/cluster-adaptor-std/tests/`
+- `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md`

--- a/openspec/changes/stabilize-grain-runtime-operational-contract/specs/cluster-grain-runtime-operational-contract/spec.md
+++ b/openspec/changes/stabilize-grain-runtime-operational-contract/specs/cluster-grain-runtime-operational-contract/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Grain identity resolution is deterministic and state-aware
+
+Grain identity lookup SHALL resolve a `GrainKey` from the current authority topology and SHALL report unresolved states explicitly. It MUST NOT return a stale PID when the lookup is stopped, has no authorities, or is waiting for asynchronous activation.
+
+#### Scenario: no authority is reported explicitly
+
+- **WHEN** member-mode identity lookup resolves a `GrainKey` before any authority is present
+- **THEN** resolution fails with `LookupError::NoAuthority`
+- **AND** no PID is cached for that `GrainKey`
+
+#### Scenario: same key and topology resolve deterministically
+
+- **GIVEN** two identity lookup instances have the same authority topology
+- **WHEN** both instances resolve the same `GrainKey`
+- **THEN** both select the same authority
+- **AND** both produce a placement decision for that authority
+
+#### Scenario: cache hit reuses the active PID
+
+- **GIVEN** a `GrainKey` has been resolved and its activation is still valid
+- **WHEN** the same `GrainKey` is resolved again before PID TTL or passivation invalidates it
+- **THEN** lookup returns the same PID
+- **AND** the returned PID belongs to the same authority decision
+
+#### Scenario: distributed activation exposes pending resolution
+
+- **GIVEN** distributed activation is enabled for a local authority
+- **WHEN** lookup starts resolving a `GrainKey` that requires lock, load, ensure, and store commands
+- **THEN** lookup reports `LookupError::Pending` until the command results complete
+- **AND** lookup returns a PID only after activation is stored and the lock is released
+
+### Requirement: Topology changes invalidate absent authorities
+
+Cluster topology updates SHALL invalidate activation and PID cache entries that belong to authorities no longer present in the active authority set. Lookup MUST NOT return a PID for an authority that is absent from the latest topology.
+
+#### Scenario: topology replacement removes stale authority cache
+
+- **GIVEN** a `GrainKey` resolved to an authority in the previous topology
+- **WHEN** topology is replaced with a set that does not include that authority
+- **THEN** activation and PID cache entries for the absent authority are invalidated
+- **AND** the next resolution uses only authorities from the new topology
+
+#### Scenario: member departure invalidates matching authority
+
+- **GIVEN** a `GrainKey` has an activation owned by an authority
+- **WHEN** the identity lookup observes that authority leaving or being downed
+- **THEN** activation and PID cache entries for that authority are invalidated
+- **AND** a later resolution MUST NOT return the previous PID
+
+#### Scenario: unknown member departure is a no-op
+
+- **GIVEN** activation and PID cache entries belong to active authorities
+- **WHEN** identity lookup observes departure for an unknown authority
+- **THEN** existing activation and PID cache entries remain available
+- **AND** subsequent lookup for the same `GrainKey` may still return the active cached PID
+
+### Requirement: Passivation removes reusable activation state
+
+Passivation SHALL remove idle activation state and its PID cache entry. A passivated `GrainKey` MUST be resolved as a new placement decision instead of a cache hit.
+
+#### Scenario: idle activation is passivated
+
+- **GIVEN** a `GrainKey` has an activation whose last access is older than the idle TTL
+- **WHEN** passivation is evaluated at the current time
+- **THEN** the activation is removed
+- **AND** the PID cache entry for that `GrainKey` is invalidated
+- **AND** a passivation event is observable
+
+#### Scenario: recent activation is retained
+
+- **GIVEN** a `GrainKey` has an activation whose last access is within the idle TTL
+- **WHEN** passivation is evaluated at the current time
+- **THEN** the activation remains reusable
+- **AND** lookup may return the active cached PID
+
+### Requirement: Rolling update contract is bounded to stale placement prevention
+
+During rolling update, Grain runtime SHALL prevent stale placement reuse for departed authorities and SHALL resolve against the latest topology. It MUST NOT promise shard rebalance, remembered entity recovery, or in-flight request draining as part of this contract.
+
+#### Scenario: replacement node becomes the only resolution candidate
+
+- **GIVEN** an old authority owns a `GrainKey`
+- **AND** a replacement authority joins the topology
+- **WHEN** the old authority leaves or is downed and topology is updated
+- **THEN** stale activation and PID cache entries for the old authority are invalidated
+- **AND** the next resolution selects from the replacement topology
+
+#### Scenario: rolling update does not imply rebalance guarantee
+
+- **WHEN** topology changes during rolling update
+- **THEN** Grain runtime guarantees stale authority invalidation and re-resolution
+- **AND** Grain runtime does not guarantee minimum movement, remembered activation recovery, or automatic shard draining in this capability
+
+### Requirement: Provider and downing integration remains an input boundary
+
+Cluster providers, failure detectors, and downing strategies SHALL feed topology update or member departure signals into the Grain runtime contract. This capability MUST NOT require a specific discovery backend, Split Brain Resolver, or reachability matrix implementation.
+
+#### Scenario: provider supplies topology update
+
+- **WHEN** a provider publishes or applies a topology update to identity lookup
+- **THEN** Grain runtime applies the topology invalidation contract
+- **AND** provider-specific discovery details remain outside this capability
+
+#### Scenario: downing supplies member departure
+
+- **WHEN** failure detection or downing decides that an authority has departed
+- **THEN** Grain runtime handles it as member departure input
+- **AND** downing decision rules remain outside this capability

--- a/openspec/changes/stabilize-grain-runtime-operational-contract/tasks.md
+++ b/openspec/changes/stabilize-grain-runtime-operational-contract/tasks.md
@@ -1,0 +1,37 @@
+## 1. Contract Test Baseline
+
+- [ ] 1.1 Review existing `PartitionIdentityLookup`, `PlacementCoordinatorCore`, `VirtualActorRegistry`, and `PidCache` tests against the new spec scenarios.
+- [ ] 1.2 Add a focused contract test module for Grain runtime operational behavior instead of scattering new scenarios across unrelated unit tests.
+- [ ] 1.3 Ensure contract tests use public or crate-level cluster APIs that match intended caller boundaries.
+
+## 2. Identity Resolution Contract
+
+- [ ] 2.1 Add tests for no-authority resolution returning `LookupError::NoAuthority` without caching a PID.
+- [ ] 2.2 Add tests proving deterministic authority selection for identical topology and `GrainKey`.
+- [ ] 2.3 Add tests proving repeated lookup returns the same active cached PID before TTL or passivation invalidates it.
+- [ ] 2.4 Add tests for distributed activation pending flow and completion after command results.
+
+## 3. Topology And Member Departure Contract
+
+- [ ] 3.1 Add tests proving topology replacement invalidates activation and PID cache entries for absent authorities.
+- [ ] 3.2 Add tests proving `on_member_left` invalidates entries for the departed authority.
+- [ ] 3.3 Add tests proving unknown member departure does not invalidate unrelated active entries.
+- [ ] 3.4 Add assertions for emitted placement or PID cache events where the contract requires observability.
+
+## 4. Passivation Contract
+
+- [ ] 4.1 Add tests proving idle activation passivation removes activation state and PID cache entries.
+- [ ] 4.2 Add tests proving recent activation remains reusable when idle TTL has not elapsed.
+- [ ] 4.3 Add tests proving passivated keys resolve through a new placement decision rather than stale cache hit.
+
+## 5. Rolling Update Boundary
+
+- [ ] 5.1 Add a scenario test for old authority removal and replacement authority re-resolution.
+- [ ] 5.2 Document in test names or comments that rolling update guarantees stale authority invalidation, not rebalance or remembered entity recovery.
+- [ ] 5.3 Avoid adding rebalance, remembered entity, SBR, or reachability matrix implementation in this change.
+
+## 6. Verification
+
+- [ ] 6.1 Run targeted cluster-core tests for identity, placement, grain registry, and the new operational contract module.
+- [ ] 6.2 Run `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate stabilize-grain-runtime-operational-contract --strict`.
+- [ ] 6.3 Run formatting checks for touched Rust and Markdown files.


### PR DESCRIPTION
## Summary
- `docs/gap-analysis/persistence-gap-analysis.md` を現行の `persistence-core-kernel` / `persistence-core-typed` 構成に合わせて整理しました。
- 比較スコープ、対象外項目、raw 抽出値、カバレッジ集計を見直し、旧 `modules/persistence-core/src/core/` 前提の記述を解消しました。
- Pekko 側との対応表も、実装済み・対象外・部分実装の切り分けが分かる形に更新しました。

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit abfb5fb5dfb3a759f5c28a67105f43429f0f9c4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->