### PR TITLE
cluster discovery provider interop を実装

### DIFF
--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -14,7 +14,7 @@
   - _Requirements: 2.1, 2.2, 2.4, 4.2_
   - _Boundary: DiscoveredAuthority, DiscoveryResult_
 
-- [ ] 3. DiscoveryTopologyMapper を追加する
+- [x] 3. DiscoveryTopologyMapper を追加する
   - discovery result から joined / left の差分だけを topology update として生成する。
   - duplicate authority の dedup、failure 時に既存 topology を破壊しないこと、block list contract を維持することを unit test で確認する。
   - 完了時には static seed / generic discovery / AWS ECS result が同じ topology update contract に変換される。

--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -22,7 +22,7 @@
   - _Boundary: DiscoveryTopologyMapper_
   - _Depends: 2_
 
-- [ ] 4. std generic discovery backend contract を追加する
+- [x] 4. std generic discovery backend contract を追加する
   - std adaptor 側で backend execution を表す trait と observable failure error を定義する。
   - polling または subscription の入力が `DiscoveryResult` に変換されることを fake backend test で確認する。
   - 完了時には特定 cloud provider に依存しない discovery backend bridge を追加できる。

--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -30,7 +30,7 @@
   - _Boundary: GenericDiscoveryAdapter_
   - _Depends: 2, 3_
 
-- [ ] 5. provider lifecycle bridge を実装する
+- [x] 5. provider lifecycle bridge を実装する
   - member start では seed/discovery を join input に変換し、client start では full member 自己登録を生成しないようにする。
   - shutdown で polling/subscription が停止し、provider を strong reference で生存させないことを std test で確認する。
   - 完了時には provider lifecycle と discovery lifecycle の停止境界が観測できる。

--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -38,7 +38,7 @@
   - _Boundary: ProviderLifecycleBridge, GenericDiscoveryAdapter_
   - _Depends: 1, 4_
 
-- [ ] 6. 既存 Local / static / AWS ECS provider との interop を確認する
+- [x] 6. 既存 Local / static / AWS ECS provider との interop を確認する
   - Local provider の seed node input が SeedNodeProcess bridge を通じて topology update になることを確認する。
   - Static provider が discovery polling を開始しない既存 contract を維持することを確認する。
   - AWS ECS provider の existing polling behavior を壊さず、generic mapping contract と矛盾しないことを確認する。

--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -7,7 +7,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 3.1, 3.2_
   - _Boundary: SeedNodeProcess_
 
-- [ ] 2. provider-neutral discovery result model を追加する
+- [x] 2. provider-neutral discovery result model を追加する
   - backend-neutral な discovered authority、source identity、observation time、empty result、failure result を表現する。
   - provider-specific metadata が placement / membership input として公開されないことを test で確認する。
   - 完了時には generic backend result を cluster core が読める最小 value contract に正規化できる。

--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -1,6 +1,6 @@
 # 実装計画
 
-- [ ] 1. SeedNodeProcess の core contract を追加する
+- [x] 1. SeedNodeProcess の core contract を追加する
   - seed authority を provider lifecycle から受け取り、member mode と client mode の違いを観測できる contract を定義する。
   - empty seed、self authority、duplicate authority、invalid authority、shutdown 後入力停止を unit test で確認する。
   - 完了時には seed node source から join input を生成する最小 surface が `no_std` core で参照できる。

--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -55,7 +55,7 @@
   - _Boundary: ScopeGuard_
   - _Depends: 6_
 
-- [ ] 8. gap analysis evidence と targeted verification を更新する
+- [x] 8. gap analysis evidence と targeted verification を更新する
   - `SeedNodeProcess` と generic discovery adapter の evidence だけを `docs/gap-analysis/cluster-gap-analysis.md` に反映する。
   - Deferred Pekko concepts と downstream spec 項目を完了扱いにしないことを確認する。
   - 対象 crate の unit tests / std tests / no-std check を実行し、provider/discovery interop の contract が同時に成立することを確認する。

--- a/.kiro/specs/cluster-discovery-provider-interop/tasks.md
+++ b/.kiro/specs/cluster-discovery-provider-interop/tasks.md
@@ -47,7 +47,7 @@
   - _Boundary: SeedNodeProcessBridge, GenericDiscoveryAdapter_
   - _Depends: 3, 5_
 
-- [ ] 7. 隣接 spec の scope を吸収していないことを検証する
+- [x] 7. 隣接 spec の scope を吸収していないことを検証する
   - membership reachability、WeaklyUp、gossip heartbeat、downing/SBR、pubsub、serialization の実装をこの feature に含めていないことを差分で確認する。
   - discovery result の source identity が placement / membership policy の入力になっていないことを確認する。
   - 完了時には provider/discovery interop の boundary が roadmap の downstream spec と分離されたままになる。

--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -1,6 +1,6 @@
 # cluster モジュール ギャップ分析
 
-更新日: 2026-06-01 (cluster-gossip-heartbeat-protocol evidence reflected)
+更新日: 2026-06-02 (cluster-discovery-provider-interop evidence reflected)
 
 ## 位置づけ
 
@@ -63,12 +63,12 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 204 件 (core-kerne
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象概念 | 約 121 |
-| fraktor-rs 固定スコープ対応概念 | 約 70 |
-| 固定スコープ概念カバレッジ | 約 70/121 (58%) |
+| fraktor-rs 固定スコープ対応概念 | 約 72 |
+| 固定スコープ概念カバレッジ | 約 72/121 (60%) |
 | raw public type declarations | 204 (core-kernel: 183, core-typed: 9, std: 12) |
 | raw public method declarations | 485 (core-kernel: 415, core-typed: 32, std: 38) |
 | hard gap | 16 |
-| medium gap | 18 |
+| medium gap | 16 |
 | easy gap | 9 |
 | trivial gap | 2 |
 | panic 系スタブ | 0 件 |
@@ -82,12 +82,12 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 
 | 層 | Pekko 対応範囲 | fraktor-rs 現状 | 評価 |
 |----|----------------|-----------------|------|
-| core / membership | `Cluster`, `Member`, `MemberStatus`, `CurrentClusterState`, `ClusterEvent`, `Gossip`, `Reachability` | `ClusterExtension`, `ClusterApi`, `NodeRecord`, `NodeStatus`, `CurrentClusterState`, `MembershipCoordinator`, `GossipDisseminationCoordinator`, `ReachabilityMatrix`, `GossipStateModel`, `HeartbeatProtocolState`, `CrossDcHeartbeat` | UniqueAddress、data center、WeaklyUp、reachability matrix、gossip envelope、full gossip merge / tombstone / seen digest、dedicated heartbeat evidence の core contract はある。seed process は限定的 |
+| core / membership | `Cluster`, `Member`, `MemberStatus`, `CurrentClusterState`, `ClusterEvent`, `Gossip`, `Reachability` | `ClusterExtension`, `ClusterApi`, `NodeRecord`, `NodeStatus`, `CurrentClusterState`, `MembershipCoordinator`, `GossipDisseminationCoordinator`, `ReachabilityMatrix`, `GossipStateModel`, `HeartbeatProtocolState`, `CrossDcHeartbeat` | UniqueAddress、data center、WeaklyUp、reachability matrix、gossip envelope、full gossip merge / tombstone / seen digest、dedicated heartbeat evidence、SeedNodeProcess の core contract はある |
 | core / downing | `DowningProvider`, `NoDowning`, SBR | `DowningProvider`, `DowningInput`, `DowningDecision`, `FailureObservation`, `IndirectConnectionEvidence`, `NoopDowningProvider`, `SplitBrainResolverSettings`, `SplitBrainResolverStrategy` | downing input boundary は indirect evidence を受け取れるが、SBR 実行 actor / strategy 判定は未実装 |
 | core / typed | typed `Cluster`, command, subscription, singleton, sharding typed API | `modules/cluster-core-typed` に typed `Cluster` / command / state subscription / self events / setup がある | typed Cluster の薄い facade はあるが、singleton / sharding typed API は未実装 |
 | core / virtual actor | `ClusterSharding`, `EntityRef`, `EntityTypeKey`, `ShardRegion`, coordinator | `GrainRef`, `GrainKey`, `VirtualActorRegistry`, `PlacementCoordinatorCore`, `PartitionIdentityLookup` | protoactor-go style の同等機能は強いが Pekko public API と remember/rebalance が不足 |
 | core / distributed state | `DistributedData`, `Replicator`, CRDT 型群 | なし | 未実装 |
-| std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `MembershipCoordinatorDriver`, `LocalClusterProvider`, `AwsEcsClusterProvider` | Rust adapter と logical envelope handoff はあるが seed / discovery / serializer integration は限定的 |
+| std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `MembershipCoordinatorDriver`, `LocalClusterProvider`, `StaticClusterProvider`, `AwsEcsClusterProvider`, `GenericDiscoveryAdapter`, `ProviderLifecycleBridge` | Rust adapter、logical envelope handoff、seed/discovery provider boundary はある。cluster message serializer integration は限定的 |
 
 ## カテゴリ別ギャップ
 
@@ -103,7 +103,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 
 実装済みとして扱うもの: cluster extension、join/leave/down、event stream subscription、current state snapshot、member/up/removed callback、roles/app_version 設定、leader/role leader 算出、startup/shutdown event。
 
-### 2. Gossip / reachability / failure detection　✅ 実装済み 13/15 (87%)
+### 2. Gossip / reachability / failure detection　✅ 実装済み 14/15 (93%)
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
@@ -112,7 +112,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | `GossipEnvelope` | `Gossip.scala:307` | core + logical handoff 実装済み | core/membership + std/handoff | medium | `GossipEnvelope` が from/to `UniqueAddress`、payload kind、membership version、deadline を保持する。`GossipTransportHandoff` / `TokioGossipTransport` は identity と payload kind を失わない logical handoff を扱う。serializer bytes は downstream scope |
 | dedicated `ClusterHeartbeatSender` / receiver protocol | `ClusterHeartbeat.scala:82`, `ClusterHeartbeat.scala:90` | core protocol 実装済み | core/membership | medium | `HeartbeatProtocolState` が peer ごとの sequence、request/response 照合、first / regular timeout evidence を扱う。evidence は reachability input であり downing decision は実行しない。tests: `heartbeat_*` |
 | `CrossDcClusterHeartbeat` | `CrossDcClusterHeartbeat.scala:230` | core evidence 実装済み | core/membership | hard | `CrossDcHeartbeat` が data center pair、cross-DC request/response、target add/remove/retain、timeout evidence を扱う。routing、discovery、downing strategy は決定しない。tests: `cross_dc_*` |
-| `SeedNodeProcess` | `SeedNodeProcess.scala:22` | 部分実装 | std/provider | medium | `LocalClusterProvider::with_seed_nodes` はあるが InitJoin/JoinSeedNode プロセスはない |
+| `SeedNodeProcess` | `SeedNodeProcess.scala:22` | core + std provider boundary 実装済み | core/cluster_provider + std/provider | medium | `SeedNodeInput` と `SeedNodeProcess` が empty seed、self filtering、duplicate seed、invalid authority、client start、shutdown 後停止を扱う。`ProviderLifecycleBridge` が seed input を topology update に接続する。tests: `seed_node_process_*`, `provider_lifecycle_bridge_seed_input_publishes_topology_update`, `provider_lifecycle_bridge_shutdown_stops_seed_and_discovery_lifecycle` |
 | config compatibility full key set | `JoinConfigCompatChecker.scala:25`, `JoinConfigCompatCheckCluster.scala:27` | baseline 実装済み | core/config | easy | `ClusterCompatibilityKeyCatalog` が required/excluded key を公開し、`JoinCompatibilityComposition` と `ClusterExtensionConfig::check_join_compatibility` が pubsub、downing provider、SBR settings の mismatch reason を合成する。`cluster_compatibility_key` / `join_compatibility` tests で確認 |
 | failure detector implementation choice | `Cluster.scala:124`, `Cluster.scala:131` | 部分実装 | core/failure_detector | easy | registry はあるが cluster config から deadline/phi などを選ぶ設定 contract がない |
 
@@ -207,17 +207,17 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | read/write consistency levels | `Replicator.scala:284` | 未対応 | core/ddata | easy | ReadLocal/ReadMajority/WriteMajority 等 |
 | typed DistributedData API | `cluster-typed/ddata/typed/scaladsl/DistributedData.scala:33` | 未対応 | core/typed | medium | typed actor ref adapter が必要 |
 
-### 10. std adapter / discovery / wire integration　✅ 実装済み 5/9 (56%)
+### 10. std adapter / discovery / wire integration　✅ 実装済み 7/9 (78%)
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
 | cluster message serializer contract | `ClusterMessageSerializer.scala:83`, `ClusterShardingMessageSerializer.scala`, `DistributedPubSubMessageSerializer.scala` | 部分実装 | std/wire + actor-core serialization | hard | gossip delta は postcard wire だが Pekko cluster/sharding/pubsub message serializer に相当する contract がない |
-| seed node discovery process | `SeedNodeProcess.scala:22` | 部分実装 | std/provider | medium | seed list は保持できるが active join orchestration がない |
-| generic discovery adapter | `Cluster.scala:354`, `ClusterClient.scala:65` | 部分実装 | std/provider | medium | static/local/AWS ECS はあるが discovery provider abstraction は限定的 |
+| seed node discovery process | `SeedNodeProcess.scala:22` | boundary contract 実装済み | core/cluster_provider + std/provider | medium | `SeedNodeProcess` が seed authority を provider-neutral join input に変換し、`DiscoveryTopologyMapper` が topology update へ写像する。`ProviderLifecycleBridge` が lifecycle 内で seed/discovery input を同じ contract に接続する。tests: `seed_node_process_*`, `discovery_topology_mapper_*`, `provider_lifecycle_bridge_*` |
+| generic discovery adapter | `Cluster.scala:354`, `ClusterClient.scala:65` | boundary contract 実装済み | core/cluster_provider + std/provider | medium | `DiscoveryBackend` / `DiscoveryBackendError` / `GenericDiscoveryAdapter` が backend success、empty success、failure、AWS ECS style authority を `DiscoveryResult` / `DiscoveredAuthority` に正規化する。tests: `generic_discovery_adapter_*`, `discovery_result_*`, `aws_ecs` feature tests |
 | std `ClusterApi` wrapper parity | `Cluster.scala:328`, `Cluster.scala:384`, `Cluster.scala:395` | 部分実装 | std/api | trivial | std wrapper は `get/request/down` のみで `join/leave/subscribe` を再公開していない |
 | transport lifecycle to membership bridge retention | `local_cluster_provider_ext.rs` | 実装済み | std/provider | easy | `subscribe_remoting_events` が `EventStreamSubscription` を返し、guard 保持中だけ connected/quarantined events を topology input にする。weak provider retention により subscription は provider を延命しない。`local_cluster_provider_ext` tests で確認 |
 
-実装済みとして扱うもの: `TokioGossipTransport`、`MembershipCoordinatorDriver`、`LocalClusterProvider`、`StaticClusterProvider`、`AwsEcsClusterProvider`。logical gossip envelope handoff は `GossipEnvelope` evidence の一部として扱い、この section の独立 completed concept には数えない。
+実装済みとして扱うもの: `TokioGossipTransport`、`MembershipCoordinatorDriver`、`LocalClusterProvider`、`StaticClusterProvider`、`AwsEcsClusterProvider`、`SeedNodeProcess`、`DiscoveryTopologyMapper`、`GenericDiscoveryAdapter`、`ProviderLifecycleBridge`。logical gossip envelope handoff は `GossipEnvelope` evidence の一部として扱い、この section の独立 completed concept には数えない。
 
 ## 対象外 (n/a)
 
@@ -264,7 +264,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | `Reachability` matrix | core/membership | core contract 実装済み | `ReachabilityMatrix` / `ReachabilityRecord` / `ReachabilitySnapshot` が observer / subject / status / version、reachable prune、terminated precedence、aggregate status、snapshot propagation を保持。tests: `reachability_matrix::*`, `reachability_snapshot_tracks_failure_detector_and_heartbeat_receipt` |
 | indirect connection handling | core/membership + core/downing_provider | evidence contract 実装済み | `IndirectConnectionEvidence` と `DowningInput::IndirectConnectionEvidence` が partial connectivity evidence を渡す。downing decision、lease majority、SBR strategy は実行しない。tests: `indirect_connection_evidence::*` |
 
-この completed table は `cluster-membership-reachability-model` の core contract evidence だけを表す。次の責務は未完了のまま downstream spec に残す: SplitBrainResolver / DowningStrategy / lease-based majority、SeedNodeProcess / generic discovery adapter、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、Deferred Pekko concepts。
+この completed table は `cluster-membership-reachability-model` の core contract evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離する。次の責務は未完了のまま downstream spec に残す: SplitBrainResolver / DowningStrategy / lease-based majority、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、Deferred Pekko concepts。
 
 ### Completed active follow-up: gossip / heartbeat protocol
 
@@ -275,17 +275,24 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | dedicated cluster heartbeat protocol | core/membership | core protocol 実装済み | `HeartbeatProtocolState`、`HeartbeatRequest`、`HeartbeatResponse`、`HeartbeatEvidence` が sequence number、request/response 照合、first / regular timeout evidence を扱う。tests: `heartbeat_tick_generates_sequence_per_peer`, `heartbeat_request_roundtrip_produces_reachable_evidence`, `first_and_regular_heartbeat_timeouts_are_observable` |
 | `CrossDcClusterHeartbeat` | core/membership | core evidence 実装済み | `CrossDcHeartbeat`、`CrossDcHeartbeatRequest`、`CrossDcHeartbeatResponse`、`CrossDcHeartbeatEvidence` が data center pair 付き cross-DC liveness evidence と target change を扱う。tests: `cross_dc_*` |
 
-この completed table は `cluster-gossip-heartbeat-protocol` の evidence だけを表す。次の責務は未完了のまま downstream spec に残す: SplitBrainResolver / DowningStrategy / lease-based majority、SeedNodeProcess / generic discovery adapter、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、versioned transport handoff / serde-postcard envelope bytes、Deferred Pekko concepts。
+この completed table は `cluster-gossip-heartbeat-protocol` の evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離する。次の責務は未完了のまま downstream spec に残す: SplitBrainResolver / DowningStrategy / lease-based majority、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、versioned transport handoff / serde-postcard envelope bytes、Deferred Pekko concepts。
+
+### Completed active follow-up: discovery provider interop
+
+| 項目 | 実装先層 | 状態 | 根拠 / evidence |
+|------|----------|------|-----------------|
+| `SeedNodeProcess` | core/cluster_provider + std/provider | boundary contract 実装済み | `SeedNodeInput` / `SeedNodeProcess` が seed authority を provider-neutral join input に変換し、empty seed、self filtering、duplicate seed、invalid authority、client start、shutdown 後停止を扱う。`ProviderLifecycleBridge` が seed input を topology update に接続する。tests: `seed_node_process_*`, `provider_lifecycle_bridge_*` |
+| generic discovery adapter | core/cluster_provider + std/provider | boundary contract 実装済み | `DiscoveredAuthority` / `DiscoveryResult` / `DiscoveryTopologyMapper` と `DiscoveryBackend` / `DiscoveryBackendError` / `GenericDiscoveryAdapter` が backend result を provider-neutral topology input に正規化する。tests: `discovery_result_*`, `discovery_topology_mapper_*`, `generic_discovery_adapter_*`, `static_cluster_provider`, `aws_ecs` feature tests |
+
+この completed table は `cluster-discovery-provider-interop` の SeedNodeProcess と generic discovery adapter evidence だけを表す。gossip heartbeat / full Gossip、reachability / WeaklyUp はそれぞれ既存の専用 completed table の evidence に留め、この feature の完了根拠には含めない。次の責務は未完了のまま downstream spec に残す: downing / SBR execution、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、Deferred Pekko concepts。
 
 ### Active comparison follow-up: medium
 
 | 項目 | 実装先層 | 根拠 |
 |------|----------|------|
-| `SeedNodeProcess` | std/provider | カテゴリ2 |
 | `DistributedPubSubMediator` protocol | core/pub_sub + std | カテゴリ7 |
 | `DistributedPubSubSettings` | core/pub_sub | カテゴリ7 |
 | `Send` / `SendToAll` path semantics | core/pub_sub + actor-core | カテゴリ7 |
-| generic discovery adapter | std/provider | カテゴリ10 |
 
 ### Active comparison follow-up: hard
 

--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -360,7 +360,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 
 ## 内部モジュール構造ギャップ
 
-今回は API / 実動作ギャップが支配的であり、内部モジュール構造ギャップの詳細分析は省略する。Pekko comparison の固定スコープ概念カバレッジは約 58% で、hard / medium gap も多い。責務分割の細部比較より先に、Grain runtime の公開契約と end-to-end runtime を閉じる段階である。
+今回は API / 実動作ギャップが支配的であり、内部モジュール構造ギャップの詳細分析は省略する。Pekko comparison の固定スコープ概念カバレッジは約 60% で、hard / medium gap も多い。責務分割の細部比較より先に、Grain runtime の公開契約と end-to-end runtime を閉じる段階である。
 
 次版で構造分析へ進む場合の観点は以下になる。
 

--- a/modules/cluster-adaptor-std/src/cluster_provider.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider.rs
@@ -2,18 +2,27 @@
 
 #[cfg(feature = "aws-ecs")]
 mod aws_ecs_cluster_provider;
+/// Generic discovery backend execution contract.
+mod discovery_backend;
+/// Observable generic discovery backend failure.
+mod discovery_backend_error;
 #[cfg(feature = "aws-ecs")]
 mod ecs_cluster_config;
 #[cfg(feature = "aws-ecs")]
 mod ecs_poller_error;
 #[cfg(feature = "aws-ecs")]
 mod ecs_task_discovery;
+/// Generic discovery backend adapter contract.
+mod generic_discovery_adapter;
 mod local_cluster_provider_ext;
 
 #[cfg(feature = "aws-ecs")]
 pub use aws_ecs_cluster_provider::AwsEcsClusterProvider;
+pub use discovery_backend::DiscoveryBackend;
+pub use discovery_backend_error::DiscoveryBackendError;
 #[cfg(feature = "aws-ecs")]
 pub use ecs_cluster_config::EcsClusterConfig;
 #[cfg(feature = "aws-ecs")]
 pub use ecs_poller_error::EcsPollerError;
+pub use generic_discovery_adapter::GenericDiscoveryAdapter;
 pub use local_cluster_provider_ext::{subscribe_remoting_events, wrap_local_cluster_provider};

--- a/modules/cluster-adaptor-std/src/cluster_provider.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider.rs
@@ -15,6 +15,8 @@ mod ecs_task_discovery;
 /// Generic discovery backend adapter contract.
 mod generic_discovery_adapter;
 mod local_cluster_provider_ext;
+/// Provider lifecycle bridge for seed and discovery input.
+mod provider_lifecycle_bridge;
 
 #[cfg(feature = "aws-ecs")]
 pub use aws_ecs_cluster_provider::AwsEcsClusterProvider;
@@ -26,3 +28,4 @@ pub use ecs_cluster_config::EcsClusterConfig;
 pub use ecs_poller_error::EcsPollerError;
 pub use generic_discovery_adapter::GenericDiscoveryAdapter;
 pub use local_cluster_provider_ext::{subscribe_remoting_events, wrap_local_cluster_provider};
+pub use provider_lifecycle_bridge::ProviderLifecycleBridge;

--- a/modules/cluster-adaptor-std/src/cluster_provider/aws_ecs_cluster_provider_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/aws_ecs_cluster_provider_test.rs
@@ -143,6 +143,33 @@ async fn start_member_publishes_startup_event() {
 }
 
 #[tokio::test]
+async fn start_member_initial_topology_uses_authority_only_contract() {
+  let event_stream = EventStreamShared::default();
+  let block_list: ArcShared<dyn BlockListProvider> = ArcShared::new(EmptyBlockList);
+
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+
+  let mut provider = AwsEcsClusterProvider::new(event_stream, block_list, "127.0.0.1:8080");
+
+  let result = provider.start_member();
+  assert!(result.is_ok());
+
+  let events = subscriber_impl.events();
+  let topology_event = events.iter().find(|event| matches!(event, ClusterEvent::TopologyUpdated { .. }));
+  assert!(matches!(
+    topology_event,
+    Some(ClusterEvent::TopologyUpdated { update })
+    if update.joined == vec![String::from("127.0.0.1:8080")]
+      && update.members == vec![String::from("127.0.0.1:8080")]
+      && update.left.is_empty()
+      && update.dead.is_empty()
+      && update.blocked.is_empty()
+  ));
+
+  assert!(provider.shutdown(true).is_ok());
+}
+
+#[tokio::test]
 async fn start_client_publishes_startup_event() {
   let event_stream = EventStreamShared::default();
   let block_list: ArcShared<dyn BlockListProvider> = ArcShared::new(EmptyBlockList);

--- a/modules/cluster-adaptor-std/src/cluster_provider/discovery_backend.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/discovery_backend.rs
@@ -1,0 +1,18 @@
+//! Generic discovery backend execution contract.
+
+use std::{string::String, vec::Vec};
+
+use super::DiscoveryBackendError;
+
+/// Backend that produces provider-neutral authority snapshots.
+pub trait DiscoveryBackend {
+  /// Returns the backend identity used for observability.
+  fn source_identity(&self) -> &str;
+
+  /// Discovers the next authority snapshot from polling or subscription input.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`DiscoveryBackendError`] when the backend cannot produce an authority snapshot.
+  fn discover(&mut self) -> Result<Vec<String>, DiscoveryBackendError>;
+}

--- a/modules/cluster-adaptor-std/src/cluster_provider/discovery_backend_error.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/discovery_backend_error.rs
@@ -40,6 +40,6 @@ impl Error for DiscoveryBackendError {}
 
 impl From<DiscoveryBackendError> for ClusterProviderError {
   fn from(error: DiscoveryBackendError) -> Self {
-    ClusterProviderError::start_member(error.reason())
+    ClusterProviderError::join(error.reason())
   }
 }

--- a/modules/cluster-adaptor-std/src/cluster_provider/discovery_backend_error.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/discovery_backend_error.rs
@@ -1,0 +1,45 @@
+//! Observable generic discovery backend failure.
+
+use std::{
+  error::Error,
+  fmt::{Display, Formatter, Result},
+};
+
+use fraktor_cluster_core_kernel_rs::extension::ClusterProviderError;
+
+/// Error reported by a generic discovery backend.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryBackendError {
+  /// Backend failed temporarily and should be observed without clearing topology.
+  Temporary(String),
+}
+
+impl DiscoveryBackendError {
+  /// Creates a temporary backend failure.
+  #[must_use]
+  pub fn temporary(reason: impl Into<String>) -> Self {
+    Self::Temporary(reason.into())
+  }
+
+  /// Returns the failure reason.
+  #[must_use]
+  pub const fn reason(&self) -> &str {
+    match self {
+      | Self::Temporary(reason) => reason.as_str(),
+    }
+  }
+}
+
+impl Display for DiscoveryBackendError {
+  fn fmt(&self, formatter: &mut Formatter<'_>) -> Result {
+    formatter.write_str(self.reason())
+  }
+}
+
+impl Error for DiscoveryBackendError {}
+
+impl From<DiscoveryBackendError> for ClusterProviderError {
+  fn from(error: DiscoveryBackendError) -> Self {
+    ClusterProviderError::start_member(error.reason())
+  }
+}

--- a/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter.rs
@@ -2,7 +2,9 @@
 
 use std::string::ToString;
 
-use fraktor_cluster_core_kernel_rs::cluster_provider::{DiscoveredAuthority, DiscoveryResult};
+use fraktor_cluster_core_kernel_rs::cluster_provider::{
+  DiscoveredAuthority, DiscoveryResult, LocalClusterProviderWeak,
+};
 use fraktor_utils_core_rs::time::TimerInstant;
 
 use super::DiscoveryBackend;
@@ -13,14 +15,38 @@ mod tests;
 
 /// Adapter that normalizes generic backend output into discovery results.
 pub struct GenericDiscoveryAdapter<B> {
-  backend: B,
+  backend:     B,
+  provider:    Option<LocalClusterProviderWeak>,
+  is_shutdown: bool,
 }
 
 impl<B> GenericDiscoveryAdapter<B> {
   /// Creates a generic discovery adapter.
   #[must_use]
   pub const fn new(backend: B) -> Self {
-    Self { backend }
+    Self { backend, provider: None, is_shutdown: false }
+  }
+
+  /// Attaches a weak provider handle for lifecycle boundary checks.
+  pub fn attach_provider(&mut self, provider: LocalClusterProviderWeak) {
+    self.provider = Some(provider);
+  }
+
+  /// Returns whether the attached provider is still alive.
+  #[must_use]
+  pub fn provider_is_alive(&self) -> bool {
+    self.provider.as_ref().is_some_and(|provider| provider.upgrade().is_some())
+  }
+
+  /// Stops synchronous polling/subscription lifecycle.
+  pub const fn shutdown(&mut self) {
+    self.is_shutdown = true;
+  }
+
+  /// Returns whether discovery lifecycle has been stopped.
+  #[must_use]
+  pub const fn is_shutdown(&self) -> bool {
+    self.is_shutdown
   }
 }
 
@@ -28,6 +54,15 @@ impl<B> GenericDiscoveryAdapter<B>
 where
   B: DiscoveryBackend,
 {
+  /// Polls the backend when lifecycle is still active.
+  #[must_use]
+  pub fn poll(&mut self, observed_at: TimerInstant) -> Option<DiscoveryResult> {
+    if self.is_shutdown || self.provider.as_ref().is_some_and(|provider| provider.upgrade().is_none()) {
+      return None;
+    }
+    Some(self.discover(observed_at))
+  }
+
   /// Runs the backend and returns a provider-neutral discovery result.
   #[must_use]
   pub fn discover(&mut self, observed_at: TimerInstant) -> DiscoveryResult {

--- a/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter.rs
@@ -1,0 +1,46 @@
+//! Generic discovery backend adapter contract.
+
+use std::string::ToString;
+
+use fraktor_cluster_core_kernel_rs::cluster_provider::{DiscoveredAuthority, DiscoveryResult};
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use super::DiscoveryBackend;
+
+#[cfg(test)]
+#[path = "generic_discovery_adapter_test.rs"]
+mod tests;
+
+/// Adapter that normalizes generic backend output into discovery results.
+pub struct GenericDiscoveryAdapter<B> {
+  backend: B,
+}
+
+impl<B> GenericDiscoveryAdapter<B> {
+  /// Creates a generic discovery adapter.
+  #[must_use]
+  pub const fn new(backend: B) -> Self {
+    Self { backend }
+  }
+}
+
+impl<B> GenericDiscoveryAdapter<B>
+where
+  B: DiscoveryBackend,
+{
+  /// Runs the backend and returns a provider-neutral discovery result.
+  #[must_use]
+  pub fn discover(&mut self, observed_at: TimerInstant) -> DiscoveryResult {
+    let source_identity = self.backend.source_identity().to_string();
+    match self.backend.discover() {
+      | Ok(authorities) if authorities.is_empty() => DiscoveryResult::empty(source_identity, observed_at),
+      | Ok(authorities) => DiscoveryResult::discovered(
+        authorities
+          .into_iter()
+          .map(|authority| DiscoveredAuthority::new(authority, source_identity.clone(), observed_at))
+          .collect(),
+      ),
+      | Err(error) => DiscoveryResult::failed(source_identity, observed_at, error.into()),
+    }
+  }
+}

--- a/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter.rs
@@ -2,8 +2,9 @@
 
 use std::string::ToString;
 
-use fraktor_cluster_core_kernel_rs::cluster_provider::{
-  DiscoveredAuthority, DiscoveryResult, LocalClusterProviderWeak,
+use fraktor_cluster_core_kernel_rs::{
+  cluster_provider::{DiscoveredAuthority, DiscoveryResult, LocalClusterProviderWeak},
+  extension::ClusterProviderError,
 };
 use fraktor_utils_core_rs::time::TimerInstant;
 
@@ -69,6 +70,9 @@ where
     let source_identity = self.backend.source_identity().to_string();
     match self.backend.discover() {
       | Ok(authorities) if authorities.is_empty() => DiscoveryResult::empty(source_identity, observed_at),
+      | Ok(authorities) if authorities.iter().any(|authority| !Self::is_valid_authority(authority)) => {
+        DiscoveryResult::failed(source_identity, observed_at, ClusterProviderError::join("invalid discovery authority"))
+      },
       | Ok(authorities) => DiscoveryResult::discovered(
         authorities
           .into_iter()
@@ -77,5 +81,9 @@ where
       ),
       | Err(error) => DiscoveryResult::failed(source_identity, observed_at, error.into()),
     }
+  }
+
+  fn is_valid_authority(authority: &str) -> bool {
+    !authority.is_empty() && !authority.chars().any(char::is_whitespace)
   }
 }

--- a/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
@@ -4,12 +4,21 @@ use std::{
 };
 
 use fraktor_cluster_core_kernel_rs::{
-  cluster_provider::{DiscoveredAuthority, DiscoveryResult},
+  cluster_provider::{DiscoveredAuthority, DiscoveryResult, DiscoveryTopologyMapper},
   extension::ClusterProviderError,
+  topology::BlockListProvider,
 };
-use fraktor_utils_core_rs::time::TimerInstant;
+use fraktor_utils_core_rs::{sync::ArcShared, time::TimerInstant};
 
 use crate::cluster_provider::{DiscoveryBackend, DiscoveryBackendError, GenericDiscoveryAdapter};
+
+struct EmptyBlockList;
+
+impl BlockListProvider for EmptyBlockList {
+  fn blocked_members(&self) -> Vec<String> {
+    Vec::new()
+  }
+}
 
 struct FakeDiscoveryBackend {
   source_identity: String,
@@ -38,6 +47,10 @@ impl DiscoveryBackend for FakeDiscoveryBackend {
 
 fn observed_at(ticks: u64) -> TimerInstant {
   TimerInstant::from_ticks(ticks, Duration::from_secs(1))
+}
+
+fn mapper() -> DiscoveryTopologyMapper {
+  DiscoveryTopologyMapper::new(ArcShared::new(EmptyBlockList))
 }
 
 fn assert_authority(authority: &DiscoveredAuthority, expected_authority: &str, expected_source: &str) {
@@ -88,4 +101,22 @@ fn generic_discovery_adapter_converts_backend_failure_to_observable_discovery_re
     matches!(result, DiscoveryResult::Failed(_, _, ClusterProviderError::StartMemberFailed(ref reason)) if reason == "backend unavailable")
   );
   assert!(result.to_authorities().is_empty());
+}
+
+#[test]
+fn generic_discovery_adapter_keeps_aws_ecs_style_authorities_compatible_with_topology_mapping() {
+  let backend = FakeDiscoveryBackend::successful(
+    "aws-ecs",
+    Vec::from([String::from("10.0.1.12:8080"), String::from("10.0.1.12:8080")]),
+  );
+  let mut adapter = GenericDiscoveryAdapter::new(backend);
+  let mut mapper = mapper();
+
+  let result = adapter.discover(observed_at(42));
+  let update = mapper.apply(&result).expect("aws ecs style authority should publish topology");
+
+  assert_eq!(update.joined, vec![String::from("10.0.1.12:8080")]);
+  assert_eq!(update.members, update.joined);
+  assert!(update.left.is_empty());
+  assert!(update.blocked.is_empty());
 }

--- a/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
@@ -1,0 +1,91 @@
+use std::{
+  string::{String, ToString},
+  time::Duration,
+};
+
+use fraktor_cluster_core_kernel_rs::{
+  cluster_provider::{DiscoveredAuthority, DiscoveryResult},
+  extension::ClusterProviderError,
+};
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use crate::cluster_provider::{DiscoveryBackend, DiscoveryBackendError, GenericDiscoveryAdapter};
+
+struct FakeDiscoveryBackend {
+  source_identity: String,
+  outcome:         Result<Vec<String>, DiscoveryBackendError>,
+}
+
+impl FakeDiscoveryBackend {
+  fn successful(source_identity: &str, authorities: Vec<String>) -> Self {
+    Self { source_identity: source_identity.to_string(), outcome: Ok(authorities) }
+  }
+
+  fn failing(source_identity: &str, error: DiscoveryBackendError) -> Self {
+    Self { source_identity: source_identity.to_string(), outcome: Err(error) }
+  }
+}
+
+impl DiscoveryBackend for FakeDiscoveryBackend {
+  fn source_identity(&self) -> &str {
+    self.source_identity.as_str()
+  }
+
+  fn discover(&mut self) -> Result<Vec<String>, DiscoveryBackendError> {
+    self.outcome.clone()
+  }
+}
+
+fn observed_at(ticks: u64) -> TimerInstant {
+  TimerInstant::from_ticks(ticks, Duration::from_secs(1))
+}
+
+fn assert_authority(authority: &DiscoveredAuthority, expected_authority: &str, expected_source: &str) {
+  assert_eq!(authority.authority(), expected_authority);
+  assert_eq!(authority.source_identity(), expected_source);
+  assert_eq!(authority.observed_at(), observed_at(42));
+}
+
+#[test]
+fn generic_discovery_adapter_converts_backend_polling_success_to_discovery_result() {
+  let backend = FakeDiscoveryBackend::successful(
+    "fake-poller",
+    Vec::from([String::from("node-a.example:7331"), String::from("node-b.example:7331")]),
+  );
+  let mut adapter = GenericDiscoveryAdapter::new(backend);
+
+  let result = adapter.discover(observed_at(42));
+
+  assert_eq!(result.authorities().len(), 2);
+  assert_authority(&result.authorities()[0], "node-a.example:7331", "fake-poller");
+  assert_authority(&result.authorities()[1], "node-b.example:7331", "fake-poller");
+}
+
+#[test]
+fn generic_discovery_adapter_converts_empty_backend_success_to_empty_discovery_result() {
+  let backend = FakeDiscoveryBackend::successful("fake-subscription", Vec::new());
+  let mut adapter = GenericDiscoveryAdapter::new(backend);
+
+  let result = adapter.discover(observed_at(42));
+
+  assert!(result.is_empty());
+  assert_eq!(result.source_identity(), Some("fake-subscription"));
+  assert_eq!(result.observed_at(), Some(observed_at(42)));
+}
+
+#[test]
+fn generic_discovery_adapter_converts_backend_failure_to_observable_discovery_result() {
+  let error = DiscoveryBackendError::temporary("backend unavailable");
+  let backend = FakeDiscoveryBackend::failing("fake-poller", error);
+  let mut adapter = GenericDiscoveryAdapter::new(backend);
+
+  let result = adapter.discover(observed_at(42));
+
+  assert!(result.is_failed());
+  assert_eq!(result.source_identity(), Some("fake-poller"));
+  assert_eq!(result.observed_at(), Some(observed_at(42)));
+  assert!(
+    matches!(result, DiscoveryResult::Failed(_, _, ClusterProviderError::StartMemberFailed(ref reason)) if reason == "backend unavailable")
+  );
+  assert!(result.to_authorities().is_empty());
+}

--- a/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
@@ -98,7 +98,7 @@ fn generic_discovery_adapter_converts_backend_failure_to_observable_discovery_re
   assert_eq!(result.source_identity(), Some("fake-poller"));
   assert_eq!(result.observed_at(), Some(observed_at(42)));
   assert!(
-    matches!(result, DiscoveryResult::Failed(_, _, ClusterProviderError::StartMemberFailed(ref reason)) if reason == "backend unavailable")
+    matches!(result, DiscoveryResult::Failed(_, _, ClusterProviderError::JoinFailed(ref reason)) if reason == "backend unavailable")
   );
   assert!(result.to_authorities().is_empty());
 }

--- a/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/generic_discovery_adapter_test.rs
@@ -104,6 +104,24 @@ fn generic_discovery_adapter_converts_backend_failure_to_observable_discovery_re
 }
 
 #[test]
+fn generic_discovery_adapter_rejects_invalid_backend_authorities() {
+  let backend = FakeDiscoveryBackend::successful(
+    "fake-poller",
+    Vec::from([String::from("valid-node"), String::from("invalid node")]),
+  );
+  let mut adapter = GenericDiscoveryAdapter::new(backend);
+
+  let result = adapter.discover(observed_at(42));
+
+  assert!(result.is_failed());
+  assert!(matches!(
+    result,
+    DiscoveryResult::Failed(_, _, ClusterProviderError::JoinFailed(ref reason)) if reason == "invalid discovery authority"
+  ));
+  assert!(result.to_authorities().is_empty());
+}
+
+#[test]
 fn generic_discovery_adapter_keeps_aws_ecs_style_authorities_compatible_with_topology_mapping() {
   let backend = FakeDiscoveryBackend::successful(
     "aws-ecs",

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
@@ -117,10 +117,13 @@ where
 
     let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::start_member("provider unavailable"))?;
     let observed_at = self.next_observed_at();
-    if let Some(result) = self.discovery_adapter.poll(observed_at)
-      && let Some(update) = self.topology_mapper.apply(&result)
-    {
-      Self::apply_topology_update(&provider, &update)?;
+    if let Some(result) = self.discovery_adapter.poll(observed_at) {
+      if let Some(error) = result.error() {
+        return Err(error.clone());
+      }
+      if let Some(update) = self.topology_mapper.apply(&result) {
+        Self::apply_topology_update(&provider, &update)?;
+      }
     }
     Ok(())
   }

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
@@ -8,7 +8,7 @@ use fraktor_cluster_core_kernel_rs::{
     SeedNodeProcess,
   },
   extension::ClusterProviderError,
-  topology::TopologyUpdate,
+  topology::{ClusterTopology, TopologyUpdate},
 };
 use fraktor_utils_core_rs::{sync::SharedAccess, time::TimerInstant};
 
@@ -115,14 +115,14 @@ where
       return Ok(());
     }
 
-    let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::start_member("provider unavailable"))?;
+    let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::join("provider unavailable"))?;
     let observed_at = self.next_observed_at();
     if let Some(result) = self.discovery_adapter.poll(observed_at) {
       if let Some(error) = result.error() {
         return Err(error.clone());
       }
       if let Some(update) = self.topology_mapper.apply(&result) {
-        Self::apply_topology_update(&provider, &update, self.seed_input.advertised_authority())?;
+        Self::apply_topology_update(&provider, &update, &self.seed_input)?;
       }
     }
     Ok(())
@@ -147,20 +147,33 @@ where
   fn apply_topology_update(
     provider: &LocalClusterProviderShared,
     update: &TopologyUpdate,
-    local_authority: &str,
+    seed_input: &SeedNodeInput,
   ) -> Result<(), ClusterProviderError> {
-    for authority in update.joined.iter() {
-      if authority == local_authority {
-        continue;
-      }
-      provider.with_write(|provider| provider.join(authority.as_str()))?;
+    let local_authority = seed_input.advertised_authority();
+    let joined: Vec<_> =
+      update.joined.iter().filter(|authority| authority.as_str() != local_authority).cloned().collect();
+    let left: Vec<_> = update
+      .left
+      .iter()
+      .filter(|authority| authority.as_str() != local_authority && !seed_input.seed_authorities().contains(authority))
+      .cloned()
+      .collect();
+    let dead: Vec<_> = update.dead.iter().filter(|authority| authority.as_str() != local_authority).cloned().collect();
+    if joined.is_empty() && left.is_empty() && dead.is_empty() {
+      return Ok(());
     }
-    for authority in update.left.iter() {
-      if authority == local_authority {
-        continue;
-      }
-      provider.with_write(|provider| provider.leave(authority.as_str()))?;
-    }
+
+    let topology = ClusterTopology::new(update.topology.hash(), joined.clone(), left.clone(), dead.clone());
+    let filtered = TopologyUpdate::new(
+      topology,
+      update.members.clone(),
+      joined,
+      left,
+      dead,
+      update.blocked.clone(),
+      update.observed_at,
+    );
+    provider.with_write(|provider| provider.apply_topology_update(&filtered));
     Ok(())
   }
 

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
@@ -98,9 +98,9 @@ where
       return Ok(());
     }
 
+    let seed_joins = self.seed_process.start_client(&self.seed_input)?;
     let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::start_client("provider unavailable"))?;
     provider.with_write(ClusterProvider::start_client)?;
-    let seed_joins = self.seed_process.start_client(&self.seed_input)?;
     debug_assert!(seed_joins.is_empty());
     Ok(())
   }
@@ -122,7 +122,7 @@ where
         return Err(error.clone());
       }
       if let Some(update) = self.topology_mapper.apply(&result) {
-        Self::apply_topology_update(&provider, &update)?;
+        Self::apply_topology_update(&provider, &update, self.seed_input.advertised_authority())?;
       }
     }
     Ok(())
@@ -147,11 +147,18 @@ where
   fn apply_topology_update(
     provider: &LocalClusterProviderShared,
     update: &TopologyUpdate,
+    local_authority: &str,
   ) -> Result<(), ClusterProviderError> {
     for authority in update.joined.iter() {
+      if authority == local_authority {
+        continue;
+      }
       provider.with_write(|provider| provider.join(authority.as_str()))?;
     }
     for authority in update.left.iter() {
+      if authority == local_authority {
+        continue;
+      }
       provider.with_write(|provider| provider.leave(authority.as_str()))?;
     }
     Ok(())

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
@@ -20,12 +20,13 @@ mod tests;
 
 /// Bridges provider start/shutdown with seed and discovery lifecycle.
 pub struct ProviderLifecycleBridge<B> {
-  provider:          LocalClusterProviderWeak,
-  seed_process:      SeedNodeProcess,
-  seed_input:        SeedNodeInput,
-  discovery_adapter: GenericDiscoveryAdapter<B>,
-  topology_mapper:   DiscoveryTopologyMapper,
-  is_shutdown:       bool,
+  provider:              LocalClusterProviderWeak,
+  seed_process:          SeedNodeProcess,
+  seed_input:            SeedNodeInput,
+  discovery_adapter:     GenericDiscoveryAdapter<B>,
+  topology_mapper:       DiscoveryTopologyMapper,
+  next_observation_tick: u64,
+  is_shutdown:           bool,
 }
 
 impl<B> ProviderLifecycleBridge<B> {
@@ -44,6 +45,7 @@ impl<B> ProviderLifecycleBridge<B> {
       seed_input,
       discovery_adapter,
       topology_mapper,
+      next_observation_tick: 1,
       is_shutdown: false,
     }
   }
@@ -83,7 +85,8 @@ where
       provider.with_write(|provider| provider.join(authority.as_str()))?;
     }
 
-    if let Some(result) = self.discovery_adapter.poll(Self::observed_at())
+    let observed_at = self.next_observed_at();
+    if let Some(result) = self.discovery_adapter.poll(observed_at)
       && let Some(update) = self.topology_mapper.apply(&result)
     {
       Self::apply_topology_update(&provider, &update)?;
@@ -137,7 +140,9 @@ where
     Ok(())
   }
 
-  const fn observed_at() -> TimerInstant {
-    TimerInstant::from_ticks(1, Duration::from_secs(1))
+  fn next_observed_at(&mut self) -> TimerInstant {
+    let observed_at = TimerInstant::from_ticks(self.next_observation_tick, Duration::from_secs(1));
+    self.next_observation_tick = self.next_observation_tick.saturating_add(1);
+    observed_at
   }
 }

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
@@ -1,0 +1,143 @@
+//! Provider lifecycle bridge for seed and discovery input.
+
+use std::time::Duration;
+
+use fraktor_cluster_core_kernel_rs::{
+  cluster_provider::{
+    ClusterProvider, DiscoveryTopologyMapper, LocalClusterProviderShared, LocalClusterProviderWeak, SeedNodeInput,
+    SeedNodeProcess,
+  },
+  extension::ClusterProviderError,
+  topology::TopologyUpdate,
+};
+use fraktor_utils_core_rs::{sync::SharedAccess, time::TimerInstant};
+
+use super::{DiscoveryBackend, GenericDiscoveryAdapter};
+
+#[cfg(test)]
+#[path = "provider_lifecycle_bridge_test.rs"]
+mod tests;
+
+/// Bridges provider start/shutdown with seed and discovery lifecycle.
+pub struct ProviderLifecycleBridge<B> {
+  provider:          LocalClusterProviderWeak,
+  seed_process:      SeedNodeProcess,
+  seed_input:        SeedNodeInput,
+  discovery_adapter: GenericDiscoveryAdapter<B>,
+  topology_mapper:   DiscoveryTopologyMapper,
+  is_shutdown:       bool,
+}
+
+impl<B> ProviderLifecycleBridge<B> {
+  /// Creates a provider lifecycle bridge.
+  #[must_use]
+  pub fn new(
+    provider: LocalClusterProviderWeak,
+    seed_input: SeedNodeInput,
+    mut discovery_adapter: GenericDiscoveryAdapter<B>,
+    topology_mapper: DiscoveryTopologyMapper,
+  ) -> Self {
+    discovery_adapter.attach_provider(provider.clone());
+    Self {
+      provider,
+      seed_process: SeedNodeProcess::new(),
+      seed_input,
+      discovery_adapter,
+      topology_mapper,
+      is_shutdown: false,
+    }
+  }
+
+  /// Returns whether the bridge has been shut down.
+  #[must_use]
+  pub const fn is_shutdown(&self) -> bool {
+    self.is_shutdown
+  }
+
+  /// Returns whether the weak provider handle can still be upgraded.
+  #[must_use]
+  pub fn provider_is_alive(&self) -> bool {
+    self.provider.upgrade().is_some()
+  }
+}
+
+impl<B> ProviderLifecycleBridge<B>
+where
+  B: DiscoveryBackend,
+{
+  /// Starts member lifecycle and applies seed/discovery join input.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError`] when provider startup or join input application fails.
+  pub fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    if self.is_shutdown {
+      return Ok(());
+    }
+
+    let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::start_member("provider unavailable"))?;
+    provider.with_write(ClusterProvider::start_member)?;
+
+    let seed_joins = self.seed_process.start_member(&self.seed_input)?;
+    for authority in seed_joins {
+      provider.with_write(|provider| provider.join(authority.as_str()))?;
+    }
+
+    if let Some(result) = self.discovery_adapter.poll(Self::observed_at())
+      && let Some(update) = self.topology_mapper.apply(&result)
+    {
+      Self::apply_topology_update(&provider, &update)?;
+    }
+    Ok(())
+  }
+
+  /// Starts client lifecycle without producing full member self-registration.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError`] when provider client startup or seed validation fails.
+  pub fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    if self.is_shutdown {
+      return Ok(());
+    }
+
+    let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::start_client("provider unavailable"))?;
+    provider.with_write(ClusterProvider::start_client)?;
+    let seed_joins = self.seed_process.start_client(&self.seed_input)?;
+    debug_assert!(seed_joins.is_empty());
+    Ok(())
+  }
+
+  /// Shuts down provider, seed, and discovery lifecycle.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError`] when seed or provider shutdown fails.
+  pub fn shutdown(&mut self, graceful: bool) -> Result<(), ClusterProviderError> {
+    self.seed_process.shutdown()?;
+    self.discovery_adapter.shutdown();
+    self.is_shutdown = true;
+
+    if let Some(provider) = self.provider.upgrade() {
+      provider.with_write(|provider| provider.shutdown(graceful))?;
+    }
+    Ok(())
+  }
+
+  fn apply_topology_update(
+    provider: &LocalClusterProviderShared,
+    update: &TopologyUpdate,
+  ) -> Result<(), ClusterProviderError> {
+    for authority in update.joined.iter() {
+      provider.with_write(|provider| provider.join(authority.as_str()))?;
+    }
+    for authority in update.left.iter() {
+      provider.with_write(|provider| provider.leave(authority.as_str()))?;
+    }
+    Ok(())
+  }
+
+  const fn observed_at() -> TimerInstant {
+    TimerInstant::from_ticks(1, Duration::from_secs(1))
+  }
+}

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge.rs
@@ -77,21 +77,15 @@ where
       return Ok(());
     }
 
+    let seed_joins = self.seed_process.start_member(&self.seed_input)?;
     let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::start_member("provider unavailable"))?;
     provider.with_write(ClusterProvider::start_member)?;
 
-    let seed_joins = self.seed_process.start_member(&self.seed_input)?;
     for authority in seed_joins {
       provider.with_write(|provider| provider.join(authority.as_str()))?;
     }
 
-    let observed_at = self.next_observed_at();
-    if let Some(result) = self.discovery_adapter.poll(observed_at)
-      && let Some(update) = self.topology_mapper.apply(&result)
-    {
-      Self::apply_topology_update(&provider, &update)?;
-    }
-    Ok(())
+    self.refresh_discovery()
   }
 
   /// Starts client lifecycle without producing full member self-registration.
@@ -108,6 +102,26 @@ where
     provider.with_write(ClusterProvider::start_client)?;
     let seed_joins = self.seed_process.start_client(&self.seed_input)?;
     debug_assert!(seed_joins.is_empty());
+    Ok(())
+  }
+
+  /// Polls discovery and applies any joined/left topology delta.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError`] when provider join/leave application fails.
+  pub fn refresh_discovery(&mut self) -> Result<(), ClusterProviderError> {
+    if self.is_shutdown {
+      return Ok(());
+    }
+
+    let provider = self.provider.upgrade().ok_or_else(|| ClusterProviderError::start_member("provider unavailable"))?;
+    let observed_at = self.next_observed_at();
+    if let Some(result) = self.discovery_adapter.poll(observed_at)
+      && let Some(update) = self.topology_mapper.apply(&result)
+    {
+      Self::apply_topology_update(&provider, &update)?;
+    }
     Ok(())
   }
 

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
@@ -93,6 +93,26 @@ impl DiscoveryBackend for CountingDiscoveryBackend {
   }
 }
 
+struct FailingDiscoveryBackend {
+  source_identity: String,
+}
+
+impl FailingDiscoveryBackend {
+  fn new(source_identity: &str) -> Self {
+    Self { source_identity: source_identity.to_string() }
+  }
+}
+
+impl DiscoveryBackend for FailingDiscoveryBackend {
+  fn source_identity(&self) -> &str {
+    self.source_identity.as_str()
+  }
+
+  fn discover(&mut self) -> Result<Vec<String>, DiscoveryBackendError> {
+    Err(DiscoveryBackendError::temporary("backend unavailable"))
+  }
+}
+
 fn block_list() -> ArcShared<dyn BlockListProvider> {
   ArcShared::new(EmptyBlockList)
 }
@@ -222,6 +242,26 @@ fn provider_lifecycle_bridge_refreshes_discovery_after_member_start() {
       && update.left == vec![String::from("node-b")]
       && update.members == vec![String::from("node-a"), String::from("node-c")]
   ));
+}
+
+#[test]
+fn provider_lifecycle_bridge_propagates_backend_failure_without_destroying_topology() {
+  let event_stream = EventStreamShared::default();
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::new()),
+    GenericDiscoveryAdapter::new(FailingDiscoveryBackend::new("test-discovery")),
+    mapper(),
+  );
+
+  let result = bridge.start_member();
+
+  assert!(matches!(
+    result,
+    Err(ClusterProviderError::StartMemberFailed(ref reason)) if reason == "backend unavailable"
+  ));
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 1);
 }
 
 #[test]

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
@@ -10,6 +10,7 @@ use fraktor_actor_core_kernel_rs::event::stream::{
 };
 use fraktor_cluster_core_kernel_rs::{
   cluster_provider::{DiscoveryTopologyMapper, LocalClusterProvider, LocalClusterProviderWeak, SeedNodeInput},
+  extension::ClusterProviderError,
   topology::{BlockListProvider, ClusterEvent},
 };
 use fraktor_utils_core_rs::{
@@ -32,16 +33,16 @@ impl BlockListProvider for EmptyBlockList {
 
 #[derive(Clone)]
 struct RecordingClusterEvents {
-  events: ArcShared<SpinSyncMutex<Vec<ClusterEvent>>>,
+  events: SharedLock<Vec<ClusterEvent>>,
 }
 
 impl RecordingClusterEvents {
   fn new() -> Self {
-    Self { events: ArcShared::new(SpinSyncMutex::new(Vec::new())) }
+    Self { events: SharedLock::new_with_driver::<SpinSyncMutex<_>>(Vec::new()) }
   }
 
   fn events(&self) -> Vec<ClusterEvent> {
-    self.events.lock().clone()
+    self.events.with_read(|events| events.clone())
   }
 }
 
@@ -51,7 +52,7 @@ impl EventStreamSubscriber for RecordingClusterEvents {
       && name == "cluster"
       && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
     {
-      self.events.lock().push(cluster_event.clone());
+      self.events.with_write(|events| events.push(cluster_event.clone()));
     }
   }
 }
@@ -59,17 +60,25 @@ impl EventStreamSubscriber for RecordingClusterEvents {
 #[derive(Clone)]
 struct CountingDiscoveryBackend {
   source_identity: String,
-  authorities:     Vec<String>,
-  calls:           ArcShared<SpinSyncMutex<usize>>,
+  authorities:     SharedLock<Vec<String>>,
+  calls:           SharedLock<usize>,
 }
 
 impl CountingDiscoveryBackend {
   fn new(source_identity: &str, authorities: Vec<String>) -> Self {
-    Self { source_identity: source_identity.to_string(), authorities, calls: ArcShared::new(SpinSyncMutex::new(0)) }
+    Self {
+      source_identity: source_identity.to_string(),
+      authorities:     SharedLock::new_with_driver::<SpinSyncMutex<_>>(authorities),
+      calls:           SharedLock::new_with_driver::<SpinSyncMutex<_>>(0),
+    }
   }
 
   fn call_count(&self) -> usize {
-    *self.calls.lock()
+    self.calls.with_read(|calls| *calls)
+  }
+
+  fn replace_authorities(&self, authorities: Vec<String>) {
+    self.authorities.with_write(|current| *current = authorities);
   }
 }
 
@@ -79,8 +88,8 @@ impl DiscoveryBackend for CountingDiscoveryBackend {
   }
 
   fn discover(&mut self) -> Result<Vec<String>, DiscoveryBackendError> {
-    *self.calls.lock() += 1;
-    Ok(self.authorities.clone())
+    self.calls.with_write(|calls| *calls += 1);
+    Ok(self.authorities.with_read(|authorities| authorities.clone()))
   }
 }
 
@@ -151,6 +160,68 @@ fn provider_lifecycle_bridge_member_start_joins_seed_and_discovery_authorities()
   bridge.start_member().expect("member lifecycle should start");
 
   assert_eq!(provider.with_read(|provider| provider.member_count()), 3);
+}
+
+#[test]
+fn provider_lifecycle_bridge_validates_seed_before_provider_start() {
+  let event_stream = EventStreamShared::default();
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::new());
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::from(["invalid seed"])),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  let result = bridge.start_member();
+
+  assert!(matches!(
+    result,
+    Err(ClusterProviderError::JoinFailed(ref reason)) if reason == "invalid seed authority"
+  ));
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 0);
+  assert!(!provider.with_read(|provider| provider.is_started()));
+}
+
+#[test]
+fn provider_lifecycle_bridge_refreshes_discovery_after_member_start() {
+  let event_stream = EventStreamShared::default();
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-b")]));
+  let backend_probe = backend.clone();
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::new()),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_member().expect("member lifecycle should start");
+  backend_probe.replace_authorities(Vec::from([String::from("node-c")]));
+  bridge.refresh_discovery().expect("discovery refresh should apply delta");
+
+  let events = subscriber_impl.events();
+  let topology_events: Vec<&ClusterEvent> =
+    events.iter().filter(|event| matches!(event, ClusterEvent::TopologyUpdated { .. })).collect();
+  assert_eq!(backend_probe.call_count(), 2);
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 2);
+  assert_eq!(topology_events.len(), 3);
+  assert!(matches!(
+    topology_events[1],
+    ClusterEvent::TopologyUpdated { update }
+    if update.joined == vec![String::from("node-c")]
+      && update.left.is_empty()
+      && update.members == vec![String::from("node-a"), String::from("node-b"), String::from("node-c")]
+  ));
+  assert!(matches!(
+    topology_events[2],
+    ClusterEvent::TopologyUpdated { update }
+    if update.joined.is_empty()
+      && update.left == vec![String::from("node-b")]
+      && update.members == vec![String::from("node-a"), String::from("node-c")]
+  ));
 }
 
 #[test]

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
@@ -1,16 +1,19 @@
+use alloc::boxed::Box;
 use std::{
   string::{String, ToString},
   time::Duration,
   vec::Vec,
 };
 
-use fraktor_actor_core_kernel_rs::event::stream::EventStreamShared;
+use fraktor_actor_core_kernel_rs::event::stream::{
+  EventStreamEvent, EventStreamShared, EventStreamSubscriber, EventStreamSubscriberShared, EventStreamSubscription,
+};
 use fraktor_cluster_core_kernel_rs::{
   cluster_provider::{DiscoveryTopologyMapper, LocalClusterProvider, LocalClusterProviderWeak, SeedNodeInput},
-  topology::BlockListProvider,
+  topology::{BlockListProvider, ClusterEvent},
 };
 use fraktor_utils_core_rs::{
-  sync::{ArcShared, SharedAccess, SpinSyncMutex},
+  sync::{ArcShared, SharedAccess, SharedLock, SpinSyncMutex},
   time::TimerInstant,
 };
 
@@ -24,6 +27,32 @@ struct EmptyBlockList;
 impl BlockListProvider for EmptyBlockList {
   fn blocked_members(&self) -> Vec<String> {
     Vec::new()
+  }
+}
+
+#[derive(Clone)]
+struct RecordingClusterEvents {
+  events: ArcShared<SpinSyncMutex<Vec<ClusterEvent>>>,
+}
+
+impl RecordingClusterEvents {
+  fn new() -> Self {
+    Self { events: ArcShared::new(SpinSyncMutex::new(Vec::new())) }
+  }
+
+  fn events(&self) -> Vec<ClusterEvent> {
+    self.events.lock().clone()
+  }
+}
+
+impl EventStreamSubscriber for RecordingClusterEvents {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    if let EventStreamEvent::Extension { name, payload } = event
+      && name == "cluster"
+      && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
+    {
+      self.events.lock().push(cluster_event.clone());
+    }
   }
 }
 
@@ -59,6 +88,15 @@ fn block_list() -> ArcShared<dyn BlockListProvider> {
   ArcShared::new(EmptyBlockList)
 }
 
+fn subscribe_recorder(event_stream: &EventStreamShared) -> (RecordingClusterEvents, EventStreamSubscription) {
+  let subscriber_impl = RecordingClusterEvents::new();
+  let subscriber = EventStreamSubscriberShared::from_shared_lock(SharedLock::new_with_driver::<SpinSyncMutex<_>>(
+    Box::new(subscriber_impl.clone()),
+  ));
+  let subscription = event_stream.subscribe(&subscriber);
+  (subscriber_impl, subscription)
+}
+
 fn seed_input(advertised_authority: &str, seed_authorities: Vec<&str>) -> SeedNodeInput {
   SeedNodeInput::new(String::from(advertised_authority), seed_authorities.into_iter().map(String::from).collect())
 }
@@ -69,6 +107,33 @@ fn mapper() -> DiscoveryTopologyMapper {
 
 fn observed_at() -> TimerInstant {
   TimerInstant::from_ticks(1, Duration::from_secs(1))
+}
+
+#[test]
+fn provider_lifecycle_bridge_seed_input_publishes_topology_update() {
+  let event_stream = EventStreamShared::default();
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::new());
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::from(["node-a", "node-b"])),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_member().expect("member lifecycle should start");
+
+  let events = subscriber_impl.events();
+  let topology_events: Vec<&ClusterEvent> =
+    events.iter().filter(|event| matches!(event, ClusterEvent::TopologyUpdated { .. })).collect();
+  assert_eq!(topology_events.len(), 1);
+  assert!(matches!(
+    topology_events[0],
+    ClusterEvent::TopologyUpdated { update }
+    if update.joined == vec![String::from("node-b")]
+      && update.members == vec![String::from("node-a"), String::from("node-b")]
+  ));
 }
 
 #[test]

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
@@ -212,6 +212,21 @@ fn provider_lifecycle_bridge_does_not_keep_provider_alive() {
 }
 
 #[test]
+fn provider_lifecycle_bridge_observation_time_advances_per_poll() {
+  let event_stream = EventStreamShared::default();
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::new()),
+    GenericDiscoveryAdapter::new(CountingDiscoveryBackend::new("test-discovery", Vec::new())),
+    mapper(),
+  );
+
+  assert_eq!(bridge.next_observed_at(), TimerInstant::from_ticks(1, Duration::from_secs(1)));
+  assert_eq!(bridge.next_observed_at(), TimerInstant::from_ticks(2, Duration::from_secs(1)));
+}
+
+#[test]
 fn generic_discovery_adapter_shutdown_stops_polling() {
   let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-b")]));
   let backend_probe = backend.clone();

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
@@ -249,20 +249,14 @@ fn provider_lifecycle_bridge_refreshes_discovery_after_member_start() {
     events.iter().filter(|event| matches!(event, ClusterEvent::TopologyUpdated { .. })).collect();
   assert_eq!(backend_probe.call_count(), 2);
   assert_eq!(provider.with_read(|provider| provider.member_count()), 2);
-  assert_eq!(topology_events.len(), 3);
+  assert_eq!(topology_events.len(), 2);
   assert!(matches!(
     topology_events[1],
     ClusterEvent::TopologyUpdated { update }
     if update.joined == vec![String::from("node-c")]
-      && update.left.is_empty()
-      && update.members == vec![String::from("node-a"), String::from("node-b"), String::from("node-c")]
-  ));
-  assert!(matches!(
-    topology_events[2],
-    ClusterEvent::TopologyUpdated { update }
-    if update.joined.is_empty()
       && update.left == vec![String::from("node-b")]
       && update.members == vec![String::from("node-a"), String::from("node-c")]
+      && update.observed_at == TimerInstant::from_ticks(2, Duration::from_secs(1))
   ));
 }
 
@@ -281,9 +275,40 @@ fn provider_lifecycle_bridge_propagates_backend_failure_without_destroying_topol
 
   assert!(matches!(
     result,
-    Err(ClusterProviderError::StartMemberFailed(ref reason)) if reason == "backend unavailable"
+    Err(ClusterProviderError::JoinFailed(ref reason)) if reason == "backend unavailable"
   ));
   assert_eq!(provider.with_read(|provider| provider.member_count()), 1);
+}
+
+#[test]
+fn provider_lifecycle_bridge_preserves_discovery_observation_time_after_no_delta_poll() {
+  let event_stream = EventStreamShared::default();
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-b")]));
+  let backend_probe = backend.clone();
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::new()),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_member().expect("member lifecycle should start");
+  bridge.refresh_discovery().expect("unchanged discovery should not publish");
+  backend_probe.replace_authorities(Vec::from([String::from("node-b"), String::from("node-c")]));
+  bridge.refresh_discovery().expect("changed discovery should publish");
+
+  let events = subscriber_impl.events();
+  let topology_events: Vec<&ClusterEvent> =
+    events.iter().filter(|event| matches!(event, ClusterEvent::TopologyUpdated { .. })).collect();
+  assert_eq!(topology_events.len(), 2);
+  assert!(matches!(
+    topology_events[1],
+    ClusterEvent::TopologyUpdated { update }
+    if update.joined == vec![String::from("node-c")]
+      && update.observed_at == TimerInstant::from_ticks(3, Duration::from_secs(1))
+  ));
 }
 
 #[test]
@@ -310,6 +335,32 @@ fn provider_lifecycle_bridge_ignores_self_authority_from_discovery_delta() {
   assert!(!events.iter().any(|event| matches!(
     event,
     ClusterEvent::TopologyUpdated { update } if update.left == vec![String::from("node-a")]
+  )));
+}
+
+#[test]
+fn provider_lifecycle_bridge_keeps_seed_authority_when_discovery_delta_leaves_it() {
+  let event_stream = EventStreamShared::default();
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-b")]));
+  let backend_probe = backend.clone();
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::from(["node-b"])),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_member().expect("member lifecycle should start");
+  backend_probe.replace_authorities(Vec::new());
+  bridge.refresh_discovery().expect("seed leave should be ignored");
+
+  let events = subscriber_impl.events();
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 2);
+  assert!(!events.iter().any(|event| matches!(
+    event,
+    ClusterEvent::TopologyUpdated { update } if update.left == vec![String::from("node-b")]
   )));
 }
 

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
@@ -1,0 +1,161 @@
+use std::{
+  string::{String, ToString},
+  time::Duration,
+  vec::Vec,
+};
+
+use fraktor_actor_core_kernel_rs::event::stream::EventStreamShared;
+use fraktor_cluster_core_kernel_rs::{
+  cluster_provider::{DiscoveryTopologyMapper, LocalClusterProvider, LocalClusterProviderWeak, SeedNodeInput},
+  topology::BlockListProvider,
+};
+use fraktor_utils_core_rs::{
+  sync::{ArcShared, SharedAccess, SpinSyncMutex},
+  time::TimerInstant,
+};
+
+use crate::cluster_provider::{
+  DiscoveryBackend, DiscoveryBackendError, GenericDiscoveryAdapter, ProviderLifecycleBridge,
+  wrap_local_cluster_provider,
+};
+
+struct EmptyBlockList;
+
+impl BlockListProvider for EmptyBlockList {
+  fn blocked_members(&self) -> Vec<String> {
+    Vec::new()
+  }
+}
+
+#[derive(Clone)]
+struct CountingDiscoveryBackend {
+  source_identity: String,
+  authorities:     Vec<String>,
+  calls:           ArcShared<SpinSyncMutex<usize>>,
+}
+
+impl CountingDiscoveryBackend {
+  fn new(source_identity: &str, authorities: Vec<String>) -> Self {
+    Self { source_identity: source_identity.to_string(), authorities, calls: ArcShared::new(SpinSyncMutex::new(0)) }
+  }
+
+  fn call_count(&self) -> usize {
+    *self.calls.lock()
+  }
+}
+
+impl DiscoveryBackend for CountingDiscoveryBackend {
+  fn source_identity(&self) -> &str {
+    self.source_identity.as_str()
+  }
+
+  fn discover(&mut self) -> Result<Vec<String>, DiscoveryBackendError> {
+    *self.calls.lock() += 1;
+    Ok(self.authorities.clone())
+  }
+}
+
+fn block_list() -> ArcShared<dyn BlockListProvider> {
+  ArcShared::new(EmptyBlockList)
+}
+
+fn seed_input(advertised_authority: &str, seed_authorities: Vec<&str>) -> SeedNodeInput {
+  SeedNodeInput::new(String::from(advertised_authority), seed_authorities.into_iter().map(String::from).collect())
+}
+
+fn mapper() -> DiscoveryTopologyMapper {
+  DiscoveryTopologyMapper::new(block_list())
+}
+
+fn observed_at() -> TimerInstant {
+  TimerInstant::from_ticks(1, Duration::from_secs(1))
+}
+
+#[test]
+fn provider_lifecycle_bridge_member_start_joins_seed_and_discovery_authorities() {
+  let event_stream = EventStreamShared::default();
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-c")]));
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::from(["node-a", "node-b"])),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_member().expect("member lifecycle should start");
+
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 3);
+}
+
+#[test]
+fn provider_lifecycle_bridge_client_start_does_not_register_full_member_self() {
+  let event_stream = EventStreamShared::default();
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-b")]));
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::from(["node-a", "node-b"])),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_client().expect("client lifecycle should start");
+
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 0);
+}
+
+#[test]
+fn provider_lifecycle_bridge_shutdown_stops_seed_and_discovery_lifecycle() {
+  let event_stream = EventStreamShared::default();
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-c")]));
+  let backend_probe = backend.clone();
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::from(["node-b"])),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_member().expect("member lifecycle should start");
+  bridge.shutdown(true).expect("bridge should shutdown");
+  bridge.start_member().expect("stopped bridge should not emit additional join input");
+
+  assert_eq!(backend_probe.call_count(), 1);
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 0);
+  assert!(bridge.is_shutdown());
+}
+
+#[test]
+fn provider_lifecycle_bridge_does_not_keep_provider_alive() {
+  let weak_provider: LocalClusterProviderWeak;
+  let bridge = {
+    let event_stream = EventStreamShared::default();
+    let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+    weak_provider = provider.downgrade();
+    ProviderLifecycleBridge::new(
+      provider.downgrade(),
+      seed_input("node-a", Vec::new()),
+      GenericDiscoveryAdapter::new(CountingDiscoveryBackend::new("test-discovery", Vec::new())),
+      mapper(),
+    )
+  };
+
+  assert!(weak_provider.upgrade().is_none());
+  assert!(!bridge.provider_is_alive());
+}
+
+#[test]
+fn generic_discovery_adapter_shutdown_stops_polling() {
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-b")]));
+  let backend_probe = backend.clone();
+  let mut adapter = GenericDiscoveryAdapter::new(backend);
+
+  assert!(adapter.poll(observed_at()).is_some());
+  adapter.shutdown();
+  assert!(adapter.poll(observed_at()).is_none());
+
+  assert_eq!(backend_probe.call_count(), 1);
+  assert!(adapter.is_shutdown());
+}

--- a/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/provider_lifecycle_bridge_test.rs
@@ -205,6 +205,28 @@ fn provider_lifecycle_bridge_validates_seed_before_provider_start() {
 }
 
 #[test]
+fn provider_lifecycle_bridge_validates_client_seed_before_provider_start() {
+  let event_stream = EventStreamShared::default();
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend = CountingDiscoveryBackend::new("test-discovery", Vec::new());
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::from(["invalid seed"])),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  let result = bridge.start_client();
+
+  assert!(matches!(
+    result,
+    Err(ClusterProviderError::JoinFailed(ref reason)) if reason == "invalid seed authority"
+  ));
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 0);
+  assert!(!provider.with_read(|provider| provider.is_started()));
+}
+
+#[test]
 fn provider_lifecycle_bridge_refreshes_discovery_after_member_start() {
   let event_stream = EventStreamShared::default();
   let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
@@ -262,6 +284,33 @@ fn provider_lifecycle_bridge_propagates_backend_failure_without_destroying_topol
     Err(ClusterProviderError::StartMemberFailed(ref reason)) if reason == "backend unavailable"
   ));
   assert_eq!(provider.with_read(|provider| provider.member_count()), 1);
+}
+
+#[test]
+fn provider_lifecycle_bridge_ignores_self_authority_from_discovery_delta() {
+  let event_stream = EventStreamShared::default();
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+  let provider = wrap_local_cluster_provider(LocalClusterProvider::new(event_stream, block_list(), "node-a"));
+  let backend =
+    CountingDiscoveryBackend::new("test-discovery", Vec::from([String::from("node-a"), String::from("node-b")]));
+  let backend_probe = backend.clone();
+  let mut bridge = ProviderLifecycleBridge::new(
+    provider.downgrade(),
+    seed_input("node-a", Vec::new()),
+    GenericDiscoveryAdapter::new(backend),
+    mapper(),
+  );
+
+  bridge.start_member().expect("member lifecycle should start");
+  backend_probe.replace_authorities(Vec::from([String::from("node-b")]));
+  bridge.refresh_discovery().expect("self leave should be ignored");
+
+  let events = subscriber_impl.events();
+  assert_eq!(provider.with_read(|provider| provider.member_count()), 2);
+  assert!(!events.iter().any(|event| matches!(
+    event,
+    ClusterEvent::TopologyUpdated { update } if update.left == vec![String::from("node-a")]
+  )));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/cluster_provider.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider.rs
@@ -13,6 +13,10 @@ mod local_cluster_provider_shared_generic;
 mod local_cluster_provider_weak;
 /// No-op provider useful for tests and single-process runs.
 mod noop_cluster_provider;
+/// Seed node input captured from provider lifecycle.
+mod seed_node_input;
+/// Lifecycle-aware seed node join input processing.
+mod seed_node_process;
 /// Static cluster provider for predetermined topology scenarios.
 mod static_cluster_provider;
 
@@ -20,6 +24,8 @@ pub use local_cluster_provider_generic::LocalClusterProvider;
 pub use local_cluster_provider_shared_generic::LocalClusterProviderShared;
 pub use local_cluster_provider_weak::LocalClusterProviderWeak;
 pub use noop_cluster_provider::NoopClusterProvider;
+pub use seed_node_input::SeedNodeInput;
+pub use seed_node_process::SeedNodeProcess;
 pub use static_cluster_provider::StaticClusterProvider;
 
 /// Integrates the cluster runtime with an external membership system.

--- a/modules/cluster-core-kernel/src/cluster_provider.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider.rs
@@ -5,6 +5,10 @@
 
 use crate::extension::ClusterProviderError;
 
+/// Provider-neutral discovered authority value.
+mod discovered_authority;
+/// Provider-neutral discovery outcome value.
+mod discovery_result;
 /// Local cluster provider for membership-aware scenarios.
 mod local_cluster_provider_generic;
 /// Shared wrapper for LocalClusterProvider implementations.
@@ -20,6 +24,8 @@ mod seed_node_process;
 /// Static cluster provider for predetermined topology scenarios.
 mod static_cluster_provider;
 
+pub use discovered_authority::DiscoveredAuthority;
+pub use discovery_result::DiscoveryResult;
 pub use local_cluster_provider_generic::LocalClusterProvider;
 pub use local_cluster_provider_shared_generic::LocalClusterProviderShared;
 pub use local_cluster_provider_weak::LocalClusterProviderWeak;

--- a/modules/cluster-core-kernel/src/cluster_provider.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider.rs
@@ -9,6 +9,8 @@ use crate::extension::ClusterProviderError;
 mod discovered_authority;
 /// Provider-neutral discovery outcome value.
 mod discovery_result;
+/// Discovery result to topology delta mapper.
+mod discovery_topology_mapper;
 /// Local cluster provider for membership-aware scenarios.
 mod local_cluster_provider_generic;
 /// Shared wrapper for LocalClusterProvider implementations.
@@ -26,6 +28,7 @@ mod static_cluster_provider;
 
 pub use discovered_authority::DiscoveredAuthority;
 pub use discovery_result::DiscoveryResult;
+pub use discovery_topology_mapper::DiscoveryTopologyMapper;
 pub use local_cluster_provider_generic::LocalClusterProvider;
 pub use local_cluster_provider_shared_generic::LocalClusterProviderShared;
 pub use local_cluster_provider_weak::LocalClusterProviderWeak;

--- a/modules/cluster-core-kernel/src/cluster_provider/discovered_authority.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovered_authority.rs
@@ -1,0 +1,49 @@
+//! Provider-neutral discovered authority value.
+
+use alloc::string::String;
+
+use fraktor_utils_core_rs::time::TimerInstant;
+
+#[cfg(test)]
+#[path = "discovered_authority_test.rs"]
+mod tests;
+
+/// Authority observed from a discovery backend without backend-specific metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredAuthority {
+  authority:       String,
+  source_identity: String,
+  observed_at:     TimerInstant,
+}
+
+impl DiscoveredAuthority {
+  /// Creates a discovered authority value.
+  #[must_use]
+  pub const fn new(authority: String, source_identity: String, observed_at: TimerInstant) -> Self {
+    Self { authority, source_identity, observed_at }
+  }
+
+  /// Returns the discovered authority.
+  #[must_use]
+  pub const fn authority(&self) -> &str {
+    self.authority.as_str()
+  }
+
+  /// Returns the discovery source identity used for observability.
+  #[must_use]
+  pub const fn source_identity(&self) -> &str {
+    self.source_identity.as_str()
+  }
+
+  /// Returns when the authority was observed.
+  #[must_use]
+  pub const fn observed_at(&self) -> TimerInstant {
+    self.observed_at
+  }
+
+  /// Returns only the authority value used by placement and membership inputs.
+  #[must_use]
+  pub fn to_authority(&self) -> String {
+    self.authority.clone()
+  }
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/discovered_authority_test.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovered_authority_test.rs
@@ -1,0 +1,28 @@
+use alloc::string::String;
+use core::time::Duration;
+
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use crate::cluster_provider::DiscoveredAuthority;
+
+fn observed_at(ticks: u64) -> TimerInstant {
+  TimerInstant::from_ticks(ticks, Duration::from_secs(1))
+}
+
+#[test]
+fn discovered_authority_preserves_provider_neutral_observation_fields() {
+  let authority =
+    DiscoveredAuthority::new(String::from("node-a.example:7331"), String::from("aws-ecs-primary"), observed_at(42));
+
+  assert_eq!(authority.authority(), "node-a.example:7331");
+  assert_eq!(authority.source_identity(), "aws-ecs-primary");
+  assert_eq!(authority.observed_at(), observed_at(42));
+}
+
+#[test]
+fn discovered_authority_normalizes_to_authority_only_input() {
+  let authority =
+    DiscoveredAuthority::new(String::from("node-a.example:7331"), String::from("aws-ecs-primary"), observed_at(42));
+
+  assert_eq!(authority.to_authority(), String::from("node-a.example:7331"));
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/discovery_result.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovery_result.rs
@@ -1,0 +1,97 @@
+//! Provider-neutral discovery outcome value.
+
+use alloc::{string::String, vec::Vec};
+
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use super::DiscoveredAuthority;
+use crate::ClusterProviderError;
+
+#[cfg(test)]
+#[path = "discovery_result_test.rs"]
+mod tests;
+
+/// Discovery backend outcome normalized at the cluster provider boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveryResult {
+  /// Authorities were discovered successfully.
+  Discovered(Vec<DiscoveredAuthority>),
+  /// Discovery completed successfully without authorities.
+  Empty(String, TimerInstant),
+  /// Discovery failed without producing destructive topology input.
+  Failed(String, TimerInstant, ClusterProviderError),
+}
+
+impl DiscoveryResult {
+  /// Creates a successful discovery result.
+  #[must_use]
+  pub const fn discovered(authorities: Vec<DiscoveredAuthority>) -> Self {
+    Self::Discovered(authorities)
+  }
+
+  /// Creates an empty successful discovery result.
+  #[must_use]
+  pub const fn empty(source_identity: String, observed_at: TimerInstant) -> Self {
+    Self::Empty(source_identity, observed_at)
+  }
+
+  /// Creates a failed discovery result.
+  #[must_use]
+  pub const fn failed(source_identity: String, observed_at: TimerInstant, error: ClusterProviderError) -> Self {
+    Self::Failed(source_identity, observed_at, error)
+  }
+
+  /// Returns discovered authorities.
+  #[must_use]
+  pub const fn authorities(&self) -> &[DiscoveredAuthority] {
+    match self {
+      | Self::Discovered(authorities) => authorities.as_slice(),
+      | Self::Empty(_, _) | Self::Failed(_, _, _) => &[],
+    }
+  }
+
+  /// Returns whether discovery completed successfully without authorities.
+  #[must_use]
+  pub const fn is_empty(&self) -> bool {
+    matches!(self, Self::Empty(_, _))
+  }
+
+  /// Returns whether discovery failed.
+  #[must_use]
+  pub const fn is_failed(&self) -> bool {
+    matches!(self, Self::Failed(_, _, _))
+  }
+
+  /// Returns the discovery source identity for result-level outcomes.
+  #[must_use]
+  pub const fn source_identity(&self) -> Option<&str> {
+    match self {
+      | Self::Discovered(_) => None,
+      | Self::Empty(source_identity, _) | Self::Failed(source_identity, _, _) => Some(source_identity.as_str()),
+    }
+  }
+
+  /// Returns the result-level observation time.
+  #[must_use]
+  pub const fn observed_at(&self) -> Option<TimerInstant> {
+    match self {
+      | Self::Discovered(_) => None,
+      | Self::Empty(_, observed_at) | Self::Failed(_, observed_at, _) => Some(*observed_at),
+    }
+  }
+
+  /// Returns the observable failure, when discovery failed.
+  #[must_use]
+  pub const fn error(&self) -> Option<&ClusterProviderError> {
+    match self {
+      | Self::Failed(_, _, error) => Some(error),
+      | Self::Discovered(_) | Self::Empty(_, _) => None,
+    }
+  }
+
+  /// Returns only authority values suitable for placement and membership input.
+  #[must_use]
+  pub fn to_authorities(&self) -> Vec<String> {
+    self.authorities().iter().map(DiscoveredAuthority::to_authority).collect()
+  }
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/discovery_result_test.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovery_result_test.rs
@@ -1,0 +1,46 @@
+use alloc::{string::String, vec};
+use core::time::Duration;
+
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use crate::{
+  ClusterProviderError,
+  cluster_provider::{DiscoveredAuthority, DiscoveryResult},
+};
+
+fn observed_at(ticks: u64) -> TimerInstant {
+  TimerInstant::from_ticks(ticks, Duration::from_secs(1))
+}
+
+#[test]
+fn discovery_result_represents_discovered_authorities() {
+  let result = DiscoveryResult::discovered(vec![
+    DiscoveredAuthority::new(String::from("node-a.example:7331"), String::from("aws-ecs-primary"), observed_at(7)),
+    DiscoveredAuthority::new(String::from("node-b.example:7331"), String::from("aws-ecs-primary"), observed_at(7)),
+  ]);
+
+  assert_eq!(result.authorities().len(), 2);
+  assert_eq!(result.to_authorities(), vec![String::from("node-a.example:7331"), String::from("node-b.example:7331")]);
+}
+
+#[test]
+fn discovery_result_represents_empty_success() {
+  let result = DiscoveryResult::empty(String::from("static-empty"), observed_at(8));
+
+  assert!(result.is_empty());
+  assert_eq!(result.source_identity(), Some("static-empty"));
+  assert_eq!(result.observed_at(), Some(observed_at(8)));
+  assert!(result.to_authorities().is_empty());
+}
+
+#[test]
+fn discovery_result_represents_observable_failure_without_authority_input() {
+  let error = ClusterProviderError::start_member("temporary discovery failure");
+  let result = DiscoveryResult::failed(String::from("aws-ecs-primary"), observed_at(9), error.clone());
+
+  assert!(result.is_failed());
+  assert_eq!(result.source_identity(), Some("aws-ecs-primary"));
+  assert_eq!(result.observed_at(), Some(observed_at(9)));
+  assert_eq!(result.error(), Some(&error));
+  assert!(result.to_authorities().is_empty());
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper.rs
@@ -1,0 +1,80 @@
+//! Maps discovery outcomes to topology update deltas.
+
+use alloc::{string::String, vec::Vec};
+use core::time::Duration;
+
+use fraktor_utils_core_rs::{sync::ArcShared, time::TimerInstant};
+
+use super::DiscoveryResult;
+use crate::{BlockListProvider, ClusterTopology, TopologyUpdate};
+
+#[cfg(test)]
+#[path = "discovery_topology_mapper_test.rs"]
+mod tests;
+
+/// Stateful mapper from discovery outcomes to topology update deltas.
+pub struct DiscoveryTopologyMapper {
+  block_list_provider: ArcShared<dyn BlockListProvider>,
+  authorities:         Vec<String>,
+  version:             u64,
+}
+
+impl DiscoveryTopologyMapper {
+  /// Creates a discovery topology mapper.
+  #[must_use]
+  pub const fn new(block_list_provider: ArcShared<dyn BlockListProvider>) -> Self {
+    Self { block_list_provider, authorities: Vec::new(), version: 0 }
+  }
+
+  /// Applies a discovery result and returns a topology delta when membership changed.
+  #[must_use]
+  pub fn apply(&mut self, result: &DiscoveryResult) -> Option<TopologyUpdate> {
+    if result.is_failed() {
+      return None;
+    }
+
+    let current = Self::deduplicated_authorities(result);
+    let joined = Self::joined_authorities(&self.authorities, &current);
+    let left = Self::left_authorities(&self.authorities, &current);
+
+    if joined.is_empty() && left.is_empty() {
+      return None;
+    }
+
+    self.authorities = current.clone();
+    self.version += 1;
+
+    let topology = ClusterTopology::new(self.version, joined.clone(), left.clone(), Vec::new());
+    Some(TopologyUpdate::new(
+      topology,
+      current,
+      joined,
+      left,
+      Vec::new(),
+      self.block_list_provider.blocked_members(),
+      Self::observed_at(self.version),
+    ))
+  }
+
+  fn deduplicated_authorities(result: &DiscoveryResult) -> Vec<String> {
+    let mut authorities = Vec::new();
+    for authority in result.authorities() {
+      if !authorities.iter().any(|known| known == authority.authority()) {
+        authorities.push(authority.to_authority());
+      }
+    }
+    authorities
+  }
+
+  fn joined_authorities(previous: &[String], current: &[String]) -> Vec<String> {
+    current.iter().filter(|authority| !previous.contains(authority)).cloned().collect()
+  }
+
+  fn left_authorities(previous: &[String], current: &[String]) -> Vec<String> {
+    previous.iter().filter(|authority| !current.contains(authority)).cloned().collect()
+  }
+
+  const fn observed_at(version: u64) -> TimerInstant {
+    TimerInstant::from_ticks(version, Duration::from_secs(1))
+  }
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper.rs
@@ -5,7 +5,7 @@ use core::time::Duration;
 
 use fraktor_utils_core_rs::{sync::ArcShared, time::TimerInstant};
 
-use super::DiscoveryResult;
+use super::{DiscoveredAuthority, DiscoveryResult};
 use crate::{BlockListProvider, ClusterTopology, TopologyUpdate};
 
 #[cfg(test)]
@@ -52,7 +52,7 @@ impl DiscoveryTopologyMapper {
       left,
       Vec::new(),
       self.block_list_provider.blocked_members(),
-      Self::observed_at(self.version),
+      Self::observed_at(result, self.version),
     ))
   }
 
@@ -74,7 +74,10 @@ impl DiscoveryTopologyMapper {
     previous.iter().filter(|authority| !current.contains(authority)).cloned().collect()
   }
 
-  const fn observed_at(version: u64) -> TimerInstant {
-    TimerInstant::from_ticks(version, Duration::from_secs(1))
+  fn observed_at(result: &DiscoveryResult, version: u64) -> TimerInstant {
+    result
+      .observed_at()
+      .or_else(|| result.authorities().first().map(DiscoveredAuthority::observed_at))
+      .unwrap_or_else(|| TimerInstant::from_ticks(version, Duration::from_secs(1)))
   }
 }

--- a/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper_test.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper_test.rs
@@ -62,6 +62,7 @@ fn discovered_authorities_publish_only_joined_delta_and_deduplicate_authority() 
   assert_eq!(update.members, update.joined);
   assert_eq!(update.topology.joined(), &update.joined);
   assert_eq!(update.topology.left(), &update.left);
+  assert_eq!(update.observed_at, observed_at(10));
 }
 
 #[test]
@@ -83,6 +84,7 @@ fn refresh_publishes_only_joined_and_left_authority_delta() {
   assert_eq!(update.joined, vec![String::from("node-c.example:7331")]);
   assert_eq!(update.left, vec![String::from("node-a.example:7331")]);
   assert_eq!(update.members, vec![String::from("node-b.example:7331"), String::from("node-c.example:7331")]);
+  assert_eq!(update.observed_at, observed_at(11));
 }
 
 #[test]
@@ -118,6 +120,7 @@ fn failed_discovery_returns_no_update_and_preserves_previous_topology() {
   assert!(update.joined.is_empty());
   assert_eq!(update.left, vec![String::from("node-a.example:7331")]);
   assert!(update.members.is_empty());
+  assert_eq!(update.observed_at, observed_at(12));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper_test.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/discovery_topology_mapper_test.rs
@@ -1,0 +1,152 @@
+use alloc::{string::String, vec, vec::Vec};
+use core::time::Duration;
+
+use fraktor_utils_core_rs::{sync::ArcShared, time::TimerInstant};
+
+use super::*;
+use crate::{
+  BlockListProvider, ClusterProviderError,
+  cluster_provider::{DiscoveredAuthority, DiscoveryResult},
+};
+
+struct EmptyBlockList;
+
+impl BlockListProvider for EmptyBlockList {
+  fn blocked_members(&self) -> Vec<String> {
+    Vec::new()
+  }
+}
+
+struct RecordingBlockList {
+  blocked: Vec<String>,
+}
+
+impl RecordingBlockList {
+  fn new(blocked: Vec<String>) -> Self {
+    Self { blocked }
+  }
+}
+
+impl BlockListProvider for RecordingBlockList {
+  fn blocked_members(&self) -> Vec<String> {
+    self.blocked.clone()
+  }
+}
+
+fn observed_at(ticks: u64) -> TimerInstant {
+  TimerInstant::from_ticks(ticks, Duration::from_secs(1))
+}
+
+fn authority(value: &str, source_identity: &str, ticks: u64) -> DiscoveredAuthority {
+  DiscoveredAuthority::new(String::from(value), String::from(source_identity), observed_at(ticks))
+}
+
+fn empty_block_list() -> ArcShared<dyn BlockListProvider> {
+  ArcShared::new(EmptyBlockList)
+}
+
+#[test]
+fn discovered_authorities_publish_only_joined_delta_and_deduplicate_authority() {
+  let mut mapper = DiscoveryTopologyMapper::new(empty_block_list());
+
+  let update = mapper
+    .apply(&DiscoveryResult::discovered(vec![
+      authority("node-a.example:7331", "generic-discovery", 10),
+      authority("node-a.example:7331", "aws-ecs", 10),
+      authority("node-b.example:7331", "static-seed", 10),
+    ]))
+    .expect("first discovery should publish topology");
+
+  assert_eq!(update.joined, vec![String::from("node-a.example:7331"), String::from("node-b.example:7331")]);
+  assert!(update.left.is_empty());
+  assert_eq!(update.members, update.joined);
+  assert_eq!(update.topology.joined(), &update.joined);
+  assert_eq!(update.topology.left(), &update.left);
+}
+
+#[test]
+fn refresh_publishes_only_joined_and_left_authority_delta() {
+  let mut mapper = DiscoveryTopologyMapper::new(empty_block_list());
+  let first_update = mapper.apply(&DiscoveryResult::discovered(vec![
+    authority("node-a.example:7331", "generic-discovery", 10),
+    authority("node-b.example:7331", "generic-discovery", 10),
+  ]));
+  assert!(first_update.is_some());
+
+  let update = mapper
+    .apply(&DiscoveryResult::discovered(vec![
+      authority("node-b.example:7331", "generic-discovery", 11),
+      authority("node-c.example:7331", "generic-discovery", 11),
+    ]))
+    .expect("changed discovery should publish topology");
+
+  assert_eq!(update.joined, vec![String::from("node-c.example:7331")]);
+  assert_eq!(update.left, vec![String::from("node-a.example:7331")]);
+  assert_eq!(update.members, vec![String::from("node-b.example:7331"), String::from("node-c.example:7331")]);
+}
+
+#[test]
+fn repeated_success_without_delta_returns_no_topology_update() {
+  let mut mapper = DiscoveryTopologyMapper::new(empty_block_list());
+  let first_update =
+    mapper.apply(&DiscoveryResult::discovered(vec![authority("node-a.example:7331", "generic-discovery", 10)]));
+  assert!(first_update.is_some());
+
+  let update = mapper.apply(&DiscoveryResult::discovered(vec![authority("node-a.example:7331", "aws-ecs", 11)]));
+
+  assert!(update.is_none());
+}
+
+#[test]
+fn failed_discovery_returns_no_update_and_preserves_previous_topology() {
+  let mut mapper = DiscoveryTopologyMapper::new(empty_block_list());
+  let first_update =
+    mapper.apply(&DiscoveryResult::discovered(vec![authority("node-a.example:7331", "generic-discovery", 10)]));
+  assert!(first_update.is_some());
+
+  let failed = mapper.apply(&DiscoveryResult::failed(
+    String::from("generic-discovery"),
+    observed_at(11),
+    ClusterProviderError::start_member("temporary backend failure"),
+  ));
+  assert!(failed.is_none());
+
+  let update = mapper
+    .apply(&DiscoveryResult::empty(String::from("generic-discovery"), observed_at(12)))
+    .expect("empty success should remove previously discovered authorities");
+
+  assert!(update.joined.is_empty());
+  assert_eq!(update.left, vec![String::from("node-a.example:7331")]);
+  assert!(update.members.is_empty());
+}
+
+#[test]
+fn block_list_provider_output_is_preserved_in_topology_update() {
+  let block_list: ArcShared<dyn BlockListProvider> =
+    ArcShared::new(RecordingBlockList::new(vec![String::from("blocked-a"), String::from("blocked-b")]));
+  let mut mapper = DiscoveryTopologyMapper::new(block_list);
+
+  let update = mapper
+    .apply(&DiscoveryResult::discovered(vec![authority("node-a.example:7331", "aws-ecs", 10)]))
+    .expect("discovery should publish topology");
+
+  assert_eq!(update.blocked, vec![String::from("blocked-a"), String::from("blocked-b")]);
+}
+
+#[test]
+fn static_generic_and_aws_sources_share_authority_only_topology_contract() {
+  let static_update = DiscoveryTopologyMapper::new(empty_block_list())
+    .apply(&DiscoveryResult::discovered(vec![authority("node-a.example:7331", "static-seed", 10)]))
+    .expect("static seed should publish topology");
+  let generic_update = DiscoveryTopologyMapper::new(empty_block_list())
+    .apply(&DiscoveryResult::discovered(vec![authority("node-a.example:7331", "generic-discovery", 10)]))
+    .expect("generic discovery should publish topology");
+  let aws_update = DiscoveryTopologyMapper::new(empty_block_list())
+    .apply(&DiscoveryResult::discovered(vec![authority("node-a.example:7331", "aws-ecs", 10)]))
+    .expect("aws ecs discovery should publish topology");
+
+  assert_eq!(static_update.joined, generic_update.joined);
+  assert_eq!(generic_update.joined, aws_update.joined);
+  assert_eq!(static_update.members, generic_update.members);
+  assert_eq!(generic_update.members, aws_update.members);
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/local_cluster_provider_generic.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/local_cluster_provider_generic.rs
@@ -134,6 +134,56 @@ impl LocalClusterProvider {
     self.publish_topology(version, alloc::vec![], alloc::vec![authority]);
   }
 
+  /// Applies an externally computed topology delta as one atomic topology event.
+  pub fn apply_topology_update(&mut self, update: &TopologyUpdate) {
+    let mut joined = Vec::new();
+    for authority in update.joined.iter() {
+      if authority == &self.advertised_address || self.members.contains(authority) {
+        continue;
+      }
+      self.members.push(authority.clone());
+      joined.push(authority.clone());
+    }
+
+    let mut left = Vec::new();
+    for authority in update.left.iter() {
+      if !self.members.contains(authority) {
+        continue;
+      }
+      self.members.retain(|member| member != authority);
+      left.push(authority.clone());
+    }
+
+    let mut dead = Vec::new();
+    for authority in update.dead.iter() {
+      if !self.members.contains(authority) {
+        continue;
+      }
+      self.members.retain(|member| member != authority);
+      dead.push(authority.clone());
+    }
+
+    if joined.is_empty() && left.is_empty() && dead.is_empty() {
+      return;
+    }
+
+    let version = self.next_version();
+    let topology = ClusterTopology::new(version, joined.clone(), left.clone(), dead.clone());
+    let update = TopologyUpdate::new(
+      topology,
+      self.members.clone(),
+      joined,
+      left,
+      dead,
+      self.block_list_provider.blocked_members(),
+      update.observed_at,
+    );
+    let event = ClusterEvent::TopologyUpdated { update };
+    let payload = AnyMessage::new(event);
+    let extension_event = EventStreamEvent::Extension { name: String::from("cluster"), payload };
+    self.event_stream.publish(&extension_event);
+  }
+
   /// Returns the current member count.
   #[must_use]
   #[allow(clippy::missing_const_for_fn)]

--- a/modules/cluster-core-kernel/src/cluster_provider/seed_node_input.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/seed_node_input.rs
@@ -1,0 +1,30 @@
+//! Seed node input captured from provider lifecycle.
+
+use alloc::{string::String, vec::Vec};
+
+/// Seed authorities observed when a cluster provider starts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeedNodeInput {
+  advertised_authority: String,
+  seed_authorities:     Vec<String>,
+}
+
+impl SeedNodeInput {
+  /// Creates seed node input for the advertised local authority.
+  #[must_use]
+  pub const fn new(advertised_authority: String, seed_authorities: Vec<String>) -> Self {
+    Self { advertised_authority, seed_authorities }
+  }
+
+  /// Returns the advertised local authority.
+  #[must_use]
+  pub const fn advertised_authority(&self) -> &str {
+    self.advertised_authority.as_str()
+  }
+
+  /// Returns candidate seed authorities.
+  #[must_use]
+  pub const fn seed_authorities(&self) -> &[String] {
+    self.seed_authorities.as_slice()
+  }
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/seed_node_process.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/seed_node_process.rs
@@ -1,0 +1,82 @@
+//! Lifecycle-aware seed node join input processing.
+
+use alloc::{string::String, vec::Vec};
+
+use super::SeedNodeInput;
+use crate::ClusterProviderError;
+
+#[cfg(test)]
+#[path = "seed_node_process_test.rs"]
+mod tests;
+
+/// Converts lifecycle seed authorities into provider-neutral join input.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SeedNodeProcess {
+  is_shutdown: bool,
+}
+
+impl SeedNodeProcess {
+  /// Creates a seed node process.
+  #[must_use]
+  pub const fn new() -> Self {
+    Self { is_shutdown: false }
+  }
+
+  /// Starts seed processing for member mode.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError`] when a seed authority is invalid.
+  pub fn start_member(&mut self, input: &SeedNodeInput) -> Result<Vec<String>, ClusterProviderError> {
+    if self.is_shutdown {
+      return Ok(Vec::new());
+    }
+
+    Self::validate_seed_authorities(input)?;
+
+    let mut joins = Vec::new();
+    for authority in input.seed_authorities() {
+      if authority == input.advertised_authority() || joins.contains(authority) {
+        continue;
+      }
+      joins.push(authority.clone());
+    }
+    Ok(joins)
+  }
+
+  /// Starts seed processing for client mode.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError`] when a seed authority is invalid.
+  pub fn start_client(&mut self, input: &SeedNodeInput) -> Result<Vec<String>, ClusterProviderError> {
+    if self.is_shutdown {
+      return Ok(Vec::new());
+    }
+
+    Self::validate_seed_authorities(input)?;
+    Ok(Vec::new())
+  }
+
+  /// Shuts down the seed process.
+  ///
+  /// # Errors
+  ///
+  /// This implementation does not fail, but returns `Result` to match provider
+  /// lifecycle contracts.
+  pub const fn shutdown(&mut self) -> Result<(), ClusterProviderError> {
+    self.is_shutdown = true;
+    Ok(())
+  }
+
+  fn validate_seed_authorities(input: &SeedNodeInput) -> Result<(), ClusterProviderError> {
+    if input.seed_authorities().iter().any(|authority| !Self::is_valid_authority(authority)) {
+      return Err(ClusterProviderError::join("invalid seed authority"));
+    }
+    Ok(())
+  }
+
+  fn is_valid_authority(authority: &str) -> bool {
+    !authority.is_empty() && !authority.chars().any(char::is_whitespace)
+  }
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/seed_node_process_test.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/seed_node_process_test.rs
@@ -1,0 +1,67 @@
+use alloc::{string::String, vec, vec::Vec};
+
+use crate::{
+  ClusterProviderError,
+  cluster_provider::{SeedNodeInput, SeedNodeProcess},
+};
+
+fn input(advertised_authority: &str, seed_authorities: Vec<&str>) -> SeedNodeInput {
+  SeedNodeInput::new(String::from(advertised_authority), seed_authorities.into_iter().map(String::from).collect())
+}
+
+#[test]
+fn seed_node_process_member_start_reports_empty_seed_without_failure() {
+  let mut process = SeedNodeProcess::new();
+
+  let joins = process.start_member(&input("node-a", vec![])).unwrap();
+
+  assert!(joins.is_empty());
+}
+
+#[test]
+fn seed_node_process_member_start_filters_self_authority() {
+  let mut process = SeedNodeProcess::new();
+
+  let joins = process.start_member(&input("node-a", vec!["node-a", "node-b"])).unwrap();
+
+  assert_eq!(joins, vec![String::from("node-b")]);
+}
+
+#[test]
+fn seed_node_process_member_start_deduplicates_seed_authorities() {
+  let mut process = SeedNodeProcess::new();
+
+  let joins = process.start_member(&input("node-a", vec!["node-b", "node-b", "node-c"])).unwrap();
+
+  assert_eq!(joins, vec![String::from("node-b"), String::from("node-c")]);
+}
+
+#[test]
+fn seed_node_process_member_start_reports_invalid_authority() {
+  let mut process = SeedNodeProcess::new();
+
+  let error = process.start_member(&input("node-a", vec!["node-b", ""])).unwrap_err();
+
+  assert_eq!(error, ClusterProviderError::join("invalid seed authority"));
+}
+
+#[test]
+fn seed_node_process_client_start_does_not_emit_member_join_input() {
+  let mut process = SeedNodeProcess::new();
+
+  let joins = process.start_client(&input("node-a", vec!["node-b"])).unwrap();
+
+  assert!(joins.is_empty());
+}
+
+#[test]
+fn seed_node_process_stops_join_input_after_shutdown() {
+  let mut process = SeedNodeProcess::new();
+  let initial = process.start_member(&input("node-a", vec!["node-b"])).unwrap();
+  process.shutdown().unwrap();
+
+  let joins = process.start_member(&input("node-a", vec!["node-c"])).unwrap();
+
+  assert_eq!(initial, vec![String::from("node-b")]);
+  assert!(joins.is_empty());
+}

--- a/modules/cluster-core-kernel/src/cluster_provider/static_cluster_provider_test.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/static_cluster_provider_test.rs
@@ -137,7 +137,6 @@ fn start_member_uses_only_configured_static_topology_contract() {
 
   let events = subscriber_impl.events();
   assert_eq!(events.len(), 1);
-  assert!(events.iter().all(|event| matches!(event, ClusterEvent::TopologyUpdated { .. })));
   assert!(matches!(
     &events[0],
     ClusterEvent::TopologyUpdated { update }

--- a/modules/cluster-core-kernel/src/cluster_provider/static_cluster_provider_test.rs
+++ b/modules/cluster-core-kernel/src/cluster_provider/static_cluster_provider_test.rs
@@ -123,6 +123,32 @@ fn start_client_also_publishes_static_topology() {
 }
 
 #[test]
+fn start_member_uses_only_configured_static_topology_contract() {
+  let event_stream = EventStreamShared::default();
+  let block_list: ArcShared<dyn BlockListProvider> = ArcShared::new(EmptyBlockList);
+
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+
+  let static_topology = ClusterTopology::new(210, vec![String::from("node-static")], vec![], Vec::new());
+  let mut provider =
+    StaticClusterProvider::new(event_stream, block_list, "node-a").with_static_topology(static_topology);
+
+  provider.start_member().unwrap();
+
+  let events = subscriber_impl.events();
+  assert_eq!(events.len(), 1);
+  assert!(events.iter().all(|event| matches!(event, ClusterEvent::TopologyUpdated { .. })));
+  assert!(matches!(
+    &events[0],
+    ClusterEvent::TopologyUpdated { update }
+    if update.joined == vec![String::from("node-static")]
+      && update.members == vec![String::from("node-static"), String::from("node-a")]
+      && update.left.is_empty()
+      && update.blocked.is_empty()
+  ));
+}
+
+#[test]
 fn topology_includes_blocked_members_from_block_list_provider() {
   let event_stream = EventStreamShared::default();
   let block_list: ArcShared<dyn BlockListProvider> =


### PR DESCRIPTION
## 概要

- `SeedNodeProcess` と discovery result/topology mapper の core contract を追加しました。
- std adaptor 側に generic discovery backend adapter と provider lifecycle bridge を追加しました。
- Local / Static / AWS ECS provider との interop をテストで固定し、gap analysis の evidence を更新しました。

## スコープ

- provider/discovery interop の境界に限定しています。
- gossip、downing/SBR、pubsub mediator、cluster message serializer、Deferred Pekko concepts はこの PR の完了扱いにしていません。

## 検証

- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-kernel-rs seed_node_process`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-kernel-rs discovery_result`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-kernel-rs discovery_topology_mapper`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-kernel-rs static_cluster_provider`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-adaptor-std-rs generic_discovery_adapter`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-adaptor-std-rs provider_lifecycle_bridge`
- `AWS_LC_SYS_CFLAGS=-g0 MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-adaptor-std-rs --features aws-ecs aws_ecs`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo check -p fraktor-cluster-core-kernel-rs --no-default-features`
- `git diff --check`

## 備考

- 作業前から存在していた `.kiro` archive 移動と `mise.toml` の未コミット差分は、この PR には含めていません。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster membership topology and provider lifecycle wiring (join/leave filtering, discovery failures on start); scope is bounded and heavily tested, but incorrect integration could affect member sets at runtime.
> 
> **Overview**
> Adds a **provider-neutral discovery interop layer** so seed lists and generic discovery backends feed the same topology contract as static and AWS ECS providers.
> 
> **Core (`cluster-core-kernel`):** New `SeedNodeInput` / `SeedNodeProcess` (member vs client join rules, validation, shutdown), `DiscoveredAuthority` / `DiscoveryResult`, and `DiscoveryTopologyMapper` (join/leave deltas, dedup, failures that do not wipe prior state). `LocalClusterProvider` gains `apply_topology_update` for atomic external deltas.
> 
> **Std adaptor:** `DiscoveryBackend`, `DiscoveryBackendError`, `GenericDiscoveryAdapter` (normalize poll results), and `ProviderLifecycleBridge` (member/client start, discovery refresh, weak provider handles, shutdown stops polling). Tests cover lifecycle, seed preservation, and ECS-style authorities.
> 
> **Docs:** Spec tasks marked complete; `cluster-gap-analysis.md` records discovery/seed evidence and bumps fixed-scope coverage (~60%).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33ac3df1e1a398f29c7b079f20997f360b80a3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * クラスタプロバイダに汎用ディスカバリーバックエンド機能を追加。シードノード処理とディスカバリートポロジマッピング機能をサポートし、プロバイダのライフサイクル管理を統合しました。

* **Tests**
  * ディスカバリーアダプタ、トポロジマッピング、シードノードプロセス、プロバイダライフサイクルブリッジの動作検証テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->