### PR TITLE
Placement scalability の残項目を閉じる change を追加

### DIFF
--- a/openspec/changes/close-cluster-placement-scalability-roadmap/.openspec.yaml
+++ b/openspec/changes/close-cluster-placement-scalability-roadmap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/close-cluster-placement-scalability-roadmap/design.md
+++ b/openspec/changes/close-cluster-placement-scalability-roadmap/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` still shows "Rendezvous hashing のまま伸ばす範囲を明確にする" as open.
+Current `openspec/specs/cluster-grain-runtime-operational-contract/spec.md` already contains the corresponding contract:
+
+- deterministic Rendezvous owner selection for the same key and topology
+- no immediate movement for existing active activations on join
+- expanded topology use for new resolutions after join
+- no minimum movement guarantee across topology changes
+- rolling update bounded to stale placement prevention
+
+The archived `define-placement-movement-contract` change and the completed `test-grain-pending-activation-contract` change cover the remaining placement-related contract gaps.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Update the roadmap so Task slice 5 reflects current completed placement contracts.
+- Point readers at the completed OpenSpec work that closed the Rendezvous / movement scope.
+- Keep the roadmap useful for deciding future rebalance or remembered entity work.
+
+**Non-Goals:**
+
+- Add or modify OpenSpec requirements.
+- Change placement algorithm behavior.
+- Implement rebalance, remembered entities, persistence recovery, or in-flight drain.
+- Modify Rust source or public APIs.
+
+## Decisions
+
+1. Treat this as a docs-only roadmap alignment change.
+
+   The behavioral contract already exists in `cluster-grain-runtime-operational-contract`, so adding another capability would duplicate the source of truth.
+   Alternative: create a new placement scalability capability. That would make the same constraints appear in two places and increase archive drift risk.
+
+2. Mark the roadmap item complete instead of creating new implementation tasks.
+
+   The remaining visible item is stale roadmap state, not missing runtime behavior.
+   Alternative: leave it open as a reminder for future rebalance work. That is misleading because rebalance / remembered entities are already deferred scope, not part of the current Placement scalability slice.
+
+3. Keep future scalability work separate.
+
+   Real rebalance, remembered entities, recovery, and draining require their own contracts and should not be bundled into this cleanup.
+
+## Risks / Trade-offs
+
+- [Risk] Readers may think all future placement scalability work is done. -> Mitigation: keep deferred scope explicit and reference that rebalance / remembered entities remain future changes.
+- [Risk] Docs-only change may look too small for OpenSpec. -> Mitigation: this change exists because the roadmap is being used as work-tracking input and needs an auditable closure.

--- a/openspec/changes/close-cluster-placement-scalability-roadmap/proposal.md
+++ b/openspec/changes/close-cluster-placement-scalability-roadmap/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` still shows part of Task slice 5 as open, even though `define-placement-movement-contract` and `test-grain-pending-activation-contract` have already fixed the relevant Placement scalability contracts.
+This change closes that roadmap drift so the remaining cluster work is not misread as an implementation gap.
+
+## What Changes
+
+- Mark the remaining Placement scalability roadmap item as completed where current specs and archived changes already cover it.
+- Link the roadmap status to the completed placement movement and pending activation contract work.
+- Keep future rebalance, remembered entities, recovery, and in-flight drain out of scope.
+- Do not change Rust source, public APIs, runtime behavior, dependencies, or OpenSpec requirements.
+
+## Capabilities
+
+### New Capabilities
+
+- なし
+
+### Modified Capabilities
+
+- `cluster-grain-runtime-operational-contract`: Clarify that the existing Rendezvous / movement contract is the bounded Placement scalability contract for this roadmap slice.
+
+## Impact
+
+- `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md`
+- OpenSpec change artifacts only

--- a/openspec/changes/close-cluster-placement-scalability-roadmap/specs/cluster-grain-runtime-operational-contract/spec.md
+++ b/openspec/changes/close-cluster-placement-scalability-roadmap/specs/cluster-grain-runtime-operational-contract/spec.md
@@ -1,0 +1,62 @@
+## MODIFIED Requirements
+
+### Requirement: Grain identity resolution is deterministic and state-aware
+
+Grain identity lookup SHALL resolve a `GrainKey` from the current authority topology and SHALL report unresolved states explicitly. It MUST NOT return a stale PID when the lookup is stopped, has no authorities, or is waiting for asynchronous activation.
+
+Rendezvous hashing SHALL provide deterministic owner selection for the same `GrainKey` and same authority topology. New placement decisions MUST use the active authority topology. Existing active activations MUST NOT move only because a new authority joined.
+
+This requirement SHALL be treated as the bounded Placement scalability contract for the current Grain runtime roadmap slice. It MUST NOT imply least-shard rebalance, minimum movement guarantees, remembered entity recovery, persistence-backed activation recovery, or in-flight request draining.
+
+#### Scenario: no authority is reported explicitly
+
+- **WHEN** member-mode identity lookup resolves a `GrainKey` before any authority is present
+- **THEN** resolution fails with `LookupError::NoAuthority`
+- **AND** no PID is cached for that `GrainKey`
+
+#### Scenario: same key and topology resolve deterministically
+
+- **GIVEN** two identity lookup instances have the same authority topology
+- **WHEN** both instances resolve the same `GrainKey`
+- **THEN** both select the same authority
+- **AND** both produce a placement decision for that authority
+
+#### Scenario: cache hit reuses the active PID
+
+- **GIVEN** a `GrainKey` has been resolved and its activation is still valid
+- **WHEN** the same `GrainKey` is resolved again before PID TTL or passivation invalidates it
+- **THEN** lookup returns the same PID
+- **AND** the returned PID belongs to the same authority decision
+
+#### Scenario: distributed activation exposes pending resolution
+
+- **GIVEN** distributed activation is enabled for a local authority
+- **WHEN** lookup starts resolving a `GrainKey` that requires lock, load, ensure, and store commands
+- **THEN** lookup reports `LookupError::Pending` until the command results complete
+- **AND** lookup returns a PID only after activation is stored and the lock is released
+
+#### Scenario: same topology produces stable owner
+
+- **GIVEN** the same non-empty authority topology
+- **WHEN** the same `GrainKey` is selected multiple times
+- **THEN** Rendezvous placement returns the same authority each time
+
+#### Scenario: join does not move existing active activation
+
+- **GIVEN** a `GrainKey` has an active activation owned by an authority in the current topology
+- **WHEN** a new authority joins the topology
+- **THEN** lookup may continue returning the existing active PID for that `GrainKey`
+- **AND** no passivation or PID cache drop is emitted only because of the join
+
+#### Scenario: new resolution after join uses expanded topology
+
+- **GIVEN** a new authority joined the topology
+- **WHEN** a `GrainKey` without an active activation is resolved
+- **THEN** placement selection uses the expanded active topology
+- **AND** the selected authority belongs to that topology
+
+#### Scenario: topology change permits owner change without movement guarantee
+
+- **WHEN** authority topology changes by join or leave
+- **THEN** future placement decisions may select a different owner according to Rendezvous hashing
+- **AND** the runtime does not guarantee minimum movement across all keys

--- a/openspec/changes/close-cluster-placement-scalability-roadmap/tasks.md
+++ b/openspec/changes/close-cluster-placement-scalability-roadmap/tasks.md
@@ -1,0 +1,17 @@
+## 1. Roadmap Alignment
+
+- [ ] 1.1 Confirm `define-placement-movement-contract` is archived and reflected in `cluster-grain-runtime-operational-contract`.
+- [ ] 1.2 Confirm `test-grain-pending-activation-contract` is complete and no longer leaves an open pending activation roadmap gap.
+- [ ] 1.3 Update `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` so Task slice 5 marks the Rendezvous hashing scope as complete.
+- [ ] 1.4 Keep future rebalance, remembered entities, persistence recovery, and in-flight drain listed only as deferred or future scope.
+
+## 2. Specification Alignment
+
+- [ ] 2.1 Apply the spec clarification that the existing Rendezvous / movement requirement is the bounded Placement scalability contract.
+- [ ] 2.2 Ensure the clarification does not introduce a new placement algorithm, rebalance guarantee, or public API requirement.
+
+## 3. Validation
+
+- [ ] 3.1 Run `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate close-cluster-placement-scalability-roadmap --strict`.
+- [ ] 3.2 Run `git diff --check`.
+- [ ] 3.3 Review the final diff and confirm only OpenSpec artifacts and roadmap documentation changed.


### PR DESCRIPTION
## 概要

`cluster-grain-runtime-roadmap` の Placement scalability 残項目を閉じるための OpenSpec change を追加しました。

## 背景

`define-placement-movement-contract` と `test-grain-pending-activation-contract` は完了済みで、Rendezvous hashing / movement / pending activation 周りの contract は現在の spec に反映済みです。一方で roadmap 上は Task slice 5 の一部が未完了に見えるため、実装ギャップではなく roadmap drift として扱います。

## 変更内容

- `close-cluster-placement-scalability-roadmap` change を追加
- proposal / design / tasks を作成
- `cluster-grain-runtime-operational-contract` に、既存の Rendezvous / movement requirement が現在の bounded Placement scalability contract であることを明記する delta spec を追加
- rebalance / remembered entities / recovery / in-flight drain は引き続き future scope として分離

## 確認

- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate close-cluster-placement-scalability-roadmap --strict`
- `git diff --check`

Rust コードは変更していません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenSpec delta only; no production code or placement algorithm changes.
> 
> **Overview**
> Adds the OpenSpec change **`close-cluster-placement-scalability-roadmap`** so Placement scalability on the cluster grain roadmap can be closed as **documentation/spec alignment**, not as missing runtime work.
> 
> The change records that **`define-placement-movement-contract`** and **`test-grain-pending-activation-contract`** already cover Rendezvous / movement / pending activation, and proposes marking the open roadmap line (“Rendezvous hashing のまま伸ばす範囲を明確にする”) complete while keeping **rebalance**, **remembered entities**, **recovery**, and **in-flight drain** as future scope. It includes **proposal**, **design**, **tasks**, and a **delta** to **`cluster-grain-runtime-operational-contract`** that states the existing deterministic Rendezvous requirement is the **bounded** Placement scalability contract for the current roadmap slice and must **not** be read as promising least-shard rebalance, minimum movement, or recovery/drain behavior.
> 
> **No Rust, APIs, or runtime behavior** are changed in this diff; follow-up work in the task list includes updating `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` and running `openspec validate`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a98b84d9b585d32340a1d25f3cc7ead0327334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->