### PR TITLE
cluster message serialization contract を追加

### DIFF
--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -26,7 +26,7 @@
   - _Boundary: ActorSerializationBridge_
 
 - [ ] 3. std/wire frame と codec を追加する
-- [ ] 3.1 versioned cluster wire frame を定義する
+- [x] 3.1 versioned cluster wire frame を定義する
   - version、payload kind tag、serializer id、manifest、payload length、payload bytes を含む v1 frame を追加する。
   - frame は endpoint、association、retry state を持たない。
   - 完了時には v1 frame encode/decode が metadata を保持して roundtrip する。

--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -58,7 +58,7 @@
   - _Depends: 1.2, 2.1, 3.2_
 
 - [ ] 5. integration evidence と gap analysis を更新する
-- [ ] 5.1 serializer contract follow-up の evidence を更新し、targeted checks を実行する
+- [x] 5.1 serializer contract follow-up の evidence を更新し、targeted checks を実行する
   - `docs/gap-analysis/cluster-gap-analysis.md` の cluster message serializer contract 項目だけを implementation evidence で更新する。
   - protobuf / Pekko binary compatibility は scope 外として残し、別 follow-up に吸収しない。
   - 完了時には targeted unit/integration tests と `cluster-core-kernel` no_std check が通る。

--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -41,7 +41,7 @@
   - _Boundary: ClusterWireCodec, ClusterWireDecodeFailure_
 
 - [ ] 4. upstream gossip/pubsub payload と境界検証を接続する
-- [ ] 4.1 (P) gossip payload の serialization bridge smoke test を追加する
+- [x] 4.1 (P) gossip payload の serialization bridge smoke test を追加する
   - upstream gossip payload contract 由来の値を payload kind `Gossip` として serialized message に包む。
   - bridge は gossip merge、seen digest、heartbeat evidence、reachability update を実行しないことを検証する。
   - 完了時には gossip payload の wire roundtrip smoke test が semantics evaluation なしで通る。

--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -17,7 +17,7 @@
   - _Boundary: ClusterSerializedMessage_
 
 - [ ] 2. actor-core serialization との接続点を実装する
-- [ ] 2.1 `SerializationExtension` を使う cluster bridge を追加する
+- [x] 2.1 `SerializationExtension` を使う cluster bridge を追加する
   - cluster payload kind、`SerializationCallScope`、typed payload を受け取り、actor-core serialization の結果を `ClusterSerializedMessage` として返す。
   - wire bridge caller は `SerializationCallScope::Remote` を渡し、manifest-required scope を Local 扱いで迂回しない。
   - 未登録 serializer、serialize failure、deserialize failure を cluster 独自 fallback に変換しない。

--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -9,7 +9,7 @@
   - _Requirements: 2.1, 2.4, 2.5, 4.2, 4.4_
   - _Boundary: ClusterMessagePayloadKind, ClusterMessageManifest_
 
-- [ ] 1.2 actor-core serialized metadata を保持する bridge message を定義する
+- [x] 1.2 actor-core serialized metadata を保持する bridge message を定義する
   - payload kind と actor-core `SerializedMessage` を束ねる immutable value を追加する。
   - serializer id、manifest、payload bytes が constructor と accessor で欠落なく観測できるようにする。
   - 完了時には manifest あり / なしの metadata preservation test が通る。

--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -1,7 +1,7 @@
 # 実装計画
 
 - [ ] 1. cluster message serialization の core contract を追加する
-- [ ] 1.1 payload kind と manifest preservation rule を定義する
+- [x] 1.1 payload kind と manifest preservation rule を定義する
   - gossip と pubsub を stable payload kind として表し、unknown raw tag を既知 kind に丸めない。
   - actor-core manifest を opaque に保持し、payload kind tag と二重管理しないことを検証する。
   - unknown manifest / manifest route failure は actor-core deserialize failure として観測可能にし、cluster 固有 fallback に変換しない。

--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -33,7 +33,7 @@
   - _Requirements: 3.1, 3.2, 3.4, 5.3_
   - _Boundary: ClusterWireFrameV1_
 
-- [ ] 3.2 decode failure taxonomy と malformed payload rejection を実装する
+- [x] 3.2 decode failure taxonomy と malformed payload rejection を実装する
   - unknown version、unknown payload kind、unknown manifest、length mismatch、invalid manifest bytes を区別する。
   - decode failure 時に actor message、empty message、dead-letter message へ変換しない。
   - 完了時には各 failure category の unit test が個別に失敗種別を検証する。

--- a/.kiro/specs/cluster-message-serialization-contract/tasks.md
+++ b/.kiro/specs/cluster-message-serialization-contract/tasks.md
@@ -49,7 +49,7 @@
   - _Boundary: ScopeGuard, ActorSerializationBridge_
   - _Depends: 1.2, 2.1, 3.2_
 
-- [ ] 4.2 (P) pubsub payload の serialization bridge smoke test を追加する
+- [x] 4.2 (P) pubsub payload の serialization bridge smoke test を追加する
   - upstream pubsub payload contract 由来の値を payload kind `PubSub` として serialized message に包む。
   - bridge は mediator command application、delivery target selection、registry delta application を実行しないことを検証する。
   - 完了時には pubsub payload の wire roundtrip smoke test が mediator state mutation なしで通る。

--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -1,6 +1,6 @@
 # cluster モジュール ギャップ分析
 
-更新日: 2026-06-02 (cluster-downing-sbr-decision-model / cluster-discovery-provider-interop evidence reflected)
+更新日: 2026-06-05 (cluster-message-serialization-contract evidence reflected)
 
 ## 位置づけ
 

--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -87,7 +87,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | core / typed | typed `Cluster`, command, subscription, singleton, sharding typed API | `modules/cluster-core-typed` に typed `Cluster` / command / state subscription / self events / setup がある | typed Cluster の薄い facade はあるが、singleton / sharding typed API は未実装 |
 | core / virtual actor | `ClusterSharding`, `EntityRef`, `EntityTypeKey`, `ShardRegion`, coordinator | `GrainRef`, `GrainKey`, `VirtualActorRegistry`, `PlacementCoordinatorCore`, `PartitionIdentityLookup` | protoactor-go style の同等機能は強いが Pekko public API と remember/rebalance が不足 |
 | core / distributed state | `DistributedData`, `Replicator`, CRDT 型群 | なし | 未実装 |
-| std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `MembershipCoordinatorDriver`, `LocalClusterProvider`, `StaticClusterProvider`, `AwsEcsClusterProvider`, `GenericDiscoveryAdapter`, `ProviderLifecycleBridge` | Rust adapter、logical envelope handoff、seed/discovery provider boundary はある。cluster message serializer integration は限定的 |
+| std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `MembershipCoordinatorDriver`, `LocalClusterProvider`, `StaticClusterProvider`, `AwsEcsClusterProvider`, `GenericDiscoveryAdapter`, `ProviderLifecycleBridge`, `ClusterWireCodec` | Rust adapter、logical envelope handoff、seed/discovery provider boundary、cluster message serializer contract はある。Pekko/protobuf 完全バイナリ互換は scope 外 |
 
 ## カテゴリ別ギャップ
 
@@ -207,17 +207,17 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | read/write consistency levels | `Replicator.scala:284` | 未対応 | core/ddata | easy | ReadLocal/ReadMajority/WriteMajority 等 |
 | typed DistributedData API | `cluster-typed/ddata/typed/scaladsl/DistributedData.scala:33` | 未対応 | core/typed | medium | typed actor ref adapter が必要 |
 
-### 10. std adapter / discovery / wire integration　✅ 実装済み 7/9 (78%)
+### 10. std adapter / discovery / wire integration　✅ 実装済み 8/9 (89%)
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
-| cluster message serializer contract | `ClusterMessageSerializer.scala:83`, `ClusterShardingMessageSerializer.scala`, `DistributedPubSubMessageSerializer.scala` | 部分実装 | std/wire + actor-core serialization | hard | gossip delta は postcard wire だが Pekko cluster/sharding/pubsub message serializer に相当する contract がない |
+| cluster message serializer contract | `ClusterMessageSerializer.scala:83`, `ClusterShardingMessageSerializer.scala`, `DistributedPubSubMessageSerializer.scala` | contract 実装済み | std/wire + actor-core serialization | hard | core `message_serialization` は `ClusterMessagePayloadKind`、`ClusterMessageManifest`、`ClusterSerializedMessage`、`ActorSerializationBridge` を公開する。std `message_wire` は `ClusterWireFrameV1`、`ClusterWireCodec`、`ClusterWireDecodeFailure` を公開する。tests: actor-core metadata preservation、unknown payload/version/malformed payload failure、gossip/pubsub wire smoke。gossip semantics、pubsub mediator semantics、transport lifecycle、Pekko/protobuf 完全バイナリ互換は scope 外 |
 | seed node discovery process | `SeedNodeProcess.scala:22` | boundary contract 実装済み | core/cluster_provider + std/provider | medium | `SeedNodeProcess` が seed authority を provider-neutral join input に変換し、`DiscoveryTopologyMapper` が topology update へ写像する。`ProviderLifecycleBridge` が lifecycle 内で seed/discovery input を同じ contract に接続する。tests: `seed_node_process_*`, `discovery_topology_mapper_*`, `provider_lifecycle_bridge_*` |
 | generic discovery adapter | `Cluster.scala:354`, `ClusterClient.scala:65` | boundary contract 実装済み | core/cluster_provider + std/provider | medium | `DiscoveryBackend` / `DiscoveryBackendError` / `GenericDiscoveryAdapter` が backend success、empty success、failure、AWS ECS style authority を `DiscoveryResult` / `DiscoveredAuthority` に正規化する。tests: `generic_discovery_adapter_*`, `discovery_result_*`, `aws_ecs` feature tests |
 | std `ClusterApi` wrapper parity | `Cluster.scala:328`, `Cluster.scala:384`, `Cluster.scala:395` | 部分実装 | std/api | trivial | std wrapper は `get/request/down` のみで `join/leave/subscribe` を再公開していない |
 | transport lifecycle to membership bridge retention | `local_cluster_provider_ext.rs` | 実装済み | std/provider | easy | `subscribe_remoting_events` が `EventStreamSubscription` を返し、guard 保持中だけ connected/quarantined events を topology input にする。weak provider retention により subscription は provider を延命しない。`local_cluster_provider_ext` tests で確認 |
 
-実装済みとして扱うもの: `TokioGossipTransport`、`MembershipCoordinatorDriver`、`LocalClusterProvider`、`StaticClusterProvider`、`AwsEcsClusterProvider`、`SeedNodeProcess`、`DiscoveryTopologyMapper`、`GenericDiscoveryAdapter`、`ProviderLifecycleBridge`。logical gossip envelope handoff は `GossipEnvelope` evidence の一部として扱い、この section の独立 completed concept には数えない。
+実装済みとして扱うもの: `TokioGossipTransport`、`MembershipCoordinatorDriver`、`LocalClusterProvider`、`StaticClusterProvider`、`AwsEcsClusterProvider`、`SeedNodeProcess`、`DiscoveryTopologyMapper`、`GenericDiscoveryAdapter`、`ProviderLifecycleBridge`、`ClusterMessagePayloadKind`、`ClusterMessageManifest`、`ClusterSerializedMessage`、`ActorSerializationBridge`、`ClusterWireFrameV1`、`ClusterWireCodec`、`ClusterWireDecodeFailure`。logical gossip envelope handoff は `GossipEnvelope` evidence の一部として扱い、この section の独立 completed concept には数えない。
 
 ## 対象外 (n/a)
 
@@ -251,7 +251,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | `remotePathOf` | core/extension | 実装済み | `ClusterApi::remote_path_of`。tests: `remote_path_of_*` |
 | transport lifecycle bridge retention | std/provider | 実装済み | `subscribe_remoting_events`、`EventStreamSubscription`、weak provider retention。tests: `local_cluster_provider_ext` |
 
-上記は cluster-active-compatibility-baseline の完了 evidence であり、次の項目を完了扱いにしない: seed process / discovery provider、pubsub mediator / serialization / cluster message serializer、Deferred Pekko concepts。`SplitBrainResolverProvider` は下の `cluster-downing-sbr-decision-model` evidence に移動した。
+上記は cluster-active-compatibility-baseline の完了 evidence であり、次の項目を完了扱いにしない: seed process / discovery provider、pubsub mediator semantics / registry gossip、Deferred Pekko concepts。`SplitBrainResolverProvider` は下の `cluster-downing-sbr-decision-model` evidence に移動し、cluster message serializer contract は専用 completed table に分離した。
 
 ### Completed active follow-up: membership / reachability model
 
@@ -263,7 +263,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | `Reachability` matrix | core/membership | core contract 実装済み | `ReachabilityMatrix` / `ReachabilityRecord` / `ReachabilitySnapshot` が observer / subject / status / version、reachable prune、terminated precedence、aggregate status、snapshot propagation を保持。tests: `reachability_matrix::*`, `reachability_snapshot_tracks_failure_detector_and_heartbeat_receipt` |
 | indirect connection handling | core/membership + core/downing_provider | evidence contract 実装済み | `IndirectConnectionEvidence` と `DowningInput::IndirectConnectionEvidence` が partial connectivity evidence を渡す。downing decision、lease majority、SBR strategy は実行しない。tests: `indirect_connection_evidence::*` |
 
-この completed table は `cluster-membership-reachability-model` の core contract evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離し、downing / SBR decision model は専用の completed table に分離する。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、Deferred Pekko concepts。
+この completed table は `cluster-membership-reachability-model` の core contract evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離し、downing / SBR decision model は専用の completed table に分離する。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、Deferred Pekko concepts。
 
 ### Completed active follow-up: gossip / heartbeat protocol
 
@@ -274,7 +274,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | dedicated cluster heartbeat protocol | core/membership | core protocol 実装済み | `HeartbeatProtocolState`、`HeartbeatRequest`、`HeartbeatResponse`、`HeartbeatEvidence` が sequence number、request/response 照合、first / regular timeout evidence を扱う。tests: `heartbeat_tick_generates_sequence_per_peer`, `heartbeat_request_roundtrip_produces_reachable_evidence`, `first_and_regular_heartbeat_timeouts_are_observable` |
 | `CrossDcClusterHeartbeat` | core/membership | core evidence 実装済み | `CrossDcHeartbeat`、`CrossDcHeartbeatRequest`、`CrossDcHeartbeatResponse`、`CrossDcHeartbeatEvidence` が data center pair 付き cross-DC liveness evidence と target change を扱う。tests: `cross_dc_*` |
 
-この completed table は `cluster-gossip-heartbeat-protocol` の evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離し、downing / SBR decision model は専用の completed table に分離する。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、versioned transport handoff / serde-postcard envelope bytes、Deferred Pekko concepts。
+この completed table は `cluster-gossip-heartbeat-protocol` の evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離し、downing / SBR decision model は専用の completed table に分離する。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、versioned transport handoff / serde-postcard envelope bytes、Deferred Pekko concepts。
 
 ### Completed active follow-up: downing / SBR decision model
 
@@ -286,7 +286,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | lease-based majority | core/downing_provider + std/provider | port contract + std binding 実装済み | `LeaseMajorityPort` / `LeaseAcquisitionOutcome` と `StdLeaseMajorityBackend` が lease outcome を core vocabulary へ変換し、`StdSplitBrainResolverProvider` が lifecycle 内で backend を所有する。tests: `lease_majority_port`, `lease_acquisition_outcome`, `split_brain_resolver_provider` |
 | provider-facing SBR integration | core/downing_provider + std/provider | provider binding 実装済み | `SplitBrainResolverProviderHook` が compatibility metadata と decision/error mapping を提供し、`StdSplitBrainResolverProvider` が start/stop/drop lifecycle で hook と backend adapter を管理する。tests: `split_brain_resolver_provider_hook`, `split_brain_resolver_provider` |
 
-この completed table は `cluster-downing-sbr-decision-model` の evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離する。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、責任ノード選択、reachability 変化監視、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、Deferred Pekko concepts。
+この completed table は `cluster-downing-sbr-decision-model` の evidence だけを表す。SeedNodeProcess / generic discovery adapter は discovery provider interop の completed table に分離する。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、責任ノード選択、reachability 変化監視、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、Deferred Pekko concepts。
 
 ### Completed active follow-up: discovery provider interop
 
@@ -295,7 +295,15 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | `SeedNodeProcess` | core/cluster_provider + std/provider | boundary contract 実装済み | `SeedNodeInput` / `SeedNodeProcess` が seed authority を provider-neutral join input に変換し、empty seed、self filtering、duplicate seed、invalid authority、client start、shutdown 後停止を扱う。`ProviderLifecycleBridge` が seed input を topology update に接続する。tests: `seed_node_process_*`, `provider_lifecycle_bridge_*` |
 | generic discovery adapter | core/cluster_provider + std/provider | boundary contract 実装済み | `DiscoveredAuthority` / `DiscoveryResult` / `DiscoveryTopologyMapper` と `DiscoveryBackend` / `DiscoveryBackendError` / `GenericDiscoveryAdapter` が backend result を provider-neutral topology input に正規化する。tests: `discovery_result_*`, `discovery_topology_mapper_*`, `generic_discovery_adapter_*`, `static_cluster_provider`, `aws_ecs` feature tests |
 
-この completed table は `cluster-discovery-provider-interop` の SeedNodeProcess と generic discovery adapter evidence だけを表す。gossip heartbeat / full Gossip、reachability / WeaklyUp、downing / SBR decision model はそれぞれ専用 completed table の evidence に留め、この feature の完了根拠には含めない。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、cluster message serializer contract、Deferred Pekko concepts。
+この completed table は `cluster-discovery-provider-interop` の SeedNodeProcess と generic discovery adapter evidence だけを表す。gossip heartbeat / full Gossip、reachability / WeaklyUp、downing / SBR decision model はそれぞれ専用 completed table の evidence に留め、この feature の完了根拠には含めない。次の責務は未完了のまま downstream / future scope に残す: SBR runtime actor、provider からの実 down execution loop、concrete lease coordination backend、DistributedPubSubMediator / topic registry gossip、Deferred Pekko concepts。
+
+### Completed active follow-up: cluster message serialization contract
+
+| 項目 | 実装先層 | 状態 | 根拠 / evidence |
+|------|----------|------|-----------------|
+| cluster message serializer contract | core/message_serialization + std/message_wire | contract evidence 実装済み | core contract は `ClusterMessagePayloadKind`、`ClusterMessageManifest`、`ClusterSerializedMessage`、`ActorSerializationBridge` で actor-core `SerializationExtension` と std/wire を橋渡しする。std adaptor は `ClusterWireFrameV1`、`ClusterWireCodec`、`ClusterWireDecodeFailure` で versioned frame と decode failure を扱う。tests: actor-core metadata preservation、unknown payload/version/malformed payload failure、gossip wire smoke、pubsub wire smoke |
+
+この completed table は `cluster-message-serialization-contract` の serializer bridge evidence だけを表す。gossip merge / heartbeat / reachability semantics、pubsub mediator state / delivery / registry semantics、remote transport lifecycle、Pekko/protobuf 完全バイナリ互換は scope 外のまま残す。
 
 ### Active comparison follow-up: medium
 
@@ -310,7 +318,6 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | 項目 | 実装先層 | 根拠 |
 |------|----------|------|
 | topic registry gossip / delta collection | core/pub_sub + membership | カテゴリ7 |
-| cluster message serializer contract | std/wire + actor-core serialization | カテゴリ10 |
 
 ### Deferred Pekko concepts: trivial / easy
 
@@ -367,15 +374,15 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | 構造観点 | 現状 | 次に見るべき点 |
 |----------|------|----------------|
 | membership と provider の境界 | pure coordinator と provider/event-stream adapter が分かれている | SeedNodeProcess / discovery / downing がどちらに入るべきか |
-| gossip と wire の境界 | core gossip / heartbeat contract + std logical handoff + existing postcard delta UDP | cluster message serializer contract を actor-core serialization に寄せるか |
+| gossip と wire の境界 | core gossip / heartbeat contract + std logical handoff + existing postcard delta UDP + actor-core serialization bridge | Pekko/protobuf 完全バイナリ互換を将来採用するか |
 | grain と typed sharding の境界 | protoactor-go style の Grain API が中心 | Pekko typed sharding wrapper を薄く載せられるか |
 | pubsub と distributed-data の境界 | PubSub は独自 broker、CRDT は未実装 | PubSub registry gossip を ddata Replicator 相当に寄せるか |
 | singleton / client の配置 | 対応モジュールなし | cluster-tools 相当を core contract と std actor runtime にどう分けるか |
 
 ## まとめ
 
-cluster は membership、gossip / heartbeat contract、downing/SBR decision model、typed Cluster facade、Grain/Placement/Identity、PubSub、std UDP gossip transport という fraktor-rs 独自の基礎は強い。一方で、Pekko comparison の固定スコープ全体としては SBR runtime actor / down execution loop、singleton/client/receptionist、Distributed Data/CRDT、Pekko sharding public API が大きく未実装で、現時点の比較カバレッジは中程度である。
+cluster は membership、gossip / heartbeat contract、downing/SBR decision model、typed Cluster facade、Grain/Placement/Identity、PubSub、std UDP gossip transport、cluster message serializer contract という fraktor-rs 独自の基礎は強い。一方で、Pekko comparison の固定スコープ全体としては SBR runtime actor / down execution loop、singleton/client/receptionist、Distributed Data/CRDT、Pekko sharding public API が大きく未実装で、現時点の比較カバレッジは中程度である。
 
-Pekko 概念を将来採用するなら、低コストで comparison gap を縮めやすいのは、`PrepareForFullClusterShutdown` command、基本 CRDT、std `ClusterApi` wrapper の再公開である。join config compatibility の checker composition、membership/reachability model、gossip/heartbeat protocol の core contract は契約化済み。router role/max-per-node 設定は、Pekko public API parity ではなく現行 router contract の拡張として実装済み。ただし、残りの実装には個別の OpenSpec change が必要であり、現在の Grain runtime roadmap の直近優先度とは分けて扱う。
+Pekko 概念を将来採用するなら、低コストで comparison gap を縮めやすいのは、`PrepareForFullClusterShutdown` command、基本 CRDT、std `ClusterApi` wrapper の再公開である。join config compatibility の checker composition、membership/reachability model、gossip/heartbeat protocol の core contract、cluster message serializer contract は契約化済み。router role/max-per-node 設定は、Pekko public API parity ではなく現行 router contract の拡張として実装済み。ただし、残りの実装には個別の OpenSpec change が必要であり、現在の Grain runtime roadmap の直近優先度とは分けて扱う。
 
-主要な comparison gap は、Split Brain Resolver、cluster singleton/client、topic registry gossip、sharding rebalance/remembered entities、Distributed Data Replicator、cluster/sharding/pubsub serializer contract である。内部構造比較は、将来これらの scope を採用する OpenSpec change が立った後に進めるのが妥当である。
+主要な comparison gap は、Split Brain Resolver runtime、cluster singleton/client、topic registry gossip、sharding rebalance/remembered entities、Distributed Data Replicator、Pekko/protobuf serializer 完全バイナリ互換である。内部構造比較は、将来これらの scope を採用する OpenSpec change が立った後に進めるのが妥当である。

--- a/modules/cluster-adaptor-std/Cargo.toml
+++ b/modules/cluster-adaptor-std/Cargo.toml
@@ -24,6 +24,7 @@ fraktor-remote-core-rs = { workspace = true }
 fraktor-utils-core-rs = { workspace = true, features = ["alloc", "unsize", "std-locks"] }
 serde = { workspace = true }
 postcard = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true, features = ["std"] }
 aws-sdk-ecs = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }

--- a/modules/cluster-adaptor-std/src/lib.rs
+++ b/modules/cluster-adaptor-std/src/lib.rs
@@ -16,5 +16,7 @@ pub mod extension;
 pub mod grain;
 /// Tokio-backed membership and gossip adaptors.
 pub mod membership;
+/// Cluster message wire frame adaptors.
+pub mod message_wire;
 /// Cluster publish/subscribe delivery adaptors.
 pub mod pub_sub;

--- a/modules/cluster-adaptor-std/src/message_wire.rs
+++ b/modules/cluster-adaptor-std/src/message_wire.rs
@@ -1,0 +1,5 @@
+//! Cluster message wire frame adaptors.
+
+mod cluster_wire_frame_v1;
+
+pub use cluster_wire_frame_v1::ClusterWireFrameV1;

--- a/modules/cluster-adaptor-std/src/message_wire.rs
+++ b/modules/cluster-adaptor-std/src/message_wire.rs
@@ -1,5 +1,9 @@
 //! Cluster message wire frame adaptors.
 
+mod cluster_wire_codec;
+mod cluster_wire_decode_failure;
 mod cluster_wire_frame_v1;
 
+pub use cluster_wire_codec::ClusterWireCodec;
+pub use cluster_wire_decode_failure::ClusterWireDecodeFailure;
 pub use cluster_wire_frame_v1::ClusterWireFrameV1;

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec.rs
@@ -1,0 +1,55 @@
+//! Cluster message wire codec.
+
+#[cfg(test)]
+#[path = "cluster_wire_codec_test.rs"]
+mod tests;
+
+use alloc::{borrow::ToOwned, vec::Vec};
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
+use fraktor_cluster_core_kernel_rs::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+use postcard::{Error, take_from_bytes, to_allocvec};
+
+use super::{ClusterWireDecodeFailure, ClusterWireFrameV1};
+
+/// Encodes and decodes cluster serialized messages at the std wire boundary.
+pub struct ClusterWireCodec;
+
+impl ClusterWireCodec {
+  /// Encodes a cluster serialized message into a versioned wire frame.
+  ///
+  /// # Errors
+  ///
+  /// Returns a postcard encode error when the frame cannot be serialized.
+  pub fn encode(&self, message: &ClusterSerializedMessage) -> Result<Vec<u8>, Error> {
+    let frame = ClusterWireFrameV1::from_cluster_serialized_message(message);
+    to_allocvec(&frame)
+  }
+
+  /// Decodes a versioned wire frame into a cluster serialized message.
+  ///
+  /// # Errors
+  ///
+  /// Returns a typed decode failure when the frame is unsupported or malformed.
+  pub fn decode(&self, bytes: &[u8]) -> Result<ClusterSerializedMessage, ClusterWireDecodeFailure> {
+    let (frame, remainder): (ClusterWireFrameV1, &[u8]) =
+      take_from_bytes(bytes).map_err(|_| ClusterWireDecodeFailure::MalformedPayload)?;
+    if !remainder.is_empty() {
+      return Err(ClusterWireDecodeFailure::MalformedPayload);
+    }
+    if frame.version() != ClusterWireFrameV1::VERSION {
+      return Err(ClusterWireDecodeFailure::UnknownVersion);
+    }
+    let payload_kind = ClusterMessagePayloadKind::from_tag(frame.payload_kind_tag())
+      .ok_or(ClusterWireDecodeFailure::UnknownPayloadKind)?;
+    if frame.payload_len() as usize != frame.payload_bytes().len() {
+      return Err(ClusterWireDecodeFailure::MalformedPayload);
+    }
+    let serialized_message = SerializedMessage::new(
+      SerializerId::from_raw(frame.serializer_id()),
+      frame.manifest().map(ToOwned::to_owned),
+      frame.payload_bytes().to_vec(),
+    );
+    Ok(ClusterSerializedMessage::new(payload_kind, serialized_message))
+  }
+}

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec.rs
@@ -22,7 +22,7 @@ impl ClusterWireCodec {
   ///
   /// Returns a postcard encode error when the frame cannot be serialized.
   pub fn encode(&self, message: &ClusterSerializedMessage) -> Result<Vec<u8>, Error> {
-    let frame = ClusterWireFrameV1::from_cluster_serialized_message(message);
+    let frame = ClusterWireFrameV1::try_from_cluster_serialized_message(message)?;
     to_allocvec(&frame)
   }
 
@@ -34,11 +34,11 @@ impl ClusterWireCodec {
   pub fn decode(&self, bytes: &[u8]) -> Result<ClusterSerializedMessage, ClusterWireDecodeFailure> {
     let (frame, remainder): (ClusterWireFrameV1, &[u8]) =
       take_from_bytes(bytes).map_err(|_| ClusterWireDecodeFailure::MalformedPayload)?;
-    if !remainder.is_empty() {
-      return Err(ClusterWireDecodeFailure::MalformedPayload);
-    }
     if frame.version() != ClusterWireFrameV1::VERSION {
       return Err(ClusterWireDecodeFailure::UnknownVersion);
+    }
+    if !remainder.is_empty() {
+      return Err(ClusterWireDecodeFailure::MalformedPayload);
     }
     let payload_kind = ClusterMessagePayloadKind::from_tag(frame.payload_kind_tag())
       .ok_or(ClusterWireDecodeFailure::UnknownPayloadKind)?;

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
@@ -357,7 +357,7 @@ fn cluster_message() -> ClusterSerializedMessage {
 }
 
 fn encoded_frame(message: &ClusterSerializedMessage) -> Vec<u8> {
-  let frame = ClusterWireFrameV1::from_cluster_serialized_message(message);
+  let frame = ClusterWireFrameV1::try_from_cluster_serialized_message(message).expect("frame");
   to_allocvec(&frame).expect("encode frame")
 }
 
@@ -380,6 +380,18 @@ fn unsupported_frame_version_returns_unknown_version() {
   let codec = ClusterWireCodec;
   let mut encoded = encoded_frame(&cluster_message());
   encoded[0] = 2;
+
+  let failure = codec.decode(&encoded).expect_err("unknown version");
+
+  assert_eq!(failure, ClusterWireDecodeFailure::UnknownVersion);
+}
+
+#[test]
+fn unsupported_frame_version_with_trailing_bytes_returns_unknown_version() {
+  let codec = ClusterWireCodec;
+  let mut encoded = encoded_frame(&cluster_message());
+  encoded[0] = 2;
+  encoded.extend_from_slice(&[0x01, 0x02]);
 
   let failure = codec.decode(&encoded).expect_err("unknown version");
 

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
@@ -12,6 +12,7 @@ use fraktor_actor_core_kernel_rs::{
 use fraktor_cluster_core_kernel_rs::{
   membership::{GossipEnvelope, GossipPayloadKind, MembershipVersion},
   message_serialization::{ActorSerializationBridge, ClusterMessagePayloadKind, ClusterSerializedMessage},
+  pub_sub::{PubSubGossipHandoff, TopicRegistryGossipPayload, TopicRegistryStatus, TopicRegistryVersion},
 };
 use fraktor_remote_core_rs::address::{Address, UniqueAddress};
 use fraktor_utils_core_rs::sync::ArcShared;
@@ -22,6 +23,7 @@ use super::ClusterWireCodec;
 use crate::message_wire::{ClusterWireDecodeFailure, ClusterWireFrameV1};
 
 const GOSSIP_MANIFEST: &str = "cluster.payload/GossipEnvelope";
+const PUBSUB_MANIFEST: &str = "cluster.payload/PubSubGossipHandoff";
 
 #[derive(Debug, Deserialize, Serialize)]
 struct GossipEnvelopeRecord {
@@ -64,11 +66,81 @@ impl GossipEnvelopeRecord {
   }
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+struct PubSubOwnerVersionRecord {
+  system:  String,
+  host:    String,
+  port:    u16,
+  uid:     u64,
+  version: u64,
+}
+
+impl PubSubOwnerVersionRecord {
+  fn from_owner_version(owner: &UniqueAddress, version: TopicRegistryVersion) -> Self {
+    Self {
+      system:  String::from(owner.address().system()),
+      host:    String::from(owner.address().host()),
+      port:    owner.address().port(),
+      uid:     owner.uid(),
+      version: version.value(),
+    }
+  }
+
+  fn into_owner_version(self) -> (UniqueAddress, TopicRegistryVersion) {
+    (
+      UniqueAddress::new(Address::new(self.system, self.host, self.port), self.uid),
+      TopicRegistryVersion::new(self.version),
+    )
+  }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct PubSubGossipHandoffRecord {
+  payload_kind_tag: u8,
+  owner_versions:   Vec<PubSubOwnerVersionRecord>,
+}
+
+impl PubSubGossipHandoffRecord {
+  fn from_handoff(handoff: &PubSubGossipHandoff) -> Result<Self, SerializationError> {
+    let TopicRegistryGossipPayload::Status(status) = handoff.payload() else {
+      return Err(SerializationError::invalid_format());
+    };
+    Ok(Self {
+      payload_kind_tag: payload_kind_tag(handoff.payload_kind()),
+      owner_versions:   status
+        .owner_versions()
+        .iter()
+        .map(|(owner, version)| PubSubOwnerVersionRecord::from_owner_version(owner, *version))
+        .collect(),
+    })
+  }
+
+  fn into_handoff(self) -> Result<PubSubGossipHandoff, SerializationError> {
+    let payload_kind = payload_kind_from_tag(self.payload_kind_tag)?;
+    if payload_kind != GossipPayloadKind::PubSubRegistryStatus {
+      return Err(SerializationError::invalid_format());
+    }
+    Ok(PubSubGossipHandoff::status(TopicRegistryStatus::new(
+      self.owner_versions.into_iter().map(PubSubOwnerVersionRecord::into_owner_version).collect(),
+    )))
+  }
+}
+
 struct GossipEnvelopeSerializer {
   id: SerializerId,
 }
 
+struct PubSubGossipHandoffSerializer {
+  id: SerializerId,
+}
+
 impl GossipEnvelopeSerializer {
+  const fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl PubSubGossipHandoffSerializer {
   const fn new(id: SerializerId) -> Self {
     Self { id }
   }
@@ -114,6 +186,46 @@ impl Serializer for GossipEnvelopeSerializer {
   }
 }
 
+impl Serializer for PubSubGossipHandoffSerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let handoff = message.downcast_ref::<PubSubGossipHandoff>().ok_or_else(|| {
+      SerializationError::not_serializable(NotSerializableError::new(
+        type_name::<PubSubGossipHandoff>(),
+        Some(self.id),
+        Some(String::from(PUBSUB_MANIFEST)),
+        None,
+        None,
+      ))
+    })?;
+    to_allocvec(&PubSubGossipHandoffRecord::from_handoff(handoff)?).map_err(|_| SerializationError::invalid_format())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    let record: PubSubGossipHandoffRecord = from_bytes(bytes).map_err(|_| SerializationError::invalid_format())?;
+    Ok(Box::new(record.into_handoff()?))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+
+  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
+    Some(self)
+  }
+}
+
 impl SerializerWithStringManifest for GossipEnvelopeSerializer {
   fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
     Cow::Borrowed(GOSSIP_MANIFEST)
@@ -125,6 +237,23 @@ impl SerializerWithStringManifest for GossipEnvelopeSerializer {
     manifest: &str,
   ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
     if manifest != GOSSIP_MANIFEST {
+      return Err(SerializationError::unknown_manifest(manifest));
+    }
+    self.from_binary(bytes, None)
+  }
+}
+
+impl SerializerWithStringManifest for PubSubGossipHandoffSerializer {
+  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    Cow::Borrowed(PUBSUB_MANIFEST)
+  }
+
+  fn from_binary_with_manifest(
+    &self,
+    bytes: &[u8],
+    manifest: &str,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if manifest != PUBSUB_MANIFEST {
       return Err(SerializationError::unknown_manifest(manifest));
     }
     self.from_binary(bytes, None)
@@ -173,6 +302,13 @@ fn gossip_envelope() -> GossipEnvelope {
   .expect("confirmed identities should build an envelope")
 }
 
+fn pubsub_status_handoff() -> PubSubGossipHandoff {
+  PubSubGossipHandoff::status(TopicRegistryStatus::new(vec![
+    (unique_address("node-a", 20), TopicRegistryVersion::new(3)),
+    (unique_address("node-b", 21), TopicRegistryVersion::new(5)),
+  ]))
+}
+
 fn build_gossip_bridge_extension() -> (SerializationExtension, SerializerId, ActorSystem) {
   let serializer_id = SerializerId::try_from(601).expect("serializer id");
   let serializer: ArcShared<dyn Serializer> = ArcShared::new(GossipEnvelopeSerializer::new(serializer_id));
@@ -184,6 +320,25 @@ fn build_gossip_bridge_extension() -> (SerializationExtension, SerializerId, Act
     .bind::<GossipEnvelope>("gossip-envelope")
     .expect("bind gossip envelope")
     .bind_remote_manifest::<GossipEnvelope>(GOSSIP_MANIFEST)
+    .expect("manifest")
+    .require_manifest_for_scope(SerializationCallScope::Remote)
+    .build()
+    .expect("setup");
+  let system = create_noop_actor_system();
+  (SerializationExtension::new(&system, setup), serializer_id, system)
+}
+
+fn build_pubsub_bridge_extension() -> (SerializationExtension, SerializerId, ActorSystem) {
+  let serializer_id = SerializerId::try_from(602).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(PubSubGossipHandoffSerializer::new(serializer_id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("pubsub-handoff", serializer_id, serializer)
+    .expect("register pubsub serializer")
+    .set_fallback("pubsub-handoff")
+    .expect("fallback")
+    .bind::<PubSubGossipHandoff>("pubsub-handoff")
+    .expect("bind pubsub handoff")
+    .bind_remote_manifest::<PubSubGossipHandoff>(PUBSUB_MANIFEST)
     .expect("manifest")
     .require_manifest_for_scope(SerializationCallScope::Remote)
     .build()
@@ -318,5 +473,29 @@ fn gossip_payload_bridge_roundtrip_does_not_evaluate_gossip_semantics() {
   assert_eq!(decoded.payload_kind(), ClusterMessagePayloadKind::Gossip);
   assert_eq!(decoded.serializer_id(), serializer_id);
   assert_eq!(decoded.manifest(), Some(GOSSIP_MANIFEST));
+  assert_eq!(*restored, payload);
+}
+
+#[test]
+fn pubsub_payload_bridge_roundtrip_does_not_mutate_mediator_state() {
+  let (extension, serializer_id, _system) = build_pubsub_bridge_extension();
+  let codec = ClusterWireCodec;
+  let payload = pubsub_status_handoff();
+
+  let cluster_message = extension
+    .serialize_cluster_message(ClusterMessagePayloadKind::PubSub, SerializationCallScope::Remote, &payload)
+    .expect("serialize pubsub payload");
+  let encoded = codec.encode(&cluster_message).expect("encode pubsub payload");
+  let decoded = codec.decode(&encoded).expect("decode pubsub payload");
+  let restored = extension
+    .deserialize_cluster_message(&decoded, Some(TypeId::of::<PubSubGossipHandoff>()))
+    .expect("deserialize pubsub payload")
+    .downcast::<PubSubGossipHandoff>()
+    .expect("pubsub handoff");
+
+  assert_eq!(cluster_message.payload_kind(), ClusterMessagePayloadKind::PubSub);
+  assert_eq!(decoded.payload_kind(), ClusterMessagePayloadKind::PubSub);
+  assert_eq!(decoded.serializer_id(), serializer_id);
+  assert_eq!(decoded.manifest(), Some(PUBSUB_MANIFEST));
   assert_eq!(*restored, payload);
 }

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
@@ -1,11 +1,196 @@
-use alloc::{string::String, vec, vec::Vec};
+use alloc::{borrow::Cow, boxed::Box, string::String, vec, vec::Vec};
+use core::any::{Any, TypeId, type_name};
 
-use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
-use fraktor_cluster_core_kernel_rs::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
-use postcard::to_allocvec;
+use fraktor_actor_adaptor_std_rs::system::create_noop_actor_system;
+use fraktor_actor_core_kernel_rs::{
+  serialization::{
+    NotSerializableError, SerializationCallScope, SerializationError, SerializationExtension,
+    SerializationSetupBuilder, SerializedMessage, Serializer, SerializerId, SerializerWithStringManifest,
+  },
+  system::ActorSystem,
+};
+use fraktor_cluster_core_kernel_rs::{
+  membership::{GossipEnvelope, GossipPayloadKind, MembershipVersion},
+  message_serialization::{ActorSerializationBridge, ClusterMessagePayloadKind, ClusterSerializedMessage},
+};
+use fraktor_remote_core_rs::address::{Address, UniqueAddress};
+use fraktor_utils_core_rs::sync::ArcShared;
+use postcard::{from_bytes, to_allocvec};
+use serde::{Deserialize, Serialize};
 
 use super::ClusterWireCodec;
 use crate::message_wire::{ClusterWireDecodeFailure, ClusterWireFrameV1};
+
+const GOSSIP_MANIFEST: &str = "cluster.payload/GossipEnvelope";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct GossipEnvelopeRecord {
+  from_system:        String,
+  from_host:          String,
+  from_port:          u16,
+  from_uid:           u64,
+  to_system:          String,
+  to_host:            String,
+  to_port:            u16,
+  to_uid:             u64,
+  payload_kind_tag:   u8,
+  membership_version: u64,
+  deadline_tick:      u64,
+}
+
+impl GossipEnvelopeRecord {
+  fn from_envelope(envelope: &GossipEnvelope) -> Self {
+    Self {
+      from_system:        String::from(envelope.from().address().system()),
+      from_host:          String::from(envelope.from().address().host()),
+      from_port:          envelope.from().address().port(),
+      from_uid:           envelope.from().uid(),
+      to_system:          String::from(envelope.to().address().system()),
+      to_host:            String::from(envelope.to().address().host()),
+      to_port:            envelope.to().address().port(),
+      to_uid:             envelope.to().uid(),
+      payload_kind_tag:   payload_kind_tag(envelope.payload_kind()),
+      membership_version: envelope.membership_version().value(),
+      deadline_tick:      envelope.deadline_tick(),
+    }
+  }
+
+  fn into_envelope(self) -> Result<GossipEnvelope, SerializationError> {
+    let from = UniqueAddress::new(Address::new(self.from_system, self.from_host, self.from_port), self.from_uid);
+    let to = UniqueAddress::new(Address::new(self.to_system, self.to_host, self.to_port), self.to_uid);
+    let payload_kind = payload_kind_from_tag(self.payload_kind_tag)?;
+    GossipEnvelope::try_new(from, to, payload_kind, MembershipVersion::new(self.membership_version), self.deadline_tick)
+      .map_err(|_| SerializationError::invalid_format())
+  }
+}
+
+struct GossipEnvelopeSerializer {
+  id: SerializerId,
+}
+
+impl GossipEnvelopeSerializer {
+  const fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for GossipEnvelopeSerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let envelope = message.downcast_ref::<GossipEnvelope>().ok_or_else(|| {
+      SerializationError::not_serializable(NotSerializableError::new(
+        type_name::<GossipEnvelope>(),
+        Some(self.id),
+        Some(String::from(GOSSIP_MANIFEST)),
+        None,
+        None,
+      ))
+    })?;
+    to_allocvec(&GossipEnvelopeRecord::from_envelope(envelope)).map_err(|_| SerializationError::invalid_format())
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    let record: GossipEnvelopeRecord = from_bytes(bytes).map_err(|_| SerializationError::invalid_format())?;
+    Ok(Box::new(record.into_envelope()?))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+
+  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
+    Some(self)
+  }
+}
+
+impl SerializerWithStringManifest for GossipEnvelopeSerializer {
+  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    Cow::Borrowed(GOSSIP_MANIFEST)
+  }
+
+  fn from_binary_with_manifest(
+    &self,
+    bytes: &[u8],
+    manifest: &str,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if manifest != GOSSIP_MANIFEST {
+      return Err(SerializationError::unknown_manifest(manifest));
+    }
+    self.from_binary(bytes, None)
+  }
+}
+
+const fn payload_kind_tag(kind: GossipPayloadKind) -> u8 {
+  match kind {
+    | GossipPayloadKind::Delta => 0,
+    | GossipPayloadKind::FullState => 1,
+    | GossipPayloadKind::SeenDigest => 2,
+    | GossipPayloadKind::HeartbeatRequest => 3,
+    | GossipPayloadKind::HeartbeatResponse => 4,
+    | GossipPayloadKind::CrossDcHeartbeat => 5,
+    | GossipPayloadKind::PubSubRegistryStatus => 6,
+    | GossipPayloadKind::PubSubRegistryDelta => 7,
+  }
+}
+
+const fn payload_kind_from_tag(tag: u8) -> Result<GossipPayloadKind, SerializationError> {
+  match tag {
+    | 0 => Ok(GossipPayloadKind::Delta),
+    | 1 => Ok(GossipPayloadKind::FullState),
+    | 2 => Ok(GossipPayloadKind::SeenDigest),
+    | 3 => Ok(GossipPayloadKind::HeartbeatRequest),
+    | 4 => Ok(GossipPayloadKind::HeartbeatResponse),
+    | 5 => Ok(GossipPayloadKind::CrossDcHeartbeat),
+    | 6 => Ok(GossipPayloadKind::PubSubRegistryStatus),
+    | 7 => Ok(GossipPayloadKind::PubSubRegistryDelta),
+    | _ => Err(SerializationError::invalid_format()),
+  }
+}
+
+fn unique_address(host: &str, uid: u64) -> UniqueAddress {
+  UniqueAddress::new(Address::new("cluster", host, 2552), uid)
+}
+
+fn gossip_envelope() -> GossipEnvelope {
+  GossipEnvelope::try_new(
+    unique_address("node-a", 10),
+    unique_address("node-b", 11),
+    GossipPayloadKind::FullState,
+    MembershipVersion::new(7),
+    100,
+  )
+  .expect("confirmed identities should build an envelope")
+}
+
+fn build_gossip_bridge_extension() -> (SerializationExtension, SerializerId, ActorSystem) {
+  let serializer_id = SerializerId::try_from(601).expect("serializer id");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(GossipEnvelopeSerializer::new(serializer_id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("gossip-envelope", serializer_id, serializer)
+    .expect("register gossip serializer")
+    .set_fallback("gossip-envelope")
+    .expect("fallback")
+    .bind::<GossipEnvelope>("gossip-envelope")
+    .expect("bind gossip envelope")
+    .bind_remote_manifest::<GossipEnvelope>(GOSSIP_MANIFEST)
+    .expect("manifest")
+    .require_manifest_for_scope(SerializationCallScope::Remote)
+    .build()
+    .expect("setup");
+  let system = create_noop_actor_system();
+  (SerializationExtension::new(&system, setup), serializer_id, system)
+}
 
 fn cluster_message_with_manifest(manifest: Option<String>, payload_bytes: Vec<u8>) -> ClusterSerializedMessage {
   let serialized_message = SerializedMessage::new(SerializerId::from_raw(41), manifest, payload_bytes);
@@ -110,4 +295,28 @@ fn decode_failure_returns_error_without_fallback_message() {
   let result = codec.decode(&encoded);
 
   assert!(matches!(result, Err(ClusterWireDecodeFailure::UnknownPayloadKind)));
+}
+
+#[test]
+fn gossip_payload_bridge_roundtrip_does_not_evaluate_gossip_semantics() {
+  let (extension, serializer_id, _system) = build_gossip_bridge_extension();
+  let codec = ClusterWireCodec;
+  let payload = gossip_envelope();
+
+  let cluster_message = extension
+    .serialize_cluster_message(ClusterMessagePayloadKind::Gossip, SerializationCallScope::Remote, &payload)
+    .expect("serialize gossip payload");
+  let encoded = codec.encode(&cluster_message).expect("encode gossip payload");
+  let decoded = codec.decode(&encoded).expect("decode gossip payload");
+  let restored = extension
+    .deserialize_cluster_message(&decoded, Some(TypeId::of::<GossipEnvelope>()))
+    .expect("deserialize gossip payload")
+    .downcast::<GossipEnvelope>()
+    .expect("gossip envelope");
+
+  assert_eq!(cluster_message.payload_kind(), ClusterMessagePayloadKind::Gossip);
+  assert_eq!(decoded.payload_kind(), ClusterMessagePayloadKind::Gossip);
+  assert_eq!(decoded.serializer_id(), serializer_id);
+  assert_eq!(decoded.manifest(), Some(GOSSIP_MANIFEST));
+  assert_eq!(*restored, payload);
 }

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_codec_test.rs
@@ -1,0 +1,113 @@
+use alloc::{string::String, vec, vec::Vec};
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
+use fraktor_cluster_core_kernel_rs::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+use postcard::to_allocvec;
+
+use super::ClusterWireCodec;
+use crate::message_wire::{ClusterWireDecodeFailure, ClusterWireFrameV1};
+
+fn cluster_message_with_manifest(manifest: Option<String>, payload_bytes: Vec<u8>) -> ClusterSerializedMessage {
+  let serialized_message = SerializedMessage::new(SerializerId::from_raw(41), manifest, payload_bytes);
+  ClusterSerializedMessage::new(ClusterMessagePayloadKind::Gossip, serialized_message)
+}
+
+fn cluster_message() -> ClusterSerializedMessage {
+  cluster_message_with_manifest(Some(String::from("cluster.payload/gossip")), vec![1, 1, 2, 3, 5, 8])
+}
+
+fn encoded_frame(message: &ClusterSerializedMessage) -> Vec<u8> {
+  let frame = ClusterWireFrameV1::from_cluster_serialized_message(message);
+  to_allocvec(&frame).expect("encode frame")
+}
+
+#[test]
+fn decode_roundtrip_preserves_cluster_serialized_metadata() {
+  let codec = ClusterWireCodec;
+  let message = cluster_message();
+
+  let encoded = codec.encode(&message).expect("encode message");
+  let decoded = codec.decode(&encoded).expect("decode message");
+
+  assert_eq!(decoded.payload_kind(), ClusterMessagePayloadKind::Gossip);
+  assert_eq!(decoded.serializer_id().value(), 41);
+  assert_eq!(decoded.manifest(), Some("cluster.payload/gossip"));
+  assert_eq!(decoded.payload_bytes(), &[1, 1, 2, 3, 5, 8]);
+}
+
+#[test]
+fn unsupported_frame_version_returns_unknown_version() {
+  let codec = ClusterWireCodec;
+  let mut encoded = encoded_frame(&cluster_message());
+  encoded[0] = 2;
+
+  let failure = codec.decode(&encoded).expect_err("unknown version");
+
+  assert_eq!(failure, ClusterWireDecodeFailure::UnknownVersion);
+}
+
+#[test]
+fn unknown_payload_kind_tag_returns_unknown_payload_kind() {
+  let codec = ClusterWireCodec;
+  let mut encoded = encoded_frame(&cluster_message());
+  encoded[1] = 99;
+
+  let failure = codec.decode(&encoded).expect_err("unknown payload kind");
+
+  assert_eq!(failure, ClusterWireDecodeFailure::UnknownPayloadKind);
+}
+
+#[test]
+fn payload_length_mismatch_returns_malformed_payload() {
+  let codec = ClusterWireCodec;
+  let mut encoded = encoded_frame(&cluster_message_with_manifest(None, vec![1, 2, 3]));
+  encoded[4] = 4;
+
+  let failure = codec.decode(&encoded).expect_err("payload length mismatch");
+
+  assert_eq!(failure, ClusterWireDecodeFailure::MalformedPayload);
+}
+
+#[test]
+fn invalid_manifest_bytes_returns_malformed_payload() {
+  let codec = ClusterWireCodec;
+  let mut encoded = encoded_frame(&cluster_message_with_manifest(Some(String::from("a")), Vec::new()));
+  let manifest_byte = encoded.iter().position(|byte| *byte == b'a').expect("manifest byte");
+  encoded[manifest_byte] = 0xff;
+
+  let failure = codec.decode(&encoded).expect_err("invalid manifest bytes");
+
+  assert_eq!(failure, ClusterWireDecodeFailure::MalformedPayload);
+}
+
+#[test]
+fn invalid_postcard_bytes_return_malformed_payload() {
+  let codec = ClusterWireCodec;
+  let encoded = [0xff];
+
+  let failure = codec.decode(&encoded).expect_err("invalid postcard bytes");
+
+  assert_eq!(failure, ClusterWireDecodeFailure::MalformedPayload);
+}
+
+#[test]
+fn trailing_bytes_return_malformed_payload() {
+  let codec = ClusterWireCodec;
+  let mut encoded = encoded_frame(&cluster_message());
+  encoded.extend_from_slice(&[0x01, 0x02]);
+
+  let failure = codec.decode(&encoded).expect_err("trailing bytes");
+
+  assert_eq!(failure, ClusterWireDecodeFailure::MalformedPayload);
+}
+
+#[test]
+fn decode_failure_returns_error_without_fallback_message() {
+  let codec = ClusterWireCodec;
+  let mut encoded = encoded_frame(&cluster_message());
+  encoded[1] = 99;
+
+  let result = codec.decode(&encoded);
+
+  assert!(matches!(result, Err(ClusterWireDecodeFailure::UnknownPayloadKind)));
+}

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_decode_failure.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_decode_failure.rs
@@ -1,14 +1,17 @@
 //! Cluster wire decode failure taxonomy.
 
+use thiserror::Error;
+
 /// Typed failures raised while decoding cluster wire messages.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ClusterWireDecodeFailure {
   /// The frame declares an unsupported version.
+  #[error("unsupported cluster wire frame version")]
   UnknownVersion,
   /// The frame declares an unknown payload kind tag.
+  #[error("unknown cluster wire payload kind")]
   UnknownPayloadKind,
-  /// The actor-core manifest route is unknown.
-  UnknownManifest,
   /// The frame bytes are malformed.
+  #[error("malformed cluster wire frame payload")]
   MalformedPayload,
 }

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_decode_failure.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_decode_failure.rs
@@ -1,0 +1,14 @@
+//! Cluster wire decode failure taxonomy.
+
+/// Typed failures raised while decoding cluster wire messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClusterWireDecodeFailure {
+  /// The frame declares an unsupported version.
+  UnknownVersion,
+  /// The frame declares an unknown payload kind tag.
+  UnknownPayloadKind,
+  /// The actor-core manifest route is unknown.
+  UnknownManifest,
+  /// The frame bytes are malformed.
+  MalformedPayload,
+}

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1.rs
@@ -8,6 +8,7 @@ use alloc::{borrow::ToOwned, string::String, vec::Vec};
 
 use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
 use fraktor_cluster_core_kernel_rs::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+use postcard::Error;
 use serde::{Deserialize, Serialize};
 
 /// Version one cluster message wire frame.
@@ -27,27 +28,30 @@ impl ClusterWireFrameV1 {
 
   /// Creates a version one frame from a cluster serialized message.
   ///
-  /// # Panics
+  /// # Errors
   ///
-  /// Panics when the payload length does not fit into the v1 `u32` length field.
-  #[must_use]
-  pub fn from_cluster_serialized_message(message: &ClusterSerializedMessage) -> Self {
+  /// Returns a postcard encode error when the payload length does not fit into
+  /// the v1 `u32` length field.
+  pub fn try_from_cluster_serialized_message(message: &ClusterSerializedMessage) -> Result<Self, Error> {
     let payload_bytes = message.payload_bytes().to_vec();
-    let payload_len = payload_bytes.len().try_into().expect("cluster wire frame payload length exceeds u32");
-    Self {
+    let payload_len = payload_bytes.len().try_into().map_err(|_| Error::SerializeBufferFull)?;
+    Ok(Self {
       version: Self::VERSION,
       payload_kind: message.payload_kind().tag(),
       serializer_id: message.serializer_id().value(),
       manifest: message.manifest().map(ToOwned::to_owned),
       payload_len,
       payload_bytes,
-    }
+    })
   }
 
   /// Reconstructs the cluster serialized message when the payload kind tag is known.
   #[must_use]
   pub fn to_cluster_serialized_message(&self) -> Option<ClusterSerializedMessage> {
     if self.version != Self::VERSION {
+      return None;
+    }
+    if self.payload_len as usize != self.payload_bytes.len() {
       return None;
     }
     let payload_kind = ClusterMessagePayloadKind::from_tag(self.payload_kind)?;

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1.rs
@@ -1,0 +1,97 @@
+//! Versioned cluster message wire frame.
+
+#[cfg(test)]
+#[path = "cluster_wire_frame_v1_test.rs"]
+mod tests;
+
+use alloc::{borrow::ToOwned, string::String, vec::Vec};
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
+use fraktor_cluster_core_kernel_rs::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+use serde::{Deserialize, Serialize};
+
+/// Version one cluster message wire frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClusterWireFrameV1 {
+  version:       u16,
+  payload_kind:  u16,
+  serializer_id: u32,
+  manifest:      Option<String>,
+  payload_len:   u32,
+  payload_bytes: Vec<u8>,
+}
+
+impl ClusterWireFrameV1 {
+  /// Supported frame version.
+  pub const VERSION: u16 = 1;
+
+  /// Creates a version one frame from a cluster serialized message.
+  ///
+  /// # Panics
+  ///
+  /// Panics when the payload length does not fit into the v1 `u32` length field.
+  #[must_use]
+  pub fn from_cluster_serialized_message(message: &ClusterSerializedMessage) -> Self {
+    let payload_bytes = message.payload_bytes().to_vec();
+    let payload_len = payload_bytes.len().try_into().expect("cluster wire frame payload length exceeds u32");
+    Self {
+      version: Self::VERSION,
+      payload_kind: message.payload_kind().tag(),
+      serializer_id: message.serializer_id().value(),
+      manifest: message.manifest().map(ToOwned::to_owned),
+      payload_len,
+      payload_bytes,
+    }
+  }
+
+  /// Reconstructs the cluster serialized message when the payload kind tag is known.
+  #[must_use]
+  pub fn to_cluster_serialized_message(&self) -> Option<ClusterSerializedMessage> {
+    if self.version != Self::VERSION {
+      return None;
+    }
+    let payload_kind = ClusterMessagePayloadKind::from_tag(self.payload_kind)?;
+    let serialized_message = SerializedMessage::new(
+      SerializerId::from_raw(self.serializer_id),
+      self.manifest.clone(),
+      self.payload_bytes.clone(),
+    );
+    Some(ClusterSerializedMessage::new(payload_kind, serialized_message))
+  }
+
+  /// Returns the frame version.
+  #[must_use]
+  pub const fn version(&self) -> u16 {
+    self.version
+  }
+
+  /// Returns the raw cluster payload kind tag.
+  #[must_use]
+  pub const fn payload_kind_tag(&self) -> u16 {
+    self.payload_kind
+  }
+
+  /// Returns the raw actor-core serializer identifier.
+  #[must_use]
+  pub const fn serializer_id(&self) -> u32 {
+    self.serializer_id
+  }
+
+  /// Returns the actor-core manifest.
+  #[must_use]
+  pub fn manifest(&self) -> Option<&str> {
+    self.manifest.as_deref()
+  }
+
+  /// Returns the declared payload length.
+  #[must_use]
+  pub const fn payload_len(&self) -> u32 {
+    self.payload_len
+  }
+
+  /// Returns the payload bytes.
+  #[must_use]
+  pub fn payload_bytes(&self) -> &[u8] {
+    &self.payload_bytes
+  }
+}

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1_test.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1_test.rs
@@ -16,7 +16,7 @@ fn cluster_message() -> ClusterSerializedMessage {
 fn from_cluster_serialized_message_preserves_v1_metadata() {
   let message = cluster_message();
 
-  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&message);
+  let frame = ClusterWireFrameV1::try_from_cluster_serialized_message(&message).expect("frame");
 
   assert_eq!(frame.version(), ClusterWireFrameV1::VERSION);
   assert_eq!(frame.payload_kind_tag(), ClusterMessagePayloadKind::Gossip.tag());
@@ -29,7 +29,7 @@ fn from_cluster_serialized_message_preserves_v1_metadata() {
 #[test]
 fn postcard_roundtrip_preserves_metadata_and_reconstructs_cluster_message() {
   let message = cluster_message();
-  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&message);
+  let frame = ClusterWireFrameV1::try_from_cluster_serialized_message(&message).expect("frame");
 
   let encoded = postcard::to_allocvec(&frame).expect("encode frame");
   let decoded: ClusterWireFrameV1 = postcard::from_bytes(&encoded).expect("decode frame");
@@ -44,7 +44,7 @@ fn postcard_roundtrip_preserves_metadata_and_reconstructs_cluster_message() {
 
 #[test]
 fn non_v1_frame_is_not_reconstructed() {
-  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&cluster_message());
+  let frame = ClusterWireFrameV1::try_from_cluster_serialized_message(&cluster_message()).expect("frame");
   let mut encoded = postcard::to_allocvec(&frame).expect("encode frame");
   encoded[0] = 2;
   let decoded: ClusterWireFrameV1 = postcard::from_bytes(&encoded).expect("decode frame");
@@ -54,8 +54,16 @@ fn non_v1_frame_is_not_reconstructed() {
 }
 
 #[test]
+fn payload_length_mismatch_is_not_reconstructed() {
+  let mut frame = ClusterWireFrameV1::try_from_cluster_serialized_message(&cluster_message()).expect("frame");
+  frame.payload_len += 1;
+
+  assert!(frame.to_cluster_serialized_message().is_none());
+}
+
+#[test]
 fn frame_debug_shape_exposes_only_wire_metadata() {
-  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&cluster_message());
+  let frame = ClusterWireFrameV1::try_from_cluster_serialized_message(&cluster_message()).expect("frame");
   let debug = format!("{frame:?}");
 
   for field in ["version", "payload_kind", "serializer_id", "manifest", "payload_len", "payload_bytes"] {

--- a/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1_test.rs
+++ b/modules/cluster-adaptor-std/src/message_wire/cluster_wire_frame_v1_test.rs
@@ -1,0 +1,67 @@
+use alloc::{format, string::String, vec};
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
+use fraktor_cluster_core_kernel_rs::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+
+use super::ClusterWireFrameV1;
+
+fn cluster_message() -> ClusterSerializedMessage {
+  let serializer_id = SerializerId::try_from(41).expect("serializer id");
+  let serialized_message =
+    SerializedMessage::new(serializer_id, Some(String::from("cluster.payload/gossip")), vec![1, 1, 2, 3, 5, 8]);
+  ClusterSerializedMessage::new(ClusterMessagePayloadKind::Gossip, serialized_message)
+}
+
+#[test]
+fn from_cluster_serialized_message_preserves_v1_metadata() {
+  let message = cluster_message();
+
+  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&message);
+
+  assert_eq!(frame.version(), ClusterWireFrameV1::VERSION);
+  assert_eq!(frame.payload_kind_tag(), ClusterMessagePayloadKind::Gossip.tag());
+  assert_eq!(frame.serializer_id(), 41);
+  assert_eq!(frame.manifest(), Some("cluster.payload/gossip"));
+  assert_eq!(frame.payload_len(), 6);
+  assert_eq!(frame.payload_bytes(), &[1, 1, 2, 3, 5, 8]);
+}
+
+#[test]
+fn postcard_roundtrip_preserves_metadata_and_reconstructs_cluster_message() {
+  let message = cluster_message();
+  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&message);
+
+  let encoded = postcard::to_allocvec(&frame).expect("encode frame");
+  let decoded: ClusterWireFrameV1 = postcard::from_bytes(&encoded).expect("decode frame");
+  let reconstructed = decoded.to_cluster_serialized_message().expect("known payload kind");
+
+  assert_eq!(decoded, frame);
+  assert_eq!(reconstructed.payload_kind(), ClusterMessagePayloadKind::Gossip);
+  assert_eq!(reconstructed.serializer_id().value(), 41);
+  assert_eq!(reconstructed.manifest(), Some("cluster.payload/gossip"));
+  assert_eq!(reconstructed.payload_bytes(), &[1, 1, 2, 3, 5, 8]);
+}
+
+#[test]
+fn non_v1_frame_is_not_reconstructed() {
+  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&cluster_message());
+  let mut encoded = postcard::to_allocvec(&frame).expect("encode frame");
+  encoded[0] = 2;
+  let decoded: ClusterWireFrameV1 = postcard::from_bytes(&encoded).expect("decode frame");
+
+  assert_eq!(decoded.version(), 2);
+  assert!(decoded.to_cluster_serialized_message().is_none());
+}
+
+#[test]
+fn frame_debug_shape_exposes_only_wire_metadata() {
+  let frame = ClusterWireFrameV1::from_cluster_serialized_message(&cluster_message());
+  let debug = format!("{frame:?}");
+
+  for field in ["version", "payload_kind", "serializer_id", "manifest", "payload_len", "payload_bytes"] {
+    assert!(debug.contains(field), "missing field {field} in {debug}");
+  }
+  for excluded in ["endpoint", "association", "retry"] {
+    assert!(!debug.contains(excluded), "unexpected transport field {excluded} in {debug}");
+  }
+}

--- a/modules/cluster-core-kernel/src/lib.rs
+++ b/modules/cluster-core-kernel/src/lib.rs
@@ -68,6 +68,8 @@ pub mod failure_detector;
 pub mod grain;
 /// Membership management, gossip dissemination, and node lifecycle.
 pub mod membership;
+/// Cluster message serialization contracts.
+pub mod message_serialization;
 /// Outbound message pipeline coordination.
 pub mod outbound;
 /// Cluster-wide publish/subscribe messaging coordination.

--- a/modules/cluster-core-kernel/src/message_serialization.rs
+++ b/modules/cluster-core-kernel/src/message_serialization.rs
@@ -2,6 +2,8 @@
 
 mod cluster_message_manifest;
 mod cluster_message_payload_kind;
+mod cluster_serialized_message;
 
 pub use cluster_message_manifest::ClusterMessageManifest;
 pub use cluster_message_payload_kind::ClusterMessagePayloadKind;
+pub use cluster_serialized_message::ClusterSerializedMessage;

--- a/modules/cluster-core-kernel/src/message_serialization.rs
+++ b/modules/cluster-core-kernel/src/message_serialization.rs
@@ -1,0 +1,7 @@
+//! Cluster message serialization contracts.
+
+mod cluster_message_manifest;
+mod cluster_message_payload_kind;
+
+pub use cluster_message_manifest::ClusterMessageManifest;
+pub use cluster_message_payload_kind::ClusterMessagePayloadKind;

--- a/modules/cluster-core-kernel/src/message_serialization.rs
+++ b/modules/cluster-core-kernel/src/message_serialization.rs
@@ -1,9 +1,11 @@
 //! Cluster message serialization contracts.
 
+mod actor_serialization_bridge;
 mod cluster_message_manifest;
 mod cluster_message_payload_kind;
 mod cluster_serialized_message;
 
+pub use actor_serialization_bridge::ActorSerializationBridge;
 pub use cluster_message_manifest::ClusterMessageManifest;
 pub use cluster_message_payload_kind::ClusterMessagePayloadKind;
 pub use cluster_serialized_message::ClusterSerializedMessage;

--- a/modules/cluster-core-kernel/src/message_serialization/actor_serialization_bridge.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/actor_serialization_bridge.rs
@@ -1,0 +1,58 @@
+//! Bridge between cluster message metadata and actor-core serialization.
+
+#[cfg(test)]
+#[path = "actor_serialization_bridge_test.rs"]
+mod tests;
+
+use alloc::boxed::Box;
+use core::any::{Any, TypeId};
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializationCallScope, SerializationError, SerializationExtension};
+
+use super::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+
+/// Connects cluster payload kind metadata to actor-core serialization.
+pub trait ActorSerializationBridge {
+  /// Serializes a typed cluster payload through actor-core serialization.
+  ///
+  /// # Errors
+  ///
+  /// Returns the actor-core [`SerializationError`] from the underlying serialization extension.
+  fn serialize_cluster_message(
+    &self,
+    kind: ClusterMessagePayloadKind,
+    scope: SerializationCallScope,
+    message: &(dyn Any + Send + Sync),
+  ) -> Result<ClusterSerializedMessage, SerializationError>;
+
+  /// Deserializes a cluster serialized message through actor-core serialization.
+  ///
+  /// # Errors
+  ///
+  /// Returns the actor-core [`SerializationError`] from the underlying serialization extension.
+  fn deserialize_cluster_message(
+    &self,
+    message: &ClusterSerializedMessage,
+    type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError>;
+}
+
+impl ActorSerializationBridge for SerializationExtension {
+  fn serialize_cluster_message(
+    &self,
+    kind: ClusterMessagePayloadKind,
+    scope: SerializationCallScope,
+    message: &(dyn Any + Send + Sync),
+  ) -> Result<ClusterSerializedMessage, SerializationError> {
+    let serialized_message = self.serialize(message, scope)?;
+    Ok(ClusterSerializedMessage::new(kind, serialized_message))
+  }
+
+  fn deserialize_cluster_message(
+    &self,
+    message: &ClusterSerializedMessage,
+    type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    self.deserialize(message.serialized_message(), type_hint)
+  }
+}

--- a/modules/cluster-core-kernel/src/message_serialization/actor_serialization_bridge_test.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/actor_serialization_bridge_test.rs
@@ -1,0 +1,240 @@
+use alloc::{borrow::Cow, boxed::Box, string::String, vec, vec::Vec};
+use core::any::{Any, TypeId, type_name};
+
+use fraktor_actor_adaptor_std_rs::system::create_noop_actor_system;
+use fraktor_actor_core_kernel_rs::{
+  serialization::{
+    NotSerializableError, SerializationCallScope, SerializationError, SerializationExtension,
+    SerializationSetupBuilder, SerializedMessage, Serializer, SerializerId, SerializerWithStringManifest,
+  },
+  system::ActorSystem,
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use super::ActorSerializationBridge;
+use crate::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+
+const BRIDGE_MANIFEST: &str = "cluster.bridge.Payload";
+
+#[derive(Debug, PartialEq)]
+struct BridgePayload {
+  node:  u16,
+  value: i16,
+}
+
+#[derive(Debug, PartialEq)]
+struct RuntimeBoundPayload(u8);
+
+struct BridgeSerializer {
+  id: SerializerId,
+}
+
+impl BridgeSerializer {
+  const fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+
+  fn not_serializable(&self, type_name: &str) -> SerializationError {
+    SerializationError::not_serializable(NotSerializableError::new(
+      type_name,
+      Some(self.id),
+      Some(String::from(BRIDGE_MANIFEST)),
+      None,
+      None,
+    ))
+  }
+
+  fn decode(bytes: &[u8]) -> Result<BridgePayload, SerializationError> {
+    if bytes.len() != 4 {
+      return Err(SerializationError::invalid_format());
+    }
+    let node = u16::from_le_bytes(bytes[0..2].try_into().map_err(|_| SerializationError::invalid_format())?);
+    let value = i16::from_le_bytes(bytes[2..4].try_into().map_err(|_| SerializationError::invalid_format())?);
+    Ok(BridgePayload { node, value })
+  }
+}
+
+impl Serializer for BridgeSerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let payload =
+      message.downcast_ref::<BridgePayload>().ok_or_else(|| self.not_serializable(type_name::<BridgePayload>()))?;
+    let mut buffer = Vec::with_capacity(4);
+    buffer.extend_from_slice(&payload.node.to_le_bytes());
+    buffer.extend_from_slice(&payload.value.to_le_bytes());
+    Ok(buffer)
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    Ok(Box::new(Self::decode(bytes)?))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+
+  fn as_string_manifest(&self) -> Option<&dyn SerializerWithStringManifest> {
+    Some(self)
+  }
+}
+
+impl SerializerWithStringManifest for BridgeSerializer {
+  fn manifest(&self, _message: &(dyn Any + Send + Sync)) -> Cow<'_, str> {
+    Cow::Borrowed(BRIDGE_MANIFEST)
+  }
+
+  fn from_binary_with_manifest(
+    &self,
+    bytes: &[u8],
+    manifest: &str,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    if manifest != BRIDGE_MANIFEST {
+      return Err(SerializationError::unknown_manifest(manifest));
+    }
+    self.from_binary(bytes, None)
+  }
+}
+
+struct RuntimeBoundSerializer {
+  id: SerializerId,
+}
+
+impl RuntimeBoundSerializer {
+  const fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for RuntimeBoundSerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn to_binary(&self, message: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let payload = message.downcast_ref::<RuntimeBoundPayload>().ok_or_else(SerializationError::invalid_format)?;
+    Ok(vec![payload.0])
+  }
+
+  fn from_binary(
+    &self,
+    bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    Ok(Box::new(RuntimeBoundPayload(bytes.first().copied().unwrap_or_default())))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}
+
+fn build_bridge_extension() -> (SerializationExtension, SerializerId, SerializerId, ActorSystem) {
+  let bridge_id = SerializerId::try_from(501).expect("bridge id");
+  let runtime_bound_id = SerializerId::try_from(502).expect("runtime bound id");
+  let bridge_serializer: ArcShared<dyn Serializer> = ArcShared::new(BridgeSerializer::new(bridge_id));
+  let runtime_bound_serializer: ArcShared<dyn Serializer> =
+    ArcShared::new(RuntimeBoundSerializer::new(runtime_bound_id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("bridge", bridge_id, bridge_serializer)
+    .expect("register bridge")
+    .register_serializer("runtime-bound", runtime_bound_id, runtime_bound_serializer)
+    .expect("register runtime bound")
+    .set_fallback("bridge")
+    .expect("fallback")
+    .bind::<BridgePayload>("bridge")
+    .expect("bind")
+    .bind_remote_manifest::<BridgePayload>(BRIDGE_MANIFEST)
+    .expect("manifest")
+    .require_manifest_for_scope(SerializationCallScope::Remote)
+    .build()
+    .expect("setup");
+  let system = create_noop_actor_system();
+  (SerializationExtension::new(&system, setup), bridge_id, runtime_bound_id, system)
+}
+
+#[test]
+fn serialize_cluster_message_preserves_serializer_id_and_manifest_for_roundtrip() {
+  let (extension, serializer_id, _runtime_bound_id, _system) = build_bridge_extension();
+  let payload = BridgePayload { node: 7, value: -23 };
+
+  let cluster_message = extension
+    .serialize_cluster_message(ClusterMessagePayloadKind::Gossip, SerializationCallScope::Remote, &payload)
+    .expect("serialize");
+
+  assert_eq!(cluster_message.payload_kind(), ClusterMessagePayloadKind::Gossip);
+  assert_eq!(cluster_message.serializer_id(), serializer_id);
+  assert_eq!(cluster_message.manifest(), Some(BRIDGE_MANIFEST));
+  assert_eq!(cluster_message.payload_bytes(), &[7, 0, 233, 255]);
+
+  let restored = extension
+    .deserialize_cluster_message(&cluster_message, Some(TypeId::of::<BridgePayload>()))
+    .expect("deserialize")
+    .downcast::<BridgePayload>()
+    .expect("payload");
+  assert_eq!(*restored, payload);
+}
+
+#[test]
+fn remote_scope_manifest_requirement_is_not_bypassed() {
+  let (extension, _serializer_id, runtime_bound_id, _system) = build_bridge_extension();
+  extension
+    .register_binding(TypeId::of::<RuntimeBoundPayload>(), type_name::<RuntimeBoundPayload>(), runtime_bound_id)
+    .expect("runtime binding");
+
+  let error = extension
+    .serialize_cluster_message(
+      ClusterMessagePayloadKind::PubSub,
+      SerializationCallScope::Remote,
+      &RuntimeBoundPayload(1),
+    )
+    .expect_err("manifest missing");
+
+  assert!(matches!(error, SerializationError::ManifestMissing { scope: SerializationCallScope::Remote }));
+}
+
+#[test]
+fn serialize_failure_surfaces_as_actor_core_error() {
+  let (extension, _serializer_id, _runtime_bound_id, _system) = build_bridge_extension();
+
+  let error = extension
+    .serialize_cluster_message(ClusterMessagePayloadKind::Gossip, SerializationCallScope::Remote, &"not bridge payload")
+    .expect_err("serialize failure");
+
+  assert!(matches!(error, SerializationError::NotSerializable(_)));
+}
+
+#[test]
+fn deserialize_failure_surfaces_as_actor_core_error() {
+  let (extension, serializer_id, _runtime_bound_id, _system) = build_bridge_extension();
+  let serialized = SerializedMessage::new(serializer_id, Some(String::from(BRIDGE_MANIFEST)), vec![1, 2, 3]);
+  let cluster_message = ClusterSerializedMessage::new(ClusterMessagePayloadKind::Gossip, serialized);
+
+  let error = extension
+    .deserialize_cluster_message(&cluster_message, Some(TypeId::of::<BridgePayload>()))
+    .expect_err("deserialize failure");
+
+  assert_eq!(error, SerializationError::InvalidFormat);
+}
+
+#[test]
+fn unknown_serializer_surfaces_as_actor_core_error() {
+  let (extension, _serializer_id, _runtime_bound_id, _system) = build_bridge_extension();
+  let unknown_id = SerializerId::try_from(599).expect("unknown id");
+  let serialized = SerializedMessage::new(unknown_id, None, Vec::new());
+  let cluster_message = ClusterSerializedMessage::new(ClusterMessagePayloadKind::PubSub, serialized);
+
+  let error = extension.deserialize_cluster_message(&cluster_message, None).expect_err("unknown serializer");
+
+  assert_eq!(error, SerializationError::UnknownSerializer(unknown_id));
+}

--- a/modules/cluster-core-kernel/src/message_serialization/cluster_message_manifest.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/cluster_message_manifest.rs
@@ -1,0 +1,33 @@
+//! Actor-core manifest preservation rule for cluster messages.
+
+#[cfg(test)]
+#[path = "cluster_message_manifest_test.rs"]
+mod tests;
+
+use alloc::string::{String, ToString};
+
+/// Opaque actor-core manifest preserved by cluster message serialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterMessageManifest {
+  actor_manifest: Option<String>,
+}
+
+impl ClusterMessageManifest {
+  /// Creates a cluster manifest holder from actor-core manifest metadata.
+  #[must_use]
+  pub fn from_actor_manifest(manifest: Option<&str>) -> Self {
+    Self { actor_manifest: manifest.map(ToString::to_string) }
+  }
+
+  /// Returns the preserved actor-core manifest.
+  #[must_use]
+  pub fn actor_manifest(&self) -> Option<&str> {
+    self.actor_manifest.as_deref()
+  }
+
+  /// Converts this holder back into actor-core manifest metadata.
+  #[must_use]
+  pub fn into_actor_manifest(self) -> Option<String> {
+    self.actor_manifest
+  }
+}

--- a/modules/cluster-core-kernel/src/message_serialization/cluster_message_manifest_test.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/cluster_message_manifest_test.rs
@@ -1,0 +1,105 @@
+use alloc::{boxed::Box, vec, vec::Vec};
+use core::any::{Any, TypeId};
+
+use fraktor_actor_adaptor_std_rs::system::create_noop_actor_system;
+use fraktor_actor_core_kernel_rs::serialization::{
+  SerializationError, SerializationExtension, SerializationSetupBuilder, SerializedMessage, Serializer, SerializerId,
+};
+use fraktor_utils_core_rs::sync::ArcShared;
+
+use super::ClusterMessageManifest;
+use crate::message_serialization::ClusterMessagePayloadKind;
+
+#[derive(Debug, PartialEq)]
+struct TestPayload(u8);
+
+struct VersionedSerializer {
+  id: SerializerId,
+}
+
+impl VersionedSerializer {
+  const fn new(id: SerializerId) -> Self {
+    Self { id }
+  }
+}
+
+impl Serializer for VersionedSerializer {
+  fn identifier(&self) -> SerializerId {
+    self.id
+  }
+
+  fn include_manifest(&self) -> bool {
+    true
+  }
+
+  fn to_binary(&self, value: &(dyn Any + Send + Sync)) -> Result<Vec<u8>, SerializationError> {
+    let payload = value.downcast_ref::<TestPayload>().expect("TestPayload expected");
+    Ok(vec![payload.0])
+  }
+
+  fn from_binary(
+    &self,
+    _bytes: &[u8],
+    _type_hint: Option<TypeId>,
+  ) -> Result<Box<dyn Any + Send + Sync>, SerializationError> {
+    Err(SerializationError::UnknownManifest("missing.Manifest".into()))
+  }
+
+  fn as_any(&self) -> &(dyn Any + Send + Sync) {
+    self
+  }
+}
+
+#[test]
+fn manifest_preserves_actor_manifest_opaquely() {
+  let manifest = ClusterMessageManifest::from_actor_manifest(Some("cluster.payload/gossip"));
+
+  assert_eq!(manifest.actor_manifest(), Some("cluster.payload/gossip"));
+}
+
+#[test]
+fn manifest_absence_is_preserved_without_payload_kind_fallback() {
+  let kind = ClusterMessagePayloadKind::Gossip;
+  let manifest = ClusterMessageManifest::from_actor_manifest(None);
+
+  assert_eq!(kind.tag(), 1);
+  assert_eq!(manifest.actor_manifest(), None);
+}
+
+#[test]
+fn manifest_preservation_is_independent_from_payload_kind_tag() {
+  let kind = ClusterMessagePayloadKind::Gossip;
+  let manifest = ClusterMessageManifest::from_actor_manifest(Some("2"));
+
+  assert_eq!(kind.tag(), 1);
+  assert_eq!(manifest.actor_manifest(), Some("2"));
+}
+
+#[test]
+fn unknown_actor_manifest_route_failure_remains_actor_core_deserialize_failure() {
+  let serializer_id = SerializerId::try_from(422).expect("serializer");
+  let serializer: ArcShared<dyn Serializer> = ArcShared::new(VersionedSerializer::new(serializer_id));
+  let setup = SerializationSetupBuilder::new()
+    .register_serializer("current", serializer_id, serializer)
+    .expect("register")
+    .set_fallback("current")
+    .expect("fallback")
+    .bind::<TestPayload>("current")
+    .expect("bind")
+    .build()
+    .expect("build");
+  let system = create_noop_actor_system();
+  let extension = SerializationExtension::new(&system, setup);
+  let manifest = ClusterMessageManifest::from_actor_manifest(Some("missing.Manifest"));
+  let serialized = SerializedMessage::new(serializer_id, manifest.into_actor_manifest(), vec![99]);
+
+  let error = extension.deserialize(&serialized, Some(TypeId::of::<TestPayload>())).expect_err("should fail");
+
+  match error {
+    | SerializationError::NotSerializable(payload) => {
+      assert_eq!(payload.manifest(), Some("missing.Manifest"));
+      assert_eq!(payload.serializer_id(), Some(serializer_id));
+    },
+    | other => panic!("unexpected error: {other:?}"),
+  }
+}

--- a/modules/cluster-core-kernel/src/message_serialization/cluster_message_payload_kind.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/cluster_message_payload_kind.rs
@@ -1,0 +1,40 @@
+//! Stable cluster message payload kind tags.
+
+#[cfg(test)]
+#[path = "cluster_message_payload_kind_test.rs"]
+mod tests;
+
+/// Stable protocol-family tag carried by cluster serialized messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClusterMessagePayloadKind {
+  /// Gossip envelope payload.
+  Gossip,
+  /// Publish-subscribe mediator payload.
+  PubSub,
+}
+
+impl ClusterMessagePayloadKind {
+  /// Stable wire tag for gossip payloads.
+  pub const GOSSIP_TAG: u16 = 1;
+  /// Stable wire tag for publish-subscribe payloads.
+  pub const PUB_SUB_TAG: u16 = 2;
+
+  /// Returns the stable payload kind tag.
+  #[must_use]
+  pub const fn tag(self) -> u16 {
+    match self {
+      | Self::Gossip => Self::GOSSIP_TAG,
+      | Self::PubSub => Self::PUB_SUB_TAG,
+    }
+  }
+
+  /// Decodes a stable payload kind tag.
+  #[must_use]
+  pub const fn from_tag(tag: u16) -> Option<Self> {
+    match tag {
+      | Self::GOSSIP_TAG => Some(Self::Gossip),
+      | Self::PUB_SUB_TAG => Some(Self::PubSub),
+      | _ => None,
+    }
+  }
+}

--- a/modules/cluster-core-kernel/src/message_serialization/cluster_message_payload_kind_test.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/cluster_message_payload_kind_test.rs
@@ -1,0 +1,19 @@
+use super::ClusterMessagePayloadKind;
+
+#[test]
+fn payload_kind_tags_are_stable() {
+  assert_eq!(ClusterMessagePayloadKind::Gossip.tag(), 1);
+  assert_eq!(ClusterMessagePayloadKind::PubSub.tag(), 2);
+}
+
+#[test]
+fn payload_kind_decodes_known_tags() {
+  assert_eq!(ClusterMessagePayloadKind::from_tag(1), Some(ClusterMessagePayloadKind::Gossip));
+  assert_eq!(ClusterMessagePayloadKind::from_tag(2), Some(ClusterMessagePayloadKind::PubSub));
+}
+
+#[test]
+fn payload_kind_does_not_round_unknown_tag_to_known_kind() {
+  assert_eq!(ClusterMessagePayloadKind::from_tag(0), None);
+  assert_eq!(ClusterMessagePayloadKind::from_tag(99), None);
+}

--- a/modules/cluster-core-kernel/src/message_serialization/cluster_serialized_message.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/cluster_serialized_message.rs
@@ -1,0 +1,54 @@
+//! Bridge value for cluster payload kind and actor-core serialized metadata.
+
+#[cfg(test)]
+#[path = "cluster_serialized_message_test.rs"]
+mod tests;
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
+
+use super::ClusterMessagePayloadKind;
+
+/// Immutable bridge value for cluster payload kind and actor-core serialized metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterSerializedMessage {
+  payload_kind:       ClusterMessagePayloadKind,
+  serialized_message: SerializedMessage,
+}
+
+impl ClusterSerializedMessage {
+  /// Creates a new cluster serialized message.
+  #[must_use]
+  pub const fn new(payload_kind: ClusterMessagePayloadKind, serialized_message: SerializedMessage) -> Self {
+    Self { payload_kind, serialized_message }
+  }
+
+  /// Returns the cluster payload kind.
+  #[must_use]
+  pub const fn payload_kind(&self) -> ClusterMessagePayloadKind {
+    self.payload_kind
+  }
+
+  /// Returns the actor-core serialized message.
+  #[must_use]
+  pub const fn serialized_message(&self) -> &SerializedMessage {
+    &self.serialized_message
+  }
+
+  /// Returns the actor-core serializer identifier.
+  #[must_use]
+  pub const fn serializer_id(&self) -> SerializerId {
+    self.serialized_message.serializer_id()
+  }
+
+  /// Returns the actor-core manifest.
+  #[must_use]
+  pub fn manifest(&self) -> Option<&str> {
+    self.serialized_message.manifest()
+  }
+
+  /// Returns the actor-core serialized payload bytes.
+  #[must_use]
+  pub fn payload_bytes(&self) -> &[u8] {
+    self.serialized_message.bytes()
+  }
+}

--- a/modules/cluster-core-kernel/src/message_serialization/cluster_serialized_message_test.rs
+++ b/modules/cluster-core-kernel/src/message_serialization/cluster_serialized_message_test.rs
@@ -1,0 +1,34 @@
+use alloc::{string::String, vec};
+
+use fraktor_actor_core_kernel_rs::serialization::{SerializedMessage, SerializerId};
+
+use crate::message_serialization::{ClusterMessagePayloadKind, ClusterSerializedMessage};
+
+#[test]
+fn serialized_message_preserves_manifest_metadata() {
+  let serializer_id = SerializerId::try_from(41).expect("serializer");
+  let actor_message =
+    SerializedMessage::new(serializer_id, Some(String::from("cluster.payload/gossip")), vec![1, 2, 3]);
+
+  let cluster_message = ClusterSerializedMessage::new(ClusterMessagePayloadKind::Gossip, actor_message);
+
+  assert_eq!(cluster_message.payload_kind(), ClusterMessagePayloadKind::Gossip);
+  assert_eq!(cluster_message.serialized_message().serializer_id(), serializer_id);
+  assert_eq!(cluster_message.serializer_id(), serializer_id);
+  assert_eq!(cluster_message.manifest(), Some("cluster.payload/gossip"));
+  assert_eq!(cluster_message.payload_bytes(), &[1, 2, 3]);
+}
+
+#[test]
+fn serialized_message_preserves_absent_manifest_metadata() {
+  let serializer_id = SerializerId::try_from(42).expect("serializer");
+  let actor_message = SerializedMessage::new(serializer_id, None, vec![4, 5, 6]);
+
+  let cluster_message = ClusterSerializedMessage::new(ClusterMessagePayloadKind::PubSub, actor_message);
+
+  assert_eq!(cluster_message.payload_kind(), ClusterMessagePayloadKind::PubSub);
+  assert_eq!(cluster_message.serialized_message().serializer_id(), serializer_id);
+  assert_eq!(cluster_message.serializer_id(), serializer_id);
+  assert_eq!(cluster_message.manifest(), None);
+  assert_eq!(cluster_message.payload_bytes(), &[4, 5, 6]);
+}


### PR DESCRIPTION
## 概要
- cluster message の payload kind / manifest preservation / serialized metadata contract を core に追加
- actor-core `SerializationExtension` と cluster payload kind をつなぐ bridge を追加
- std adaptor に versioned wire frame / codec / decode failure taxonomy を追加
- gossip / pubsub payload の wire smoke test と gap analysis evidence を更新

## Scope
- gossip merge / heartbeat / reachability semantics は対象外
- pubsub mediator state / delivery / registry semantics は対象外
- remote transport lifecycle と Pekko/protobuf 完全バイナリ互換は対象外

## 検証
- `cargo test -p fraktor-cluster-core-kernel-rs message_serialization`
- `cargo test -p fraktor-cluster-adaptor-std-rs message_wire`
- `cargo check -p fraktor-cluster-core-kernel-rs --no-default-features`
- `cargo check -p fraktor-cluster-adaptor-std-rs`
- `./scripts/ci-check.sh lint`
- `./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public APIs on cluster-core and cluster-adaptor-std define wire format and serialization boundaries; failures are explicit but any future transport integration must use these contracts correctly.
> 
> **Overview**
> Introduces a **cluster message serialization contract** that links actor-core serialization to a versioned std wire format, without changing gossip/pubsub protocol semantics or transport.
> 
> **Core (`message_serialization`)** adds stable **Gossip / PubSub** payload kind tags, opaque **manifest** handling, **`ClusterSerializedMessage`** (kind + `SerializedMessage`), and **`ActorSerializationBridge`** on `SerializationExtension` so serialize/deserialize errors and remote manifest rules are not masked by cluster-specific fallbacks.
> 
> **Std (`message_wire`)** adds **v1 postcard frames** (`ClusterWireFrameV1`), **`ClusterWireCodec`**, and **`ClusterWireDecodeFailure`** (unknown version/kind, malformed payload) with tests for metadata roundtrip, failure taxonomy, and gossip/pubsub wire smoke paths.
> 
> **Docs** mark the spec tasks complete and update **cluster gap analysis** to treat the serializer contract as implemented (Pekko/protobuf binary parity remains out of scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 452bd280601371ee722e412a8eea0ef05b913c8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * クラスターメッセージのワイヤフレーム処理機能を実装しました。エンコード・デコード機能により、シリアライズ済みメッセージのバージョン管理とペイロード種別の安定化を実現します。
  * クラスターメッセージのシリアライズ契約を定式化し、Gossip と PubSub ペイロード種別の統一的な取り扱いを確立しました。

* **Documentation**
  * ギャップ分析ドキュメントを拡張し、メッセージシリアライズ契約に関する範囲定義と実装状況を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->