### PR TITLE
non-Rust PR の review gate status を軽量成功にする

### DIFF
--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -56,6 +56,18 @@ jobs:
               | grep -Eq '\.rs$'
           }
 
+          publish_non_rust_success() {
+            local pr_number="$1"
+            local head_sha
+            head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '.head.sha')"
+            gh api "repos/${GITHUB_REPOSITORY}/statuses/${head_sha}" \
+              -f state=success \
+              -f context="Check unresolved comments" \
+              -f description="Skipped for PR without Rust source changes." \
+              -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              > /dev/null
+          }
+
           pr_candidates=()
           if [[ "${EVENT_NAME}" == "issue_comment" && "${IS_PR_ISSUE_COMMENT}" != "true" ]]; then
             pr_candidates=()
@@ -72,8 +84,12 @@ jobs:
 
           selected=()
           for pr_number in "${pr_candidates[@]}"; do
-            if [[ "${pr_number}" =~ ^[0-9]+$ ]] && has_rust_changes "${pr_number}"; then
-              selected+=("${pr_number}")
+            if [[ "${pr_number}" =~ ^[0-9]+$ ]]; then
+              if has_rust_changes "${pr_number}"; then
+                selected+=("${pr_number}")
+              else
+                publish_non_rust_success "${pr_number}"
+              fi
             fi
           done
 

--- a/.github/workflows/review-thread-resolution.yml
+++ b/.github/workflows/review-thread-resolution.yml
@@ -46,26 +46,62 @@ jobs:
           INPUT_PR_NUMBER: ${{ inputs.pr_number || '' }}
           IS_PR_ISSUE_COMMENT: ${{ github.event.issue.pull_request != null }}
           BASE_BRANCH: main
+          REQUIRED_CONTEXT: Check unresolved comments
         run: |
           set -euo pipefail
 
+          fetch_pr_head_sha() {
+            local pr_number="$1"
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '.head.sha'
+          }
+
           has_rust_changes() {
             local pr_number="$1"
-            gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
-              --jq '.[] | .filename, (.previous_filename // empty)' \
-              | grep -Eq '\.rs$'
+            local changed_paths
+            if ! changed_paths="$(
+              gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}/files?per_page=100" \
+                --jq '.[] | .filename, (.previous_filename // empty)'
+            )"; then
+              return 2
+            fi
+
+            if printf '%s\n' "${changed_paths}" | grep -E '\.rs$' > /dev/null; then
+              return 0
+            fi
+
+            return 1
           }
 
           publish_non_rust_success() {
             local pr_number="$1"
+            local expected_head_sha="$2"
             local head_sha
-            head_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '.head.sha')"
-            gh api "repos/${GITHUB_REPOSITORY}/statuses/${head_sha}" \
+            local head_repo
+            local pr_metadata
+            if ! pr_metadata="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '"\(.head.sha)\t\(.head.repo.full_name)"')"; then
+              echo "::warning::Unable to fetch PR #${pr_number} head metadata; leaving ${REQUIRED_CONTEXT} unchanged."
+              return 0
+            fi
+
+            IFS=$'\t' read -r head_sha head_repo <<< "${pr_metadata}"
+            if [[ "${head_sha}" != "${expected_head_sha}" ]]; then
+              echo "::warning::PR #${pr_number} head changed from ${expected_head_sha} to ${head_sha}; leaving ${REQUIRED_CONTEXT} unchanged."
+              return 0
+            fi
+
+            if [[ "${head_repo}" != "${GITHUB_REPOSITORY}" ]]; then
+              echo "::notice::Skipping ${REQUIRED_CONTEXT} status publication for cross-repository PR #${pr_number}."
+              return 0
+            fi
+
+            if ! gh api "repos/${GITHUB_REPOSITORY}/statuses/${head_sha}" \
               -f state=success \
-              -f context="Check unresolved comments" \
+              -f context="${REQUIRED_CONTEXT}" \
               -f description="Skipped for PR without Rust source changes." \
               -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-              > /dev/null
+              > /dev/null; then
+              echo "::warning::Unable to publish ${REQUIRED_CONTEXT} success for PR #${pr_number}."
+            fi
           }
 
           pr_candidates=()
@@ -85,11 +121,24 @@ jobs:
           selected=()
           for pr_number in "${pr_candidates[@]}"; do
             if [[ "${pr_number}" =~ ^[0-9]+$ ]]; then
-              if has_rust_changes "${pr_number}"; then
-                selected+=("${pr_number}")
-              else
-                publish_non_rust_success "${pr_number}"
+              if ! head_sha="$(fetch_pr_head_sha "${pr_number}")"; then
+                echo "::warning::Unable to fetch PR #${pr_number} head SHA; leaving ${REQUIRED_CONTEXT} unchanged."
+                continue
               fi
+
+              rust_change_result=0
+              has_rust_changes "${pr_number}" || rust_change_result=$?
+              case "${rust_change_result}" in
+                0)
+                  selected+=("${pr_number}")
+                  ;;
+                1)
+                  publish_non_rust_success "${pr_number}" "${head_sha}"
+                  ;;
+                *)
+                  echo "::warning::Unable to inspect PR #${pr_number} changed files; leaving ${REQUIRED_CONTEXT} unchanged."
+                  ;;
+              esac
             fi
           done
 


### PR DESCRIPTION
## 変更内容

- `Review Thread Refresh` の前段判定で、`.rs` 変更がない PR に対して `Check unresolved comments` status を `success` として publish します。
- `.rs` 変更がある PR だけ、従来どおり shared review-thread workflow を呼びます。

## 背景

PR #1963 で non-`.rs` PR の重い review-thread workflow を skip するようにしましたが、過去に `Check unresolved comments` failure が publish された PR では stale failure が残り続けます。

GitHub の required check は path 条件で動的に required/unrequired を切り替えられないため、non-`.rs` PR では lightweight な success status を publish して required check を満たします。

## 検証

- `git diff --check origin/main..HEAD -- .github/workflows/review-thread-resolution.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/review-thread-resolution.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub Actions shell logic only; it adjusts when statuses are published and does not change application or auth code.
> 
> **Overview**
> The **Review Thread Refresh** selection step now treats non-Rust PRs differently so the **`Check unresolved comments`** required check can pass without running the heavy shared review-thread workflow.
> 
> For each candidate PR it fetches the head SHA, classifies Rust changes via a refactored **`has_rust_changes`** (distinct exit codes for “has `.rs`”, “no `.rs`”, and API/listing failure). PRs **with** Rust files still go into **`pr_numbers`** for the downstream refresh job. PRs **without** `.rs` changes call **`publish_non_rust_success`**, which posts a **success** commit status on that context (with guards for head-SHA drift, cross-repo forks, and publish failures). Failures to inspect changed files leave the status unchanged and log warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd23881a4354d6136891fd218021cd8da13fec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * PR レビュープロセスのステータス報告ロジックを改善し、Rust 関連の変更がないケースでの状態表示をより正確に処理するようになりました。

* **Chores**
  * PR 候補の検証・スキャン処理をより堅牢に更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/j5ik2o/fraktor-rs/pull/1967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->