### PR TITLE
[codex] simplify agent runner scripts

### DIFF
--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -2,24 +2,6 @@
 
 export CLAUDE_IDENTITY="corporate"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
-
-# 親プロセス（Claude Code セッション等）から継承した OAuth トークンを除去し、
-# CLAUDE_CONFIG_DIR に対応する keychain エントリから認証情報を読ませる
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-# --happy オプションを検出して Happy Coder モードで起動
-use_happy=false
-args=()
-for arg in "$@"; do
-  if [[ "$arg" == "--happy" ]]; then
-    use_happy=true
-  else
-    args+=("$arg")
-  fi
-done
-
-if $use_happy; then
-  exec happy --permission-mode bypassPermissions "${args[@]}"
-else
-  exec claude --dangerously-skip-permissions "${args[@]}"
-fi
+exec mise exec -- claude --dangerously-skip-permissions "$@"

--- a/scripts/run-claude-personal.sh
+++ b/scripts/run-claude-personal.sh
@@ -2,24 +2,6 @@
 
 export CLAUDE_IDENTITY="personal"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude-${CLAUDE_IDENTITY}"
-
-# 親プロセス（Claude Code セッション等）から継承した OAuth トークンを除去し、
-# CLAUDE_CONFIG_DIR に対応する keychain エントリから認証情報を読ませる
 unset CLAUDE_CODE_OAUTH_TOKEN
 
-# --happy オプションを検出して Happy Coder モードで起動
-use_happy=false
-args=()
-for arg in "$@"; do
-  if [[ "$arg" == "--happy" ]]; then
-    use_happy=true
-  else
-    args+=("$arg")
-  fi
-done
-
-if $use_happy; then
-  exec happy --permission-mode bypassPermissions "${args[@]}"
-else
-  exec claude --dangerously-skip-permissions "${args[@]}"
-fi
+exec mise exec -- claude --dangerously-skip-permissions "$@"

--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -1,27 +1,5 @@
 #!/usr/bin/env bash
 
 export CODEX_HOME="${HOME}/.codex-corporate"
-
-ensure_local_codex_config() {
-  local config_path="${CODEX_HOME}/config.toml"
-  local base_config="${HOME}/.codex/config.toml"
-  local project_header="[projects.\"${HOME}\"]"
-
-  mkdir -p "${CODEX_HOME}"
-  if [[ -L "${config_path}" ]]; then
-    rm "${config_path}"
-  fi
-  if [[ ! -f "${config_path}" ]]; then
-    cp "${base_config}" "${config_path}"
-  fi
-  if ! grep -Fq "${project_header}" "${config_path}"; then
-    {
-      echo ""
-      echo "${project_header}"
-      echo 'trust_level = "trusted"'
-    } >> "${config_path}"
-  fi
-}
-
-ensure_local_codex_config
+mkdir -p "${CODEX_HOME}"
 exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/scripts/run-codex-personal.sh
+++ b/scripts/run-codex-personal.sh
@@ -1,27 +1,5 @@
 #!/usr/bin/env bash
 
 export CODEX_HOME="${HOME}/.codex-personal"
-
-ensure_local_codex_config() {
-  local config_path="${CODEX_HOME}/config.toml"
-  local base_config="${HOME}/.codex/config.toml"
-  local project_header="[projects.\"${HOME}\"]"
-
-  mkdir -p "${CODEX_HOME}"
-  if [[ -L "${config_path}" ]]; then
-    rm "${config_path}"
-  fi
-  if [[ ! -f "${config_path}" ]]; then
-    cp "${base_config}" "${config_path}"
-  fi
-  if ! grep -Fq "${project_header}" "${config_path}"; then
-    {
-      echo ""
-      echo "${project_header}"
-      echo 'trust_level = "trusted"'
-    } >> "${config_path}"
-  fi
-}
-
-ensure_local_codex_config
+mkdir -p "${CODEX_HOME}"
 exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"


### PR DESCRIPTION
## Summary

- Simplify Claude runner scripts to always invoke `claude` through `mise exec` while preserving forwarded arguments.
- Simplify Codex runner scripts by removing local config bootstrap logic.
- Keep the PR scoped to `scripts/` only.

## Validation

- `bash -n scripts/run-claude-corporate.sh scripts/run-claude-personal.sh scripts/run-codex-corporate.sh scripts/run-codex-personal.sh`
- `git diff --cached --check` before commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes `--happy` and automatic Codex `config.toml` seeding, so launch behavior changes for anyone depending on those paths.
> 
> **Overview**
> **Claude corporate/personal runners** no longer parse `--happy` or branch to `happy`; they always `exec mise exec -- claude --dangerously-skip-permissions` with all arguments forwarded. Identity env vars (`CLAUDE_IDENTITY`, `CLAUDE_CONFIG_DIR`) and `unset CLAUDE_CODE_OAUTH_TOKEN` are unchanged.
> 
> **Codex corporate/personal runners** drop `ensure_local_codex_config` (copy from `~/.codex/config.toml`, symlink cleanup, and append home-project `trust_level = "trusted"`). They only `mkdir -p` `CODEX_HOME` and `exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69bbb77193579ddc840832f880aae739df40dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 起動スクリプトの実行フローを簡略化し、統一的な起動方法に変更しました。
  * セキュリティトークンの明示的な管理を強化しました。
  * ローカル設定ファイル処理を削減し、起動プロセスを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->