### PR TITLE
cluster placement scalability ロードマップを完了扱いに更新

### DIFF
--- a/docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md
+++ b/docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md
@@ -100,7 +100,7 @@ Cons:
 ### 2. Operational contract tests
 
 - ~~identity lookup の成功 / no authority を contract test として固定する。~~
-- pending activation の public `IdentityLookup::resolve` contract は `test-grain-pending-activation-contract` で継続中。
+- ~~pending activation の public `IdentityLookup::resolve` contract を固定する。~~
 - ~~topology update 後に absent authority の activation / cache が無効化されることを固定する。~~
 - ~~leave / down / passivation と `GrainRef` 解決の関係を固定する。~~
 
@@ -120,11 +120,13 @@ Cons:
 
 作業メモ: [2026-05-26_failure-downing-boundary.md](2026-05-26_failure-downing-boundary.md) で、failure observation と member departure input を分離し、`DowningProvider` を decision port として扱う最小 contract を整理する。
 
-### 5. Placement scalability
+### ~~5. Placement scalability~~
 
-- Rendezvous hashing のまま伸ばす範囲を明確にする。
+- ~~Rendezvous hashing のまま伸ばす範囲を明確にする。~~
 - ~~rebalance を即実装する前に、join / leave / rolling update 時の movement と cache invalidation の期待値を固定する。~~
 - ~~remembered entities は persistence integration の要求が明確になるまで deferred とする。~~
+
+作業メモ: `define-placement-movement-contract` と `test-grain-pending-activation-contract` により、現行の bounded Placement scalability contract は `cluster-grain-runtime-operational-contract` に集約済み。今後の rebalance / remembered entities / recovery / drain は別 change として扱う。
 
 ## Deferred scope
 
@@ -137,6 +139,9 @@ Cons:
 - sharding delivery controllers
 - replicated sharding / direct replication
 - Pekko serializer binary compatibility
+- least-shard rebalance / minimum movement guarantee
+- remembered entities / persistence-backed activation recovery
+- in-flight request draining
 
 ## OpenSpec 境界
 

--- a/openspec/changes/close-cluster-placement-scalability-roadmap/tasks.md
+++ b/openspec/changes/close-cluster-placement-scalability-roadmap/tasks.md
@@ -1,17 +1,17 @@
 ## 1. Roadmap Alignment
 
-- [ ] 1.1 Confirm `define-placement-movement-contract` is archived and reflected in `cluster-grain-runtime-operational-contract`.
-- [ ] 1.2 Confirm `test-grain-pending-activation-contract` is complete and no longer leaves an open pending activation roadmap gap.
-- [ ] 1.3 Update `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` so Task slice 5 marks the Rendezvous hashing scope as complete.
-- [ ] 1.4 Keep future rebalance, remembered entities, persistence recovery, and in-flight drain listed only as deferred or future scope.
+- [x] 1.1 Confirm `define-placement-movement-contract` is archived and reflected in `cluster-grain-runtime-operational-contract`.
+- [x] 1.2 Confirm `test-grain-pending-activation-contract` is complete and no longer leaves an open pending activation roadmap gap.
+- [x] 1.3 Update `docs/plan/2026-05-25_cluster-grain-runtime-roadmap.md` so Task slice 5 marks the Rendezvous hashing scope as complete.
+- [x] 1.4 Keep future rebalance, remembered entities, persistence recovery, and in-flight drain listed only as deferred or future scope.
 
 ## 2. Specification Alignment
 
-- [ ] 2.1 Apply the spec clarification that the existing Rendezvous / movement requirement is the bounded Placement scalability contract.
-- [ ] 2.2 Ensure the clarification does not introduce a new placement algorithm, rebalance guarantee, or public API requirement.
+- [x] 2.1 Apply the spec clarification that the existing Rendezvous / movement requirement is the bounded Placement scalability contract.
+- [x] 2.2 Ensure the clarification does not introduce a new placement algorithm, rebalance guarantee, or public API requirement.
 
 ## 3. Validation
 
-- [ ] 3.1 Run `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate close-cluster-placement-scalability-roadmap --strict`.
-- [ ] 3.2 Run `git diff --check`.
-- [ ] 3.3 Review the final diff and confirm only OpenSpec artifacts and roadmap documentation changed.
+- [x] 3.1 Run `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate close-cluster-placement-scalability-roadmap --strict`.
+- [x] 3.2 Run `git diff --check`.
+- [x] 3.3 Review the final diff and confirm only OpenSpec artifacts and roadmap documentation changed.


### PR DESCRIPTION
## 概要
- cluster Grain runtime roadmap の pending activation と Placement scalability を完了扱いに更新しました。
- 現行の bounded Placement scalability contract が `cluster-grain-runtime-operational-contract` に集約済みであることを追記しました。
- rebalance / remembered entities / recovery / in-flight drain は deferred scope に限定しました。

## 影響範囲
- ドキュメントと OpenSpec tasks のみです。
- Rust ソース、公開 API、runtime behavior は変更していません。

## 検証
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- openspec validate close-cluster-placement-scalability-roadmap --strict`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ドキュメントと OpenSpec タスクチェックリストのみで、実行時コードや公開 API は触っていません。
> 
> **Overview**
> **Cluster Grain runtime roadmap** のドキュメントを更新し、**Placement scalability（Task slice 5）** と **pending activation** の運用 contract 作業を完了扱いにしました。bounded contract が `cluster-grain-runtime-operational-contract` に集約済みである旨の作業メモを追記し、**least-shard rebalance**、**remembered entities / persistence recovery**、**in-flight drain** を **Deferred scope** に明示しました。
> 
> OpenSpec change `close-cluster-placement-scalability-roadmap` の **tasks.md** は、roadmap / spec 整合と検証項目をすべて `[x]` に更新しただけです。**Rust コード・公開 API・ランタイム挙動の変更はありません。**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68294d75d03350600d460365d28693fb3a15a119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->