### PR TITLE
persistence ギャップ分析の再検証結果を反映

### DIFF
--- a/docs/gap-analysis/persistence-gap-analysis.md
+++ b/docs/gap-analysis/persistence-gap-analysis.md
@@ -1,6 +1,6 @@
 # persistence モジュール ギャップ分析
 
-更新日: 2026-05-24 JST
+更新日: 2026-05-27 JST
 
 ## 比較スコープ定義
 
@@ -54,7 +54,7 @@ raw declaration count は参考値であり、parity 分母に使わない。
 
 classic write-side persistence は、persistent actor、journal、snapshot、event adapter、at-least-once delivery、durable state store の基本契約が揃っている。typed write-side は Pekko typed `EventSourcedBehavior` / `Effect` の直移植ではなく、通常の typed `Behavior` を保ったまま hidden child store actor に永続化を委譲する effector-first API として実装されている。
 
-2026-05-24 の再検証では、現行 crate 境界が `persistence-core-kernel` / `persistence-core-typed` であり、`persistence-adaptor-std` は存在しないことを確認した。前回「部分実装」として残っていた adapter manifest と serializer manifest の接続は、`PersistenceContext::to_journal_repr`、`PersistentRepr::adapter_type_id`、`MessageSerializer` の wire encoding で接続済みと判定する。
+2026-05-27 の再検証では、現行 crate 境界が `persistence-core-kernel` / `persistence-core-typed` であり、`persistence-adaptor-std` は存在しないことを確認した。Pekko 側 raw extraction と fraktor-rs 側 raw / externally reachable extraction の件数は 2026-05-24 版から変化していない。前回「部分実装」として残っていた adapter manifest と serializer manifest の接続は、`PersistenceContext::to_journal_repr`、`PersistentRepr::adapter_type_id`、`MessageSerializer` の wire encoding で接続済みと判定する。
 
 ## 層別カバレッジ
 


### PR DESCRIPTION
## 概要
- persistence ギャップ分析ドキュメントの更新日を 2026-05-27 に更新
- 現行 checkout で Pekko / fraktor-rs の raw extraction 件数が前版から変化していないことを追記

## 検証
- Pekko submodule を初期化し、Pekko 側 raw type/method count を再抽出
- fraktor-rs 側 raw / externally reachable public type/method count を再抽出
- persistence 本体の todo / unimplemented / placeholder / stub 検索を実行
- ドキュメントのみの変更のため cargo test は未実行

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to gap analysis metadata and re-verification notes; no code or behavior changes.
> 
> **Overview**
> Updates **`docs/gap-analysis/persistence-gap-analysis.md`** to record a **2026-05-27 JST** re-check of the persistence parity gap analysis.
> 
> The **再検証** paragraph now states that Pekko and fraktor-rs **raw / externally reachable** extraction counts are **unchanged** since the 2026-05-24 version, while still confirming the current crate split (`persistence-core-kernel` / `persistence-core-typed`, no `persistence-adaptor-std`) and prior conclusions on adapter/serializer manifest wiring. No runtime or API code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d66edf338eee96e37de7c216eb5184a5477bb4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->