### PR TITLE
Update wait_for_other_checks to default to true

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -42,5 +42,5 @@ jobs:
       pull-requests: read
     with:
       pr_number: ${{ inputs.pr_number }}
-      wait_for_other_checks: ${{ inputs.wait_for_other_checks }}
+      wait_for_other_checks: ${{ inputs.wait_for_other_checks || 'true' }}
       ci_ref: a672e3d9fca1de4b7b6b648c08c9ad263267dff6

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -42,5 +42,5 @@ jobs:
       pull-requests: read
     with:
       pr_number: ${{ inputs.pr_number }}
-      wait_for_other_checks: ${{ inputs.wait_for_other_checks || 'true' }}
+      wait_for_other_checks: ${{ inputs.wait_for_other_checks == '' && 'true' || inputs.wait_for_other_checks }}
       ci_ref: a672e3d9fca1de4b7b6b648c08c9ad263267dff6


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single workflow input expression change; only affects when review-thread refresh waits on other PR checks.
> 
> **Overview**
> The standalone **Review Thread Refresh** workflow now passes **`wait_for_other_checks: "true"`** to the reusable `j5ik2o/ci` job when the input is unset, instead of forwarding an empty value.
> 
> That matters for runs triggered by **review comments**, **issue comments**, or the **15-minute schedule**, where `workflow_dispatch` inputs are not present even though the dispatch UI default is `"true"`. Manual dispatch still honors the **true/false** choice when provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f318c7b26c9c92e51c233ab0cf77283fa36f06d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ワークフローの処理ロジックを改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->