### PR TITLE
cluster typed API と downing provider 互換性チェックを追加する

### DIFF
--- a/modules/cluster-adaptor-std/src/membership/tokio_gossip_transport.rs
+++ b/modules/cluster-adaptor-std/src/membership/tokio_gossip_transport.rs
@@ -82,10 +82,10 @@ impl TokioGossipTransport {
         if !allowed_peers.contains(&addr) {
           continue;
         }
-        if let Ok(delta) = decode_delta(bytes) {
-          if let Err(err) = inbound_tx.try_send((addr.to_string(), delta)) {
-            tracing::warn!(from = %addr, "failed to enqueue inbound gossip delta: {err}");
-          }
+        if let Ok(delta) = decode_delta(bytes)
+          && let Err(err) = inbound_tx.try_send((addr.to_string(), delta))
+        {
+          tracing::warn!(from = %addr, "failed to enqueue inbound gossip delta: {err}");
         }
       }
     });

--- a/modules/cluster-adaptor-std/src/membership/tokio_gossiper.rs
+++ b/modules/cluster-adaptor-std/src/membership/tokio_gossiper.rs
@@ -95,13 +95,15 @@ impl Gossiper for TokioGossiper {
 
   fn stop(&mut self) -> Result<(), &'static str> {
     let shutdown = self.shutdown.take().ok_or("not started")?;
-    // must-ignore: shutdown best-effort。receiver 先行 drop の Result<(), ()> 失敗は意図どおり。
-    let _ = shutdown.send(());
+    if shutdown.send(()).is_err() {
+      tracing::debug!("gossip shutdown receiver already closed");
+    }
     if let Some(task) = self.task.take() {
       // spawn は JoinHandle を返すが、join 不要の fire-and-forget shutdown 経路のため破棄する。
       drop(self.tokio_handle.spawn(async move {
-        // must-ignore: task 終了理由 (Ok/Err/Cancelled) は後片付けパスでは参照しない。
-        let _ = task.await;
+        if let Err(err) = task.await {
+          tracing::debug!("gossip task join failed during shutdown: {err}");
+        }
       }));
     }
     Ok(())

--- a/modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs
@@ -100,5 +100,5 @@ async fn start_twice_returns_err() {
   let mut gossiper = TokioGossiper::new(config, coordinator, transport, event_stream, Handle::current());
   assert!(gossiper.start().is_ok());
   assert!(gossiper.start().is_err());
-  let _ = gossiper.stop();
+  assert!(gossiper.stop().is_ok());
 }

--- a/modules/cluster-core-kernel/src/activation/partition_identity_lookup_test.rs
+++ b/modules/cluster-core-kernel/src/activation/partition_identity_lookup_test.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 fn setup_member_mode(lookup: &mut PartitionIdentityLookup) {
-  let _ = lookup.setup_member(&[]);
+  drop(lookup.setup_member(&[]));
 }
 
 // ============================================================================
@@ -154,11 +154,11 @@ fn test_setup_member_overwrites_previous_kinds() {
   let mut lookup = PartitionIdentityLookup::with_defaults();
 
   let kinds1 = vec![ActivatedKind::new("user".to_string())];
-  let _ = lookup.setup_member(&kinds1);
+  drop(lookup.setup_member(&kinds1));
   assert_eq!(lookup.member_kinds().len(), 1);
 
   let kinds2 = vec![ActivatedKind::new("order".to_string()), ActivatedKind::new("device".to_string())];
-  let _ = lookup.setup_member(&kinds2);
+  drop(lookup.setup_member(&kinds2));
   assert_eq!(lookup.member_kinds().len(), 2);
   assert_eq!(lookup.member_kinds()[0].name(), "order");
 }
@@ -298,7 +298,7 @@ fn test_resolve_generates_activated_event_on_first_call() {
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
 
-  let _ = lookup.resolve(&key, now);
+  drop(lookup.resolve(&key, now));
   let events = lookup.drain_events();
 
   assert!(!events.is_empty());
@@ -317,14 +317,14 @@ fn test_resolve_generates_activated_event_on_subsequent_calls() {
   let now = 1000;
 
   // 初回: Activated イベント
-  let _ = lookup.resolve(&key, now);
-  let _ = lookup.drain_events();
+  drop(lookup.resolve(&key, now));
+  drop(lookup.drain_events());
 
   // キャッシュを無効化して ensure_activation を再度通過させる
   // （通常は TTL 経過後や topology 変更時に発生）
   // ここではキャッシュを手動で無効化できないため、新しいキーでテスト
   let key2 = GrainKey::new("user/456".to_string());
-  let _ = lookup.resolve(&key2, now);
+  drop(lookup.resolve(&key2, now));
   let events = lookup.drain_events();
 
   assert!(!events.is_empty());
@@ -382,15 +382,15 @@ fn test_remove_pid_invalidates_cache() {
   let now = 1000;
 
   // アクティベーションを作成
-  let _ = lookup.resolve(&key, now);
-  let _ = lookup.drain_events();
+  drop(lookup.resolve(&key, now));
+  drop(lookup.drain_events());
 
   // 削除
   lookup.remove_pid(&key);
-  let _ = lookup.drain_events();
+  drop(lookup.drain_events());
 
   // 再度 get を呼ぶと新しいアクティベーションが作成される
-  let _ = lookup.resolve(&key, now);
+  drop(lookup.resolve(&key, now));
   let events = lookup.drain_events();
 
   // 新しい Activated イベントが生成されるはず
@@ -435,8 +435,8 @@ fn test_update_topology_invalidates_absent_authorities() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
-  let _ = lookup.drain_events();
+  drop(lookup.resolve(&key, now));
+  drop(lookup.drain_events());
 
   // node1 を含まない新しいトポロジに更新
   lookup.update_topology(vec!["node2:8080".to_string()]);
@@ -459,8 +459,8 @@ fn test_on_member_left_invalidates_authority_entries() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
-  let _ = lookup.drain_events();
+  drop(lookup.resolve(&key, now));
+  drop(lookup.drain_events());
 
   // node1 が離脱
   lookup.on_member_left("node1:8080");
@@ -479,8 +479,8 @@ fn test_on_member_left_with_unknown_authority_does_nothing() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
-  let _ = lookup.drain_events();
+  drop(lookup.resolve(&key, now));
+  drop(lookup.drain_events());
 
   // 存在しない node2 が離脱
   lookup.on_member_left("node2:8080");
@@ -503,8 +503,8 @@ fn test_passivate_idle_removes_expired_activations() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
-  let _ = lookup.drain_events();
+  drop(lookup.resolve(&key, now));
+  drop(lookup.drain_events());
 
   // idle_ttl を超えた時間でパッシベーション
   let later = now + 4000; // 4000秒後（idle_ttl=3600 を超過）
@@ -524,8 +524,8 @@ fn test_passivate_idle_keeps_recent_activations() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
-  let _ = lookup.drain_events();
+  drop(lookup.resolve(&key, now));
+  drop(lookup.drain_events());
 
   // idle_ttl 未満の時間でパッシベーション
   let later = now + 100; // 100秒後（idle_ttl=3600 未満）
@@ -549,7 +549,7 @@ fn test_drain_events_returns_and_clears_events() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
+  drop(lookup.resolve(&key, now));
 
   // 1回目: イベントを取得
   let events1 = lookup.drain_events();
@@ -569,7 +569,7 @@ fn test_drain_cache_events_returns_cache_events_on_invalidation() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
+  drop(lookup.resolve(&key, now));
 
   // キャッシュを無効化（remove_pid 経由で PidCache::invalidate_key が呼ばれる）
   lookup.remove_pid(&key);
@@ -588,7 +588,7 @@ fn test_drain_cache_events_clears_after_drain() {
 
   let key = GrainKey::new("user/123".to_string());
   let now = 1000;
-  let _ = lookup.resolve(&key, now);
+  drop(lookup.resolve(&key, now));
 
   // キャッシュを無効化してイベントを生成
   lookup.remove_pid(&key);

--- a/modules/cluster-core-kernel/src/downing_provider.rs
+++ b/modules/cluster-core-kernel/src/downing_provider.rs
@@ -2,15 +2,21 @@
 
 mod downing_decision;
 mod downing_input;
+mod downing_provider_compatibility;
 mod failure_observation;
 mod failure_observation_kind;
 mod noop_downing_provider;
+mod split_brain_resolver_settings;
+mod split_brain_resolver_strategy;
 
 pub use downing_decision::DowningDecision;
 pub use downing_input::DowningInput;
+pub use downing_provider_compatibility::DowningProviderCompatibility;
 pub use failure_observation::FailureObservation;
 pub use failure_observation_kind::FailureObservationKind;
 pub use noop_downing_provider::NoopDowningProvider;
+pub use split_brain_resolver_settings::SplitBrainResolverSettings;
+pub use split_brain_resolver_strategy::SplitBrainResolverStrategy;
 
 use crate::ClusterProviderError;
 

--- a/modules/cluster-core-kernel/src/downing_provider/downing_provider_compatibility.rs
+++ b/modules/cluster-core-kernel/src/downing_provider/downing_provider_compatibility.rs
@@ -1,0 +1,54 @@
+//! Downing provider compatibility metadata for join checks.
+
+use alloc::string::String;
+
+use super::SplitBrainResolverSettings;
+
+pub(crate) const NOOP_DOWNING_PROVIDER_KEY: &str = "noop";
+const EMPTY_DOWNING_PROVIDER_KEY_REASON: &str = "downing provider compatibility key must not be empty";
+
+/// Compatibility identity advertised by a configured downing provider.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DowningProviderCompatibility {
+  provider_key:                  String,
+  split_brain_resolver_settings: Option<SplitBrainResolverSettings>,
+}
+
+impl DowningProviderCompatibility {
+  /// Creates compatibility metadata for the given provider key.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `provider_key` is empty.
+  #[must_use]
+  pub fn new(provider_key: impl Into<String>) -> Self {
+    let provider_key = provider_key.into();
+    assert!(!provider_key.is_empty(), "{EMPTY_DOWNING_PROVIDER_KEY_REASON}");
+    Self { provider_key, split_brain_resolver_settings: None }
+  }
+
+  /// Creates compatibility metadata for the built-in no-op downing provider.
+  #[must_use]
+  pub(crate) fn noop() -> Self {
+    Self::new(NOOP_DOWNING_PROVIDER_KEY)
+  }
+
+  /// Returns the stable provider key used for compatibility comparison.
+  #[must_use]
+  pub fn provider_key(&self) -> &str {
+    &self.provider_key
+  }
+
+  /// Returns optional Split Brain Resolver settings.
+  #[must_use]
+  pub const fn split_brain_resolver_settings(&self) -> Option<&SplitBrainResolverSettings> {
+    self.split_brain_resolver_settings.as_ref()
+  }
+
+  /// Attaches Split Brain Resolver settings to this compatibility identity.
+  #[must_use]
+  pub const fn with_split_brain_resolver_settings(mut self, settings: SplitBrainResolverSettings) -> Self {
+    self.split_brain_resolver_settings = Some(settings);
+    self
+  }
+}

--- a/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_settings.rs
+++ b/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_settings.rs
@@ -1,0 +1,43 @@
+//! Split Brain Resolver settings used for join compatibility checks.
+
+use core::time::Duration;
+
+use super::SplitBrainResolverStrategy;
+
+/// Split Brain Resolver settings exposed by cluster configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SplitBrainResolverSettings {
+  stable_after:           Duration,
+  active_strategy:        SplitBrainResolverStrategy,
+  down_all_when_unstable: Duration,
+}
+
+impl SplitBrainResolverSettings {
+  /// Creates settings with explicit timing and active strategy.
+  #[must_use]
+  pub const fn new(
+    stable_after: Duration,
+    active_strategy: SplitBrainResolverStrategy,
+    down_all_when_unstable: Duration,
+  ) -> Self {
+    Self { stable_after, active_strategy, down_all_when_unstable }
+  }
+
+  /// Returns how long membership must stay stable before decisions are applied.
+  #[must_use]
+  pub const fn stable_after(self) -> Duration {
+    self.stable_after
+  }
+
+  /// Returns the active downing strategy identifier.
+  #[must_use]
+  pub const fn active_strategy(self) -> SplitBrainResolverStrategy {
+    self.active_strategy
+  }
+
+  /// Returns the timeout after which every member is downed while unstable.
+  #[must_use]
+  pub const fn down_all_when_unstable(self) -> Duration {
+    self.down_all_when_unstable
+  }
+}

--- a/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_strategy.rs
+++ b/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_strategy.rs
@@ -1,0 +1,36 @@
+//! Split Brain Resolver active strategy identifiers.
+
+const KEEP_MAJORITY_IDENTIFIER: &str = "keep-majority";
+const LEASE_MAJORITY_IDENTIFIER: &str = "lease-majority";
+const STATIC_QUORUM_IDENTIFIER: &str = "static-quorum";
+const KEEP_OLDEST_IDENTIFIER: &str = "keep-oldest";
+const DOWN_ALL_IDENTIFIER: &str = "down-all";
+
+/// Split Brain Resolver strategy selected as the active downing rule.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SplitBrainResolverStrategy {
+  /// Keep the partition that contains a majority of observed members.
+  KeepMajority,
+  /// Keep the majority partition only after acquiring a lease.
+  LeaseMajority,
+  /// Keep the partition that satisfies a configured static quorum.
+  StaticQuorum,
+  /// Keep the partition that contains the oldest member.
+  KeepOldest,
+  /// Down every observed member when the cluster remains unstable.
+  DownAll,
+}
+
+impl SplitBrainResolverStrategy {
+  /// Returns the Pekko-compatible strategy identifier.
+  #[must_use]
+  pub const fn as_str(self) -> &'static str {
+    match self {
+      | Self::KeepMajority => KEEP_MAJORITY_IDENTIFIER,
+      | Self::LeaseMajority => LEASE_MAJORITY_IDENTIFIER,
+      | Self::StaticQuorum => STATIC_QUORUM_IDENTIFIER,
+      | Self::KeepOldest => KEEP_OLDEST_IDENTIFIER,
+      | Self::DownAll => DOWN_ALL_IDENTIFIER,
+    }
+  }
+}

--- a/modules/cluster-core-kernel/src/extension/cluster_api.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_api.rs
@@ -14,7 +14,7 @@ use core::time::Duration;
 
 use fraktor_actor_core_kernel_rs::{
   actor::{
-    actor_path::ActorPathParser,
+    actor_path::{ActorPath, ActorPathParser},
     actor_ref::ActorRef,
     messaging::{AnyMessage, AskError, AskResponse, AskResult},
     scheduler::{ExecutionBatch, SchedulerCommand, SchedulerRunnable},
@@ -34,9 +34,12 @@ use crate::{
   activation::{ClusterIdentity, LookupError, PlacementEvent},
   extension::ClusterIdentityResolver,
   grain::{GRAIN_EVENT_STREAM_NAME, GrainEvent, GrainMetricsShared},
+  membership::CurrentClusterState,
 };
 
 const CLUSTER_EVENT_STREAM_NAME: &str = "cluster";
+const REMOTE_ACTOR_PATH_SCHEME: &str = "fraktor.tcp";
+const CANONICAL_PATH_UNAVAILABLE_REASON: &str = "canonical path is unavailable";
 
 struct ClusterEventFilterSubscriber {
   subscriber:  EventStreamSubscriberShared,
@@ -68,6 +71,7 @@ impl EventStreamSubscriber for ClusterEventFilterSubscriber {
 }
 
 /// Cluster API facade bound to an actor system.
+#[derive(Clone)]
 pub struct ClusterApi {
   system:    ActorSystem,
   extension: ArcShared<ClusterExtension>,
@@ -165,6 +169,48 @@ impl ClusterApi {
   /// Returns an error when the cluster is not started or leave processing fails.
   pub fn leave(&self, authority: &str) -> Result<(), ClusterError> {
     self.extension.leave(authority)
+  }
+
+  /// Returns the remote canonical path for an actor reference.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error when the actor reference has no canonical path or the
+  /// cluster advertised address cannot be formatted as an actor path authority.
+  pub fn remote_path_of(&self, actor_ref: &ActorRef) -> Result<ActorPath, ClusterResolveError> {
+    let canonical_path = actor_ref.canonical_path().ok_or_else(|| ClusterResolveError::InvalidPidFormat {
+      pid:    actor_ref.pid().to_string(),
+      reason: CANONICAL_PATH_UNAVAILABLE_REASON.into(),
+    })?;
+    if canonical_path.parts().authority_endpoint().is_some() {
+      return Ok(canonical_path);
+    }
+
+    let system_name = canonical_path.parts().system();
+    let authority = self.extension.core_shared().with_lock(|core| core.startup_address());
+    let canonical =
+      format!("{REMOTE_ACTOR_PATH_SCHEME}://{system_name}@{authority}{}", canonical_path.to_relative_string());
+    let mut remote_path = ActorPathParser::parse(&canonical).map_err(|error| {
+      ClusterResolveError::InvalidPidFormat { pid: actor_ref.pid().to_string(), reason: error.to_string() }
+    })?;
+    if let Some(uid) = canonical_path.uid() {
+      remote_path = remote_path.with_uid(uid);
+    }
+    Ok(remote_path)
+  }
+
+  /// Returns the current cluster-state snapshot.
+  #[must_use]
+  pub fn current_state(&self) -> CurrentClusterState {
+    let core = self.extension.core_shared();
+    let (state, _) = core.with_lock(|core| core.current_cluster_state_snapshot());
+    state
+  }
+
+  /// Returns the authority advertised by the local cluster member.
+  #[must_use]
+  pub fn self_authority(&self) -> String {
+    self.extension.core_shared().with_lock(|core| core.startup_address())
   }
 
   /// Subscribes to cluster events with explicit initial-state mode and event filters.

--- a/modules/cluster-core-kernel/src/extension/cluster_api_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_api_test.rs
@@ -5,8 +5,8 @@ use fraktor_actor_adaptor_std_rs::{system::create_noop_actor_system, tick_driver
 use fraktor_actor_core_kernel_rs::{
   actor::{
     Actor, ActorContext, Pid,
-    actor_path::{ActorPath, ActorPathScheme},
-    actor_ref::{ActorRef, ActorRefSender, SendOutcome},
+    actor_path::{ActorPath, ActorPathParser, ActorPathScheme, ActorUid},
+    actor_ref::{ActorRef, ActorRefSender, ActorRefSenderShared, SendOutcome},
     actor_ref_provider::{ActorRefProvider, ActorRefProviderHandleShared},
     error::{ActorError, SendError},
     extension::ExtensionInstallers,
@@ -35,7 +35,7 @@ use crate::{
     PlacementDecision, PlacementEvent, PlacementLocality, PlacementResolution,
   },
   cluster_provider::{ClusterProvider, NoopClusterProvider},
-  downing_provider::{DowningDecision, DowningInput, DowningProvider},
+  downing_provider::{DowningDecision, DowningInput, DowningProvider, DowningProviderCompatibility},
   extension::ClusterExtensionInstaller,
   grain::{GRAIN_EVENT_STREAM_NAME, GrainEvent, GrainKey},
 };
@@ -123,6 +123,44 @@ fn get_resolves_actor_ref_for_registered_kind() {
 
   let actor_ref = api.get(&identity).expect("resolved actor ref");
   assert_eq!(actor_ref.pid(), Pid::new(1, 0));
+}
+
+#[test]
+fn remote_path_of_uses_cluster_advertised_authority_for_local_ref() {
+  let (system, _ext) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+  let local_path = ActorPath::root().child("worker").with_uid(ActorUid::new(42));
+  let actor_ref = ActorRef::with_canonical_path(Pid::new(10, 0), TestSender, local_path);
+
+  let remote_path = api.remote_path_of(&actor_ref).expect("remote path");
+
+  assert_eq!(remote_path.to_canonical_uri(), "fraktor.tcp://cellactor@node1:8080/user/worker#42");
+  assert_eq!(remote_path.uid().map(|uid| uid.value()), Some(42));
+}
+
+#[test]
+fn remote_path_of_preserves_existing_remote_authority() {
+  let (system, _ext) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+  let remote_path =
+    ActorPathParser::parse("fraktor.tcp://cellactor@node2:8080/user/worker").expect("remote path parses");
+  let actor_ref = ActorRef::with_canonical_path(Pid::new(11, 0), TestSender, remote_path.clone());
+
+  let resolved = api.remote_path_of(&actor_ref).expect("remote path");
+
+  assert_eq!(resolved.to_canonical_uri(), remote_path.to_canonical_uri());
+}
+
+#[test]
+fn remote_path_of_reports_invalid_pid_format_when_canonical_path_is_unavailable() {
+  let (system, _ext) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+  let sender = ActorRefSenderShared::new(Box::new(TestSender));
+  let actor_ref = ActorRef::new(Pid::new(12, 0), sender);
+
+  let err = api.remote_path_of(&actor_ref).expect_err("canonical path is required");
+
+  assert!(matches!(err, ClusterResolveError::InvalidPidFormat { .. }));
 }
 
 #[test]
@@ -214,7 +252,9 @@ fn down_delegates_to_cluster_provider() {
     ClusterExtensionInstaller::new(cluster_config, move |_event_stream, _block_list, _address| {
       Box::new(RecordingDownProvider { downed: downed_for_provider.clone() })
     })
-    .with_downing_provider_factory(move || Box::new(RecordingDowningProvider { downed: downed_for_strategy.clone() }))
+    .with_downing_provider_factory(DowningProviderCompatibility::new("recording-downing-provider"), move || {
+      Box::new(RecordingDowningProvider { downed: downed_for_strategy.clone() })
+    })
     .with_identity_lookup_factory(|| Box::new(StaticIdentityLookup::new("node1:8080")));
   let extensions = ExtensionInstallers::default().with_extension_installer(cluster_installer);
   let config = ActorSystemConfig::new(TestTickDriver::default())
@@ -391,6 +431,26 @@ fn subscribe_snapshot_mode_keeps_current_cluster_state_first_when_topology_updat
 }
 
 #[test]
+fn current_state_returns_current_cluster_state_snapshot() {
+  let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  extension.start_member().expect("start member");
+
+  let first = build_topology_update(7, vec![String::from("node2:8080")], Vec::new());
+  extension.on_topology(&first);
+
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+  let state = api.current_state();
+
+  assert_eq!(state.members.iter().map(|record| record.authority.as_str()).collect::<Vec<_>>(), vec![
+    "node1:8080",
+    "node2:8080"
+  ]);
+  assert!(state.unreachable.is_empty());
+  assert!(state.seen_by.is_empty());
+  assert_eq!(state.leader.as_deref(), Some("node1:8080"));
+}
+
+#[test]
 fn subscribe_no_replay_skips_buffered_cluster_events() {
   let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
   extension.start_member().expect("start member");
@@ -422,7 +482,7 @@ fn subscribe_panics_when_event_type_filter_is_empty() {
   let recorder = RecordingClusterEvents::new();
   let subscriber = test_subscriber_handle(recorder);
 
-  let _ = api.subscribe(&subscriber, ClusterSubscriptionInitialStateMode::AsEvents, &[]);
+  drop(api.subscribe(&subscriber, ClusterSubscriptionInitialStateMode::AsEvents, &[]));
 }
 
 fn run_scheduler(system: &ActorSystem, duration: Duration) {

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
@@ -10,7 +10,15 @@ use alloc::{
 };
 use core::time::Duration;
 
-use crate::{ClusterTopology, ConfigValidation, JoinConfigCompatChecker, pub_sub::PubSubConfig};
+use crate::{
+  ClusterTopology, ConfigValidation, JoinConfigCompatChecker, downing_provider::DowningProviderCompatibility,
+  pub_sub::PubSubConfig,
+};
+
+const PUBSUB_CONFIGURATION_MISMATCH_REASON: &str = "pubsub configuration mismatch";
+const DOWNING_PROVIDER_KEY_MISMATCH_REASON: &str = "downing provider compatibility key mismatch";
+const SBR_SETTINGS_MISMATCH_REASON: &str = "split brain resolver settings mismatch";
+const SPLIT_BRAIN_RESOLVER_PROVIDER_KEY: &str = "split-brain-resolver";
 
 /// Configuration applied when installing the cluster extension.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -21,6 +29,7 @@ pub struct ClusterExtensionConfig {
   pubsub_config:      PubSubConfig,
   app_version:        String,
   roles:              Vec<String>,
+  downing_provider:   DowningProviderCompatibility,
 }
 
 impl ClusterExtensionConfig {
@@ -38,6 +47,7 @@ impl ClusterExtensionConfig {
       pubsub_config:      PubSubConfig::new(Duration::from_secs(3), Duration::from_secs(60)),
       app_version:        String::from(env!("CARGO_PKG_VERSION")),
       roles:              Vec::new(),
+      downing_provider:   DowningProviderCompatibility::noop(),
     }
   }
 
@@ -97,6 +107,13 @@ impl ClusterExtensionConfig {
     self
   }
 
+  /// Sets the downing provider compatibility identity.
+  #[must_use]
+  pub fn with_downing_provider_compatibility(mut self, compatibility: DowningProviderCompatibility) -> Self {
+    self.downing_provider = compatibility;
+    self
+  }
+
   /// Returns the configured static topology.
   #[must_use]
   pub const fn static_topology(&self) -> Option<&ClusterTopology> {
@@ -120,6 +137,12 @@ impl ClusterExtensionConfig {
   pub fn roles(&self) -> &[String] {
     &self.roles
   }
+
+  /// Returns the downing provider compatibility identity.
+  #[must_use]
+  pub const fn downing_provider_compatibility(&self) -> &DowningProviderCompatibility {
+    &self.downing_provider
+  }
 }
 
 impl Default for ClusterExtensionConfig {
@@ -130,9 +153,17 @@ impl Default for ClusterExtensionConfig {
 
 impl JoinConfigCompatChecker for ClusterExtensionConfig {
   fn check_join_compatibility(&self, joining: &ClusterExtensionConfig) -> ConfigValidation {
-    // TODO(#248): gossip_config、app_version、roles 等の互換性チェックを追加する
     if self.pubsub_config != joining.pubsub_config {
-      return ConfigValidation::Incompatible { reason: "pubsub configuration mismatch".to_string() };
+      return ConfigValidation::Incompatible { reason: PUBSUB_CONFIGURATION_MISMATCH_REASON.to_string() };
+    }
+    if self.downing_provider.provider_key() != joining.downing_provider.provider_key() {
+      return ConfigValidation::Incompatible { reason: DOWNING_PROVIDER_KEY_MISMATCH_REASON.to_string() };
+    }
+    if self.downing_provider.provider_key() == SPLIT_BRAIN_RESOLVER_PROVIDER_KEY
+      && self.downing_provider.split_brain_resolver_settings()
+        != joining.downing_provider.split_brain_resolver_settings()
+    {
+      return ConfigValidation::Incompatible { reason: SBR_SETTINGS_MISMATCH_REASON.to_string() };
     }
     ConfigValidation::Compatible
   }

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
@@ -1,7 +1,11 @@
 use core::time::Duration;
 
 use super::*;
-use crate::{ClusterTopology, ConfigValidation, JoinConfigCompatChecker, pub_sub::PubSubConfig};
+use crate::{
+  ClusterTopology, ConfigValidation, JoinConfigCompatChecker,
+  downing_provider::{DowningProviderCompatibility, SplitBrainResolverSettings, SplitBrainResolverStrategy},
+  pub_sub::PubSubConfig,
+};
 
 #[test]
 fn metrics_flag_and_address_are_preserved() {
@@ -48,6 +52,15 @@ fn app_version_is_preserved() {
 }
 
 #[test]
+fn downing_provider_compatibility_is_preserved() {
+  let compatibility = DowningProviderCompatibility::new("split-brain-resolver");
+
+  let config = ClusterExtensionConfig::new().with_downing_provider_compatibility(compatibility.clone());
+
+  assert_eq!(config.downing_provider_compatibility(), &compatibility);
+}
+
+#[test]
 fn join_compatibility_reports_pubsub_mismatch() {
   let local = ClusterExtensionConfig::new()
     .with_pubsub_config(PubSubConfig::new(Duration::from_secs(3), Duration::from_secs(30)))
@@ -61,10 +74,118 @@ fn join_compatibility_reports_pubsub_mismatch() {
 }
 
 #[test]
+fn join_compatibility_reports_downing_provider_mismatch() {
+  let local =
+    ClusterExtensionConfig::new().with_downing_provider_compatibility(DowningProviderCompatibility::new("sbr"));
+  let joining =
+    ClusterExtensionConfig::new().with_downing_provider_compatibility(DowningProviderCompatibility::new("noop"));
+
+  let validation = local.check_join_compatibility(&joining);
+
+  assert_eq!(validation, ConfigValidation::Incompatible {
+    reason: "downing provider compatibility key mismatch".to_string(),
+  });
+}
+
+#[test]
+fn join_compatibility_reports_sbr_settings_mismatch_when_both_sides_configure_sbr() {
+  let local_sbr = SplitBrainResolverSettings::new(
+    Duration::from_secs(20),
+    SplitBrainResolverStrategy::KeepMajority,
+    Duration::from_secs(15),
+  );
+  let joining_sbr =
+    SplitBrainResolverSettings::new(Duration::from_secs(20), SplitBrainResolverStrategy::KeepOldest, Duration::ZERO);
+  let local = ClusterExtensionConfig::new().with_downing_provider_compatibility(
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(local_sbr),
+  );
+  let joining = ClusterExtensionConfig::new().with_downing_provider_compatibility(
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(joining_sbr),
+  );
+
+  let validation = local.check_join_compatibility(&joining);
+
+  assert_eq!(validation, ConfigValidation::Incompatible {
+    reason: "split brain resolver settings mismatch".to_string(),
+  });
+}
+
+#[test]
+fn join_compatibility_reports_sbr_settings_mismatch_against_missing_sbr_settings() {
+  let sbr = SplitBrainResolverSettings::new(
+    Duration::from_secs(20),
+    SplitBrainResolverStrategy::KeepOldest,
+    Duration::from_secs(15),
+  );
+  let local = ClusterExtensionConfig::new().with_downing_provider_compatibility(
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(sbr),
+  );
+  let joining = ClusterExtensionConfig::new()
+    .with_downing_provider_compatibility(DowningProviderCompatibility::new("split-brain-resolver"));
+
+  let validation = local.check_join_compatibility(&joining);
+
+  assert_eq!(validation, ConfigValidation::Incompatible {
+    reason: "split brain resolver settings mismatch".to_string(),
+  });
+}
+
+#[test]
+fn join_compatibility_reports_sbr_timing_mismatch_when_strategy_matches() {
+  let local_sbr = SplitBrainResolverSettings::new(
+    Duration::from_secs(20),
+    SplitBrainResolverStrategy::KeepMajority,
+    Duration::from_secs(15),
+  );
+  let joining_sbr = SplitBrainResolverSettings::new(
+    Duration::from_secs(21),
+    SplitBrainResolverStrategy::KeepMajority,
+    Duration::from_secs(15),
+  );
+  let local = ClusterExtensionConfig::new().with_downing_provider_compatibility(
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(local_sbr),
+  );
+  let joining = ClusterExtensionConfig::new().with_downing_provider_compatibility(
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(joining_sbr),
+  );
+
+  let validation = local.check_join_compatibility(&joining);
+
+  assert_eq!(validation, ConfigValidation::Incompatible {
+    reason: "split brain resolver settings mismatch".to_string(),
+  });
+}
+
+#[test]
+fn join_compatibility_accepts_same_sbr_settings() {
+  let sbr = SplitBrainResolverSettings::new(
+    Duration::from_secs(20),
+    SplitBrainResolverStrategy::KeepMajority,
+    Duration::from_secs(15),
+  );
+  let local = ClusterExtensionConfig::new().with_downing_provider_compatibility(
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(sbr),
+  );
+  let joining = ClusterExtensionConfig::new().with_downing_provider_compatibility(
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(sbr),
+  );
+
+  let validation = local.check_join_compatibility(&joining);
+
+  assert_eq!(validation, ConfigValidation::Compatible);
+}
+
+#[test]
 fn join_compatibility_accepts_same_pubsub_config() {
   let shared = PubSubConfig::new(Duration::from_secs(4), Duration::from_secs(40));
-  let local = ClusterExtensionConfig::new().with_pubsub_config(shared).with_roles(vec!["backend".to_string()]);
-  let joining = ClusterExtensionConfig::new().with_pubsub_config(shared).with_roles(vec!["frontend".to_string()]);
+  let local = ClusterExtensionConfig::new()
+    .with_pubsub_config(shared)
+    .with_app_version("1.0.0")
+    .with_roles(vec!["backend".to_string()]);
+  let joining = ClusterExtensionConfig::new()
+    .with_pubsub_config(shared)
+    .with_app_version("2.0.0")
+    .with_roles(vec!["frontend".to_string()]);
 
   let validation = local.check_join_compatibility(&joining);
   assert_eq!(validation, ConfigValidation::Compatible);

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs
@@ -1,5 +1,9 @@
 //! Installs the cluster extension into an actor system.
 
+#[cfg(test)]
+#[path = "cluster_extension_installer_test.rs"]
+mod tests;
+
 use alloc::{boxed::Box, string::String, vec::Vec};
 
 use fraktor_actor_core_kernel_rs::{
@@ -13,7 +17,7 @@ use crate::{
   BlockListProvider, ClusterExtension, ClusterExtensionConfig, ClusterExtensionId,
   activation::{IdentityLookup, NoopIdentityLookup},
   cluster_provider::{ClusterProvider, LocalClusterProvider},
-  downing_provider::{DowningProvider, NoopDowningProvider},
+  downing_provider::{DowningProvider, DowningProviderCompatibility, NoopDowningProvider},
   membership::{Gossiper, NoopGossiper},
   pub_sub::{NoopClusterPubSub, cluster_pub_sub::ClusterPubSub},
 };
@@ -178,9 +182,10 @@ impl ClusterExtensionInstaller {
   ///
   /// The factory is called during installation to create a fresh `DowningProvider` instance.
   #[must_use]
-  pub fn with_downing_provider_factory<F>(mut self, factory: F) -> Self
+  pub fn with_downing_provider_factory<F>(mut self, compatibility: DowningProviderCompatibility, factory: F) -> Self
   where
     F: Fn() -> Box<dyn DowningProvider> + Send + Sync + 'static, {
+    self.config = self.config.with_downing_provider_compatibility(compatibility);
     self.downing_provider_f = Some(ArcShared::new(factory));
     self
   }

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_installer_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_installer_test.rs
@@ -1,0 +1,57 @@
+use alloc::{boxed::Box, string::String};
+
+use fraktor_actor_adaptor_std_rs::tick_driver::TestTickDriver;
+use fraktor_actor_core_kernel_rs::{
+  actor::{
+    Actor, ActorContext, error::ActorError, extension::ExtensionInstallers, messaging::AnyMessageView, props::Props,
+    setup::ActorSystemConfig,
+  },
+  system::ActorSystem,
+};
+use fraktor_utils_core_rs::sync::{ArcShared, SpinSyncMutex};
+
+use super::ClusterExtensionInstaller;
+use crate::{
+  ClusterExtensionConfig, ClusterProviderError,
+  cluster_provider::NoopClusterProvider,
+  downing_provider::{DowningDecision, DowningInput, DowningProvider, DowningProviderCompatibility},
+  pub_sub::{NoopClusterPubSub, cluster_pub_sub::ClusterPubSub},
+};
+
+#[test]
+fn with_downing_provider_factory_propagates_compatibility_key_to_install_config() {
+  let observed_key = ArcShared::new(SpinSyncMutex::new(Option::<String>::None));
+  let observed_key_for_pubsub = observed_key.clone();
+  let compatibility = DowningProviderCompatibility::new("recording-downing-provider");
+  let cluster_config = ClusterExtensionConfig::new().with_advertised_address("node1:8080");
+  let cluster_installer = ClusterExtensionInstaller::new(cluster_config, |_event_stream, _block_list, _address| {
+    Box::new(NoopClusterProvider::new())
+  })
+  .with_downing_provider_factory(compatibility, || Box::new(RecordingDowningProvider))
+  .with_pubsub_factory(move |config| {
+    *observed_key_for_pubsub.lock() = Some(String::from(config.downing_provider_compatibility().provider_key()));
+    Box::new(NoopClusterPubSub::new()) as Box<dyn ClusterPubSub>
+  });
+  let config = ActorSystemConfig::new(TestTickDriver::default())
+    .with_extension_installers(ExtensionInstallers::default().with_extension_installer(cluster_installer));
+  let props = Props::from_fn(|| TestGuardian);
+  let _system = ActorSystem::create_from_props(&props, config).expect("build system");
+
+  assert_eq!(observed_key.lock().clone(), Some(String::from("recording-downing-provider")));
+}
+
+struct RecordingDowningProvider;
+
+impl DowningProvider for RecordingDowningProvider {
+  fn decide(&mut self, _input: &DowningInput) -> Result<DowningDecision, ClusterProviderError> {
+    Ok(DowningDecision::Keep)
+  }
+}
+
+struct TestGuardian;
+
+impl Actor for TestGuardian {
+  fn receive(&mut self, _context: &mut ActorContext<'_>, _message: AnyMessageView<'_>) -> Result<(), ActorError> {
+    Ok(())
+  }
+}

--- a/modules/cluster-core-kernel/src/extension/cluster_router_pool_config_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_router_pool_config_test.rs
@@ -10,5 +10,5 @@ fn pool_settings_store_values() {
 #[test]
 #[should_panic(expected = "total instances must be > 0")]
 fn pool_settings_reject_zero_instances() {
-  let _ = ClusterRouterPoolConfig::new(0);
+  drop(ClusterRouterPoolConfig::new(0));
 }

--- a/modules/cluster-core-kernel/src/pub_sub/batching_producer_generic_test.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/batching_producer_generic_test.rs
@@ -64,7 +64,7 @@ impl ClusterPubSub for RecordingPubSub {
 fn make_registry() -> ArcShared<SerializationRegistry> {
   let setup = default_serialization_setup();
   let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
-  let _ = register_defaults(&registry, |_name, _id| {});
+  drop(register_defaults(&registry, |_name, _id| {}));
   registry
 }
 

--- a/modules/cluster-core-kernel/src/pub_sub/pub_sub_broker_test.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/pub_sub_broker_test.rs
@@ -159,7 +159,7 @@ fn metrics_snapshot_is_emitted_and_counters_reset() {
 
   broker.mark_partitioned(&PubSubTopic::from("news"), true).expect("partition flag update should succeed");
   let options = broker.topic_options(&PubSubTopic::from("news")).expect("topic options");
-  let _ = broker.publish_targets(&PubSubTopic::from("news"), options);
+  drop(broker.publish_targets(&PubSubTopic::from("news"), options));
 
   let snapshot = broker.drain_metrics();
   assert_eq!(snapshot.delayed_messages, 0);

--- a/modules/cluster-core-kernel/tests/downing_provider_compatibility.rs
+++ b/modules/cluster-core-kernel/tests/downing_provider_compatibility.rs
@@ -1,0 +1,62 @@
+use core::time::Duration;
+
+use fraktor_cluster_core_kernel_rs::downing_provider::{
+  DowningProviderCompatibility, SplitBrainResolverSettings, SplitBrainResolverStrategy,
+};
+
+#[test]
+fn split_brain_resolver_strategy_returns_pekko_identifiers() {
+  let strategies = [
+    (SplitBrainResolverStrategy::KeepMajority, "keep-majority"),
+    (SplitBrainResolverStrategy::LeaseMajority, "lease-majority"),
+    (SplitBrainResolverStrategy::StaticQuorum, "static-quorum"),
+    (SplitBrainResolverStrategy::KeepOldest, "keep-oldest"),
+    (SplitBrainResolverStrategy::DownAll, "down-all"),
+  ];
+
+  let identifiers = strategies.map(|(strategy, _expected)| strategy.as_str());
+
+  assert_eq!(identifiers, ["keep-majority", "lease-majority", "static-quorum", "keep-oldest", "down-all"]);
+}
+
+#[test]
+fn split_brain_resolver_settings_preserve_active_strategy_and_durations() {
+  let settings = SplitBrainResolverSettings::new(
+    Duration::from_secs(20),
+    SplitBrainResolverStrategy::KeepMajority,
+    Duration::from_secs(15),
+  );
+
+  assert_eq!(settings.stable_after(), Duration::from_secs(20));
+  assert_eq!(settings.active_strategy(), SplitBrainResolverStrategy::KeepMajority);
+  assert_eq!(settings.down_all_when_unstable(), Duration::from_secs(15));
+}
+
+#[test]
+fn downing_provider_compatibility_preserves_provider_key() {
+  let compatibility = DowningProviderCompatibility::new("split-brain-resolver");
+
+  assert_eq!(compatibility.provider_key(), "split-brain-resolver");
+  assert!(compatibility.split_brain_resolver_settings().is_none());
+}
+
+#[test]
+fn downing_provider_compatibility_preserves_split_brain_resolver_settings() {
+  let settings = SplitBrainResolverSettings::new(
+    Duration::from_secs(20),
+    SplitBrainResolverStrategy::KeepMajority,
+    Duration::from_secs(15),
+  );
+
+  let compatibility =
+    DowningProviderCompatibility::new("split-brain-resolver").with_split_brain_resolver_settings(settings);
+
+  assert_eq!(compatibility.provider_key(), "split-brain-resolver");
+  assert_eq!(compatibility.split_brain_resolver_settings(), Some(&settings));
+}
+
+#[test]
+#[should_panic(expected = "downing provider compatibility key must not be empty")]
+fn downing_provider_compatibility_rejects_empty_provider_key() {
+  let _compatibility = DowningProviderCompatibility::new("");
+}

--- a/modules/cluster-core-kernel/tests/pub_sub_integration.rs
+++ b/modules/cluster-core-kernel/tests/pub_sub_integration.rs
@@ -114,7 +114,7 @@ impl BlockListProvider for EmptyBlockListProvider {
 fn make_registry() -> ArcShared<SerializationRegistry> {
   let setup = default_serialization_setup();
   let registry = ArcShared::new(SerializationRegistry::from_setup(&setup));
-  let _ = register_defaults(&registry, |_name, _id| {});
+  drop(register_defaults(&registry, |_name, _id| {}));
   registry
 }
 

--- a/modules/cluster-core-typed/Cargo.toml
+++ b/modules/cluster-core-typed/Cargo.toml
@@ -16,7 +16,13 @@ autoexamples = false
 default = []
 
 [dependencies]
+fraktor-actor-core-kernel-rs = { workspace = true }
+fraktor-actor-core-typed-rs = { workspace = true }
 fraktor-cluster-core-kernel-rs = { workspace = true }
+fraktor-utils-core-rs = { workspace = true }
+
+[dev-dependencies]
+fraktor-actor-adaptor-std-rs = { workspace = true, features = ["test-support"] }
 
 [lints]
 workspace = true

--- a/modules/cluster-core-typed/src/cluster.rs
+++ b/modules/cluster-core-typed/src/cluster.rs
@@ -61,11 +61,10 @@ impl SelfUpSubscriber {
 
   fn deliver(&mut self, cluster_event: &ClusterEvent) {
     let current_state = self.cluster.current_state();
-    if let Some(self_up) = SelfUp::try_from_cluster_event(cluster_event, &self.self_authority, current_state) {
-      if self.subscriber.try_tell(self_up).is_err() {
-        record_failed_delivery(&self.failed_deliveries);
-      }
-      complete_self_event_subscription(&self.cluster, &self.state);
+    if let Some(self_up) = SelfUp::try_from_cluster_event(cluster_event, &self.self_authority, current_state)
+      && self.subscriber.try_tell(self_up).is_err()
+    {
+      record_failed_delivery(&self.failed_deliveries);
     }
   }
 }
@@ -76,13 +75,13 @@ impl EventStreamSubscriber for SelfUpSubscriber {
       && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
       && let Some(seen_state) = update_seen_state(cluster_event, &self.self_authority)
     {
-      let should_deliver = self.state.with_write(|state| {
+      self.state.with_write(|state| {
         state.seen_state = seen_state.clone();
-        !state.replaying && !state.completed && seen_state == SelfMemberSeenState::Up
       });
-      if should_deliver {
+      if let Some(subscription_id) = claim_self_up_delivery(&self.state) {
+        unsubscribe_completed_subscription(&self.cluster, subscription_id);
         self.deliver(cluster_event);
-      } else if !is_replaying_or_completed(&self.state) && matches!(seen_state, SelfMemberSeenState::Removed(_)) {
+      } else if matches!(seen_state, SelfMemberSeenState::Removed(_)) {
         complete_self_event_subscription(&self.cluster, &self.state);
       }
     }
@@ -109,11 +108,10 @@ impl SelfRemovedSubscriber {
   }
 
   fn deliver(&mut self, cluster_event: &ClusterEvent) {
-    if let Some(self_removed) = SelfRemoved::try_from_cluster_event(cluster_event, &self.self_authority) {
-      if self.subscriber.try_tell(self_removed).is_err() {
-        record_failed_delivery(&self.failed_deliveries);
-      }
-      complete_self_event_subscription(&self.cluster, &self.state);
+    if let Some(self_removed) = SelfRemoved::try_from_cluster_event(cluster_event, &self.self_authority)
+      && self.subscriber.try_tell(self_removed).is_err()
+    {
+      record_failed_delivery(&self.failed_deliveries);
     }
   }
 }
@@ -124,11 +122,11 @@ impl EventStreamSubscriber for SelfRemovedSubscriber {
       && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
       && let Some(seen_state) = update_seen_state(cluster_event, &self.self_authority)
     {
-      let should_deliver = self.state.with_write(|state| {
+      self.state.with_write(|state| {
         state.seen_state = seen_state.clone();
-        !state.replaying && !state.completed && matches!(seen_state, SelfMemberSeenState::Removed(_))
       });
-      if should_deliver {
+      if let Some((subscription_id, _self_removed)) = claim_self_removed_delivery(&self.state) {
+        unsubscribe_completed_subscription(&self.cluster, subscription_id);
         self.deliver(cluster_event);
       }
     }
@@ -204,15 +202,39 @@ fn set_subscription_id(state: &SharedLock<SelfEventSubscriberState>, subscriptio
   })
 }
 
-fn is_replaying_or_completed(state: &SharedLock<SelfEventSubscriberState>) -> bool {
-  state.with_read(|state| state.replaying || state.completed)
+fn claim_self_up_delivery(state: &SharedLock<SelfEventSubscriberState>) -> Option<Option<u64>> {
+  state.with_write(|state| {
+    if !state.replaying && !state.completed && state.seen_state == SelfMemberSeenState::Up {
+      state.completed = true;
+      Some(state.subscription_id)
+    } else {
+      None
+    }
+  })
+}
+
+fn claim_self_removed_delivery(state: &SharedLock<SelfEventSubscriberState>) -> Option<(Option<u64>, SelfRemoved)> {
+  state.with_write(|state| match &state.seen_state {
+    | SelfMemberSeenState::Removed(self_removed) if !state.replaying && !state.completed => {
+      state.completed = true;
+      Some((state.subscription_id, self_removed.clone()))
+    },
+    | SelfMemberSeenState::BeforeUp | SelfMemberSeenState::Up | SelfMemberSeenState::Removed(_) => None,
+  })
 }
 
 fn complete_self_event_subscription(cluster: &ClusterApi, state: &SharedLock<SelfEventSubscriberState>) {
   let subscription_id = state.with_write(|state| {
+    if state.replaying || state.completed {
+      return None;
+    }
     state.completed = true;
     state.subscription_id
   });
+  unsubscribe_completed_subscription(cluster, subscription_id);
+}
+
+fn unsubscribe_completed_subscription(cluster: &ClusterApi, subscription_id: Option<u64>) {
   if let Some(subscription_id) = subscription_id {
     cluster.unsubscribe(subscription_id);
   }
@@ -293,13 +315,13 @@ impl Cluster {
     if completed {
       self.inner.unsubscribe(subscription.id());
     }
-    let should_deliver_immediately =
-      state.with_read(|state| !state.completed && state.seen_state == SelfMemberSeenState::Up);
-    if should_deliver_immediately && let Some(self_up) = self_up_from_current_state(&self_authority, current_state) {
+    if let Some(self_up) = self_up_from_current_state(&self_authority, current_state)
+      && let Some(subscription_id) = claim_self_up_delivery(&state)
+    {
+      unsubscribe_completed_subscription(&self.inner, subscription_id);
       if typed_subscriber.try_tell(self_up).is_err() {
         record_failed_delivery(&failed_deliveries);
       }
-      complete_self_event_subscription(&self.inner, &state);
     }
     ClusterEventSubscription::new(subscription, failed_deliveries)
   }
@@ -325,16 +347,12 @@ impl Cluster {
     if completed {
       self.inner.unsubscribe(subscription.id());
     }
-    let immediate_removed = state.with_read(|state| match &state.seen_state {
-      | SelfMemberSeenState::Removed(self_removed) if !state.completed => Some(self_removed.clone()),
-      | SelfMemberSeenState::BeforeUp | SelfMemberSeenState::Up | SelfMemberSeenState::Removed(_) => None,
-    });
-    if let Some(self_removed) = immediate_removed {
+    if let Some((subscription_id, self_removed)) = claim_self_removed_delivery(&state) {
+      unsubscribe_completed_subscription(&self.inner, subscription_id);
       let mut typed_subscriber = typed_subscriber;
       if typed_subscriber.try_tell(self_removed).is_err() {
         record_failed_delivery(&failed_deliveries);
       }
-      complete_self_event_subscription(&self.inner, &state);
     }
     ClusterEventSubscription::new(subscription, failed_deliveries)
   }

--- a/modules/cluster-core-typed/src/cluster.rs
+++ b/modules/cluster-core-typed/src/cluster.rs
@@ -225,7 +225,7 @@ fn claim_self_removed_delivery(state: &SharedLock<SelfEventSubscriberState>) -> 
 
 fn complete_self_event_subscription(cluster: &ClusterApi, state: &SharedLock<SelfEventSubscriberState>) {
   let subscription_id = state.with_write(|state| {
-    if state.replaying || state.completed {
+    if state.completed {
       return None;
     }
     state.completed = true;

--- a/modules/cluster-core-typed/src/cluster.rs
+++ b/modules/cluster-core-typed/src/cluster.rs
@@ -1,0 +1,366 @@
+//! Typed cluster access point.
+
+use alloc::string::String;
+
+use fraktor_actor_core_kernel_rs::event::stream::{EventStreamEvent, EventStreamSubscriber, subscriber_handle};
+use fraktor_actor_core_typed_rs::{TypedActorRef, TypedActorSystem};
+use fraktor_cluster_core_kernel_rs::{
+  extension::{ClusterApi, ClusterApiError, ClusterError, ClusterSubscriptionInitialStateMode},
+  membership::{CurrentClusterState, NodeStatus},
+  topology::{ClusterEvent, ClusterEventType},
+};
+use fraktor_utils_core_rs::sync::{DefaultMutex, SharedAccess, SharedLock};
+
+use crate::{ClusterEventSubscription, SelfRemoved, SelfUp};
+
+struct TypedClusterEventSubscriber {
+  subscriber:        TypedActorRef<ClusterEvent>,
+  failed_deliveries: SharedLock<u64>,
+}
+
+impl TypedClusterEventSubscriber {
+  const fn new(subscriber: TypedActorRef<ClusterEvent>, failed_deliveries: SharedLock<u64>) -> Self {
+    Self { subscriber, failed_deliveries }
+  }
+
+  fn deliver(&mut self, cluster_event: &ClusterEvent) {
+    if self.subscriber.try_tell(cluster_event.clone()).is_err() {
+      record_failed_delivery(&self.failed_deliveries);
+    }
+  }
+}
+
+impl EventStreamSubscriber for TypedClusterEventSubscriber {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    if let EventStreamEvent::Extension { payload, .. } = event
+      && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
+    {
+      self.deliver(cluster_event);
+    }
+  }
+}
+
+struct SelfUpSubscriber {
+  subscriber:        TypedActorRef<SelfUp>,
+  self_authority:    String,
+  cluster:           ClusterApi,
+  state:             SharedLock<SelfEventSubscriberState>,
+  failed_deliveries: SharedLock<u64>,
+}
+
+impl SelfUpSubscriber {
+  fn new(
+    subscriber: TypedActorRef<SelfUp>,
+    self_authority: String,
+    cluster: ClusterApi,
+    state: SharedLock<SelfEventSubscriberState>,
+    failed_deliveries: SharedLock<u64>,
+  ) -> Self {
+    Self { subscriber, self_authority, cluster, state, failed_deliveries }
+  }
+
+  fn deliver(&mut self, cluster_event: &ClusterEvent) {
+    let current_state = self.cluster.current_state();
+    if let Some(self_up) = SelfUp::try_from_cluster_event(cluster_event, &self.self_authority, current_state) {
+      if self.subscriber.try_tell(self_up).is_err() {
+        record_failed_delivery(&self.failed_deliveries);
+      }
+      complete_self_event_subscription(&self.cluster, &self.state);
+    }
+  }
+}
+
+impl EventStreamSubscriber for SelfUpSubscriber {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    if let EventStreamEvent::Extension { payload, .. } = event
+      && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
+      && let Some(seen_state) = update_seen_state(cluster_event, &self.self_authority)
+    {
+      let should_deliver = self.state.with_write(|state| {
+        state.seen_state = seen_state.clone();
+        !state.replaying && !state.completed && seen_state == SelfMemberSeenState::Up
+      });
+      if should_deliver {
+        self.deliver(cluster_event);
+      } else if !is_replaying_or_completed(&self.state) && matches!(seen_state, SelfMemberSeenState::Removed(_)) {
+        complete_self_event_subscription(&self.cluster, &self.state);
+      }
+    }
+  }
+}
+
+struct SelfRemovedSubscriber {
+  subscriber:        TypedActorRef<SelfRemoved>,
+  self_authority:    String,
+  cluster:           ClusterApi,
+  state:             SharedLock<SelfEventSubscriberState>,
+  failed_deliveries: SharedLock<u64>,
+}
+
+impl SelfRemovedSubscriber {
+  fn new(
+    subscriber: TypedActorRef<SelfRemoved>,
+    self_authority: String,
+    cluster: ClusterApi,
+    state: SharedLock<SelfEventSubscriberState>,
+    failed_deliveries: SharedLock<u64>,
+  ) -> Self {
+    Self { subscriber, self_authority, cluster, state, failed_deliveries }
+  }
+
+  fn deliver(&mut self, cluster_event: &ClusterEvent) {
+    if let Some(self_removed) = SelfRemoved::try_from_cluster_event(cluster_event, &self.self_authority) {
+      if self.subscriber.try_tell(self_removed).is_err() {
+        record_failed_delivery(&self.failed_deliveries);
+      }
+      complete_self_event_subscription(&self.cluster, &self.state);
+    }
+  }
+}
+
+impl EventStreamSubscriber for SelfRemovedSubscriber {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    if let EventStreamEvent::Extension { payload, .. } = event
+      && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
+      && let Some(seen_state) = update_seen_state(cluster_event, &self.self_authority)
+    {
+      let should_deliver = self.state.with_write(|state| {
+        state.seen_state = seen_state.clone();
+        !state.replaying && !state.completed && matches!(seen_state, SelfMemberSeenState::Removed(_))
+      });
+      if should_deliver {
+        self.deliver(cluster_event);
+      }
+    }
+  }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum SelfMemberSeenState {
+  BeforeUp,
+  Up,
+  Removed(SelfRemoved),
+}
+
+struct SelfEventSubscriberState {
+  subscription_id: Option<u64>,
+  replaying:       bool,
+  completed:       bool,
+  seen_state:      SelfMemberSeenState,
+}
+
+impl SelfEventSubscriberState {
+  const fn new() -> Self {
+    Self {
+      subscription_id: None,
+      replaying:       true,
+      completed:       false,
+      seen_state:      SelfMemberSeenState::BeforeUp,
+    }
+  }
+}
+
+fn update_seen_state(cluster_event: &ClusterEvent, self_authority: &str) -> Option<SelfMemberSeenState> {
+  match cluster_event {
+    | ClusterEvent::MemberStatusChanged { authority, to: NodeStatus::Up, .. } if authority == self_authority => {
+      Some(SelfMemberSeenState::Up)
+    },
+    | ClusterEvent::MemberStatusChanged { authority, to: NodeStatus::Removed, .. } if authority == self_authority => {
+      SelfRemoved::try_from_cluster_event(cluster_event, self_authority).map(SelfMemberSeenState::Removed)
+    },
+    | _ => None,
+  }
+}
+
+fn seed_seen_state_from_current_state(
+  state: &SharedLock<SelfEventSubscriberState>,
+  self_authority: &str,
+  current_state: &CurrentClusterState,
+) {
+  if let Some(record) = current_state.members.iter().find(|record| record.authority == self_authority)
+    && record.status == NodeStatus::Up
+  {
+    state.with_write(|state| {
+      if state.seen_state == SelfMemberSeenState::BeforeUp {
+        state.seen_state = SelfMemberSeenState::Up;
+      }
+    });
+  }
+}
+
+fn self_up_from_current_state(self_authority: &str, current_state: CurrentClusterState) -> Option<SelfUp> {
+  let record = current_state
+    .members
+    .iter()
+    .find(|record| record.authority == self_authority && record.status == NodeStatus::Up)?;
+  Some(SelfUp::new(record.node_id.clone(), record.authority.clone(), current_state))
+}
+
+fn set_subscription_id(state: &SharedLock<SelfEventSubscriberState>, subscription_id: u64) -> bool {
+  state.with_write(|state| {
+    state.subscription_id = Some(subscription_id);
+    state.replaying = false;
+    state.completed
+  })
+}
+
+fn is_replaying_or_completed(state: &SharedLock<SelfEventSubscriberState>) -> bool {
+  state.with_read(|state| state.replaying || state.completed)
+}
+
+fn complete_self_event_subscription(cluster: &ClusterApi, state: &SharedLock<SelfEventSubscriberState>) {
+  let subscription_id = state.with_write(|state| {
+    state.completed = true;
+    state.subscription_id
+  });
+  if let Some(subscription_id) = subscription_id {
+    cluster.unsubscribe(subscription_id);
+  }
+}
+
+fn record_failed_delivery(failed_deliveries: &SharedLock<u64>) {
+  failed_deliveries.with_write(|count| *count += 1);
+}
+
+/// Typed facade for the kernel cluster API.
+pub struct Cluster {
+  inner: ClusterApi,
+}
+
+impl Cluster {
+  /// Retrieves the typed cluster facade from a typed actor system.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the cluster extension has not been installed.
+  pub fn get<M>(system: &TypedActorSystem<M>) -> Result<Self, ClusterApiError>
+  where
+    M: Send + Sync + 'static, {
+    ClusterApi::try_from_system(system.as_untyped()).map(Self::from_api)
+  }
+
+  const fn from_api(inner: ClusterApi) -> Self {
+    Self { inner }
+  }
+
+  /// Returns the current cluster state snapshot.
+  #[must_use]
+  pub fn current_state(&self) -> CurrentClusterState {
+    self.inner.current_state()
+  }
+
+  /// Subscribes a typed actor reference to cluster events.
+  ///
+  /// The returned subscription owns the kernel subscription identifier and can
+  /// later be passed to the kernel event stream unsubscribe path.
+  ///
+  /// # Panics
+  ///
+  /// Panics when `event_types` is empty.
+  #[must_use]
+  pub fn subscribe(
+    &self,
+    subscriber: &TypedActorRef<ClusterEvent>,
+    initial_state_mode: ClusterSubscriptionInitialStateMode,
+    event_types: &[ClusterEventType],
+  ) -> ClusterEventSubscription {
+    let failed_deliveries = new_failed_delivery_counter();
+    let subscriber = subscriber_handle(TypedClusterEventSubscriber::new(subscriber.clone(), failed_deliveries.clone()));
+    let subscription = self.inner.subscribe(&subscriber, initial_state_mode, event_types);
+    ClusterEventSubscription::new(subscription, failed_deliveries)
+  }
+
+  /// Subscribes a typed actor reference to local-member up events.
+  #[must_use]
+  pub fn subscribe_self_up(&self, subscriber: &TypedActorRef<SelfUp>) -> ClusterEventSubscription {
+    let failed_deliveries = new_failed_delivery_counter();
+    let state = new_self_event_subscriber_state();
+    let self_authority = self.inner.self_authority();
+    let mut typed_subscriber = subscriber.clone();
+    let subscriber = subscriber_handle(SelfUpSubscriber::new(
+      typed_subscriber.clone(),
+      self_authority.clone(),
+      self.inner.clone(),
+      state.clone(),
+      failed_deliveries.clone(),
+    ));
+    let subscription = self
+      .inner
+      .subscribe(&subscriber, ClusterSubscriptionInitialStateMode::AsEvents, &[ClusterEventType::MemberStatusChanged]);
+    let current_state = self.inner.current_state();
+    seed_seen_state_from_current_state(&state, &self_authority, &current_state);
+    let completed = set_subscription_id(&state, subscription.id());
+    if completed {
+      self.inner.unsubscribe(subscription.id());
+    }
+    let should_deliver_immediately =
+      state.with_read(|state| !state.completed && state.seen_state == SelfMemberSeenState::Up);
+    if should_deliver_immediately && let Some(self_up) = self_up_from_current_state(&self_authority, current_state) {
+      if typed_subscriber.try_tell(self_up).is_err() {
+        record_failed_delivery(&failed_deliveries);
+      }
+      complete_self_event_subscription(&self.inner, &state);
+    }
+    ClusterEventSubscription::new(subscription, failed_deliveries)
+  }
+
+  /// Subscribes a typed actor reference to local-member removed events.
+  #[must_use]
+  pub fn subscribe_self_removed(&self, subscriber: &TypedActorRef<SelfRemoved>) -> ClusterEventSubscription {
+    let failed_deliveries = new_failed_delivery_counter();
+    let state = new_self_event_subscriber_state();
+    let self_authority = self.inner.self_authority();
+    let typed_subscriber = subscriber.clone();
+    let subscriber = subscriber_handle(SelfRemovedSubscriber::new(
+      typed_subscriber.clone(),
+      self_authority,
+      self.inner.clone(),
+      state.clone(),
+      failed_deliveries.clone(),
+    ));
+    let subscription = self
+      .inner
+      .subscribe(&subscriber, ClusterSubscriptionInitialStateMode::AsEvents, &[ClusterEventType::MemberStatusChanged]);
+    let completed = set_subscription_id(&state, subscription.id());
+    if completed {
+      self.inner.unsubscribe(subscription.id());
+    }
+    let immediate_removed = state.with_read(|state| match &state.seen_state {
+      | SelfMemberSeenState::Removed(self_removed) if !state.completed => Some(self_removed.clone()),
+      | SelfMemberSeenState::BeforeUp | SelfMemberSeenState::Up | SelfMemberSeenState::Removed(_) => None,
+    });
+    if let Some(self_removed) = immediate_removed {
+      let mut typed_subscriber = typed_subscriber;
+      if typed_subscriber.try_tell(self_removed).is_err() {
+        record_failed_delivery(&failed_deliveries);
+      }
+      complete_self_event_subscription(&self.inner, &state);
+    }
+    ClusterEventSubscription::new(subscription, failed_deliveries)
+  }
+
+  /// Unsubscribes from cluster event delivery by subscription identifier.
+  pub fn unsubscribe(&self, subscription_id: u64) {
+    self.inner.unsubscribe(subscription_id);
+  }
+
+  pub(crate) fn join(&self, authority: &str) -> Result<(), ClusterError> {
+    self.inner.join(authority)
+  }
+
+  pub(crate) fn leave(&self, authority: &str) -> Result<(), ClusterError> {
+    self.inner.leave(authority)
+  }
+
+  pub(crate) fn down(&self, authority: &str) -> Result<(), ClusterError> {
+    self.inner.down(authority)
+  }
+}
+
+fn new_failed_delivery_counter() -> SharedLock<u64> {
+  SharedLock::new_with_driver::<DefaultMutex<_>>(0)
+}
+
+fn new_self_event_subscriber_state() -> SharedLock<SelfEventSubscriberState> {
+  SharedLock::new_with_driver::<DefaultMutex<_>>(SelfEventSubscriberState::new())
+}

--- a/modules/cluster-core-typed/src/cluster_command.rs
+++ b/modules/cluster-core-typed/src/cluster_command.rs
@@ -1,0 +1,53 @@
+//! Typed cluster management commands.
+
+use alloc::{string::String, vec::Vec};
+
+use fraktor_cluster_core_kernel_rs::extension::ClusterError;
+
+use crate::Cluster;
+
+/// Commands that execute membership operations through [`Cluster`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ClusterCommand {
+  /// Join a single member authority.
+  Join {
+    /// Member authority.
+    address: String,
+  },
+  /// Join multiple seed-node authorities in order.
+  JoinSeedNodes {
+    /// Seed-node authorities.
+    addresses: Vec<String>,
+  },
+  /// Request graceful leave for a member authority.
+  Leave {
+    /// Member authority.
+    address: String,
+  },
+  /// Mark a member authority as down.
+  Down {
+    /// Member authority.
+    address: String,
+  },
+}
+
+impl ClusterCommand {
+  /// Applies this command to the supplied typed cluster facade.
+  ///
+  /// # Errors
+  ///
+  /// Returns the first kernel cluster error encountered while executing the command.
+  pub fn apply_to(&self, cluster: &Cluster) -> Result<(), ClusterError> {
+    match self {
+      | Self::Join { address } => cluster.join(address),
+      | Self::JoinSeedNodes { addresses } => {
+        for address in addresses {
+          cluster.join(address)?;
+        }
+        Ok(())
+      },
+      | Self::Leave { address } => cluster.leave(address),
+      | Self::Down { address } => cluster.down(address),
+    }
+  }
+}

--- a/modules/cluster-core-typed/src/cluster_event_subscription.rs
+++ b/modules/cluster-core-typed/src/cluster_event_subscription.rs
@@ -1,0 +1,28 @@
+//! Typed cluster event subscription handle.
+
+use fraktor_actor_core_kernel_rs::event::stream::EventStreamSubscription;
+use fraktor_utils_core_rs::sync::{SharedAccess, SharedLock};
+
+/// Subscription handle for typed cluster event delivery.
+pub struct ClusterEventSubscription {
+  subscription:      EventStreamSubscription,
+  failed_deliveries: SharedLock<u64>,
+}
+
+impl ClusterEventSubscription {
+  pub(crate) const fn new(subscription: EventStreamSubscription, failed_deliveries: SharedLock<u64>) -> Self {
+    Self { subscription, failed_deliveries }
+  }
+
+  /// Returns the kernel event-stream subscription identifier.
+  #[must_use]
+  pub const fn id(&self) -> u64 {
+    self.subscription.id()
+  }
+
+  /// Returns the number of typed messages that could not be delivered.
+  #[must_use]
+  pub fn failed_delivery_count(&self) -> u64 {
+    self.failed_deliveries.with_read(|count| *count)
+  }
+}

--- a/modules/cluster-core-typed/src/cluster_setup.rs
+++ b/modules/cluster-core-typed/src/cluster_setup.rs
@@ -1,0 +1,28 @@
+//! Typed setup wrapper for installing the cluster extension.
+
+use fraktor_actor_core_kernel_rs::{
+  actor::extension::{ExtensionInstaller, install_extension_id},
+  system::{ActorSystem, ActorSystemBuildError},
+};
+use fraktor_cluster_core_kernel_rs::extension::ClusterExtensionId;
+
+/// Typed actor-system setup that installs a cluster extension.
+#[derive(Clone)]
+pub struct ClusterSetup {
+  extension_id: ClusterExtensionId,
+}
+
+impl ClusterSetup {
+  /// Creates a setup from a cluster extension identifier.
+  #[must_use]
+  pub const fn new(extension_id: ClusterExtensionId) -> Self {
+    Self { extension_id }
+  }
+}
+
+impl ExtensionInstaller for ClusterSetup {
+  fn install(&self, system: &ActorSystem) -> Result<(), ActorSystemBuildError> {
+    install_extension_id(system, &self.extension_id);
+    Ok(())
+  }
+}

--- a/modules/cluster-core-typed/src/cluster_state_subscription.rs
+++ b/modules/cluster-core-typed/src/cluster_state_subscription.rs
@@ -1,0 +1,70 @@
+//! Typed cluster state subscription requests.
+
+use alloc::vec::Vec;
+use core::convert::Infallible;
+
+use fraktor_actor_core_typed_rs::TypedActorRef;
+use fraktor_cluster_core_kernel_rs::{
+  extension::ClusterSubscriptionInitialStateMode,
+  topology::{ClusterEvent, ClusterEventType},
+};
+
+use crate::{Cluster, ClusterStateSubscriptionResult, SelfRemoved, SelfUp};
+
+/// Requests supported by typed cluster state subscriptions.
+#[derive(Clone, Debug)]
+pub enum ClusterStateSubscription {
+  /// Subscribe a typed actor reference to cluster events.
+  Subscribe {
+    /// Typed subscriber receiving cluster events.
+    subscriber:         TypedActorRef<ClusterEvent>,
+    /// Initial state delivery mode.
+    initial_state_mode: ClusterSubscriptionInitialStateMode,
+    /// Cluster event filters.
+    event_types:        Vec<ClusterEventType>,
+  },
+  /// Subscribe a typed actor reference to local-member up events.
+  SubscribeSelfUp {
+    /// Typed subscriber receiving local-member up events.
+    subscriber: TypedActorRef<SelfUp>,
+  },
+  /// Subscribe a typed actor reference to local-member removed events.
+  SubscribeSelfRemoved {
+    /// Typed subscriber receiving local-member removed events.
+    subscriber: TypedActorRef<SelfRemoved>,
+  },
+  /// Unsubscribe from cluster events by subscription identifier.
+  Unsubscribe {
+    /// Kernel event-stream subscription identifier.
+    subscription_id: u64,
+  },
+  /// Read the current cluster state snapshot.
+  GetCurrentState,
+}
+
+impl ClusterStateSubscription {
+  /// Applies this request to the supplied typed cluster facade.
+  ///
+  /// # Errors
+  ///
+  /// This request currently cannot fail because the facade already owns a
+  /// resolved kernel cluster API.
+  pub fn apply_to(self, cluster: &Cluster) -> Result<ClusterStateSubscriptionResult, Infallible> {
+    Ok(match self {
+      | Self::Subscribe { subscriber, initial_state_mode, event_types } => {
+        ClusterStateSubscriptionResult::Subscribed(cluster.subscribe(&subscriber, initial_state_mode, &event_types))
+      },
+      | Self::SubscribeSelfUp { subscriber } => {
+        ClusterStateSubscriptionResult::Subscribed(cluster.subscribe_self_up(&subscriber))
+      },
+      | Self::SubscribeSelfRemoved { subscriber } => {
+        ClusterStateSubscriptionResult::Subscribed(cluster.subscribe_self_removed(&subscriber))
+      },
+      | Self::Unsubscribe { subscription_id } => {
+        cluster.unsubscribe(subscription_id);
+        ClusterStateSubscriptionResult::Unsubscribed
+      },
+      | Self::GetCurrentState => ClusterStateSubscriptionResult::CurrentState(cluster.current_state()),
+    })
+  }
+}

--- a/modules/cluster-core-typed/src/cluster_state_subscription_result.rs
+++ b/modules/cluster-core-typed/src/cluster_state_subscription_result.rs
@@ -1,0 +1,15 @@
+//! Results produced by typed cluster state subscription requests.
+
+use fraktor_cluster_core_kernel_rs::membership::CurrentClusterState;
+
+use crate::ClusterEventSubscription;
+
+/// Result of applying a [`ClusterStateSubscription`](crate::ClusterStateSubscription).
+pub enum ClusterStateSubscriptionResult {
+  /// A cluster-event subscription was registered.
+  Subscribed(ClusterEventSubscription),
+  /// A cluster-event subscription was removed.
+  Unsubscribed,
+  /// A current cluster-state snapshot was read.
+  CurrentState(CurrentClusterState),
+}

--- a/modules/cluster-core-typed/src/lib.rs
+++ b/modules/cluster-core-typed/src/lib.rs
@@ -11,6 +11,22 @@
 
 extern crate alloc;
 
+mod cluster;
+mod cluster_command;
+mod cluster_event_subscription;
 mod cluster_identity;
+mod cluster_setup;
+mod cluster_state_subscription;
+mod cluster_state_subscription_result;
+mod self_removed;
+mod self_up;
 
+pub use cluster::Cluster;
+pub use cluster_command::ClusterCommand;
+pub use cluster_event_subscription::ClusterEventSubscription;
 pub use cluster_identity::ClusterIdentity;
+pub use cluster_setup::ClusterSetup;
+pub use cluster_state_subscription::ClusterStateSubscription;
+pub use cluster_state_subscription_result::ClusterStateSubscriptionResult;
+pub use self_removed::SelfRemoved;
+pub use self_up::SelfUp;

--- a/modules/cluster-core-typed/src/self_removed.rs
+++ b/modules/cluster-core-typed/src/self_removed.rs
@@ -1,0 +1,60 @@
+//! Typed event emitted when the local member is removed.
+
+use alloc::string::String;
+
+use fraktor_cluster_core_kernel_rs::{membership::NodeStatus, topology::ClusterEvent};
+use fraktor_utils_core_rs::time::TimerInstant;
+
+/// Local-member removed event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelfRemoved {
+  node_id:         String,
+  authority:       String,
+  previous_status: NodeStatus,
+  observed_at:     TimerInstant,
+}
+
+impl SelfRemoved {
+  /// Creates a local-member removed event.
+  #[must_use]
+  pub const fn new(node_id: String, authority: String, previous_status: NodeStatus, observed_at: TimerInstant) -> Self {
+    Self { node_id, authority, previous_status, observed_at }
+  }
+
+  /// Derives [`SelfRemoved`] from a cluster member status change for the local authority.
+  #[must_use]
+  pub fn try_from_cluster_event(event: &ClusterEvent, self_authority: &str) -> Option<Self> {
+    match event {
+      | ClusterEvent::MemberStatusChanged { node_id, authority, from, to: NodeStatus::Removed, observed_at }
+        if authority == self_authority =>
+      {
+        Some(Self::new(node_id.clone(), authority.clone(), *from, *observed_at))
+      },
+      | _ => None,
+    }
+  }
+
+  /// Returns the local node identifier.
+  #[must_use]
+  pub fn node_id(&self) -> &str {
+    &self.node_id
+  }
+
+  /// Returns the local member authority.
+  #[must_use]
+  pub fn authority(&self) -> &str {
+    &self.authority
+  }
+
+  /// Returns the local member status before removal.
+  #[must_use]
+  pub const fn previous_status(&self) -> NodeStatus {
+    self.previous_status
+  }
+
+  /// Returns the observation timestamp.
+  #[must_use]
+  pub const fn observed_at(&self) -> TimerInstant {
+    self.observed_at
+  }
+}

--- a/modules/cluster-core-typed/src/self_up.rs
+++ b/modules/cluster-core-typed/src/self_up.rs
@@ -1,0 +1,59 @@
+//! Typed event emitted when the local member becomes up.
+
+use alloc::string::String;
+
+use fraktor_cluster_core_kernel_rs::{
+  membership::{CurrentClusterState, NodeStatus},
+  topology::ClusterEvent,
+};
+
+/// Local-member up event.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SelfUp {
+  node_id:               String,
+  authority:             String,
+  current_cluster_state: CurrentClusterState,
+}
+
+impl SelfUp {
+  /// Creates a local-member up event.
+  #[must_use]
+  pub const fn new(node_id: String, authority: String, current_cluster_state: CurrentClusterState) -> Self {
+    Self { node_id, authority, current_cluster_state }
+  }
+
+  /// Derives [`SelfUp`] from a cluster member status change for the local authority.
+  #[must_use]
+  pub fn try_from_cluster_event(
+    event: &ClusterEvent,
+    self_authority: &str,
+    current_cluster_state: CurrentClusterState,
+  ) -> Option<Self> {
+    match event {
+      | ClusterEvent::MemberStatusChanged { node_id, authority, to: NodeStatus::Up, .. }
+        if authority == self_authority =>
+      {
+        Some(Self::new(node_id.clone(), authority.clone(), current_cluster_state))
+      },
+      | _ => None,
+    }
+  }
+
+  /// Returns the local node identifier.
+  #[must_use]
+  pub fn node_id(&self) -> &str {
+    &self.node_id
+  }
+
+  /// Returns the local member authority.
+  #[must_use]
+  pub fn authority(&self) -> &str {
+    &self.authority
+  }
+
+  /// Returns the current cluster state observed when this event was emitted.
+  #[must_use]
+  pub const fn current_cluster_state(&self) -> &CurrentClusterState {
+    &self.current_cluster_state
+  }
+}

--- a/modules/cluster-core-typed/tests/cluster.rs
+++ b/modules/cluster-core-typed/tests/cluster.rs
@@ -1,0 +1,831 @@
+use alloc::{
+  collections::BTreeMap,
+  string::{String, ToString},
+  vec,
+  vec::Vec,
+};
+use core::time::Duration;
+
+extern crate alloc;
+
+use fraktor_actor_adaptor_std_rs::tick_driver::TestTickDriver;
+use fraktor_actor_core_kernel_rs::{
+  actor::{
+    Pid,
+    actor_ref::{ActorRef, ActorRefSender, ActorRefSenderShared, SendOutcome},
+    error::SendError,
+    extension::ExtensionInstallers,
+    messaging::AnyMessage,
+    setup::ActorSystemConfig,
+  },
+  event::stream::{EventStreamEvent, EventStreamShared},
+};
+use fraktor_actor_core_typed_rs::{TypedActorRef, TypedActorSystem, TypedProps, dsl::Behaviors};
+use fraktor_cluster_core_kernel_rs::{
+  activation::{
+    ActivatedKind, IdentityLookup, IdentitySetupError, LookupError, PlacementDecision, PlacementLocality,
+    PlacementResolution,
+  },
+  cluster_provider::ClusterProvider,
+  downing_provider::{DowningDecision, DowningInput, DowningProvider, DowningProviderCompatibility},
+  extension::{
+    ClusterExtension, ClusterExtensionConfig, ClusterExtensionId, ClusterExtensionInstaller, ClusterProviderError,
+    ClusterSubscriptionInitialStateMode,
+  },
+  grain::GrainKey,
+  membership::{CurrentClusterState, MembershipVersion, NodeRecord, NodeStatus, NoopGossiper},
+  pub_sub::NoopClusterPubSub,
+  topology::{BlockListProvider, ClusterEvent, ClusterEventType, ClusterTopology, TopologyUpdate},
+};
+use fraktor_cluster_core_typed_rs::{
+  Cluster, ClusterCommand, ClusterSetup, ClusterStateSubscription, ClusterStateSubscriptionResult, SelfRemoved, SelfUp,
+};
+use fraktor_utils_core_rs::{
+  sync::{ArcShared, SpinSyncMutex},
+  time::TimerInstant,
+};
+
+#[derive(Debug)]
+struct UserMessage;
+
+#[test]
+fn cluster_command_delegates_membership_operations_to_kernel_cluster_api() {
+  let joined = ArcShared::new(SpinSyncMutex::new(Vec::<String>::new()));
+  let left = ArcShared::new(SpinSyncMutex::new(Vec::<String>::new()));
+  let downed = ArcShared::new(SpinSyncMutex::new(Vec::<String>::new()));
+  let system = typed_system_with_recording_provider(joined.clone(), left.clone(), downed.clone());
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+
+  ClusterCommand::Join { address: String::from("node2:8080") }.apply_to(&cluster).expect("join");
+  ClusterCommand::JoinSeedNodes { addresses: vec![String::from("node3:8080"), String::from("node4:8080")] }
+    .apply_to(&cluster)
+    .expect("join seed nodes");
+  ClusterCommand::Leave { address: String::from("node2:8080") }.apply_to(&cluster).expect("leave");
+  ClusterCommand::Down { address: String::from("node5:8080") }.apply_to(&cluster).expect("down");
+
+  assert_eq!(joined.lock().clone(), vec![
+    String::from("node2:8080"),
+    String::from("node3:8080"),
+    String::from("node4:8080")
+  ]);
+  assert_eq!(left.lock().clone(), vec![String::from("node2:8080")]);
+  assert_eq!(downed.lock().clone(), vec![String::from("node5:8080")]);
+}
+
+#[test]
+fn cluster_command_join_seed_nodes_returns_first_kernel_error_without_joining_later_seeds() {
+  let joined = ArcShared::new(SpinSyncMutex::new(Vec::<String>::new()));
+  let system = typed_system_with_failing_join_provider(joined.clone(), "fail:8080");
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+
+  let result = (ClusterCommand::JoinSeedNodes {
+    addresses: vec![String::from("ok:8080"), String::from("fail:8080"), String::from("after:8080")],
+  })
+  .apply_to(&cluster);
+
+  assert!(result.is_err());
+  assert_eq!(joined.lock().clone(), vec![String::from("ok:8080"), String::from("fail:8080")]);
+}
+
+#[test]
+fn cluster_current_state_uses_kernel_cluster_state_snapshot() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  extension.on_topology(&topology_update(3, vec![String::from("node2:8080")], Vec::new()));
+  let cluster = Cluster::get(&system).expect("cluster");
+
+  let state = cluster.current_state();
+
+  assert_eq!(state.members.iter().map(|record| record.authority.as_str()).collect::<Vec<_>>(), vec![
+    "node1:8080",
+    "node2:8080"
+  ]);
+  assert_eq!(state.leader.as_deref(), Some("node1:8080"));
+}
+
+#[test]
+fn cluster_state_subscription_get_current_state_uses_kernel_snapshot() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  extension.on_topology(&topology_update(5, vec![String::from("node2:8080")], Vec::new()));
+  let cluster = Cluster::get(&system).expect("cluster");
+
+  let state = match ClusterStateSubscription::GetCurrentState.apply_to(&cluster).expect("current state") {
+    | ClusterStateSubscriptionResult::CurrentState(state) => state,
+    | ClusterStateSubscriptionResult::Subscribed(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+      panic!("expected current state")
+    },
+  };
+
+  assert_eq!(state.members.iter().map(|record| record.authority.as_str()).collect::<Vec<_>>(), vec![
+    "node1:8080",
+    "node2:8080"
+  ]);
+}
+
+#[test]
+fn cluster_state_subscription_subscribe_and_unsubscribe_controls_kernel_subscription() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  extension.on_topology(&topology_update(9, vec![String::from("node2:8080")], Vec::new()));
+  let cluster = Cluster::get(&system).expect("cluster");
+  let received = ArcShared::new(SpinSyncMutex::new(Vec::<ClusterEvent>::new()));
+  let subscriber = typed_cluster_event_ref(received.clone());
+
+  let subscription = match (ClusterStateSubscription::Subscribe {
+    subscriber,
+    initial_state_mode: ClusterSubscriptionInitialStateMode::AsSnapshot,
+    event_types: vec![ClusterEventType::TopologyUpdated],
+  })
+  .apply_to(&cluster)
+  .expect("subscribe")
+  {
+    | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+    | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+      panic!("expected subscription")
+    },
+  };
+
+  assert!(subscription.id() > 0);
+  assert!(matches!(
+    received.lock().first(),
+    Some(ClusterEvent::CurrentClusterState { state, .. })
+      if state.members.iter().map(|record| record.authority.as_str()).collect::<Vec<_>>() == vec![
+        "node1:8080",
+        "node2:8080",
+      ]
+  ));
+
+  received.lock().clear();
+  ClusterStateSubscription::Unsubscribe { subscription_id: subscription.id() }.apply_to(&cluster).expect("unsubscribe");
+  extension.on_topology(&topology_update(10, vec![String::from("node3:8080")], Vec::new()));
+
+  assert!(received.lock().is_empty());
+}
+
+#[test]
+fn cluster_state_subscription_exposes_delivery_failures() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+  let subscriber = failing_cluster_event_ref();
+
+  let subscription = match (ClusterStateSubscription::Subscribe {
+    subscriber,
+    initial_state_mode: ClusterSubscriptionInitialStateMode::AsSnapshot,
+    event_types: vec![ClusterEventType::CurrentClusterState],
+  })
+  .apply_to(&cluster)
+  .expect("subscribe")
+  {
+    | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+    | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+      panic!("expected subscription")
+    },
+  };
+
+  assert_eq!(subscription.failed_delivery_count(), 1);
+}
+
+#[test]
+fn cluster_state_subscription_routes_self_up_and_self_removed_events() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+  let self_up_events = ArcShared::new(SpinSyncMutex::new(Vec::<SelfUp>::new()));
+  let self_removed_events = ArcShared::new(SpinSyncMutex::new(Vec::<SelfRemoved>::new()));
+
+  let up_subscription =
+    match (ClusterStateSubscription::SubscribeSelfUp { subscriber: typed_self_up_ref(self_up_events.clone()) })
+      .apply_to(&cluster)
+      .expect("subscribe self up")
+    {
+      | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+      | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+        panic!("expected subscription")
+      },
+    };
+  let removed_subscription = match (ClusterStateSubscription::SubscribeSelfRemoved {
+    subscriber: typed_self_removed_ref(self_removed_events.clone()),
+  })
+  .apply_to(&cluster)
+  .expect("subscribe self removed")
+  {
+    | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+    | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+      panic!("expected subscription")
+    },
+  };
+
+  publish_cluster_event(
+    system.as_untyped().event_stream(),
+    member_status_changed(
+      "node1:8080",
+      NodeStatus::Joining,
+      NodeStatus::Up,
+      TimerInstant::from_ticks(21, Duration::from_secs(1)),
+    ),
+  );
+  publish_cluster_event(
+    system.as_untyped().event_stream(),
+    member_status_changed(
+      "node1:8080",
+      NodeStatus::Exiting,
+      NodeStatus::Removed,
+      TimerInstant::from_ticks(22, Duration::from_secs(1)),
+    ),
+  );
+
+  assert_eq!(self_up_events.lock().len(), 1);
+  assert_eq!(self_up_events.lock()[0].authority(), "node1:8080");
+  assert_eq!(self_up_events.lock()[0].current_cluster_state().members[0].authority, "node1:8080");
+  assert_eq!(self_removed_events.lock().len(), 1);
+  assert_eq!(self_removed_events.lock()[0].authority(), "node1:8080");
+  assert_eq!(up_subscription.failed_delivery_count(), 0);
+  assert_eq!(removed_subscription.failed_delivery_count(), 0);
+}
+
+#[test]
+fn cluster_state_subscription_records_self_up_delivery_failure() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+
+  let subscription = match (ClusterStateSubscription::SubscribeSelfUp { subscriber: failing_self_up_ref() })
+    .apply_to(&cluster)
+    .expect("subscribe self up")
+  {
+    | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+    | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+      panic!("expected subscription")
+    },
+  };
+  publish_cluster_event(
+    system.as_untyped().event_stream(),
+    member_status_changed(
+      "node1:8080",
+      NodeStatus::Joining,
+      NodeStatus::Up,
+      TimerInstant::from_ticks(23, Duration::from_secs(1)),
+    ),
+  );
+
+  assert_eq!(subscription.failed_delivery_count(), 1);
+}
+
+#[test]
+fn cluster_state_subscription_records_self_removed_delivery_failure() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+
+  let subscription = match (ClusterStateSubscription::SubscribeSelfRemoved { subscriber: failing_self_removed_ref() })
+    .apply_to(&cluster)
+    .expect("subscribe self removed")
+  {
+    | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+    | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+      panic!("expected subscription")
+    },
+  };
+  publish_cluster_event(
+    system.as_untyped().event_stream(),
+    member_status_changed(
+      "node1:8080",
+      NodeStatus::Exiting,
+      NodeStatus::Removed,
+      TimerInstant::from_ticks(24, Duration::from_secs(1)),
+    ),
+  );
+
+  assert_eq!(subscription.failed_delivery_count(), 1);
+}
+
+#[test]
+fn cluster_state_subscription_replies_to_late_self_removed_subscriber_from_seen_removed_state() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+  publish_cluster_event(
+    system.as_untyped().event_stream(),
+    member_status_changed(
+      "node1:8080",
+      NodeStatus::Exiting,
+      NodeStatus::Removed,
+      TimerInstant::from_ticks(25, Duration::from_secs(1)),
+    ),
+  );
+  let self_removed_events = ArcShared::new(SpinSyncMutex::new(Vec::<SelfRemoved>::new()));
+
+  let subscription = match (ClusterStateSubscription::SubscribeSelfRemoved {
+    subscriber: typed_self_removed_ref(self_removed_events.clone()),
+  })
+  .apply_to(&cluster)
+  .expect("subscribe self removed")
+  {
+    | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+    | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+      panic!("expected subscription")
+    },
+  };
+
+  assert_eq!(self_removed_events.lock().len(), 1);
+  assert_eq!(self_removed_events.lock()[0].previous_status(), NodeStatus::Exiting);
+  assert_eq!(subscription.failed_delivery_count(), 0);
+}
+
+#[test]
+fn cluster_state_subscription_replies_to_late_self_up_subscriber_from_current_state() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+  let self_up_events = ArcShared::new(SpinSyncMutex::new(Vec::<SelfUp>::new()));
+
+  let subscription =
+    match (ClusterStateSubscription::SubscribeSelfUp { subscriber: typed_self_up_ref(self_up_events.clone()) })
+      .apply_to(&cluster)
+      .expect("subscribe self up")
+    {
+      | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+      | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+        panic!("expected subscription")
+      },
+    };
+
+  assert_eq!(self_up_events.lock().len(), 1);
+  assert_eq!(self_up_events.lock()[0].authority(), "node1:8080");
+  assert_eq!(self_up_events.lock()[0].current_cluster_state().members[0].status, NodeStatus::Up);
+  assert_eq!(subscription.failed_delivery_count(), 0);
+}
+
+#[test]
+fn cluster_setup_installs_cluster_extension_during_typed_bootstrap() {
+  let setup = ClusterSetup::new(cluster_extension_id(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  ));
+  let installers = ExtensionInstallers::default().with_extension_installer(setup);
+  let props = TypedProps::<UserMessage>::from_behavior_factory(Behaviors::ignore);
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_extension_installers(installers);
+
+  let system = TypedActorSystem::create_from_props(&props, config).expect("typed system");
+
+  assert!(Cluster::get(&system).is_ok());
+  system.terminate().expect("terminate");
+}
+
+#[test]
+fn self_up_and_self_removed_wrap_self_member_status_events() {
+  let observed_at = TimerInstant::from_ticks(7, Duration::from_secs(1));
+  let current_state = current_state_with_self_member(NodeStatus::Up);
+  let up = SelfUp::new(String::from("node-1"), String::from("node1:8080"), current_state);
+  let removed = SelfRemoved::new(String::from("node-1"), String::from("node1:8080"), NodeStatus::Exiting, observed_at);
+
+  assert_eq!(up.node_id(), "node-1");
+  assert_eq!(up.authority(), "node1:8080");
+  assert_eq!(up.current_cluster_state().members[0].authority, "node1:8080");
+  assert_eq!(removed.node_id(), "node-1");
+  assert_eq!(removed.authority(), "node1:8080");
+  assert_eq!(removed.previous_status(), NodeStatus::Exiting);
+  assert_eq!(removed.observed_at(), observed_at);
+}
+
+#[test]
+fn self_up_derives_from_self_member_up_event() {
+  let observed_at = TimerInstant::from_ticks(11, Duration::from_secs(1));
+  let event = member_status_changed("node1:8080", NodeStatus::Joining, NodeStatus::Up, observed_at);
+
+  let up = SelfUp::try_from_cluster_event(&event, "node1:8080", current_state_with_self_member(NodeStatus::Up))
+    .expect("self up");
+
+  assert_eq!(up.node_id(), "node-node1:8080");
+  assert_eq!(up.authority(), "node1:8080");
+  assert_eq!(up.current_cluster_state().members[0].status, NodeStatus::Up);
+}
+
+#[test]
+fn self_up_ignores_other_authority() {
+  let observed_at = TimerInstant::from_ticks(12, Duration::from_secs(1));
+  let event = member_status_changed("node2:8080", NodeStatus::Joining, NodeStatus::Up, observed_at);
+
+  let up = SelfUp::try_from_cluster_event(&event, "node1:8080", current_state_with_self_member(NodeStatus::Up));
+
+  assert_eq!(up, None);
+}
+
+#[test]
+fn self_up_ignores_non_up_status() {
+  let observed_at = TimerInstant::from_ticks(13, Duration::from_secs(1));
+  let event = member_status_changed("node1:8080", NodeStatus::Joining, NodeStatus::Leaving, observed_at);
+
+  let up = SelfUp::try_from_cluster_event(&event, "node1:8080", current_state_with_self_member(NodeStatus::Up));
+
+  assert_eq!(up, None);
+}
+
+#[test]
+fn self_removed_derives_from_self_member_removed_event() {
+  let observed_at = TimerInstant::from_ticks(14, Duration::from_secs(1));
+  let event = member_status_changed("node1:8080", NodeStatus::Exiting, NodeStatus::Removed, observed_at);
+
+  let removed = SelfRemoved::try_from_cluster_event(&event, "node1:8080").expect("self removed");
+
+  assert_eq!(removed.node_id(), "node-node1:8080");
+  assert_eq!(removed.authority(), "node1:8080");
+  assert_eq!(removed.previous_status(), NodeStatus::Exiting);
+  assert_eq!(removed.observed_at(), observed_at);
+}
+
+#[test]
+fn self_removed_ignores_other_authority() {
+  let observed_at = TimerInstant::from_ticks(15, Duration::from_secs(1));
+  let event = member_status_changed("node2:8080", NodeStatus::Exiting, NodeStatus::Removed, observed_at);
+
+  let removed = SelfRemoved::try_from_cluster_event(&event, "node1:8080");
+
+  assert_eq!(removed, None);
+}
+
+#[test]
+fn self_removed_ignores_non_removed_status() {
+  let observed_at = TimerInstant::from_ticks(16, Duration::from_secs(1));
+  let event = member_status_changed("node1:8080", NodeStatus::Up, NodeStatus::Leaving, observed_at);
+
+  let removed = SelfRemoved::try_from_cluster_event(&event, "node1:8080");
+
+  assert_eq!(removed, None);
+}
+
+fn member_status_changed(authority: &str, from: NodeStatus, to: NodeStatus, observed_at: TimerInstant) -> ClusterEvent {
+  ClusterEvent::MemberStatusChanged {
+    node_id: alloc::format!("node-{authority}"),
+    authority: authority.to_string(),
+    from,
+    to,
+    observed_at,
+  }
+}
+
+fn current_state_with_self_member(status: NodeStatus) -> CurrentClusterState {
+  CurrentClusterState::new(
+    vec![NodeRecord::new(
+      String::from("node-node1:8080"),
+      String::from("node1:8080"),
+      status,
+      MembershipVersion::new(1),
+      String::from("test"),
+      Vec::new(),
+    )],
+    Vec::new(),
+    Vec::new(),
+    Some(String::from("node1:8080")),
+    BTreeMap::new(),
+  )
+}
+
+fn typed_system_with_recording_provider(
+  joined: ArcShared<SpinSyncMutex<Vec<String>>>,
+  left: ArcShared<SpinSyncMutex<Vec<String>>>,
+  downed: ArcShared<SpinSyncMutex<Vec<String>>>,
+) -> TypedActorSystem<UserMessage> {
+  let cluster_installer =
+    ClusterExtensionInstaller::new(ClusterExtensionConfig::new().with_advertised_address("node1:8080"), {
+      let joined = joined.clone();
+      let left = left.clone();
+      let downed = downed.clone();
+      move |_event_stream, _block_list, _address| {
+        Box::new(RecordingClusterProvider { joined: joined.clone(), left: left.clone(), downed: downed.clone() })
+      }
+    })
+    .with_downing_provider_factory(DowningProviderCompatibility::new("typed-recording-downing-provider"), {
+      || Box::new(RecordingDowningProvider { downed: ArcShared::new(SpinSyncMutex::new(Vec::new())) })
+    })
+    .with_identity_lookup_factory(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  let installers = ExtensionInstallers::default().with_extension_installer(cluster_installer);
+  let props = TypedProps::<UserMessage>::from_behavior_factory(Behaviors::ignore);
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_extension_installers(installers);
+  TypedActorSystem::create_from_props(&props, config).expect("typed system")
+}
+
+fn typed_system_with_failing_join_provider(
+  joined: ArcShared<SpinSyncMutex<Vec<String>>>,
+  fail_authority: &str,
+) -> TypedActorSystem<UserMessage> {
+  let fail_authority = String::from(fail_authority);
+  let cluster_installer =
+    ClusterExtensionInstaller::new(ClusterExtensionConfig::new().with_advertised_address("node1:8080"), {
+      let joined = joined.clone();
+      move |_event_stream, _block_list, _address| {
+        Box::new(FailingJoinClusterProvider { joined: joined.clone(), fail_authority: fail_authority.clone() })
+      }
+    })
+    .with_downing_provider_factory(DowningProviderCompatibility::new("typed-recording-downing-provider"), {
+      || Box::new(RecordingDowningProvider { downed: ArcShared::new(SpinSyncMutex::new(Vec::new())) })
+    })
+    .with_identity_lookup_factory(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  let installers = ExtensionInstallers::default().with_extension_installer(cluster_installer);
+  let props = TypedProps::<UserMessage>::from_behavior_factory(Behaviors::ignore);
+  let config = ActorSystemConfig::new(TestTickDriver::default()).with_extension_installers(installers);
+  TypedActorSystem::create_from_props(&props, config).expect("typed system")
+}
+
+fn installed_cluster_extension(system: &TypedActorSystem<UserMessage>) -> ArcShared<ClusterExtension> {
+  system.as_untyped().extended().extension_by_type::<ClusterExtension>().expect("cluster extension")
+}
+
+fn cluster_extension_id(
+  joined: ArcShared<SpinSyncMutex<Vec<String>>>,
+  left: ArcShared<SpinSyncMutex<Vec<String>>>,
+  downed: ArcShared<SpinSyncMutex<Vec<String>>>,
+) -> ClusterExtensionId {
+  ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address("node1:8080"),
+    Box::new(RecordingClusterProvider { joined, left, downed }),
+    ArcShared::new(EmptyBlockListProvider),
+    Box::new(RecordingDowningProvider { downed: ArcShared::new(SpinSyncMutex::new(Vec::new())) }),
+    Box::new(NoopGossiper),
+    Box::new(NoopClusterPubSub),
+    Box::new(StaticIdentityLookup::new("node1:8080")),
+  )
+}
+
+fn topology_update(version: u64, joined: Vec<String>, left: Vec<String>) -> TopologyUpdate {
+  let topology = ClusterTopology::new(version, joined.clone(), left.clone(), Vec::new());
+  let mut members = vec![String::from("node1:8080")];
+  for authority in &joined {
+    if !members.contains(authority) {
+      members.push(authority.clone());
+    }
+  }
+  members.retain(|authority| !left.contains(authority));
+  TopologyUpdate::new(
+    topology,
+    members,
+    joined,
+    left,
+    Vec::new(),
+    Vec::new(),
+    TimerInstant::from_ticks(version, Duration::from_secs(1)),
+  )
+}
+
+fn typed_cluster_event_ref(received: ArcShared<SpinSyncMutex<Vec<ClusterEvent>>>) -> TypedActorRef<ClusterEvent> {
+  TypedActorRef::from_untyped(ActorRef::new(
+    Pid::new(100, 0),
+    ActorRefSenderShared::new(Box::new(RecordingClusterEventSender { received })),
+  ))
+}
+
+fn failing_cluster_event_ref() -> TypedActorRef<ClusterEvent> {
+  TypedActorRef::from_untyped(ActorRef::new(Pid::new(101, 0), ActorRefSenderShared::new(Box::new(FailingSender))))
+}
+
+fn failing_self_up_ref() -> TypedActorRef<SelfUp> {
+  TypedActorRef::from_untyped(ActorRef::new(Pid::new(104, 0), ActorRefSenderShared::new(Box::new(FailingSender))))
+}
+
+fn failing_self_removed_ref() -> TypedActorRef<SelfRemoved> {
+  TypedActorRef::from_untyped(ActorRef::new(Pid::new(105, 0), ActorRefSenderShared::new(Box::new(FailingSender))))
+}
+
+fn typed_self_up_ref(received: ArcShared<SpinSyncMutex<Vec<SelfUp>>>) -> TypedActorRef<SelfUp> {
+  TypedActorRef::from_untyped(ActorRef::new(
+    Pid::new(102, 0),
+    ActorRefSenderShared::new(Box::new(RecordingSelfUpSender { received })),
+  ))
+}
+
+fn typed_self_removed_ref(received: ArcShared<SpinSyncMutex<Vec<SelfRemoved>>>) -> TypedActorRef<SelfRemoved> {
+  TypedActorRef::from_untyped(ActorRef::new(
+    Pid::new(103, 0),
+    ActorRefSenderShared::new(Box::new(RecordingSelfRemovedSender { received })),
+  ))
+}
+
+fn publish_cluster_event(event_stream: EventStreamShared, event: ClusterEvent) {
+  let payload = AnyMessage::new(event);
+  let extension_event = EventStreamEvent::Extension { name: String::from("cluster"), payload };
+  event_stream.publish(&extension_event);
+}
+
+struct RecordingClusterEventSender {
+  received: ArcShared<SpinSyncMutex<Vec<ClusterEvent>>>,
+}
+
+impl ActorRefSender for RecordingClusterEventSender {
+  fn send(&mut self, message: AnyMessage) -> Result<SendOutcome, SendError> {
+    if let Some(cluster_event) = message.payload().downcast_ref::<ClusterEvent>() {
+      self.received.lock().push(cluster_event.clone());
+    }
+    if let Some(EventStreamEvent::Extension { payload, .. }) = message.payload().downcast_ref::<EventStreamEvent>()
+      && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
+    {
+      self.received.lock().push(cluster_event.clone());
+    }
+    Ok(SendOutcome::Delivered)
+  }
+}
+
+struct FailingSender;
+
+impl ActorRefSender for FailingSender {
+  fn send(&mut self, message: AnyMessage) -> Result<SendOutcome, SendError> {
+    Err(SendError::closed(message))
+  }
+}
+
+struct RecordingSelfUpSender {
+  received: ArcShared<SpinSyncMutex<Vec<SelfUp>>>,
+}
+
+impl ActorRefSender for RecordingSelfUpSender {
+  fn send(&mut self, message: AnyMessage) -> Result<SendOutcome, SendError> {
+    if let Some(self_up) = message.payload().downcast_ref::<SelfUp>() {
+      self.received.lock().push(self_up.clone());
+    }
+    Ok(SendOutcome::Delivered)
+  }
+}
+
+struct RecordingSelfRemovedSender {
+  received: ArcShared<SpinSyncMutex<Vec<SelfRemoved>>>,
+}
+
+impl ActorRefSender for RecordingSelfRemovedSender {
+  fn send(&mut self, message: AnyMessage) -> Result<SendOutcome, SendError> {
+    if let Some(self_removed) = message.payload().downcast_ref::<SelfRemoved>() {
+      self.received.lock().push(self_removed.clone());
+    }
+    Ok(SendOutcome::Delivered)
+  }
+}
+
+struct RecordingClusterProvider {
+  joined: ArcShared<SpinSyncMutex<Vec<String>>>,
+  left:   ArcShared<SpinSyncMutex<Vec<String>>>,
+  downed: ArcShared<SpinSyncMutex<Vec<String>>>,
+}
+
+struct FailingJoinClusterProvider {
+  joined:         ArcShared<SpinSyncMutex<Vec<String>>>,
+  fail_authority: String,
+}
+
+impl ClusterProvider for FailingJoinClusterProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.joined.lock().push(authority.to_string());
+    if authority == self.fail_authority {
+      return Err(ClusterProviderError::join("join failed"));
+    }
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+impl ClusterProvider for RecordingClusterProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.downed.lock().push(authority.to_string());
+    Ok(())
+  }
+
+  fn join(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.joined.lock().push(authority.to_string());
+    Ok(())
+  }
+
+  fn leave(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.left.lock().push(authority.to_string());
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct RecordingDowningProvider {
+  downed: ArcShared<SpinSyncMutex<Vec<String>>>,
+}
+
+impl DowningProvider for RecordingDowningProvider {
+  fn decide(&mut self, input: &DowningInput) -> Result<DowningDecision, ClusterProviderError> {
+    if let DowningInput::ExplicitDown { authority } = input {
+      self.downed.lock().push(authority.clone());
+    }
+    Ok(DowningDecision::Down)
+  }
+}
+
+struct StaticIdentityLookup {
+  authority: String,
+}
+
+impl StaticIdentityLookup {
+  fn new(authority: &str) -> Self {
+    Self { authority: authority.to_string() }
+  }
+}
+
+impl IdentityLookup for StaticIdentityLookup {
+  fn setup_member(&mut self, _kinds: &[ActivatedKind]) -> Result<(), IdentitySetupError> {
+    Ok(())
+  }
+
+  fn setup_client(&mut self, _kinds: &[ActivatedKind]) -> Result<(), IdentitySetupError> {
+    Ok(())
+  }
+
+  fn resolve(&mut self, key: &GrainKey, now: u64) -> Result<PlacementResolution, LookupError> {
+    let pid = alloc::format!("{}::{}", self.authority, key.value());
+    Ok(PlacementResolution {
+      decision: PlacementDecision { key: key.clone(), authority: self.authority.clone(), observed_at: now },
+      locality: PlacementLocality::Remote,
+      pid,
+    })
+  }
+}
+
+struct EmptyBlockListProvider;
+
+impl BlockListProvider for EmptyBlockListProvider {
+  fn blocked_members(&self) -> Vec<String> {
+    Vec::new()
+  }
+}

--- a/modules/cluster-core-typed/tests/cluster.rs
+++ b/modules/cluster-core-typed/tests/cluster.rs
@@ -379,6 +379,51 @@ fn cluster_state_subscription_replies_to_late_self_removed_subscriber_from_seen_
 }
 
 #[test]
+fn cluster_state_subscription_completes_late_self_up_subscriber_from_seen_removed_state() {
+  let system = typed_system_with_recording_provider(
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+    ArcShared::new(SpinSyncMutex::new(Vec::new())),
+  );
+  let extension = installed_cluster_extension(&system);
+  extension.start_member().expect("start member");
+  let cluster = Cluster::get(&system).expect("cluster");
+  publish_cluster_event(
+    system.as_untyped().event_stream(),
+    member_status_changed(
+      "node1:8080",
+      NodeStatus::Exiting,
+      NodeStatus::Removed,
+      TimerInstant::from_ticks(26, Duration::from_secs(1)),
+    ),
+  );
+  let self_up_events = ArcShared::new(SpinSyncMutex::new(Vec::<SelfUp>::new()));
+
+  let subscription =
+    match (ClusterStateSubscription::SubscribeSelfUp { subscriber: typed_self_up_ref(self_up_events.clone()) })
+      .apply_to(&cluster)
+      .expect("subscribe self up")
+    {
+      | ClusterStateSubscriptionResult::Subscribed(subscription) => subscription,
+      | ClusterStateSubscriptionResult::CurrentState(_) | ClusterStateSubscriptionResult::Unsubscribed => {
+        panic!("expected subscription")
+      },
+    };
+  publish_cluster_event(
+    system.as_untyped().event_stream(),
+    member_status_changed(
+      "node1:8080",
+      NodeStatus::Joining,
+      NodeStatus::Up,
+      TimerInstant::from_ticks(27, Duration::from_secs(1)),
+    ),
+  );
+
+  assert!(self_up_events.lock().is_empty());
+  assert_eq!(subscription.failed_delivery_count(), 0);
+}
+
+#[test]
 fn cluster_state_subscription_replies_to_late_self_up_subscriber_from_current_state() {
   let system = typed_system_with_recording_provider(
     ArcShared::new(SpinSyncMutex::new(Vec::new())),


### PR DESCRIPTION
## 概要

- `cluster-core-typed` に typed cluster facade、membership command、state subscription、SelfUp/SelfRemoved event を追加しました。
- kernel `ClusterApi` に typed facade が使う `remote_path_of`、`current_state`、`self_authority` を追加しました。
- downing provider の互換性メタデータと Split Brain Resolver 設定比較を `ClusterExtensionConfig` の join compatibility に追加しました。
- std adaptor の gossip shutdown 周辺と一部テストの must-use/警告対応を整理しました。

## 注意

このPRは #1944 (`codex/enforce-port-adaptor-boundary`) に積み上げています。DIP/Port & Adapter 境界の是正を先に入れる前提です。

## 検証

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo check -p fraktor-cluster-core-kernel-rs --tests`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo check -p fraktor-cluster-core-typed-rs --tests`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo check -p fraktor-cluster-adaptor-std-rs --tests`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo test -p fraktor-cluster-core-typed-rs`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo test -p fraktor-cluster-core-kernel-rs downing_provider_compatibility`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo test -p fraktor-cluster-core-kernel-rs cluster_extension_config`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo test -p fraktor-cluster-core-kernel-rs cluster_api`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo test -p fraktor-cluster-core-kernel-rs cluster_extension_installer`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo test -p fraktor-cluster-adaptor-std-rs tokio_gossiper`
- `git diff --cached --check`
- `CARGO_TARGET_DIR=/tmp/fraktor-rs-cluster-typed-target cargo clippy -p fraktor-cluster-core-kernel-rs -p fraktor-cluster-core-typed-rs -p fraktor-cluster-adaptor-std-rs --tests -- -D warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Join compatibility and installer API changes affect cluster membership safety; typed subscriptions touch lifecycle-sensitive paths but are covered by broad new tests.
> 
> **Overview**
> Adds a **typed cluster layer** (`cluster-core-typed`) with `Cluster`, membership `ClusterCommand`, state subscription requests, and `SelfUp` / `SelfRemoved` events wired to the kernel event stream (including late subscribers and delivery-failure counts). Extends kernel **`ClusterApi`** with `remote_path_of`, `current_state`, and `self_authority`, and makes `ClusterApi` **cloneable** for typed subscribers.
> 
> Introduces **downing provider join compatibility**: `DowningProviderCompatibility`, Split Brain Resolver settings/strategy types, storage on `ClusterExtensionConfig`, join checks (provider key + SBR settings when using `split-brain-resolver`), and **`with_downing_provider_factory`** now takes a compatibility key propagated into install config.
> 
> **Std adaptor**: gossip transport uses chained `let` for decode/enqueue; gossiper shutdown logs instead of silently ignoring send/join errors; tests assert `stop()` success and replace ignored `Result`s with `drop` where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e472230ce57a2c9d27422ecd06c4a8663be5dbd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->