### PR TITLE
[codex] Implement placement movement contract

### DIFF
--- a/modules/cluster-core/src/grain/virtual_actor_registry.rs
+++ b/modules/cluster-core/src/grain/virtual_actor_registry.rs
@@ -98,6 +98,11 @@ impl VirtualActorRegistry {
     self.pid_cache.get(key, now)
   }
 
+  /// Returns PID and owner authority from cache if present and not expired.
+  pub fn cached_pid_with_authority(&mut self, key: &GrainKey, now: u64) -> Option<(String, String)> {
+    self.pid_cache.get_with_authority(key, now)
+  }
+
   /// Invalidates all activations and cache entries for an authority (e.g., quarantine).
   pub fn invalidate_authority(&mut self, authority: &str) {
     self.pid_cache.invalidate_authority(authority);

--- a/modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs
+++ b/modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs
@@ -1,8 +1,8 @@
-use alloc::string::ToString;
+use alloc::{format, string::ToString};
 
 use crate::{
   grain::GrainKey,
-  identity::{IdentityLookup, LookupError, PartitionIdentityLookup, PidCacheEvent},
+  identity::{IdentityLookup, LookupError, PartitionIdentityLookup, PidCacheEvent, RendezvousHasher},
   placement::{
     ActivationRecord, PlacementCommand, PlacementCommandResult, PlacementCoordinatorOutcome, PlacementEvent,
     PlacementLease, PlacementLocality, PlacementRequestId, PlacementResolution,
@@ -25,6 +25,18 @@ fn member_lookup() -> PartitionIdentityLookup {
 
 fn grain_key(value: &str) -> GrainKey {
   GrainKey::new(value.to_string())
+}
+
+fn key_owned_by(authorities: &[String], owner: &str, prefix: &str) -> GrainKey {
+  for index in 0..10_000 {
+    let key = grain_key(&format!("{prefix}/{index}"));
+    if let Some(selected) = RendezvousHasher::select(authorities, &key)
+      && selected == owner
+    {
+      return key;
+    }
+  }
+  panic!("no key owned by {owner} found for {prefix}");
 }
 
 fn has_passivated_event(events: &[PlacementEvent], key: &GrainKey) -> bool {
@@ -199,6 +211,45 @@ fn active_pid_is_reused_on_repeated_resolve() {
 }
 
 #[test]
+fn join_does_not_move_existing_active_activation_when_rendezvous_owner_changes() {
+  let original_topology = vec!["node-a:4050".to_string()];
+  let expanded_topology = vec!["node-a:4050".to_string(), "node-b:4051".to_string()];
+  let key = key_owned_by(&expanded_topology, "node-b:4051", "user/join-no-move");
+  let mut lookup = member_lookup();
+  lookup.update_topology(original_topology);
+
+  let original = lookup.resolve(&key, 1000).expect("original resolution");
+  assert_eq!(original.decision.authority, "node-a:4050");
+  clear_observed_events(&mut lookup);
+
+  lookup.update_topology(expanded_topology);
+  let join_events = lookup.drain_events();
+  let join_cache_events = lookup.drain_cache_events();
+  assert!(!has_passivated_event(&join_events, &key));
+  assert!(!has_cache_drop_event(&join_cache_events, &key));
+
+  let after_join = lookup.resolve(&key, 1001).expect("cached resolution after join");
+  assert_eq!(after_join.pid, original.pid);
+  assert_eq!(after_join.decision.authority, original.decision.authority);
+  assert!(lookup.drain_cache_events().is_empty());
+}
+
+#[test]
+fn new_resolution_after_join_uses_expanded_topology_candidates() {
+  let expanded_topology = vec!["node-a:4050".to_string(), "node-b:4051".to_string()];
+  let key = key_owned_by(&expanded_topology, "node-b:4051", "user/join-new-resolution");
+  let mut lookup = member_lookup();
+  lookup.update_topology(vec!["node-a:4050".to_string()]);
+
+  lookup.update_topology(expanded_topology);
+  clear_observed_events(&mut lookup);
+
+  let resolution = lookup.resolve(&key, 1000).expect("resolution after join");
+  assert_eq!(resolution.decision.authority, "node-b:4051");
+  assert!(lookup.authorities().iter().any(|authority| authority == &resolution.decision.authority));
+}
+
+#[test]
 fn distributed_activation_reports_pending_then_completes_after_command_results() {
   let mut lookup = member_lookup();
   lookup.update_topology(vec!["node-a:4050".to_string()]);
@@ -275,6 +326,33 @@ fn member_departure_with_matching_authority_invalidates_active_entries_and_block
 
   let after_departure = lookup.resolve(&key, 1002);
   assert!(matches!(after_departure, Err(LookupError::Pending)));
+}
+
+#[test]
+fn member_departure_invalidates_only_matching_authority_entries() {
+  let authorities = vec!["node-a:4050".to_string(), "node-b:4051".to_string()];
+  let node_a_key = key_owned_by(&authorities, "node-a:4050", "user/leave-node-a");
+  let node_b_key = key_owned_by(&authorities, "node-b:4051", "user/leave-node-b");
+  let mut lookup = member_lookup();
+  lookup.update_topology(authorities);
+
+  let node_a = lookup.resolve(&node_a_key, 1000).expect("node-a resolution");
+  let node_b = lookup.resolve(&node_b_key, 1000).expect("node-b resolution");
+  assert_eq!(node_a.decision.authority, "node-a:4050");
+  assert_eq!(node_b.decision.authority, "node-b:4051");
+  clear_observed_events(&mut lookup);
+
+  lookup.on_member_left("node-a:4050");
+  let placement_events = lookup.drain_events();
+  let cache_events = lookup.drain_cache_events();
+  assert!(has_passivated_event(&placement_events, &node_a_key));
+  assert!(!has_passivated_event(&placement_events, &node_b_key));
+  assert!(has_cache_drop_event(&cache_events, &node_a_key));
+  assert!(!has_cache_drop_event(&cache_events, &node_b_key));
+
+  let node_b_after_departure = lookup.resolve(&node_b_key, 1001).expect("remaining cached resolution");
+  assert_eq!(node_b_after_departure.pid, node_b.pid);
+  assert_eq!(node_b_after_departure.decision.authority, node_b.decision.authority);
 }
 
 #[test]

--- a/modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs
+++ b/modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs
@@ -235,6 +235,27 @@ fn join_does_not_move_existing_active_activation_when_rendezvous_owner_changes()
 }
 
 #[test]
+fn cached_remote_authority_is_not_reported_as_local_after_local_authority_changes() {
+  let expanded_topology = vec!["node-a:4050".to_string(), "node-b:4051".to_string()];
+  let key = key_owned_by(&expanded_topology, "node-a:4050", "user/remote-cache");
+  let mut lookup = member_lookup();
+  lookup.update_topology(vec!["node-a:4050".to_string()]);
+  lookup.set_local_authority("node-a:4050");
+
+  let original = lookup.resolve(&key, 1000).expect("original local resolution");
+  assert_eq!(original.decision.authority, "node-a:4050");
+  assert_eq!(original.locality, PlacementLocality::Local);
+  clear_observed_events(&mut lookup);
+
+  lookup.update_topology(expanded_topology);
+  lookup.set_local_authority("node-b:4051");
+
+  let after_local_change = lookup.resolve(&key, 1001).expect("remote resolution after local change");
+  assert_eq!(after_local_change.decision.authority, "node-a:4050");
+  assert_eq!(after_local_change.locality, PlacementLocality::Remote);
+}
+
+#[test]
 fn new_resolution_after_join_uses_expanded_topology_candidates() {
   let expanded_topology = vec!["node-a:4050".to_string(), "node-b:4051".to_string()];
   let key = key_owned_by(&expanded_topology, "node-b:4051", "user/join-new-resolution");

--- a/modules/cluster-core/src/identity/pid_cache.rs
+++ b/modules/cluster-core/src/identity/pid_cache.rs
@@ -44,10 +44,15 @@ impl PidCache {
 
   /// Fetches a PID if not expired.
   pub fn get(&mut self, key: &GrainKey, now: u64) -> Option<String> {
+    self.get_with_authority(key, now).map(|(pid, _)| pid)
+  }
+
+  /// Fetches a PID and its owner authority if not expired.
+  pub fn get_with_authority(&mut self, key: &GrainKey, now: u64) -> Option<(String, String)> {
     if let Some(entry) = self.entries.get(key)
       && entry.expires_at > now
     {
-      return Some(entry.pid.clone());
+      return Some((entry.pid.clone(), entry.authority.clone()));
     }
 
     if let Some(entry) = self.entries.remove(key) {

--- a/modules/cluster-core/src/placement/placement_coordinator.rs
+++ b/modules/cluster-core/src/placement/placement_coordinator.rs
@@ -173,6 +173,7 @@ impl PlacementCoordinatorCore {
 
     if let Some((pid, cached_authority)) = self.registry.cached_pid_with_authority(key, now)
       && self.authorities.contains(&cached_authority)
+      && !self.is_remote(&cached_authority)
     {
       let decision =
         PlacementDecision { key: key.clone(), authority: cached_authority.clone(), observed_at: now };

--- a/modules/cluster-core/src/placement/placement_coordinator.rs
+++ b/modules/cluster-core/src/placement/placement_coordinator.rs
@@ -171,13 +171,23 @@ impl PlacementCoordinatorCore {
       return Err(LookupError::NoAuthority);
     };
 
-    let decision = PlacementDecision { key: key.clone(), authority: owner.clone(), observed_at: now };
-    let mut events = Vec::new();
-    events.push(PlacementEvent::Resolved { key: key.clone(), authority: owner.clone(), observed_at: now });
-
-    if self.is_remote(&owner) {
-      let pid = format!("{}::{}", owner, key.value());
-      let resolution = PlacementResolution { decision, locality: PlacementLocality::Remote, pid };
+    if let Some((pid, cached_authority)) = self.registry.cached_pid_with_authority(key, now)
+      && self.authorities.contains(&cached_authority)
+    {
+      let decision =
+        PlacementDecision { key: key.clone(), authority: cached_authority.clone(), observed_at: now };
+      let resolution = PlacementResolution { decision, locality: PlacementLocality::Local, pid };
+      let mut events = Vec::new();
+      events.push(PlacementEvent::Resolved {
+        key:         key.clone(),
+        authority:   cached_authority,
+        observed_at: now,
+      });
+      events.push(PlacementEvent::Activated {
+        key:         key.clone(),
+        pid:         resolution.pid.clone(),
+        observed_at: now,
+      });
       self.events.extend(events);
       return Ok(PlacementCoordinatorOutcome {
         resolution: Some(resolution),
@@ -186,13 +196,13 @@ impl PlacementCoordinatorCore {
       });
     }
 
-    if let Some(pid) = self.registry.cached_pid(key, now) {
-      let resolution = PlacementResolution { decision, locality: PlacementLocality::Local, pid };
-      events.push(PlacementEvent::Activated {
-        key:         key.clone(),
-        pid:         resolution.pid.clone(),
-        observed_at: now,
-      });
+    let decision = PlacementDecision { key: key.clone(), authority: owner.clone(), observed_at: now };
+    let mut events = Vec::new();
+    events.push(PlacementEvent::Resolved { key: key.clone(), authority: owner.clone(), observed_at: now });
+
+    if self.is_remote(&owner) {
+      let pid = format!("{}::{}", owner, key.value());
+      let resolution = PlacementResolution { decision, locality: PlacementLocality::Remote, pid };
       self.events.extend(events);
       return Ok(PlacementCoordinatorOutcome {
         resolution: Some(resolution),

--- a/openspec/changes/define-placement-movement-contract/tasks.md
+++ b/openspec/changes/define-placement-movement-contract/tasks.md
@@ -1,25 +1,25 @@
 ## 1. Contract audit
 
-- [ ] 1.1 `RendezvousHasher` / `PartitionIdentityLookup` / `PlacementCoordinatorCore` の現行 movement behavior を spec と照合する。
-- [ ] 1.2 join / leave / down / rolling update 時に activation と PID cache がどこで invalidation されるかを確認する。
-- [ ] 1.3 rebalance / remembered entities / in-flight drain に該当する挙動が本 change に混入しないことを確認する。
+- [x] 1.1 `RendezvousHasher` / `PartitionIdentityLookup` / `PlacementCoordinatorCore` の現行 movement behavior を spec と照合する。
+- [x] 1.2 join / leave / down / rolling update 時に activation と PID cache がどこで invalidation されるかを確認する。
+- [x] 1.3 rebalance / remembered entities / in-flight drain に該当する挙動が本 change に混入しないことを確認する。
 
 ## 2. Contract tests
 
-- [ ] 2.1 same topology / same `GrainKey` の Rendezvous owner stability を contract test で固定する。
-- [ ] 2.2 new authority join が既存 active activation を移動せず、cache drop / passivation を出さないことを固定する。
-- [ ] 2.3 join 後の新規 resolution が expanded topology だけを候補にすることを固定する。
-- [ ] 2.4 leave / down が matching authority の activation / PID cache だけを invalidation することを固定する。
-- [ ] 2.5 rolling update が stale authority reuse を防ぎ、rebalance guarantee を持たないことを既存 test と重複しない形で固定する。
+- [x] 2.1 same topology / same `GrainKey` の Rendezvous owner stability を contract test で固定する。
+- [x] 2.2 new authority join が既存 active activation を移動せず、cache drop / passivation を出さないことを固定する。
+- [x] 2.3 join 後の新規 resolution が expanded topology だけを候補にすることを固定する。
+- [x] 2.4 leave / down が matching authority の activation / PID cache だけを invalidation することを固定する。
+- [x] 2.5 rolling update が stale authority reuse を防ぎ、rebalance guarantee を持たないことを既存 test と重複しない形で固定する。
 
 ## 3. Implementation adjustment
 
-- [ ] 3.1 contract tests が露出した不足があれば `PartitionIdentityLookup` / `PlacementCoordinatorCore` の最小修正で解消する。
-- [ ] 3.2 public API や provider-specific behavior に不要な変更を入れない。
-- [ ] 3.3 no_std core に `std` 依存や adapter concern が混入していないことを確認する。
+- [x] 3.1 contract tests が露出した不足があれば `PartitionIdentityLookup` / `PlacementCoordinatorCore` の最小修正で解消する。
+- [x] 3.2 public API や provider-specific behavior に不要な変更を入れない。
+- [x] 3.3 no_std core に `std` 依存や adapter concern が混入していないことを確認する。
 
 ## 4. Validation
 
-- [ ] 4.1 `define-placement-movement-contract` の OpenSpec validation を実行する。
-- [ ] 4.2 `cluster-core` の identity / placement targeted tests を実行する。
-- [ ] 4.3 変更した Markdown / Rust files の formatting checks を実行する。
+- [x] 4.1 `define-placement-movement-contract` の OpenSpec validation を実行する。
+- [x] 4.2 `cluster-core` の identity / placement targeted tests を実行する。
+- [x] 4.3 変更した Markdown / Rust files の formatting checks を実行する。


### PR DESCRIPTION
## Summary

- Implement the placement movement OpenSpec change.
- Preserve the cached active activation owner on PID cache hits so node joins do not move existing activations or create mismatched placement decisions.
- Add contract coverage for join/no-move, expanded topology resolution, matching-authority invalidation, and complete the OpenSpec task checklist.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate define-placement-movement-contract --strict`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec status --change define-placement-movement-contract --json`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-rs grain_runtime_operational_contract`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-rs rendezvous_hasher`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-rs partition_identity_lookup`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-rs placement_coordinator`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-rs --no-default-features`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo fmt --check --package fraktor-cluster-core-rs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes distributed grain placement and PID-cache resolution paths; behavior is constrained by new contract tests but affects activation locality and invalidation semantics.
> 
> **Overview**
> **Placement movement contract:** local `resolve` now reuses a cached PID together with its **stored owner authority** when that authority is still in the topology and treated as local, instead of immediately adopting the current rendezvous winner. That keeps existing activations and placement decisions stable when nodes join and rendezvous ownership would otherwise shift.
> 
> Supporting changes expose authority on PID cache reads (`get_with_authority`, `cached_pid_with_authority`) and add **grain runtime contract tests** for join-without-move, correct **local vs remote** locality after the local node identity changes, post-join resolution on expanded topology, and **authority-scoped** invalidation on member leave. The OpenSpec `define-placement-movement-contract` task checklist is marked complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea01f08ad739a8a4e62539902373458e0ef6f43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->