### PR TITLE
cluster計画ドキュメントの完了項目に取消線を追加

### DIFF
--- a/docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md
+++ b/docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md
@@ -86,39 +86,45 @@ Cons:
 
 ## Task slices
 
-### 1. Documentation alignment
+進捗の読み方:
 
-- `cluster-gap-analysis.md` を Pekko comparison として位置づけ直す。
-- README / docs で `cluster-*` の主語を Grain runtime として説明する。
-- Pekko parity ではなく参照実装としての扱いを明記する。
+- `~~取消線~~` は OpenSpec archive / current code / tests で完了確認できる項目。
+- 取消線なしは未完了または別 change として継続中の項目。
+
+### ~~1. Documentation alignment~~
+
+- ~~`cluster-gap-analysis.md` を Pekko comparison として位置づけ直す。~~
+- ~~README / docs で `cluster-*` の主語を Grain runtime として説明する。~~
+- ~~Pekko parity ではなく参照実装としての扱いを明記する。~~
 
 ### 2. Operational contract tests
 
-- identity lookup の成功 / pending / no authority を contract test として固定する。
-- topology update 後に absent authority の activation / cache が無効化されることを固定する。
-- leave / down / passivation と `GrainRef` 解決の関係を固定する。
+- ~~identity lookup の成功 / no authority を contract test として固定する。~~
+- pending activation の public `IdentityLookup::resolve` contract は `test-grain-pending-activation-contract` で継続中。
+- ~~topology update 後に absent authority の activation / cache が無効化されることを固定する。~~
+- ~~leave / down / passivation と `GrainRef` 解決の関係を固定する。~~
 
-### 3. Provider boundary hardening
+### ~~3. Provider boundary hardening~~
 
-- local / static / AWS ECS provider がどこまで membership を供給し、どこから cluster core が扱うかを文書化する。
-- seed / discovery / lifecycle adapter の責務境界を明確にする。
-- std adapter 実装で保持すべき subscription / driver lifetime を確認する。
+- ~~local / static / AWS ECS provider がどこまで membership を供給し、どこから cluster core が扱うかを文書化する。~~
+- ~~seed / discovery / lifecycle adapter の責務境界を明確にする。~~
+- ~~std adapter 実装で保持すべき subscription / driver lifetime を確認する。~~
 
 作業メモ: [2026-05-26_cluster-provider-boundary.md](2026-05-26_cluster-provider-boundary.md) で、DIP と port-and-adapter の向きを `cluster-core` が policy / port を所有し std が adapter 実装に留まる形として整理する。
 
-### 4. Failure detector and downing minimum
+### ~~4. Failure detector and downing minimum~~
 
-- `DowningProvider` を単なる explicit down hook から、failure observation に対する判断 contract へ拡張するか検討する。
-- SBR 全面実装ではなく、最小 downing decision model を先に切る。
-- Reachability matrix を入れるか、現在の suspect / unreachable event model を強化するかを比較する。
+- ~~`DowningProvider` を単なる explicit down hook から、failure observation に対する判断 contract へ拡張するか検討する。~~
+- ~~SBR 全面実装ではなく、最小 downing decision model を先に切る。~~
+- ~~Reachability matrix を入れるか、現在の suspect / unreachable event model を強化するかを比較する。~~
 
 作業メモ: [2026-05-26_failure-downing-boundary.md](2026-05-26_failure-downing-boundary.md) で、failure observation と member departure input を分離し、`DowningProvider` を decision port として扱う最小 contract を整理する。
 
 ### 5. Placement scalability
 
 - Rendezvous hashing のまま伸ばす範囲を明確にする。
-- rebalance を即実装する前に、join / leave / rolling update 時の movement と cache invalidation の期待値を固定する。
-- remembered entities は persistence integration の要求が明確になるまで deferred とする。
+- ~~rebalance を即実装する前に、join / leave / rolling update 時の movement と cache invalidation の期待値を固定する。~~
+- ~~remembered entities は persistence integration の要求が明確になるまで deferred とする。~~
 
 ## Deferred scope
 

--- a/docs/plan/2026-05-26_cluster-provider-boundary.md
+++ b/docs/plan/2026-05-26_cluster-provider-boundary.md
@@ -6,17 +6,19 @@
 
 この文書は `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` の Task slice 3 に対応する。Downing decision model、reachability matrix、rebalance、remembered entities は次の change に分ける。
 
+進捗: `document-cluster-provider-boundary` として完了済み。
+
 ## 境界
 
 ### cluster-core
 
 `cluster-core` が所有するもの:
 
-- `ClusterProvider` trait の共通操作。
-- provider port と extension lifecycle policy。
-- `LocalClusterProvider` / `StaticClusterProvider` の no_std compatible な topology publication。
-- `ClusterEvent::TopologyUpdated`、`TopologyUpdate`、`ClusterTopology` の表現。
-- Grain runtime 側の topology invalidation contract。
+- ~~`ClusterProvider` trait の共通操作。~~
+- ~~provider port と extension lifecycle policy。~~
+- ~~`LocalClusterProvider` / `StaticClusterProvider` の no_std compatible な topology publication。~~
+- ~~`ClusterEvent::TopologyUpdated`、`TopologyUpdate`、`ClusterTopology` の表現。~~
+- ~~Grain runtime 側の topology invalidation contract。~~
 
 `cluster-core` が所有しないもの:
 
@@ -30,42 +32,42 @@
 
 Local provider は core-defined `ClusterProvider` port の実装である。明示的な `join` / `leave` / `down` と、std adapter が外部 remoting lifecycle から変換した provider port input を membership input として扱う。
 
-- `start_member` は自身の advertised address を members に追加し、startup event を publish する。
-- `start_client` は client startup event を publish する。
-- static topology が設定されている場合、start 時に topology update を publish する。
-- `join` は advertised address 自身を no-op とし、それ以外の authority を joined topology input に変換する。
-- `leave` / `down` は current member を left topology input に変換する。
+- ~~`start_member` は自身の advertised address を members に追加し、startup event を publish する。~~
+- ~~`start_client` は client startup event を publish する。~~
+- ~~static topology が設定されている場合、start 時に topology update を publish する。~~
+- ~~`join` は advertised address 自身を no-op とし、それ以外の authority を joined topology input に変換する。~~
+- ~~`leave` / `down` は current member を left topology input に変換する。~~
 
 ### StaticClusterProvider
 
 Static provider は discovery を持たない。設定済み topology を start 時に EventStream へ publish するだけの provider である。
 
-- `start_member` / `start_client` は設定済み topology を topology update として publish する。
-- configured topology がなければ topology update は publish しない。
-- `join` / `leave` / `down` は topology discovery を行わない。
-- shutdown に追加の cleanup はない。
+- ~~`start_member` / `start_client` は設定済み topology を topology update として publish する。~~
+- ~~configured topology がなければ topology update は publish しない。~~
+- ~~`join` / `leave` / `down` は topology discovery を行わない。~~
+- ~~shutdown に追加の cleanup はない。~~
 
 ### std remoting lifecycle adapter
 
 `cluster-adaptor-std` の remoting lifecycle adapter は std-only の adapter である。core policy を所有せず、core-defined provider port へ外部 lifecycle signal を供給するための subscription lifetime だけを持つ。
 
-- `subscribe_remoting_events` は `RemotingLifecycleEvent::Connected` を local provider の join input に変換する。
-- `RemotingLifecycleEvent::Quarantined` は local provider の leave input に変換する。
-- provider 起動前の lifecycle event は無視する。
-- 返された `EventStreamSubscription` を保持している間だけ adapter は有効である。
-- subscription は provider を強参照し続けない。
+- ~~`subscribe_remoting_events` は `RemotingLifecycleEvent::Connected` を local provider の join input に変換する。~~
+- ~~`RemotingLifecycleEvent::Quarantined` は local provider の leave input に変換する。~~
+- ~~provider 起動前の lifecycle event は無視する。~~
+- ~~返された `EventStreamSubscription` を保持している間だけ adapter は有効である。~~
+- ~~subscription は provider を強参照し続けない。~~
 
 ### AwsEcsClusterProvider
 
 AWS ECS provider は `cluster-adaptor-std` 側の `ClusterProvider` adapter 実装であり、AWS ECS task discovery を core-defined provider port の topology input に変換する。
 
-- `start_member` は自身の advertised address を members に追加し、初回 topology update と startup event を publish し、poller を開始する。
-- `start_client` は自身を member に加えず、startup event を publish し、poller を開始する。
-- poller は ECS `ListTasks` / `DescribeTasks` の結果から running task の private IPv4 address を authority candidate に変換する。
-- discovered member 差分を joined / left topology update として publish する。
-- `down` は known remote member を left topology input に変換するが、自分自身の down は拒否する。
-- `join` / `leave` は明示操作としては非対応で、discovery source は ECS polling に限定する。
-- `shutdown` は poller stop signal を立て、members を clear し、shutdown event を publish する。
+- ~~`start_member` は自身の advertised address を members に追加し、初回 topology update と startup event を publish し、poller を開始する。~~
+- ~~`start_client` は自身を member に加えず、startup event を publish し、poller を開始する。~~
+- ~~poller は ECS `ListTasks` / `DescribeTasks` の結果から running task の private IPv4 address を authority candidate に変換する。~~
+- ~~discovered member 差分を joined / left topology update として publish する。~~
+- ~~`down` は known remote member を left topology input に変換するが、自分自身の down は拒否する。~~
+- ~~`join` / `leave` は明示操作としては非対応で、discovery source は ECS polling に限定する。~~
+- ~~`shutdown` は poller stop signal を立て、members を clear し、shutdown event を publish する。~~
 
 ## 後続
 

--- a/docs/plan/2026-05-26_failure-downing-boundary.md
+++ b/docs/plan/2026-05-26_failure-downing-boundary.md
@@ -6,14 +6,16 @@ Failure detector と membership coordination が扱う suspect / unreachable は
 
 `cluster-core` は `DowningProvider` を core-defined decision port として所有する。explicit down command と failure observation は `DowningInput` として strategy に渡され、strategy が `DowningDecision::Down` を返した場合だけ provider-neutral な departure input に進む。
 
+進捗: `define-failure-downing-minimum` として完了済み。
+
 ## 最小 contract
 
-- `DowningInput::ExplicitDown` は explicit down command の入口。
-- `DowningInput::FailureObservation` は failure detector / membership 由来の availability observation の入口。
-- `DowningDecision::Down` は active topology から authority を外す判断。
-- `DowningDecision::Keep` / `DowningDecision::Defer` は active topology を保持する判断。
-- Grain runtime は topology update の `left` / `dead` によって stale activation と PID cache を invalidation する。phi value、suspect timer、SBR details は inspect しない。
+- ~~`DowningInput::ExplicitDown` は explicit down command の入口。~~
+- ~~`DowningInput::FailureObservation` は failure detector / membership 由来の availability observation の入口。~~
+- ~~`DowningDecision::Down` は active topology から authority を外す判断。~~
+- ~~`DowningDecision::Keep` / `DowningDecision::Defer` は active topology を保持する判断。~~
+- ~~Grain runtime は topology update の `left` / `dead` によって stale activation と PID cache を invalidation する。phi value、suspect timer、SBR details は inspect しない。~~
 
 ## 対象外
 
-Split Brain Resolver、reachability matrix、rebalance、remembered entities、in-flight drain はこの change では実装しない。
+~~Split Brain Resolver、reachability matrix、rebalance、remembered entities、in-flight drain はこの change では実装しない。~~


### PR DESCRIPTION
## 概要

cluster クレート更新作業の進捗が読み取れるように、計画ドキュメントへ完了済み項目の取消線を追加しました。

## 変更内容

- `cluster-grain-runtime-roadmap` に進捗の読み方を追加
- 完了済みの documentation alignment / provider boundary / failure downing minimum を取消線で整理
- 継続中の `test-grain-pending-activation-contract` と未完了の placement scalability 項目は残存タスクとして明示
- provider boundary / failure downing boundary の個別ノートにも完了済み状態を反映

## 確認

- `git diff --check`

Rust コードは変更していないため、Rust テストは実行していません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 計画 Markdown のみの更新で、ランタイム・API・セキュリティに影響しません。
> 
> **Overview**
> Cluster Grain runtime の**計画ドキュメント**を、実装・OpenSpec 完了状況が一目で分かるよう更新しています。Rust コードの変更はありません。
> 
> **`2026-05-25_cluster-grain-runtime-roadmap.md`** に「進捗の読み方」（`~~取消線~~`＝完了確認済み、取消線なし＝未完了／別 change）を追加し、documentation alignment・provider boundary・failure/downing minimum など完了スライスと個別タスクを取消線で整理しました。operational contract tests では identity lookup の一部を完了扱いにしつつ、**pending activation** の `IdentityLookup::resolve` は `test-grain-pending-activation-contract` 継続中と明記。placement scalability の rebalance 期待値・remembered entities deferred も完了マークにしています。
> 
> **`2026-05-26_cluster-provider-boundary.md`** と **`2026-05-26_failure-downing-boundary.md`** には、それぞれ `document-cluster-provider-boundary` / `define-failure-downing-minimum` 完了の進捗行と、境界・最小 contract の各箇条への取消線を追加しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ec27ea6672724d3510c3cbdf0aabeafa6efae8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * ロードマップドキュメントの進捗状態を更新しました
  * 完了済み項目と進行中項目の区別を明確化しました
  * 複数の計画ドキュメントに完了状態を反映させました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->