### PR TITLE
workflow gate を Rust 変更時だけ実行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   changes:
-    name: Detect CI-relevant changes
+    name: Detect Rust source changes
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
     outputs:
       run_code_checks: ${{ steps.filter.outputs.run_code_checks }}
@@ -104,16 +104,9 @@ jobs:
             exit 0
           fi
 
-          is_docs_only_path() {
+          is_rust_source_path() {
             local path="$1"
-            [[ "${path}" == *.md \
-              || "${path}" == *.rst \
-              || "${path}" == *.txt \
-              || "${path}" == docs/* \
-              || "${path}" == openspec/* \
-              || "${path}" == README* \
-              || "${path}" == CHANGELOG* \
-              || "${path}" == LICENSE* ]]
+            [[ "${path}" == *.rs ]]
           }
 
           run_code_checks=false
@@ -126,7 +119,7 @@ jobs:
             esac
 
             for path in "${paths[@]}"; do
-              if ! is_docs_only_path "${path}"; then
+              if is_rust_source_path "${path}"; then
                 run_code_checks=true
                 break 2
               fi
@@ -139,6 +132,9 @@ jobs:
   format:
     name: Format Check
     runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner == 'self-hosted' && 'self-hosted' || 'ubuntu-latest' }}
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.run_code_checks == 'true' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v6
@@ -492,7 +488,7 @@ jobs:
       - codecov-status
       - docs
       - examples
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    if: ${{ always() && github.event_name == 'pull_request' && needs.changes.outputs.run_code_checks == 'true' }}
     permissions:
       contents: read
       checks: write
@@ -527,10 +523,6 @@ jobs:
           RUN_CODE_CHECKS: ${{ needs.changes.outputs.run_code_checks }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "${{ needs.format.result }}" != "success" ]]; then
-            echo "format failed"
-            exit 1
-          fi
           run_code_checks="${RUN_CODE_CHECKS}"
           if [[ "${{ needs.changes.result }}" != "success" ]]; then
             echo "changes failed"
@@ -559,6 +551,7 @@ jobs:
             fi
           }
 
+          require_result "format" "${{ needs.format.result }}" "${expected_code_job_result}"
           require_result "lint" "${{ needs.lint.result }}" "${expected_code_job_result}"
           require_result "takt-review-wrapper-tests" "${{ needs['takt-review-wrapper-tests'].result }}" "${expected_code_job_result}"
           require_result "test" "${{ needs.test.result }}" "${expected_code_job_result}"
@@ -567,7 +560,7 @@ jobs:
           require_result "codecov-status" "${{ needs['codecov-status'].result }}" "${expected_code_job_result}"
           require_result "docs" "${{ needs.docs.result }}" "${expected_code_job_result}"
           require_result "examples" "${{ needs.examples.result }}" "${expected_code_job_result}"
-          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+          if [[ "${EVENT_NAME}" == "pull_request" && "${run_code_checks}" == "true" ]]; then
             expected_review_thread_result="success"
           else
             expected_review_thread_result="skipped"

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -31,8 +31,68 @@ permissions:
   pull-requests: read
 
 jobs:
+  select-rust-prs:
+    name: Select PRs with Rust changes
+    runs-on: ubuntu-latest
+    outputs:
+      pr_numbers: ${{ steps.select.outputs.pr_numbers }}
+    steps:
+      - name: Select PRs with Rust file changes
+        id: select
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || '' }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          IS_PR_ISSUE_COMMENT: ${{ github.event.issue.pull_request != null }}
+          BASE_BRANCH: main
+        run: |
+          set -euo pipefail
+
+          has_rust_changes() {
+            local pr_number="$1"
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
+              --jq '.[] | .filename, (.previous_filename // empty)' \
+              | grep -Eq '\.rs$'
+          }
+
+          pr_candidates=()
+          if [[ "${EVENT_NAME}" == "issue_comment" && "${IS_PR_ISSUE_COMMENT}" != "true" ]]; then
+            pr_candidates=()
+          elif [[ -n "${INPUT_PR_NUMBER}" ]]; then
+            pr_candidates=("${INPUT_PR_NUMBER}")
+          elif [[ -n "${EVENT_PR_NUMBER}" ]]; then
+            pr_candidates=("${EVENT_PR_NUMBER}")
+          else
+            mapfile -t pr_candidates < <(
+              gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=${BASE_BRANCH}&per_page=100" \
+                --jq '.[].number'
+            )
+          fi
+
+          selected=()
+          for pr_number in "${pr_candidates[@]}"; do
+            if [[ "${pr_number}" =~ ^[0-9]+$ ]] && has_rust_changes "${pr_number}"; then
+              selected+=("${pr_number}")
+            fi
+          done
+
+          pr_numbers="["
+          for pr_number in "${selected[@]}"; do
+            pr_numbers+="${pr_number},"
+          done
+          pr_numbers="${pr_numbers%,}]"
+
+          echo "pr_numbers=${pr_numbers}" >> "${GITHUB_OUTPUT}"
+
   refresh:
     name: Refresh review-thread state
+    needs:
+      - select-rust-prs
+    if: ${{ needs.select-rust-prs.outputs.pr_numbers != '[]' }}
+    strategy:
+      matrix:
+        pr_number: ${{ fromJson(needs.select-rust-prs.outputs.pr_numbers) }}
     uses: j5ik2o/ci/.github/workflows/review-thread-resolution.yml@560170b61c74a9a643a483a052ccbad0d6ad409a
     permissions:
       contents: read
@@ -41,6 +101,6 @@ jobs:
       issues: read
       pull-requests: read
     with:
-      pr_number: ${{ inputs.pr_number }}
-      wait_for_other_checks: ${{ inputs.wait_for_other_checks == '' && 'true' || inputs.wait_for_other_checks }}
+      pr_number: ${{ matrix.pr_number }}
+      wait_for_other_checks: ${{ inputs.wait_for_other_checks || 'true' }}
       ci_ref: 560170b61c74a9a643a483a052ccbad0d6ad409a


### PR DESCRIPTION
## 変更内容

- CI の変更判定を docs-only ではなく `.rs` ファイル変更の有無に切り替えました。
- `.rs` 変更がない PR では format / lint / test / coverage / docs / examples / CI review-thread gate を skip し、`CI Success` は skip 状態を正常として扱います。
- standalone の review-thread refresh は対象 PR の changed files を GitHub API で確認し、`.rs` 変更がある PR だけ shared workflow に渡します。

## 背景

ドキュメントや workflow など Rust ソース以外の変更で重い Rust CI と review-thread gate が動くと、確認コストが大きいためです。

## 検証

- `git diff --check -- .github/workflows/ci.yml .github/workflows/review-thread-resolution.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml .github/workflows/review-thread-resolution.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI の合格条件とスキップ挙動が変わるため、docs/workflow のみの PR で意図せずチェックが省略される可能性がある。ロジックはワークフロー YAML のみで本番コードには触れない。
> 
> **Overview**
> Rust ソース（`*.rs`）に触れない PR では、重い Rust CI と review-thread ゲートを走らせないように **変更検知の基準を docs-only 除外から「`.rs` があるか」に切り替え**ています。
> 
> `changes` ジョブが `run_code_checks=false` のとき、format / lint / test / coverage / docs / examples などはスキップされ、**`CI Success` はそれらの skipped を正常**として扱います。PR 上の review-thread ゲートも `run_code_checks=true` のときだけ必須になります。
> 
> スタンドアロンの **Review Thread Refresh** では、対象 PR を GitHub API の changed files で絞り、**`.rs` 変更がある PR だけ** shared workflow に matrix で渡す `select-rust-prs` ジョブを追加しています。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a0c2ab016ce14711eee8e93e6498484a58cb8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->