### PR TITLE
docs: propose grain pending activation contract tests

### DIFF
--- a/openspec/changes/test-grain-pending-activation-contract/.openspec.yaml
+++ b/openspec/changes/test-grain-pending-activation-contract/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/test-grain-pending-activation-contract/design.md
+++ b/openspec/changes/test-grain-pending-activation-contract/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`cluster-grain-runtime-operational-contract` already requires distributed activation to expose pending resolution until lock/load/ensure/store/release commands complete. The existing operational test module drives part of that flow through a test-only coordinator outcome helper, but the public `IdentityLookup::resolve` behavior should also be pinned directly.
+
+This change is intentionally test-first. It should use the existing `PartitionIdentityLookup` and placement command result APIs, preserving the `no_std` core boundary and avoiding new dependencies.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add contract tests that call public `resolve` while distributed activation is incomplete.
+- Prove unresolved activation is reported as `LookupError::Pending`.
+- Prove repeated `resolve` calls do not fabricate a PID or skip the outstanding activation flow.
+- Prove a later `resolve` returns the stored PID after the emitted placement command sequence is completed.
+
+**Non-Goals:**
+
+- Do not add new public APIs solely for tests.
+- Do not implement topology invalidation, passivation, rolling update, rebalance, remembered entities, or SBR behavior.
+- Do not move test support into `std` or introduce async runtime dependencies.
+- Do not broaden Pekko Cluster / Cluster Sharding API parity.
+
+## Decisions
+
+1. Keep the tests in the existing cluster-core identity test area.
+
+   `modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs` already contains the Grain runtime operational contract tests and helper functions for placement command completion. Extending that file keeps the new scenarios near the accepted operational contract.
+
+2. Use public `IdentityLookup::resolve` for pending assertions.
+
+   The first pending assertion should go through `resolve`, not only `resolve_outcome`, because callers observe `LookupError::Pending` through the public identity lookup trait. The existing test-only outcome helper may still be used after that to capture the command request id needed to complete the activation flow.
+
+3. Treat implementation changes as defect fixes only.
+
+   If the tests fail, the implementation should be adjusted only where the public pending-resolution contract is violated. The change must not redesign placement coordination or introduce new behavior outside the pending activation path.
+
+## Risks / Trade-offs
+
+- Existing helper functions may hide part of the command sequence -> Keep assertions explicit about the public `resolve` calls before and after command completion.
+- Test-only access to coordinator internals can become too broad -> Reuse the existing helper instead of adding new public or test-only seams.
+- Repeated `resolve` while a command is outstanding may expose current behavior that starts a duplicate activation -> Fix only if that violates the pending contract and keep the scope limited to the outstanding activation state.

--- a/openspec/changes/test-grain-pending-activation-contract/proposal.md
+++ b/openspec/changes/test-grain-pending-activation-contract/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The accepted Grain runtime operational contract says distributed activation must expose pending resolution until placement commands complete. Existing tests exercise the coordinator command flow, but the public `IdentityLookup::resolve` pending behavior is not isolated as its own contract.
+
+## What Changes
+
+- Add focused contract tests for `PartitionIdentityLookup` with distributed activation enabled.
+- Verify the first public `resolve` returns `LookupError::Pending` while activation commands are outstanding.
+- Verify repeated public `resolve` calls stay pending until command results complete, instead of fabricating a PID or returning a stale cache entry.
+- Verify completion through placement command results makes a later public `resolve` return the stored PID.
+- Keep this change test-first and narrow; fix only behavior directly exposed by these tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `cluster-grain-runtime-contract-tests`: Test coverage contract for Grain runtime operational scenarios that must be executable in `cluster-core`.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: `modules/cluster-core/src/identity/*_test.rs` and, only if tests expose a defect, minimal `modules/cluster-core/src/identity` / `modules/cluster-core/src/placement` implementation changes.
+- Public APIs: none expected.
+- Dependencies: none expected.
+- Runtime behavior: no intended change beyond correcting any pending-resolution defect found by the tests.

--- a/openspec/changes/test-grain-pending-activation-contract/specs/cluster-grain-runtime-contract-tests/spec.md
+++ b/openspec/changes/test-grain-pending-activation-contract/specs/cluster-grain-runtime-contract-tests/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Pending distributed activation is covered by contract tests
+
+The cluster-core test suite SHALL cover distributed Grain activation through the public identity lookup surface. A `PartitionIdentityLookup` configured for distributed activation MUST report `LookupError::Pending` from `IdentityLookup::resolve` while placement command results are outstanding, and MUST return the stored PID only after the placement command sequence completes.
+
+#### Scenario: first public resolve reports pending
+
+- **GIVEN** `PartitionIdentityLookup` is in member mode with distributed activation enabled
+- **AND** the active topology contains a local authority for the requested `GrainKey`
+- **WHEN** `IdentityLookup::resolve` is called before placement command results complete
+- **THEN** the call returns `LookupError::Pending`
+- **AND** no completed PID is returned
+
+#### Scenario: repeated public resolve stays pending before completion
+
+- **GIVEN** distributed activation has started for a `GrainKey`
+- **AND** the emitted placement command sequence has not completed
+- **WHEN** `IdentityLookup::resolve` is called again for the same `GrainKey`
+- **THEN** the call returns `LookupError::Pending`
+- **AND** it does not return a stale PID or a fabricated activation result
+
+#### Scenario: public resolve returns stored PID after completion
+
+- **GIVEN** distributed activation has started for a `GrainKey`
+- **AND** the placement command sequence completes with a stored activation record
+- **WHEN** `IdentityLookup::resolve` is called again for the same `GrainKey`
+- **THEN** the call returns the stored PID
+- **AND** the placement decision still belongs to the selected authority

--- a/openspec/changes/test-grain-pending-activation-contract/tasks.md
+++ b/openspec/changes/test-grain-pending-activation-contract/tasks.md
@@ -1,0 +1,19 @@
+## 1. Test Placement
+
+- [ ] 1.1 Review existing `modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs` helpers for pending activation command completion.
+- [ ] 1.2 Add a focused contract test in the existing identity operational contract test module for first public `resolve` returning `LookupError::Pending`.
+- [ ] 1.3 Add a repeated public `resolve` assertion while the placement command sequence is still outstanding.
+- [ ] 1.4 Complete the emitted placement command sequence and assert a later public `resolve` returns the stored PID and selected authority.
+
+## 2. Minimal Implementation Fixes
+
+- [ ] 2.1 Run the new focused test first and inspect whether current behavior already satisfies the contract.
+- [ ] 2.2 If the test fails, adjust only `PartitionIdentityLookup` / placement coordinator behavior needed to preserve pending resolution until command completion.
+- [ ] 2.3 Confirm the fix does not broaden topology invalidation, passivation, rolling update, rebalance, remembered entities, or SBR scope.
+
+## 3. Validation
+
+- [ ] 3.1 Run the focused `cluster-core` identity operational contract test.
+- [ ] 3.2 Run the relevant `cluster-core` test package target if available.
+- [ ] 3.3 Run `openspec validate test-grain-pending-activation-contract --strict`.
+- [ ] 3.4 Run `git diff --check`.

--- a/openspec/changes/test-grain-pending-activation-contract/tasks.md
+++ b/openspec/changes/test-grain-pending-activation-contract/tasks.md
@@ -15,5 +15,5 @@
 
 - [ ] 3.1 Run the focused `cluster-core` identity operational contract test.
 - [ ] 3.2 Run the relevant `cluster-core` test package target if available.
-- [ ] 3.3 Run `openspec validate test-grain-pending-activation-contract --strict`.
+- [ ] 3.3 Run `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate test-grain-pending-activation-contract --strict`.
 - [ ] 3.4 Run `git diff --check`.


### PR DESCRIPTION
## Summary
- Propose `test-grain-pending-activation-contract` as the next cluster Grain runtime change
- Scope the change to public `IdentityLookup::resolve` pending behavior for distributed activation
- Add proposal, design, delta spec, and tasks artifacts

## Validation
- MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate test-grain-pending-activation-contract --strict
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and spec artifacts only; no runtime or API changes in this PR.
> 
> **Overview**
> Adds an **OpenSpec** change package (`test-grain-pending-activation-contract`) that plans **test-first** work—no production code in this diff.
> 
> It introduces capability **`cluster-grain-runtime-contract-tests`** with scenarios for **`PartitionIdentityLookup`** under distributed activation: public **`IdentityLookup::resolve`** must return **`LookupError::Pending`** until placement commands finish, must stay pending on repeat calls (no stale or fake PID), then return the stored PID after the command sequence completes. **Design** and **tasks** target extending **`grain_runtime_operational_contract_test.rs`**, reusing existing placement-command helpers, and allowing **minimal** identity/placement fixes only if tests fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3a61237f806a290f07385603e42e47d1d156920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->