### PR TITLE
[codex] Propose cluster Grain runtime docs alignment

### DIFF
--- a/openspec/changes/align-cluster-grain-runtime-docs/.openspec.yaml
+++ b/openspec/changes/align-cluster-grain-runtime-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/align-cluster-grain-runtime-docs/design.md
+++ b/openspec/changes/align-cluster-grain-runtime-docs/design.md
@@ -1,0 +1,46 @@
+## Context
+
+`docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` defines the current direction for `cluster-*`: it is a Virtual Actor / Grain runtime, not an Apache Pekko Cluster parity project. Recent changes have added provider-boundary, downing, and placement operational contracts, but top-level documentation and cluster gap analysis still contain enough Pekko parity framing that future work can be mis-scoped.
+
+This change is documentation-only. It does not change Rust APIs, runtime behavior, provider implementations, or OpenSpec runtime contracts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `README.md` and cluster docs describe `cluster-*` primarily as Grain runtime infrastructure.
+- Keep Pekko references, but label them as comparison and operational design input.
+- Point readers from the root README and cluster gap analysis to the cluster Grain runtime roadmap as the decision record for priority.
+- Ensure deferred Pekko concepts are explicitly presented as out of current scope unless a future OpenSpec change adopts them.
+
+**Non-Goals:**
+
+- Do not implement or change cluster runtime behavior.
+- Do not delete cluster gap-analysis evidence simply because it mentions Pekko.
+- Do not claim Pekko public API parity for cluster.
+- Do not reframe actor, stream, remote, or persistence documentation outside the cluster-specific scope.
+
+## Decisions
+
+1. Treat the roadmap as the authoritative priority document.
+
+   `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` already captures the decision that `cluster-*` is Grain runtime first. README and gap analysis should link to it instead of restating a competing priority model.
+
+2. Preserve `cluster-gap-analysis.md` as comparison, not implementation backlog.
+
+   The file contains useful references to Pekko failure cases and missing concepts. Removing that information would lose context. Instead, the implementation pass should relabel the analysis so raw API gaps and singleton/sharding/distributed-data entries do not imply immediate priority.
+
+3. Keep documentation language narrow and operational.
+
+   The docs should emphasize identity lookup, placement, activation/passivation, topology updates, provider boundaries, failure observation, and downing decisions. Deferred items should be named plainly, not hidden.
+
+4. Avoid code-adjacent churn.
+
+   Because this is a documentation alignment change, validation should focus on OpenSpec validation and Markdown diff hygiene. Rust tests are not required unless implementation unexpectedly touches code.
+
+## Risks / Trade-offs
+
+- Existing gap-analysis tables may still be long and Pekko-heavy -> Add summary and priority framing near the top so readers do not interpret the whole table as a current backlog.
+- Over-correcting could erase useful Pekko comparison context -> Preserve comparison sections and explicitly state that Pekko is a reference source.
+- README may become too detailed -> Keep root README concise and link to the roadmap / gap analysis for detail.
+- Documentation-only changes can drift again -> Add a spec requirement that future cluster docs must preserve the Grain runtime framing and roadmap link.

--- a/openspec/changes/align-cluster-grain-runtime-docs/proposal.md
+++ b/openspec/changes/align-cluster-grain-runtime-docs/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The cluster roadmap now positions `cluster-*` as a Proto.Actor-Go style Virtual Actor / Grain runtime, but some public docs still read as broad Apache Pekko Cluster parity material. Aligning the docs prevents future work from treating Cluster Singleton, ShardCoordinator, Distributed Data, or raw Pekko API parity as the immediate implementation target.
+
+## What Changes
+
+- Reframe cluster documentation so the primary subject is Grain identity lookup, placement resolution, activation/passivation, topology input, provider boundaries, and failure/downing contracts.
+- Treat Pekko Cluster / Cluster Sharding as a reference for operational failure cases and design vocabulary, not as a parity target.
+- Add explicit roadmap links from README / gap-analysis documentation to `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md`.
+- Mark Cluster Singleton, ShardCoordinator, Cluster Client, Receptionist, Distributed Data / CRDT, and sharding delivery controllers as deferred unless a future OpenSpec change explicitly adopts them.
+- Preserve existing gap-analysis evidence where useful, but relabel it as comparison context instead of direct priority.
+
+## Capabilities
+
+### New Capabilities
+
+- `cluster-grain-runtime-docs`: Documentation contract for presenting cluster as a Grain runtime and Pekko as a reference implementation, including required links, deferred scope language, and consistency across README / gap-analysis / roadmap docs.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected docs: `README.md`, `docs/gap-analysis/cluster-gap-analysis.md`, and related cluster roadmap links under `docs/plan/`.
+- No Rust API, runtime behavior, dependency, or provider implementation changes.
+- No migration or compatibility impact.

--- a/openspec/changes/align-cluster-grain-runtime-docs/specs/cluster-grain-runtime-docs/spec.md
+++ b/openspec/changes/align-cluster-grain-runtime-docs/specs/cluster-grain-runtime-docs/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Cluster docs present Grain runtime as the primary model
+
+Cluster documentation SHALL describe `cluster-*` as Virtual Actor / Grain runtime infrastructure centered on identity lookup, placement resolution, activation/passivation, topology updates, provider boundaries, failure observation, and downing decisions. It MUST NOT present Apache Pekko Cluster or Cluster Sharding public API parity as the current cluster roadmap.
+
+#### Scenario: root README summarizes cluster direction
+
+- **WHEN** a reader uses `README.md` to understand cluster support
+- **THEN** the cluster entry describes the Grain runtime direction
+- **AND** it links to the cluster Grain runtime roadmap for current priority
+
+#### Scenario: cluster gap analysis is comparison context
+
+- **WHEN** a reader opens `docs/gap-analysis/cluster-gap-analysis.md`
+- **THEN** the document states that Pekko is used as a reference for operational concerns
+- **AND** it does not treat raw Pekko API gaps as direct implementation priority
+
+### Requirement: Deferred Pekko cluster concepts are explicit
+
+Cluster documentation SHALL explicitly defer Cluster Singleton, ShardCoordinator parity, Cluster Client, Receptionist, Distributed Data / CRDT, sharding delivery controllers, and broad Pekko public API compatibility unless a future OpenSpec change adopts one of those scopes.
+
+#### Scenario: deferred scope is visible before gap tables
+
+- **WHEN** a reader reaches cluster gap-analysis detail tables
+- **THEN** the document identifies which Pekko concepts are deferred
+- **AND** the reader can distinguish deferred comparison entries from current Grain runtime tasks
+
+#### Scenario: future implementation work requires a new change
+
+- **WHEN** documentation mentions a deferred Pekko cluster concept
+- **THEN** it states or links that implementation requires a dedicated future OpenSpec change
+
+### Requirement: Cluster documentation links remain consistent
+
+Cluster documentation SHALL keep the roadmap, gap analysis, and top-level README connected so readers can move from overview to rationale to detailed comparison without conflicting priority statements.
+
+#### Scenario: overview points to rationale
+
+- **WHEN** top-level documentation mentions cluster roadmap or gap analysis
+- **THEN** it links to `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` or the cluster gap analysis as appropriate
+
+#### Scenario: detailed comparison points back to roadmap
+
+- **WHEN** the cluster gap analysis discusses implementation priority
+- **THEN** it points back to the cluster Grain runtime roadmap as the authoritative priority document

--- a/openspec/changes/align-cluster-grain-runtime-docs/tasks.md
+++ b/openspec/changes/align-cluster-grain-runtime-docs/tasks.md
@@ -1,0 +1,24 @@
+## 1. Current documentation audit
+
+- [ ] 1.1 Review `README.md` cluster references and identify wording that implies broad Pekko Cluster parity.
+- [ ] 1.2 Review `docs/gap-analysis/cluster-gap-analysis.md` for sections that read as direct implementation backlog instead of comparison context.
+- [ ] 1.3 Confirm `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` remains the authoritative priority document and does not need scope expansion.
+
+## 2. Documentation alignment
+
+- [ ] 2.1 Update `README.md` cluster overview and links so `cluster-*` is introduced as Grain runtime infrastructure.
+- [ ] 2.2 Update `docs/gap-analysis/cluster-gap-analysis.md` summary and priority framing so Pekko is clearly a reference for operational concerns.
+- [ ] 2.3 Make deferred Pekko concepts explicit before detailed gap tables.
+- [ ] 2.4 Add or adjust links between README, cluster gap analysis, and the Grain runtime roadmap.
+
+## 3. Scope guard
+
+- [ ] 3.1 Ensure the change does not modify Rust source, runtime behavior, provider implementations, or dependencies.
+- [ ] 3.2 Ensure no documentation claims Pekko Cluster / Cluster Sharding public API parity as the current roadmap.
+- [ ] 3.3 Preserve useful Pekko comparison evidence instead of deleting it wholesale.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate align-cluster-grain-runtime-docs --strict`.
+- [ ] 4.2 Run `git diff --check`.
+- [ ] 4.3 Review the final docs diff for conflicting priority statements.


### PR DESCRIPTION
## Summary

- Add an OpenSpec change for aligning cluster documentation around the Grain runtime roadmap.
- Define a documentation contract for README, cluster gap analysis, deferred Pekko concepts, and roadmap links.
- Add implementation tasks without touching runtime code or docs implementation yet.

## Validation

- MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec status --change align-cluster-grain-runtime-docs --json
- MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate align-cluster-grain-runtime-docs --strict
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only OpenSpec scaffolding with no runtime, API, or dependency changes.
> 
> **Overview**
> Adds a new OpenSpec change **`align-cluster-grain-runtime-docs`** that plans (but does not yet implement) aligning public cluster documentation with the Grain / Virtual Actor runtime roadmap instead of Apache Pekko Cluster parity framing.
> 
> The change introduces **proposal**, **design**, **tasks**, and a **`cluster-grain-runtime-docs`** spec with requirements for README and gap-analysis wording, explicit deferral of Pekko concepts (singleton, sharding coordinator, distributed data, etc.), and consistent links to `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md`. **No Rust, runtime, or existing markdown files are modified in this PR**—only the spec-driven workflow artifacts and validation checklist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7217923fb0f823e9c77b29ac9b7005de779d7bcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->