### PR TITLE
cluster gap analysis の抽出値を現行化

### DIFF
--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -54,9 +54,9 @@
 
 ### raw 抽出値の扱い
 
-固定スコープ対象ディレクトリを `src/main` ベースで raw 抽出すると、Pekko 側は型宣言 857 件、主要 `def` 3027 件が見つかる。これには private / internal / JVM 固有 / DSL wrapper / serializer 実装が含まれるため、parity カバレッジ分母には使わない。
+固定スコープ対象ディレクトリを `src/main` ベースで raw 抽出すると、Pekko 側は型宣言 857 件、主要 `def` 3027 件が見つかる。Pekko submodule は `2dc8960074bfe269da1686609eb88663cb50ad8b` を参照した。これには private / internal / JVM 固有 / DSL wrapper / serializer 実装が含まれるため、parity カバレッジ分母には使わない。
 
-fraktor-rs 側はスキル指定の `pub` 系抽出で、型 193 件 (core: 179, std: 14)、公開メソッド 443 件 (core: 389, std: 54)。ただし、この数には `pub(crate)` の wire helper も含まれる。
+fraktor-rs 側はスキル指定の `pub` 系抽出で、型 193 件 (core: 179, std: 14)、公開メソッド 445 件 (core: 389, std: 56)。ただし、この数には `pub(crate)` の wire helper も含まれる。
 
 ## サマリー
 
@@ -66,7 +66,7 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 193 件 (core: 179,
 | fraktor-rs 固定スコープ対応概念 | 約 46 |
 | 固定スコープ概念カバレッジ | 約 46/121 (38%) |
 | raw public type declarations | 193 (core: 179, std: 14) |
-| raw public method declarations | 443 (core: 389, std: 54) |
+| raw public method declarations | 445 (core: 389, std: 56) |
 | hard gap | 18 |
 | medium gap | 26 |
 | easy gap | 20 |


### PR DESCRIPTION
## 概要

- cluster gap analysis の raw public method 抽出値を現行 checkout の再抽出結果に合わせて更新
- 参照した Pekko submodule commit を明記

## 背景

`$pekko-gap-analysis cluster` の再確認で、Pekko 側 raw 抽出値と fraktor-rs 側 raw type count は既存レポートと一致した一方、fraktor-rs 側 raw public method count が `443` ではなく `445` になっていたため、docs の数値を補正しました。

## 確認

- `git diff --check`
- `cat docs/gap-analysis/cluster-gap-analysis.md`
- Pekko / fraktor-rs の raw API 抽出コマンドを再実行

Rust コード変更はないため、Rust テストは実行していません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ドキュメントのみの数値・参照コミット更新で、ランタイムや API 挙動には影響しません。
> 
> **Overview**
> **cluster gap analysis** の raw 抽出メトリクスを、現行 checkout の再抽出結果に合わせて更新しています。
> 
> **fraktor-rs** 側の **raw public method** 件数を **443 → 445**（**std: 54 → 56**）に修正し、本文の「raw 抽出値の扱い」とサマリー表の両方で一致させています。**Pekko** submodule の参照コミット **`2dc8960074bfe269da1686609eb88663cb50ad8b`** を明記し、再現性を上げています。型件数や固定スコープ概念カバレッジなど、その他の指標は変更していません。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1420dd6598becff45d71da70dda63ee1e3f37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * クラスタギャップ分析ドキュメントの指標数値を更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->