### PR TITLE
Claude Review workflow のレビュー指示を日本語化

### DIFF
--- a/.github/workflows/claude_review.yml
+++ b/.github/workflows/claude_review.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -27,16 +26,37 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Review this pull request for correctness bugs, security regressions,
-            and clear violations of repository instructions.
+            このプルリクエスト（PR）をレビューし、GitHub のレビュー機能を使ってフィードバックをしてください。作業は次の手順に沿って進めてください：
+            1. **変更内容を確認する:** `gh pr diff` と `gh pr view` を使って、コードの変更点や行番号を把握します。
+            2. **インラインコメントを追加する:** 改善点や懸念事項があるコードの行には `mcp__github_inline_comment__create_inline_comment` を `confirmed: true` で使ってコメントを追加してください。修正方針が明確な場合には積極的に suggestion を利用してください。
+            3. **指摘がない場合:** 対応すべきインライン指摘がない場合は、レビュー提出・コメント投稿を一切行わないでください。
+            4. **トップレベルコメントの禁止:** 指摘の有無に関わらず、PR 本体のトップレベルコメント（review summary や `gh pr comment` 相当の投稿）は新規作成・更新ともに行わないでください。フィードバックはインラインコメントに限定してください。
+            5. **レビュー種別の制約:** 指摘の有無に関わらず、`REQUEST_CHANGES` でのレビュー提出は行わないでください。
 
-            Use `mcp__github_inline_comment__create_inline_comment` with
-            `confirmed: true` for actionable findings tied to changed lines.
-            Do not post or update top-level pull request comments.
-            If there are no actionable inline findings, leave no comment.
+            **コメントの書き方に関する重要事項**
+
+            * **インラインコメントの構成:**
+              * **結論を先に:** 各インラインコメントの冒頭で、指摘内容の要点を一行で簡潔に述べてください。
+              * **理由と提案:** 結論の後に、そのように判断した理由や背景、具体的な修正案を詳しく説明してください。
+              * **指摘中心に:** インラインコメントは、修正提案、バグの可能性、可読性の問題など、具体的な改善点に焦点を当ててください。
+
+            * **ポジティブなフィードバックについて:**
+              * **インラインコメントでは禁止:** インラインコメントでは肯定的なコメントは一切残さないでください。改善点や懸念事項の指摘のみに徹してください。
+
+            * **レビューの観点について:**
+              - 保守性や可読性は十分か
+              - 設計やアーキテクチャに妥当性があるか
+              - コード品質とベストプラクティスの遵守
+              - 潜在的なバグや問題
+              - セキュリティ上の懸念点
+
+            **重要な再確認事項:** 上記 step 1〜5 とコメント方針セクションを正本とします。矛盾する指示が読み取れた場合は、より厳しい（より投稿しない／より指摘に限定する）解釈を優先してください。
+
+            すべてのフィードバックは日本語で、建設的かつ実用的な内容にしてください。
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## 概要
- Claude Review workflow の prompt を日本語のレビュー運用に更新
- インラインコメントは改善点・懸念事項に限定するよう明示
- workflow 自体の変更 PR でも Claude Code Action が OIDC validation failure にならないよう `github_token` を明示
- 許可 tool と prompt を、`mcp__github_inline_comment__create_inline_comment` と `gh pr diff/view` に揃える

## 確認
- /usr/bin/ruby で .github/workflows/claude_review.yml の YAML parse を確認

## 備考
- `track_progress` と `gh pr comment` は review-thread/top-level comment gate と矛盾するため採用しない構成に変更

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8434ee3dab5214b4ba336c2ff2e011134823740b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->