### PR TITLE
ci: update Codecov action wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,8 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
       - name: Upload coverage reports to Codecov
-        # third-party action の mutable tag リスクを避けるため、v6 の commit SHA に固定する。
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2
+        # third-party action の mutable tag リスクを避けるため、v7.0.0 の commit SHA に固定する。
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           use_oidc: true
           files: target/coverage/lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,8 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
       - name: Upload coverage reports to Codecov
-        # third-party action の mutable tag リスクを避けるため、v7.0.0 の commit SHA に固定する。
+        # third-party action の mutable tag リスクを避けるため、
+        # v7.0.0 tag (e534...) が指す commit SHA に固定する。
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           use_oidc: true


### PR DESCRIPTION
## 概要
- Codecov upload action の固定 SHA を v7.0.0 の実コミットへ更新
- 2026-06-08 の scheduled CI で Codecov CLI latest の GPG 署名検証が `No public key` になって失敗していたため、PGP key 取得が更新された wrapper に追従

## 失敗原因
- `Coverage Report` job の `Upload coverage reports to Codecov` が `Could not verify signature` で exit 1
- `Codecov Status` と `CI Success` は coverage job failure の後続失敗

## 検証
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ok"'`
- `actionlint` はローカル未インストールのため未実行

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 変更は `.github/workflows/ci.yml` の third-party action ピン留めのみで、アプリの認証・データ処理には触れない。
> 
> **Overview**
> **Coverage Report** の Codecov アップロードで、`codecov/codecov-action` の参照を v6 固定 SHA から **v7.0.0 が指す commit SHA**（`fb8b3582…`）へ差し替え、mutable tag を避ける旨のコメントも v7 に合わせて更新している。`use_oidc` や `files` / `fail_ci_if_error` などの upload 設定はそのまま。
> 
> scheduled CI で Codecov CLI の GPG 検証が `No public key` で落ちていたため、PGP 鍵取得が更新された v7 wrapper に追従する変更。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b4434cdca066e81f913b8b1f1dda0a36b1c43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub ActionsのCodecovアクションを最新バージョンに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->