### PR TITLE
test: cover grain pending activation resolve

### DIFF
--- a/modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs
+++ b/modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs
@@ -289,6 +289,32 @@ fn distributed_activation_reports_pending_then_completes_after_command_results()
 }
 
 #[test]
+fn public_resolve_stays_pending_until_distributed_activation_completes() {
+  let mut lookup = member_lookup();
+  lookup.update_topology(vec!["node-a:4050".to_string()]);
+  lookup.set_local_authority("node-a:4050");
+  lookup.set_distributed_activation(true);
+  let key = grain_key("user/public-pending");
+
+  let (request_id, owner) = begin_pending_activation(&mut lookup, &key, 1000);
+
+  let first = lookup.resolve(&key, 1001);
+  assert!(matches!(first, Err(LookupError::Pending)));
+
+  let repeated = lookup.resolve(&key, 1002);
+  assert!(matches!(repeated, Err(LookupError::Pending)));
+
+  let pid = "custom-public-pending-pid";
+  let completed = complete_pending_activation(&mut lookup, request_id, &key, &owner, pid);
+  assert_eq!(completed.pid, pid);
+  assert_eq!(completed.decision.authority, owner);
+
+  let cached = lookup.resolve(&key, 1003).expect("completed public resolution");
+  assert_eq!(cached.pid, pid);
+  assert_eq!(cached.decision.authority, owner);
+}
+
+#[test]
 fn topology_replacement_invalidates_absent_authority_cache_and_reresolves() {
   let mut lookup = member_lookup();
   lookup.update_topology(vec!["node-a:4050".to_string()]);

--- a/openspec/changes/test-grain-pending-activation-contract/tasks.md
+++ b/openspec/changes/test-grain-pending-activation-contract/tasks.md
@@ -1,19 +1,19 @@
 ## 1. Test Placement
 
-- [ ] 1.1 Review existing `modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs` helpers for pending activation command completion.
-- [ ] 1.2 Add a focused contract test in the existing identity operational contract test module for first public `resolve` returning `LookupError::Pending`.
-- [ ] 1.3 Add a repeated public `resolve` assertion while the placement command sequence is still outstanding.
-- [ ] 1.4 Complete the emitted placement command sequence and assert a later public `resolve` returns the stored PID and selected authority.
+- [x] 1.1 Review existing `modules/cluster-core/src/identity/grain_runtime_operational_contract_test.rs` helpers for pending activation command completion.
+- [x] 1.2 Add a focused contract test in the existing identity operational contract test module for first public `resolve` returning `LookupError::Pending`.
+- [x] 1.3 Add a repeated public `resolve` assertion while the placement command sequence is still outstanding.
+- [x] 1.4 Complete the emitted placement command sequence and assert a later public `resolve` returns the stored PID and selected authority.
 
 ## 2. Minimal Implementation Fixes
 
-- [ ] 2.1 Run the new focused test first and inspect whether current behavior already satisfies the contract.
-- [ ] 2.2 If the test fails, adjust only `PartitionIdentityLookup` / placement coordinator behavior needed to preserve pending resolution until command completion.
-- [ ] 2.3 Confirm the fix does not broaden topology invalidation, passivation, rolling update, rebalance, remembered entities, or SBR scope.
+- [x] 2.1 Run the new focused test first and inspect whether current behavior already satisfies the contract.
+- [x] 2.2 If the test fails, adjust only `PartitionIdentityLookup` / placement coordinator behavior needed to preserve pending resolution until command completion.
+- [x] 2.3 Confirm the fix does not broaden topology invalidation, passivation, rolling update, rebalance, remembered entities, or SBR scope.
 
 ## 3. Validation
 
-- [ ] 3.1 Run the focused `cluster-core` identity operational contract test.
-- [ ] 3.2 Run the relevant `cluster-core` test package target if available.
-- [ ] 3.3 Run `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate test-grain-pending-activation-contract --strict`.
-- [ ] 3.4 Run `git diff --check`.
+- [x] 3.1 Run the focused `cluster-core` identity operational contract test.
+- [x] 3.2 Run the relevant `cluster-core` test package target if available.
+- [x] 3.3 Run `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate test-grain-pending-activation-contract --strict`.
+- [x] 3.4 Run `git diff --check`.


### PR DESCRIPTION
## Summary
- Add a Grain runtime operational contract test for public `IdentityLookup::resolve` pending behavior during distributed activation
- Mark `test-grain-pending-activation-contract` tasks complete
- Keep implementation unchanged because current behavior satisfies the contract

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-rs public_resolve_stays_pending_until_distributed_activation_completes -- --nocapture`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-rs`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate test-grain-pending-activation-contract --strict`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and OpenSpec task updates; no runtime or placement logic modified.
> 
> **Overview**
> Adds an operational contract test that **public** `resolve` returns `LookupError::Pending` on first and repeated calls while distributed activation’s placement commands are still in flight, then returns the activated PID and authority after the existing test helpers finish the command sequence.
> 
> The OpenSpec change `test-grain-pending-activation-contract` task checklist is marked complete; **no production changes**—validation confirmed current `PartitionIdentityLookup` / placement behavior already meets the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412d8474b28fd1b23cdf07841a04dc454f31aa0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->