### PR TITLE
Renovate PR で TAKT Review を起動しない

### DIFF
--- a/.github/workflows/takt-review.yml
+++ b/.github/workflows/takt-review.yml
@@ -23,12 +23,17 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.draft == false &&
+        github.event.pull_request.user.login != 'app/renovate' &&
+        github.event.pull_request.user.login != 'renovate[bot]' &&
+        !startsWith(github.event.pull_request.head.ref, 'renovate/') &&
         github.event.sender.type != 'Bot'
       ) ||
       (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         github.event.issue.state == 'open' &&
+        github.event.issue.user.login != 'app/renovate' &&
+        github.event.issue.user.login != 'renovate[bot]' &&
         github.event.sender.type != 'Bot' &&
         startsWith(github.event.comment.body, '@takt') &&
         (


### PR DESCRIPTION
## 概要
- TAKT Review workflow の job 条件に Renovate PR の除外条件を追加しました。
- `pull_request` では PR author と `renovate/` head ref を見て除外します。
- `issue_comment` では Renovate が作成した PR への `@takt` 起動も除外します。

## 背景
Renovate が作成した依存更新 PR では、TAKT Review を走らせる必要がありません。現在の条件は bot sender の除外に寄っていますが、手動コメント経由などを明示的に防ぐため、PR 作成者ベースでも除外します。

## 検証
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/takt-review.yml`
- `git diff --check`
- PR #1932 の実データが `user=renovate[bot]`, `head_ref=renovate/rust-1.x` であることを確認しました。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI の起動条件のみの変更で、アプリ本体や認証・データ処理には触れません。
> 
> **Overview**
> **TAKT Review** の GitHub Actions ジョブ条件を更新し、Renovate 由来の PR ではワークフローが走らないようにします。
> 
> `pull_request` トリガーでは、PR 作成者が `app/renovate` / `renovate[bot]` の場合と、head ref が `renovate/` で始まる場合をスキップします。`issue_comment` で `@takt` から起動する経路でも、紐づく issue（PR）の作成者が同じ Renovate アカウントのときは実行しません。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d669cffa7f351e4b0000eb67eeb19c77e1c7d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->