### PR TITLE
j5ik2o/ci の参照ハッシュを更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,10 +499,10 @@ jobs:
       statuses: write
       issues: read
       pull-requests: read
-    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
     with:
       wait_for_other_checks: "false"
-      ci_ref: a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+      ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a
 
   # All jobs completion check
   ci-success:

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   refresh:
     name: Refresh review-thread state
-    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+    uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
     permissions:
       contents: read
       checks: write
@@ -43,4 +43,4 @@ jobs:
     with:
       pr_number: ${{ inputs.pr_number }}
       wait_for_other_checks: ${{ inputs.wait_for_other_checks == '' && 'true' || inputs.wait_for_other_checks }}
-      ci_ref: a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+      ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a

--- a/.github/workflows/takt-review.yml
+++ b/.github/workflows/takt-review.yml
@@ -22,7 +22,7 @@ jobs:
         startsWith(github.event.comment.body, '@takt') &&
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
       )
-    uses: j5ik2o/ci/.github/workflows/takt-review.yml@a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+    uses: j5ik2o/ci/.github/workflows/takt-review.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
     permissions:
       contents: read
       pull-requests: write
@@ -35,4 +35,4 @@ jobs:
       model: claude-sonnet-4-5-20250929
       wrapper_script: .github/scripts/takt-review-wrapper.mjs
       non_blocking: "true"
-      ci_ref: a672e3d9fca1de4b7b6b648c08c9ad263267dff6
+      ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a


### PR DESCRIPTION
## 概要

- j5ik2o/ci の reusable workflow 参照を最新の main SHA に更新しました。
- ci.yml / review-thread-resolution.yml / takt-review.yml の uses と ci_ref を同じ SHA に同期しました。

## 影響

- fraktor-rs 側の workflow が、更新済みの共有 CI workflow を参照するようになります。
- workflow 定義の参照先だけを更新しており、ジョブ構成や権限設定は変更していません。

## 検証

- yq '.' .github/workflows/ci.yml .github/workflows/review-thread-resolution.yml .github/workflows/takt-review.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/review-thread-resolution.yml .github/workflows/takt-review.yml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates external workflow commit pins; no application or CI job logic changes in this repo.
> 
> **Overview**
> This PR **pins** the shared **`j5ik2o/ci`** reusable workflows to commit **`560170b61c74a9a643a483a052ccbad0d6ad409a`** (replacing **`a672e3d9fca1de4b7b6b648c08c9ad263267dff6`**).
> 
> In **`.github/workflows/ci.yml`**, **`.github/workflows/review-thread-resolution.yml`**, and **`.github/workflows/takt-review.yml`**, both the **`uses: j5ik2o/ci/...`** refs and the matching **`ci_ref`** inputs are updated so they stay on the same SHA. Job definitions, triggers, and permissions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64211dd7f61c2ccb8786891cb259ffdbca3aaae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 内部のGitHub Actionsワークフロー設定がアップデートされました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->