### PR TITLE
failure/downing の最小境界を実装

### DIFF
--- a/docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md
+++ b/docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md
@@ -112,6 +112,8 @@ Cons:
 - SBR 全面実装ではなく、最小 downing decision model を先に切る。
 - Reachability matrix を入れるか、現在の suspect / unreachable event model を強化するかを比較する。
 
+作業メモ: [2026-05-26_failure-downing-boundary.md](2026-05-26_failure-downing-boundary.md) で、failure observation と member departure input を分離し、`DowningProvider` を decision port として扱う最小 contract を整理する。
+
 ### 5. Placement scalability
 
 - Rendezvous hashing のまま伸ばす範囲を明確にする。

--- a/docs/plan/2026-05-26_failure-downing-boundary.md
+++ b/docs/plan/2026-05-26_failure-downing-boundary.md
@@ -1,0 +1,19 @@
+# failure / downing boundary note
+
+## 決定
+
+Failure detector と membership coordination が扱う suspect / unreachable は observation であり、member departure input ではない。
+
+`cluster-core` は `DowningProvider` を core-defined decision port として所有する。explicit down command と failure observation は `DowningInput` として strategy に渡され、strategy が `DowningDecision::Down` を返した場合だけ provider-neutral な departure input に進む。
+
+## 最小 contract
+
+- `DowningInput::ExplicitDown` は explicit down command の入口。
+- `DowningInput::FailureObservation` は failure detector / membership 由来の availability observation の入口。
+- `DowningDecision::Down` は active topology から authority を外す判断。
+- `DowningDecision::Keep` / `DowningDecision::Defer` は active topology を保持する判断。
+- Grain runtime は topology update の `left` / `dead` によって stale activation と PID cache を invalidation する。phi value、suspect timer、SBR details は inspect しない。
+
+## 対象外
+
+Split Brain Resolver、reachability matrix、rebalance、remembered entities、in-flight drain はこの change では実装しない。

--- a/modules/cluster-adaptor-std/tests/failure_scenarios_integration.rs
+++ b/modules/cluster-adaptor-std/tests/failure_scenarios_integration.rs
@@ -209,7 +209,7 @@ fn assert_status_eventually(
 }
 
 #[test]
-fn node_down_is_marked_dead_after_failure_detection() {
+fn failure_detection_keeps_suspect_until_downing_decision() {
   let bus = Arc::new(Mutex::new(InMemoryBus::new()));
   let event_stream = EventStreamShared::default();
   let mut node_a = DemoNode::new("node-a", config(), bus.clone(), event_stream.clone());
@@ -261,19 +261,12 @@ fn node_down_is_marked_dead_after_failure_detection() {
     node_b.status_of("node-c")
   });
 
-  let mut tick = 7_u64;
-  assert_status_eventually("node-c", NodeStatus::Dead, 4, || {
+  for tick in 7..=10 {
     node_a.poll(now(tick));
     node_b.poll_gossip(now(tick));
-    tick += 1;
-    node_a.status_of("node-c")
-  });
-  assert_status_eventually("node-c", NodeStatus::Dead, 4, || {
-    node_a.poll(now(tick));
-    node_b.poll_gossip(now(tick));
-    tick += 1;
-    node_b.status_of("node-c")
-  });
+  }
+  assert_status(&node_a, "node-c", NodeStatus::Suspect);
+  assert_status(&node_b, "node-c", NodeStatus::Suspect);
 }
 
 #[test]

--- a/modules/cluster-core/src/cluster_api_test.rs
+++ b/modules/cluster-core/src/cluster_api_test.rs
@@ -31,7 +31,7 @@ use crate::{
   ClusterExtensionInstaller, ClusterProviderError, ClusterRequestError, ClusterResolveError,
   ClusterSubscriptionInitialStateMode, ClusterTopology, MetricsError, TopologyUpdate,
   cluster_provider::{ClusterProvider, NoopClusterProvider},
-  downing_provider::DowningProvider,
+  downing_provider::{DowningDecision, DowningInput, DowningProvider},
   grain::{GRAIN_EVENT_STREAM_NAME, GrainEvent, GrainKey},
   identity::{ClusterIdentity, IdentityLookup, IdentitySetupError, LookupError, NoopIdentityLookup},
   placement::{ActivatedKind, PlacementDecision, PlacementEvent, PlacementLocality, PlacementResolution},
@@ -738,9 +738,11 @@ struct RecordingDowningProvider {
 }
 
 impl DowningProvider for RecordingDowningProvider {
-  fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
-    self.downed.lock().push(String::from(authority));
-    Ok(())
+  fn decide(&mut self, input: &DowningInput) -> Result<DowningDecision, ClusterProviderError> {
+    if let DowningInput::ExplicitDown { authority } = input {
+      self.downed.lock().push(authority.clone());
+    }
+    Ok(DowningDecision::Down)
   }
 }
 

--- a/modules/cluster-core/src/cluster_core.rs
+++ b/modules/cluster-core/src/cluster_core.rs
@@ -25,7 +25,7 @@ use fraktor_utils_core_rs::{
 use crate::{
   BlockListProvider, ClusterError, ClusterEvent, ClusterExtensionConfig, ClusterMetrics, ClusterMetricsSnapshot,
   ClusterProviderError, ClusterProviderShared, MetricsError, StartupMode, TopologyApplyError, TopologyUpdate,
-  downing_provider::DowningProvider,
+  downing_provider::{DowningDecision, DowningInput, DowningProvider},
   grain::{GrainKey, KindRegistry},
   identity::{IdentityLookupShared, IdentitySetupError, LookupError, PidCache},
   membership::{CurrentClusterState, GossiperShared, MembershipVersion, NodeRecord, NodeStatus},
@@ -366,14 +366,26 @@ impl ClusterCore {
   ///
   /// # Errors
   ///
-  /// Returns an error if the cluster has not been started, downing strategy rejects the command,
-  /// or provider-side down processing fails.
+  /// Returns an error if the cluster has not been started, strategy evaluation fails, the strategy
+  /// does not return [`DowningDecision::Down`] for the explicit command, or provider-side down
+  /// processing fails after a [`DowningDecision::Down`] decision.
   pub fn down(&mut self, authority: &str) -> Result<(), ClusterError> {
     if self.mode.is_none() {
       return Err(ClusterError::from(ClusterProviderError::down("cluster is not started")));
     }
-    self.downing_provider.with_lock(|downing_provider| downing_provider.down(authority)).map_err(ClusterError::from)?;
-    self.provider.with_write(|provider| provider.down(authority)).map_err(ClusterError::from)
+    let input = DowningInput::explicit_down(authority);
+    let decision = self
+      .downing_provider
+      .with_lock(|downing_provider| downing_provider.decide(&input))
+      .map_err(ClusterError::from)?;
+    match decision {
+      | DowningDecision::Down => {
+        self.provider.with_write(|provider| provider.down(authority)).map_err(ClusterError::from)
+      },
+      | DowningDecision::Keep | DowningDecision::Defer => {
+        Err(ClusterError::DowningRejected { authority: String::from(authority), decision })
+      },
+    }
   }
 
   /// Requests a member join for the provided authority.

--- a/modules/cluster-core/src/cluster_core_test.rs
+++ b/modules/cluster-core/src/cluster_core_test.rs
@@ -18,7 +18,7 @@ use crate::{
   BlockListProvider, ClusterEvent, ClusterProviderError, ClusterProviderShared, ClusterTopology, MetricsError,
   StartupMode, TopologyUpdate,
   cluster_provider::ClusterProvider,
-  downing_provider::{DowningProvider, NoopDowningProvider},
+  downing_provider::{DowningDecision, DowningInput, DowningProvider, NoopDowningProvider},
   grain::{GrainKey, KindRegistry, TOPIC_ACTOR_KIND},
   identity::{IdentityLookup, IdentityLookupShared, IdentitySetupError, LookupError, PidCache, PidCacheEvent},
   membership::{Gossiper, GossiperShared},
@@ -1082,9 +1082,11 @@ fn down_invokes_strategy_before_provider_down() {
   }
 
   impl DowningProvider for RecordingDowningProvider {
-    fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
-      self.calls.lock().push(format!("strategy:{authority}"));
-      Ok(())
+    fn decide(&mut self, input: &DowningInput) -> Result<DowningDecision, ClusterProviderError> {
+      if let DowningInput::ExplicitDown { authority } = input {
+        self.calls.lock().push(format!("strategy:{authority}"));
+      }
+      Ok(DowningDecision::Down)
     }
   }
 
@@ -1112,6 +1114,152 @@ fn down_invokes_strategy_before_provider_down() {
   core.down("node-b:2552").unwrap();
 
   assert_eq!(calls.lock().clone(), vec![String::from("strategy:node-b:2552"), String::from("provider:node-b:2552"),]);
+}
+
+#[test]
+fn down_keep_decision_returns_error_without_provider_down() {
+  #[derive(Clone)]
+  struct RecordingProvider {
+    calls: ArcShared<SpinSyncMutex<Vec<String>>>,
+  }
+
+  impl ClusterProvider for RecordingProvider {
+    fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+      self.calls.lock().push(String::from(authority));
+      Ok(())
+    }
+
+    fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+  }
+
+  struct KeepDowningProvider;
+
+  impl DowningProvider for KeepDowningProvider {
+    fn decide(&mut self, _input: &DowningInput) -> Result<DowningDecision, ClusterProviderError> {
+      Ok(DowningDecision::Keep)
+    }
+  }
+
+  let calls: ArcShared<SpinSyncMutex<Vec<String>>> = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let provider = wrap_provider(RecordingProvider { calls: calls.clone() });
+  let block_list_provider = ArcShared::new(StubBlockListProvider::new(vec![]));
+  let event_stream = EventStreamShared::default();
+  let kind_registry = KindRegistry::new();
+  let identity_lookup = wrap_identity_lookup(StubIdentityLookup::new());
+  let gossiper = wrap_gossiper(StubGossiper::new());
+  let pubsub = wrap_pubsub(StubPubSub::new());
+  let mut core = ClusterCore::new(
+    &ClusterExtensionConfig::new(),
+    provider,
+    block_list_provider,
+    event_stream,
+    wrap_downing_provider(KeepDowningProvider),
+    gossiper,
+    pubsub,
+    kind_registry,
+    identity_lookup,
+  );
+  core.start_member().unwrap();
+
+  let result = core.down("node-b:2552");
+
+  assert!(matches!(
+    result,
+    Err(crate::ClusterError::DowningRejected { authority, decision: DowningDecision::Keep })
+    if authority == "node-b:2552"
+  ));
+  assert!(calls.lock().is_empty());
+}
+
+#[test]
+fn down_defer_decision_returns_error_without_provider_down() {
+  #[derive(Clone)]
+  struct RecordingProvider {
+    calls: ArcShared<SpinSyncMutex<Vec<String>>>,
+  }
+
+  impl ClusterProvider for RecordingProvider {
+    fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+      self.calls.lock().push(String::from(authority));
+      Ok(())
+    }
+
+    fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+
+    fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+      Ok(())
+    }
+  }
+
+  struct DeferDowningProvider;
+
+  impl DowningProvider for DeferDowningProvider {
+    fn decide(&mut self, _input: &DowningInput) -> Result<DowningDecision, ClusterProviderError> {
+      Ok(DowningDecision::Defer)
+    }
+  }
+
+  let calls: ArcShared<SpinSyncMutex<Vec<String>>> = ArcShared::new(SpinSyncMutex::new(Vec::new()));
+  let provider = wrap_provider(RecordingProvider { calls: calls.clone() });
+  let block_list_provider = ArcShared::new(StubBlockListProvider::new(vec![]));
+  let event_stream = EventStreamShared::default();
+  let kind_registry = KindRegistry::new();
+  let identity_lookup = wrap_identity_lookup(StubIdentityLookup::new());
+  let gossiper = wrap_gossiper(StubGossiper::new());
+  let pubsub = wrap_pubsub(StubPubSub::new());
+  let mut core = ClusterCore::new(
+    &ClusterExtensionConfig::new(),
+    provider,
+    block_list_provider,
+    event_stream,
+    wrap_downing_provider(DeferDowningProvider),
+    gossiper,
+    pubsub,
+    kind_registry,
+    identity_lookup,
+  );
+  core.start_member().unwrap();
+
+  let result = core.down("node-b:2552");
+
+  assert!(matches!(
+    result,
+    Err(crate::ClusterError::DowningRejected { authority, decision: DowningDecision::Defer })
+    if authority == "node-b:2552"
+  ));
+  assert!(calls.lock().is_empty());
 }
 
 #[test]

--- a/modules/cluster-core/src/cluster_error.rs
+++ b/modules/cluster-core/src/cluster_error.rs
@@ -1,12 +1,25 @@
 //! Consolidated cluster errors.
 
-use crate::{ClusterProviderError, identity::IdentitySetupError, pub_sub::PubSubError};
+extern crate alloc;
+
+use alloc::string::String;
+
+use crate::{
+  ClusterProviderError, downing_provider::DowningDecision, identity::IdentitySetupError, pub_sub::PubSubError,
+};
 
 /// Error type returned by cluster lifecycle operations.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClusterError {
   /// Provider-related failure.
   Provider(ClusterProviderError),
+  /// Downing strategy did not allow an explicit down command.
+  DowningRejected {
+    /// Authority that was requested to be downed.
+    authority: String,
+    /// Decision returned by the downing strategy.
+    decision:  DowningDecision,
+  },
   /// Identity lookup setup failure.
   Identity(IdentitySetupError),
   /// Gossip start/stop failure.

--- a/modules/cluster-core/src/downing_provider.rs
+++ b/modules/cluster-core/src/downing_provider.rs
@@ -1,17 +1,25 @@
-//! Downing strategy abstractions for explicit member down commands.
+//! Downing strategy abstractions for member down decisions.
 
+mod downing_decision;
+mod downing_input;
+mod failure_observation;
+mod failure_observation_kind;
 mod noop_downing_provider;
 
+pub use downing_decision::DowningDecision;
+pub use downing_input::DowningInput;
+pub use failure_observation::FailureObservation;
+pub use failure_observation_kind::FailureObservationKind;
 pub use noop_downing_provider::NoopDowningProvider;
 
 use crate::ClusterProviderError;
 
-/// Strategy hook invoked before a member is explicitly downed.
+/// Strategy hook invoked before a member is downed.
 pub trait DowningProvider: Send + Sync {
-  /// Handles explicit downing for the given authority.
+  /// Decides how cluster core should handle the downing input.
   ///
   /// # Errors
   ///
-  /// Returns [`ClusterProviderError`] when the strategy rejects the down command.
-  fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError>;
+  /// Returns [`ClusterProviderError`] when the strategy cannot decide.
+  fn decide(&mut self, input: &DowningInput) -> Result<DowningDecision, ClusterProviderError>;
 }

--- a/modules/cluster-core/src/downing_provider/downing_decision.rs
+++ b/modules/cluster-core/src/downing_provider/downing_decision.rs
@@ -1,0 +1,12 @@
+//! Decision returned by a downing strategy.
+
+/// Decision produced by the core downing boundary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DowningDecision {
+  /// Remove the authority from active topology.
+  Down,
+  /// Keep the authority in active topology.
+  Keep,
+  /// Leave the authority unchanged until more evidence is available.
+  Defer,
+}

--- a/modules/cluster-core/src/downing_provider/downing_input.rs
+++ b/modules/cluster-core/src/downing_provider/downing_input.rs
@@ -1,0 +1,25 @@
+//! Input accepted by a downing strategy.
+
+use alloc::string::String;
+
+use super::FailureObservation;
+
+/// Input passed into the core downing boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DowningInput {
+  /// Explicit down command requested by a caller.
+  ExplicitDown {
+    /// Target authority.
+    authority: String,
+  },
+  /// Availability observation from membership or failure detection.
+  FailureObservation(FailureObservation),
+}
+
+impl DowningInput {
+  /// Creates an explicit down input.
+  #[must_use]
+  pub fn explicit_down(authority: &str) -> Self {
+    Self::ExplicitDown { authority: String::from(authority) }
+  }
+}

--- a/modules/cluster-core/src/downing_provider/failure_observation.rs
+++ b/modules/cluster-core/src/downing_provider/failure_observation.rs
@@ -1,0 +1,41 @@
+//! Failure observation accepted by a downing strategy.
+
+use alloc::string::String;
+
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use super::FailureObservationKind;
+
+/// Availability observation for a member authority.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FailureObservation {
+  authority:   String,
+  kind:        FailureObservationKind,
+  observed_at: TimerInstant,
+}
+
+impl FailureObservation {
+  /// Creates a failure observation.
+  #[must_use]
+  pub fn new(authority: &str, kind: FailureObservationKind, observed_at: TimerInstant) -> Self {
+    Self { authority: String::from(authority), kind, observed_at }
+  }
+
+  /// Returns the observed authority.
+  #[must_use]
+  pub fn authority(&self) -> &str {
+    &self.authority
+  }
+
+  /// Returns the observation kind.
+  #[must_use]
+  pub const fn kind(&self) -> FailureObservationKind {
+    self.kind
+  }
+
+  /// Returns the observation time.
+  #[must_use]
+  pub const fn observed_at(&self) -> TimerInstant {
+    self.observed_at
+  }
+}

--- a/modules/cluster-core/src/downing_provider/failure_observation_kind.rs
+++ b/modules/cluster-core/src/downing_provider/failure_observation_kind.rs
@@ -1,0 +1,12 @@
+//! Failure observation kind.
+
+/// Availability observation state before a downing decision.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FailureObservationKind {
+  /// The authority is suspected but not departed.
+  Suspect,
+  /// The authority is currently unreachable but not departed.
+  Unreachable,
+  /// The authority became reachable again before a downing decision.
+  Recovered,
+}

--- a/modules/cluster-core/src/downing_provider/noop_downing_provider.rs
+++ b/modules/cluster-core/src/downing_provider/noop_downing_provider.rs
@@ -4,10 +4,10 @@
 #[path = "noop_downing_provider_test.rs"]
 mod tests;
 
-use super::DowningProvider;
+use super::{DowningDecision, DowningInput, DowningProvider, FailureObservationKind};
 use crate::ClusterProviderError;
 
-/// Downing strategy that accepts all down commands without side effects.
+/// Downing strategy that accepts all explicit down commands without side effects.
 #[derive(Default)]
 pub struct NoopDowningProvider;
 
@@ -20,7 +20,13 @@ impl NoopDowningProvider {
 }
 
 impl DowningProvider for NoopDowningProvider {
-  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
-    Ok(())
+  fn decide(&mut self, input: &DowningInput) -> Result<DowningDecision, ClusterProviderError> {
+    match input {
+      | DowningInput::ExplicitDown { .. } => Ok(DowningDecision::Down),
+      | DowningInput::FailureObservation(observation) => match observation.kind() {
+        | FailureObservationKind::Suspect | FailureObservationKind::Unreachable => Ok(DowningDecision::Defer),
+        | FailureObservationKind::Recovered => Ok(DowningDecision::Keep),
+      },
+    }
   }
 }

--- a/modules/cluster-core/src/downing_provider/noop_downing_provider_test.rs
+++ b/modules/cluster-core/src/downing_provider/noop_downing_provider_test.rs
@@ -1,7 +1,35 @@
-use crate::downing_provider::{DowningProvider, NoopDowningProvider};
+use core::time::Duration;
+
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use crate::downing_provider::{
+  DowningDecision, DowningInput, DowningProvider, FailureObservation, FailureObservationKind, NoopDowningProvider,
+};
 
 #[test]
-fn noop_downing_provider_accepts_down_command() {
+fn noop_downing_provider_downs_explicit_command() {
   let mut provider = NoopDowningProvider::new();
-  assert!(provider.down("node-a:2552").is_ok());
+  let input = DowningInput::explicit_down("node-a:2552");
+  assert_eq!(provider.decide(&input).unwrap(), DowningDecision::Down);
+}
+
+#[test]
+fn noop_downing_provider_defers_failure_observation() {
+  let mut provider = NoopDowningProvider::new();
+  let observation =
+    FailureObservation::new("node-a:2552", FailureObservationKind::Suspect, TimerInstant::zero(Duration::from_secs(1)));
+  let input = DowningInput::FailureObservation(observation);
+  assert_eq!(provider.decide(&input).unwrap(), DowningDecision::Defer);
+}
+
+#[test]
+fn noop_downing_provider_keeps_recovered_observation() {
+  let mut provider = NoopDowningProvider::new();
+  let observation = FailureObservation::new(
+    "node-a:2552",
+    FailureObservationKind::Recovered,
+    TimerInstant::zero(Duration::from_secs(1)),
+  );
+  let input = DowningInput::FailureObservation(observation);
+  assert_eq!(provider.decide(&input).unwrap(), DowningDecision::Keep);
 }

--- a/modules/cluster-core/src/membership/membership_coordinator.rs
+++ b/modules/cluster-core/src/membership/membership_coordinator.rs
@@ -167,6 +167,7 @@ impl MembershipCoordinator {
     let mut outcome = MembershipCoordinatorOutcome { membership_events, ..Default::default() };
 
     if changed {
+      self.update_suspect_tracking(&authority, NodeStatus::Joining, now);
       self.topology_accumulator.joined.insert(authority.clone());
       self.refresh_peers();
       if self.config.gossip_enabled {
@@ -216,6 +217,9 @@ impl MembershipCoordinator {
     let mut outcome = MembershipCoordinatorOutcome { membership_events, ..Default::default() };
     if self.gossip.table().record(authority).map(|record| record.status) == Some(NodeStatus::Removed) {
       self.topology_accumulator.left.insert(authority.to_string());
+    }
+    if let Some(status) = self.gossip.table().record(authority).map(|record| record.status) {
+      self.update_suspect_tracking(authority, status, now);
     }
     self.refresh_peers();
 
@@ -367,8 +371,6 @@ impl MembershipCoordinator {
 
     self.detect_suspects(now_ms, now, &mut outcome)?;
 
-    self.handle_suspect_timeouts(now, &mut outcome)?;
-
     let cleared = self.quarantine.poll_expired(now);
     for event in cleared.into_iter() {
       outcome.quarantine_events.push(event);
@@ -484,39 +486,6 @@ impl MembershipCoordinator {
     self.gossip.set_peers(peers);
   }
 
-  fn handle_suspect_timeouts(
-    &mut self,
-    now: TimerInstant,
-    outcome: &mut MembershipCoordinatorOutcome,
-  ) -> Result<(), MembershipCoordinatorError> {
-    let timeout = self.config.suspect_timeout;
-    let expired = self
-      .suspect_since
-      .iter()
-      .filter(|(_, since)| is_expired(**since, now, timeout))
-      .map(|(authority, _)| authority.clone())
-      .collect::<Vec<_>>();
-    for authority in expired {
-      self.suspect_since.remove(&authority);
-      if let Some(delta) =
-        self.gossip.table_mut().mark_dead(&authority).map_err(MembershipCoordinatorError::Membership)?
-      {
-        self.topology_accumulator.dead.insert(authority.clone());
-        if self.config.gossip_enabled {
-          outcome.gossip_outbound.extend(self.gossip.disseminate(&delta));
-        }
-        if let Some(record) = self.gossip.table().record(&authority) {
-          self.emit_status_change(&authority, NodeStatus::Suspect, record.status, now, outcome);
-        }
-        let reason = "suspect timeout".to_string();
-        let event = self.quarantine.quarantine(authority.clone(), reason.clone(), now, self.config.quarantine_ttl);
-        outcome.quarantine_events.push(event);
-        outcome.member_events.push(ClusterEvent::MemberQuarantined { authority, reason, observed_at: now });
-      }
-    }
-    Ok(())
-  }
-
   fn register_membership_change(
     &mut self,
     record: &NodeRecord,
@@ -525,6 +494,7 @@ impl MembershipCoordinator {
     outcome: &mut MembershipCoordinatorOutcome,
   ) {
     let status = record.status;
+    self.update_suspect_tracking(record.authority.as_str(), status, now);
     match status {
       | NodeStatus::Joining | NodeStatus::Up | NodeStatus::Suspect => {
         if before.is_none() || matches!(before, Some(NodeStatus::Removed | NodeStatus::Dead)) {
@@ -565,6 +535,14 @@ impl MembershipCoordinator {
       } else if from == NodeStatus::Suspect && status == NodeStatus::Up {
         Self::emit_reachable_event(record, now, outcome);
       }
+    }
+  }
+
+  fn update_suspect_tracking(&mut self, authority: &str, status: NodeStatus, now: TimerInstant) {
+    if status == NodeStatus::Suspect {
+      self.suspect_since.entry(authority.to_string()).or_insert(now);
+    } else {
+      self.suspect_since.remove(authority);
     }
   }
 
@@ -770,11 +748,6 @@ fn to_millis(now: TimerInstant) -> u64 {
   let resolution_ns = now.resolution().as_nanos().max(1);
   let ticks = now.ticks().saturating_mul(u64::try_from(resolution_ns).unwrap_or(u64::MAX));
   ticks / 1_000_000
-}
-
-fn is_expired(since: TimerInstant, now: TimerInstant, timeout: Duration) -> bool {
-  let deadline = add_duration(since, timeout);
-  now >= deadline
 }
 
 fn add_duration(now: TimerInstant, duration: Duration) -> TimerInstant {

--- a/modules/cluster-core/src/membership/membership_coordinator_test.rs
+++ b/modules/cluster-core/src/membership/membership_coordinator_test.rs
@@ -10,7 +10,7 @@ use crate::{
   failure_detector::{DefaultFailureDetectorRegistry, FailureDetector},
   membership::{
     MembershipCoordinatorConfig, MembershipCoordinatorError, MembershipCoordinatorState, MembershipDelta,
-    MembershipError, MembershipEvent, MembershipTable, MembershipVersion, NodeStatus, QuarantineEvent,
+    MembershipError, MembershipEvent, MembershipTable, MembershipVersion, NodeRecord, NodeStatus, QuarantineEvent,
   },
   pub_sub::PubSubConfig,
 };
@@ -209,7 +209,7 @@ fn quarantine_rejects_join_and_expires() {
 }
 
 #[test]
-fn suspect_timeout_marks_dead_and_quarantines() {
+fn suspect_timeout_keeps_observation_without_departure() {
   let table = MembershipTable::new(3);
   let mut config = base_config();
   config.suspect_timeout = Duration::from_secs(1);
@@ -232,12 +232,65 @@ fn suspect_timeout_marks_dead_and_quarantines() {
 
   let outcome = coordinator.poll(now(7)).unwrap();
   assert!(
-    outcome
+    !outcome
       .member_events
       .iter()
       .any(|event| matches!(event, ClusterEvent::MemberStatusChanged { to: NodeStatus::Dead, .. }))
   );
-  assert!(outcome.member_events.iter().any(|event| matches!(event, ClusterEvent::MemberQuarantined { .. })));
+  assert!(!outcome.member_events.iter().any(|event| matches!(event, ClusterEvent::MemberQuarantined { .. })));
+  assert!(coordinator.quarantine_snapshot().is_empty());
+  let snapshot = coordinator.snapshot();
+  assert!(
+    snapshot.entries.iter().any(|record| { record.authority == "node-a" && record.status == NodeStatus::Suspect })
+  );
+}
+
+#[test]
+fn non_suspect_gossip_status_clears_suspect_tracking() {
+  let table = MembershipTable::new(3);
+  let mut config = base_config();
+  config.suspect_timeout = Duration::from_secs(1);
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let _ =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a", now(2)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a", now(3)).unwrap();
+  let _ = coordinator.poll(now(5)).unwrap();
+  assert!(coordinator.suspect_since.contains_key("node-a"));
+
+  let dead_version = MembershipVersion::new(100);
+  let dead_record = NodeRecord::new(
+    "node-1".to_string(),
+    "node-a".to_string(),
+    NodeStatus::Dead,
+    dead_version,
+    "1.1.0".to_string(),
+    vec![String::from("frontend")],
+  );
+  let dead_delta = MembershipDelta::new(MembershipVersion::new(99), dead_version, vec![dead_record]);
+  let _ = coordinator.handle_gossip_delta("node-b", &dead_delta, now(6)).unwrap();
+  assert!(!coordinator.suspect_since.contains_key("node-a"));
+}
+
+#[test]
+fn local_leave_clears_suspect_tracking() {
+  let table = MembershipTable::new(3);
+  let mut config = base_config();
+  config.suspect_timeout = Duration::from_secs(1);
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let _ =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a", now(2)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a", now(3)).unwrap();
+  let _ = coordinator.poll(now(5)).unwrap();
+  assert!(coordinator.suspect_since.contains_key("node-a"));
+
+  let _ = coordinator.handle_leave("node-a", now(6)).unwrap();
+  assert!(!coordinator.suspect_since.contains_key("node-a"));
 }
 
 #[test]

--- a/openspec/changes/define-failure-downing-minimum/tasks.md
+++ b/openspec/changes/define-failure-downing-minimum/tasks.md
@@ -1,27 +1,27 @@
 ## 1. 境界確認
 
-- [ ] 1.1 既存の `FailureDetector` / `MembershipCoordinator` / `DowningProvider` の責務を `failure-downing-minimum` spec と照合する。
-- [ ] 1.2 suspect / unreachable observation と member departure input が混同されている箇所を洗い出す。
-- [ ] 1.3 `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` から failure / downing boundary note へリンクする。
+- [x] 1.1 既存の `FailureDetector` / `MembershipCoordinator` / `DowningProvider` の責務を `failure-downing-minimum` spec と照合する。
+- [x] 1.2 suspect / unreachable observation と member departure input が混同されている箇所を洗い出す。
+- [x] 1.3 `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` から failure / downing boundary note へリンクする。
 
 ## 2. Core contract
 
-- [ ] 2.1 `DowningDecision::{Down, Keep, Defer}` を `downing_provider` 配下に追加する。
-- [ ] 2.2 `DowningInput::{ExplicitDown, FailureObservation}` を `downing_provider` 配下に追加する。
-- [ ] 2.3 explicit down command が `DowningInput::ExplicitDown` として downing decision boundary を通ってから departure input になることを固定する。
-- [ ] 2.4 `FailureObservation` を `DowningInput::FailureObservation` へ渡せる入力として最小表現する。
-- [ ] 2.5 `DowningProvider` trait に `decide(&mut self, input: &DowningInput)` 相当の method を追加する。
-- [ ] 2.6 keep / defer 相当の decision が active topology を削除しないことを固定する。
+- [x] 2.1 `DowningDecision::{Down, Keep, Defer}` を `downing_provider` 配下に追加する。
+- [x] 2.2 `DowningInput::{ExplicitDown, FailureObservation}` を `downing_provider` 配下に追加する。
+- [x] 2.3 explicit down command が `DowningInput::ExplicitDown` として downing decision boundary を通ってから departure input になることを固定する。
+- [x] 2.4 `FailureObservation` を `DowningInput::FailureObservation` へ渡せる入力として最小表現する。
+- [x] 2.5 `DowningProvider` trait に `decide(&mut self, input: &DowningInput)` 相当の method を追加する。
+- [x] 2.6 keep / defer 相当の decision が active topology を削除しないことを固定する。
 
 ## 3. 契約カバレッジ
 
-- [ ] 3.1 suspect observation が即 departure にならないことを membership tests で確認する。
-- [ ] 3.2 recovered observation が downing decision なしに active member を保持することを確認する。
-- [ ] 3.3 down decision が Grain runtime の stale activation / PID cache invalidation input になることを確認する。
-- [ ] 3.4 SBR / reachability matrix / rebalance / remembered entities がこの change に入っていないことを確認する。
+- [x] 3.1 suspect observation が即 departure にならないことを membership tests で確認する。
+- [x] 3.2 recovered observation が downing decision なしに active member を保持することを確認する。
+- [x] 3.3 down decision が Grain runtime の stale activation / PID cache invalidation input になることを確認する。
+- [x] 3.4 SBR / reachability matrix / rebalance / remembered entities がこの change に入っていないことを確認する。
 
 ## 4. 検証
 
-- [ ] 4.1 `define-failure-downing-minimum` の OpenSpec validation を実行する。
-- [ ] 4.2 `cluster-core` の targeted failure / membership / downing tests を実行する。
-- [ ] 4.3 変更した Markdown / Rust files の formatting checks を実行する。
+- [x] 4.1 `define-failure-downing-minimum` の OpenSpec validation を実行する。
+- [x] 4.2 `cluster-core` の targeted failure / membership / downing tests を実行する。
+- [x] 4.3 変更した Markdown / Rust files の formatting checks を実行する。


### PR DESCRIPTION
## 概要
- DowningProvider を explicit down hook から core-defined decision boundary へ拡張
- DowningDecision / DowningInput / FailureObservation の最小 contract を追加
- suspect timeout が即 Dead / quarantine にならない contract を membership test で固定
- failure/downing boundary note を roadmap から参照し、OpenSpec tasks を完了状態へ更新

## 検証
- MISE_TRUSTED_CONFIG_PATHS=$PWD mise exec -- openspec validate define-failure-downing-minimum --strict
- cargo test -p fraktor-cluster-core-rs downing_provider --lib
- cargo test -p fraktor-cluster-core-rs membership_coordinator --lib
- cargo test -p fraktor-cluster-core-rs cluster_core --lib
- cargo test -p fraktor-cluster-core-rs down_delegates_to_cluster_provider --lib
- ./scripts/ci-check.sh ai fmt
- ./scripts/ci-check.sh ai lint dylint clippy
- git diff --check

## 補足
- cargo clippy -p fraktor-cluster-core-rs --lib --tests -- -D warnings は既存の cluster-core 全体の clippy debt で失敗するため、この PR の検証対象外にしています。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster membership semantics (suspect no longer auto-dead) and the downing API contract; behavior affects failure handling and manual down paths across adapters.
> 
> **Overview**
> Introduces a **minimum failure/downing boundary** in `cluster-core`: `DowningProvider` now exposes `decide(&DowningInput) -> DowningDecision` instead of a direct `down` hook, with **`DowningInput`** (`ExplicitDown`, `FailureObservation`) and **`DowningDecision`** (`Down`, `Keep`, `Defer`). **`ClusterCore::down`** evaluates the strategy first and only calls the cluster provider when the decision is `Down`; `Keep`/`Defer` surface as **`ClusterError::DowningRejected`**.
> 
> **Membership** no longer auto-promotes suspect members to **Dead** (or quarantine) on suspect timeout—suspect/unreachable stay **observations** until an explicit downing path removes authority. Suspect tracking is maintained/cleared on status changes; integration tests expect nodes to remain **Suspect** rather than **Dead** after prolonged failure detection.
> 
> Adds a **roadmap/boundary note** (`2026-05-26_failure-downing-boundary.md`) and marks the **OpenSpec** `define-failure-downing-minimum` tasks complete. SBR, reachability matrix, and automatic failure→down wiring are explicitly out of scope here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ba3eaa1d60a920837644a95b9cea8ec78d0764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * クラスタダウンニング処理における失敗観測と離脱判定の境界を明文化しました。

* **New Features**
  * ダウンニング戦略がExplicitDownおよびFailureObservationの入力に基づいて意思決定を行う新しいインターフェースを導入しました。
  * ノードの失敗状態（Suspect/Unreachable）がダウン決定に直結しなくなり、戦略による判定を経由するようになりました。

* **Bug Fixes**
  * Suspect状態がタイムアウトで自動的にDeadに遷移するのを停止し、明示的なダウン決定を待つようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->