### PR TITLE
[codex] placement movement contract を提案

### DIFF
--- a/openspec/changes/define-placement-movement-contract/.openspec.yaml
+++ b/openspec/changes/define-placement-movement-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/define-placement-movement-contract/design.md
+++ b/openspec/changes/define-placement-movement-contract/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`cluster-grain-runtime-operational-contract` は identity resolution、topology invalidation、passivation、rolling update の最小 contract を持つ。
+一方で `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` の Task slice 5 は、rebalance 実装前に Rendezvous hashing のまま伸ばす範囲と、join / leave / rolling update 時の movement と cache invalidation の期待値を固定することを求めている。
+
+現行実装は `RendezvousHasher`、`PartitionIdentityLookup`、`PlacementCoordinatorCore` を中心に、authority topology から owner を選び、activation / PID cache を再利用する。
+この change は新しい placement algorithm を導入せず、現行 algorithm の contract を明確化し、将来の rebalance / remembered entities 実装の境界を残す。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Rendezvous hashing が同一 topology / same key で deterministic placement を返すことを contract test として強める。
+- node join が既存 active activation を即時移動しないことを固定する。
+- node leave / down が departed authority の activation / PID cache を invalidation することを固定する。
+- rolling update 時の期待値を「stale placement prevention と latest topology re-resolution」に限定する。
+
+**Non-Goals:**
+
+- least-shard rebalance、minimum movement guarantee、coordinator protocol は実装しない。
+- remembered entities、activation recovery、persistence integration は実装しない。
+- in-flight request drain や graceful handoff protocol は実装しない。
+- Pekko Cluster Sharding public API parity は扱わない。
+
+## Decisions
+
+1. Placement scalability は algorithm 変更ではなく contract hardening として扱う。
+
+   現時点の主軸は Grain runtime であり、Rendezvous hashing は coordinator-less な placement と no_std core に適している。rebalance algorithm を先に入れると、remembered entities や draining と境界が混ざるため、本 change では既存 algorithm の保証範囲を固定する。
+
+2. Join は existing activation movement を発生させない。
+
+   新 node が join した瞬間に既存 activation を移すと、minimum movement、state handoff、in-flight drain の要件が発生する。これらは Task slice 5 の deferred scope に残し、本 change では新規 resolution だけが latest topology を使うことを明確にする。
+
+3. Leave / down は stale authority invalidation のみを強制する。
+
+   departed authority を参照する activation / PID cache は再利用してはならない。これは provider / downing の種類に依存しない Grain runtime contract であり、rebalance なしでも安全性に直結する。
+
+## Risks / Trade-offs
+
+- Join 後に既存 activation が偏る可能性がある → 本 change では許容し、rebalance capability で扱う。
+- Rolling update 中の request drain は保証されない → spec に non-goal として明記し、運用上は leave / down 後の re-resolution だけを保証する。
+- Tests が現行 implementation detail に寄りすぎる可能性がある → public-ish contract surface (`IdentityLookup`, topology update, cache events) を中心に検証する。

--- a/openspec/changes/define-placement-movement-contract/proposal.md
+++ b/openspec/changes/define-placement-movement-contract/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`cluster-grain-runtime-operational-contract` は topology invalidation と rolling update の最小境界を持っているが、Rendezvous hashing のまま伸ばす範囲と、join / leave 時の placement movement expectation はまだ明文化が薄い。
+rebalance や remembered entities を実装する前に、現在の Grain runtime が保証する movement と保証しない movement を contract として固定する。
+
+## What Changes
+
+- Rendezvous hashing による placement decision の安定性と、同一 topology / same key での deterministic selection を明確化する。
+- node join 時は既存 active activation を即時 rebalance しないことを固定する。
+- node leave / down 時は departed authority の activation / PID cache を invalidation し、次回 resolution が active topology だけを使うことを固定する。
+- rolling update 時に replacement topology へ再解決されることと、minimum movement / remembered entity recovery / in-flight drain を保証しないことを明確化する。
+- 将来の rebalance / remembered entities / draining は別 capability に残す。
+
+## Capabilities
+
+### New Capabilities
+
+- なし
+
+### Modified Capabilities
+
+- `cluster-grain-runtime-operational-contract`: placement movement と Rendezvous hashing の bounded contract を追加する。
+
+## Impact
+
+- `openspec/specs/cluster-grain-runtime-operational-contract/spec.md`
+- `modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs`
+- `modules/cluster-core/src/identity/rendezvous_hasher.rs`
+- `modules/cluster-core/src/identity/partition_identity_lookup.rs`
+- `modules/cluster-core/src/placement/placement_coordinator.rs`

--- a/openspec/changes/define-placement-movement-contract/specs/cluster-grain-runtime-operational-contract/spec.md
+++ b/openspec/changes/define-placement-movement-contract/specs/cluster-grain-runtime-operational-contract/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Placement movement is bounded by active topology changes
+
+Grain runtime SHALL use the active authority topology when making new placement decisions. It MUST NOT move existing active activations only because a new authority joined. It MUST invalidate activations and PID cache entries owned by authorities that leave or are downed.
+
+#### Scenario: join does not move existing active activation
+
+- **GIVEN** a `GrainKey` has an active activation owned by an authority in the current topology
+- **WHEN** a new authority joins the topology
+- **THEN** lookup may continue returning the existing active PID for that `GrainKey`
+- **AND** no passivation or PID cache drop is emitted only because of the join
+
+#### Scenario: new resolution after join uses expanded topology
+
+- **GIVEN** a new authority joined the topology
+- **WHEN** a `GrainKey` without an active activation is resolved
+- **THEN** placement selection uses the expanded active topology
+- **AND** the selected authority belongs to that topology
+
+#### Scenario: leave invalidates only matching authority ownership
+
+- **GIVEN** multiple active activations are owned by different authorities
+- **WHEN** one authority leaves or is downed
+- **THEN** activations and PID cache entries owned by that authority are invalidated
+- **AND** activations owned by remaining authorities stay reusable
+
+### Requirement: Rendezvous placement remains deterministic without rebalance semantics
+
+Rendezvous hashing SHALL provide deterministic owner selection for the same `GrainKey` and same authority topology. This capability MUST NOT guarantee minimum movement, proactive rebalance, remembered entity recovery, or in-flight request draining.
+
+#### Scenario: same topology produces stable owner
+
+- **GIVEN** the same non-empty authority topology
+- **WHEN** the same `GrainKey` is selected multiple times
+- **THEN** Rendezvous placement returns the same authority each time
+
+#### Scenario: topology change permits owner change without movement guarantee
+
+- **WHEN** authority topology changes by join or leave
+- **THEN** future placement decisions may select a different owner according to Rendezvous hashing
+- **AND** the runtime does not guarantee minimum movement across all keys
+
+#### Scenario: rolling update is stale-placement prevention only
+
+- **WHEN** rolling update changes the authority topology
+- **THEN** Grain runtime prevents reuse of activations owned by departed authorities
+- **AND** Grain runtime does not guarantee automatic shard rebalance, remembered entity recovery, or request draining

--- a/openspec/changes/define-placement-movement-contract/specs/cluster-grain-runtime-operational-contract/spec.md
+++ b/openspec/changes/define-placement-movement-contract/specs/cluster-grain-runtime-operational-contract/spec.md
@@ -1,8 +1,43 @@
-## ADDED Requirements
+## MODIFIED Requirements
 
-### Requirement: Placement movement is bounded by active topology changes
+### Requirement: Grain identity resolution is deterministic and state-aware
 
-Grain runtime SHALL use the active authority topology when making new placement decisions. It MUST NOT move existing active activations only because a new authority joined. It MUST invalidate activations and PID cache entries owned by authorities that leave or are downed.
+Grain identity lookup SHALL resolve a `GrainKey` from the current authority topology and SHALL report unresolved states explicitly. It MUST NOT return a stale PID when the lookup is stopped, has no authorities, or is waiting for asynchronous activation.
+
+Rendezvous hashing SHALL provide deterministic owner selection for the same `GrainKey` and same authority topology. New placement decisions MUST use the active authority topology. Existing active activations MUST NOT move only because a new authority joined.
+
+#### Scenario: no authority is reported explicitly
+
+- **WHEN** member-mode identity lookup resolves a `GrainKey` before any authority is present
+- **THEN** resolution fails with `LookupError::NoAuthority`
+- **AND** no PID is cached for that `GrainKey`
+
+#### Scenario: same key and topology resolve deterministically
+
+- **GIVEN** two identity lookup instances have the same authority topology
+- **WHEN** both instances resolve the same `GrainKey`
+- **THEN** both select the same authority
+- **AND** both produce a placement decision for that authority
+
+#### Scenario: cache hit reuses the active PID
+
+- **GIVEN** a `GrainKey` has been resolved and its activation is still valid
+- **WHEN** the same `GrainKey` is resolved again before PID TTL or passivation invalidates it
+- **THEN** lookup returns the same PID
+- **AND** the returned PID belongs to the same authority decision
+
+#### Scenario: distributed activation exposes pending resolution
+
+- **GIVEN** distributed activation is enabled for a local authority
+- **WHEN** lookup starts resolving a `GrainKey` that requires lock, load, ensure, and store commands
+- **THEN** lookup reports `LookupError::Pending` until the command results complete
+- **AND** lookup returns a PID only after activation is stored and the lock is released
+
+#### Scenario: same topology produces stable owner
+
+- **GIVEN** the same non-empty authority topology
+- **WHEN** the same `GrainKey` is selected multiple times
+- **THEN** Rendezvous placement returns the same authority each time
 
 #### Scenario: join does not move existing active activation
 
@@ -18,6 +53,39 @@ Grain runtime SHALL use the active authority topology when making new placement 
 - **THEN** placement selection uses the expanded active topology
 - **AND** the selected authority belongs to that topology
 
+#### Scenario: topology change permits owner change without movement guarantee
+
+- **WHEN** authority topology changes by join or leave
+- **THEN** future placement decisions may select a different owner according to Rendezvous hashing
+- **AND** the runtime does not guarantee minimum movement across all keys
+
+### Requirement: Topology changes invalidate absent authorities
+
+Cluster topology updates SHALL invalidate activation and PID cache entries that belong to authorities no longer present in the active authority set. Lookup MUST NOT return a PID for an authority that is absent from the latest topology.
+
+Leave or down signals MUST invalidate only activations and PID cache entries owned by the matching authority. Activations owned by authorities that remain in the active topology MUST stay reusable.
+
+#### Scenario: topology replacement removes stale authority cache
+
+- **GIVEN** a `GrainKey` resolved to an authority in the previous topology
+- **WHEN** topology is replaced with a set that does not include that authority
+- **THEN** activation and PID cache entries for the absent authority are invalidated
+- **AND** the next resolution uses only authorities from the new topology
+
+#### Scenario: member departure invalidates matching authority
+
+- **GIVEN** a `GrainKey` has an activation owned by an authority
+- **WHEN** the identity lookup observes that authority leaving or being downed
+- **THEN** activation and PID cache entries for that authority are invalidated
+- **AND** a later resolution MUST NOT return the previous PID
+
+#### Scenario: unknown member departure is a no-op
+
+- **GIVEN** activation and PID cache entries belong to active authorities
+- **WHEN** identity lookup observes departure for an unknown authority
+- **THEN** existing activation and PID cache entries remain available
+- **AND** subsequent lookup for the same `GrainKey` may still return the active cached PID
+
 #### Scenario: leave invalidates only matching authority ownership
 
 - **GIVEN** multiple active activations are owned by different authorities
@@ -25,21 +93,23 @@ Grain runtime SHALL use the active authority topology when making new placement 
 - **THEN** activations and PID cache entries owned by that authority are invalidated
 - **AND** activations owned by remaining authorities stay reusable
 
-### Requirement: Rendezvous placement remains deterministic without rebalance semantics
+### Requirement: Rolling update contract is bounded to stale placement prevention
 
-Rendezvous hashing SHALL provide deterministic owner selection for the same `GrainKey` and same authority topology. This capability MUST NOT guarantee minimum movement, proactive rebalance, remembered entity recovery, or in-flight request draining.
+During rolling update, Grain runtime SHALL prevent stale placement reuse for departed authorities and SHALL resolve against the latest topology. It MUST NOT promise shard rebalance, remembered entity recovery, or in-flight request draining as part of this contract.
 
-#### Scenario: same topology produces stable owner
+#### Scenario: replacement node becomes the only resolution candidate
 
-- **GIVEN** the same non-empty authority topology
-- **WHEN** the same `GrainKey` is selected multiple times
-- **THEN** Rendezvous placement returns the same authority each time
+- **GIVEN** an old authority owns a `GrainKey`
+- **AND** a replacement authority joins the topology
+- **WHEN** the old authority leaves or is downed and topology is updated
+- **THEN** stale activation and PID cache entries for the old authority are invalidated
+- **AND** the next resolution selects from the replacement topology
 
-#### Scenario: topology change permits owner change without movement guarantee
+#### Scenario: rolling update does not imply rebalance guarantee
 
-- **WHEN** authority topology changes by join or leave
-- **THEN** future placement decisions may select a different owner according to Rendezvous hashing
-- **AND** the runtime does not guarantee minimum movement across all keys
+- **WHEN** topology changes during rolling update
+- **THEN** Grain runtime guarantees stale authority invalidation and re-resolution
+- **AND** Grain runtime does not guarantee minimum movement, remembered activation recovery, or automatic shard draining in this capability
 
 #### Scenario: rolling update is stale-placement prevention only
 

--- a/openspec/changes/define-placement-movement-contract/tasks.md
+++ b/openspec/changes/define-placement-movement-contract/tasks.md
@@ -1,0 +1,25 @@
+## 1. Contract audit
+
+- [ ] 1.1 `RendezvousHasher` / `PartitionIdentityLookup` / `PlacementCoordinatorCore` の現行 movement behavior を spec と照合する。
+- [ ] 1.2 join / leave / down / rolling update 時に activation と PID cache がどこで invalidation されるかを確認する。
+- [ ] 1.3 rebalance / remembered entities / in-flight drain に該当する挙動が本 change に混入しないことを確認する。
+
+## 2. Contract tests
+
+- [ ] 2.1 same topology / same `GrainKey` の Rendezvous owner stability を contract test で固定する。
+- [ ] 2.2 new authority join が既存 active activation を移動せず、cache drop / passivation を出さないことを固定する。
+- [ ] 2.3 join 後の新規 resolution が expanded topology だけを候補にすることを固定する。
+- [ ] 2.4 leave / down が matching authority の activation / PID cache だけを invalidation することを固定する。
+- [ ] 2.5 rolling update が stale authority reuse を防ぎ、rebalance guarantee を持たないことを既存 test と重複しない形で固定する。
+
+## 3. Implementation adjustment
+
+- [ ] 3.1 contract tests が露出した不足があれば `PartitionIdentityLookup` / `PlacementCoordinatorCore` の最小修正で解消する。
+- [ ] 3.2 public API や provider-specific behavior に不要な変更を入れない。
+- [ ] 3.3 no_std core に `std` 依存や adapter concern が混入していないことを確認する。
+
+## 4. Validation
+
+- [ ] 4.1 `define-placement-movement-contract` の OpenSpec validation を実行する。
+- [ ] 4.2 `cluster-core` の identity / placement targeted tests を実行する。
+- [ ] 4.3 変更した Markdown / Rust files の formatting checks を実行する。


### PR DESCRIPTION
## 概要

- cluster Grain runtime roadmap の Task slice 5 に対応する OpenSpec change を追加
- Rendezvous hashing のまま伸ばす範囲を定義
- join / leave / rolling update 時の movement と cache invalidation の期待値を仕様化
- rebalance / remembered entities / in-flight drain は後続 scope として明示

## 検証

- MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate define-placement-movement-contract --strict
- MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec status --change define-placement-movement-contract --json
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Specification and planning artifacts only; no runtime or public API behavior changes in this proposal slice.
> 
> **Overview**
> Adds OpenSpec change **`define-placement-movement-contract`** (cluster Grain runtime roadmap, Task slice 5) to extend **`cluster-grain-runtime-operational-contract`** with bounded placement-movement rules—without changing placement algorithms.
> 
> The delta specs **Rendezvous hashing** (stable owner for same key + topology), **join** (no moving existing active activations; new keys use the expanded topology), **leave/down** (invalidate only departed authority activation/PID cache), and **rolling update** (stale authority invalidation and re-resolution on latest topology only). It explicitly **does not** promise minimum movement, remembered-entity recovery, in-flight drain, or shard rebalance; those stay deferred capabilities.
> 
> Includes **proposal**, **design**, **tasks**, and a MODIFIED requirements patch under the change folder; implementation impact is scoped to the canonical spec plus future **`cluster-core`** contract tests (`grain_runtime_operational_contract_test`, identity/placement modules) per the proposal checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6417d611798197be8b03f9f3f8820ec14d6dab29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->