### PR TITLE
[codex] configure cluster failure detector

### DIFF
--- a/.kiro/specs/configure-cluster-failure-detector/design.md
+++ b/.kiro/specs/configure-cluster-failure-detector/design.md
@@ -1,0 +1,427 @@
+# Technical Design
+
+## Overview
+
+この設計は、Failure Detector Configuration (故障検出器設定) を Cluster Configuration (クラスタ設定) の明示的な contract として追加する。cluster 実装者は `FailureDetectorConfig` で Availability Evidence (可用性観測証拠) の観測パラメータを保持し、cluster 運用者は Join Compatibility (参加互換性) の Compatibility Mismatch Reason (互換性不一致理由) から設定差分を判断できる。
+
+影響範囲は cluster-core の configuration / validation / compatibility と、cluster-adaptor-std の Phi Accrual bridge に限定する。Failure Detector Algorithm Selection (故障検出器アルゴリズム選択)、Downing Decision (ダウン判断)、Member Removal (メンバー除去) は扱わない。
+
+### Goals
+
+- `FailureDetectorConfig` を Cluster Configuration (クラスタ設定) として保持し、既存 cluster membership path と同等の default を提供する。
+- install / start 境界で Cluster Configuration Validation (クラスタ設定検証) を実行し、invalid config を Join Compatibility (参加互換性) と分けて扱う。
+- `cluster.failure-detector` を Join Compatibility (参加互換性) の single key として追加し、差分のある観測パラメータ名を診断に含める。
+- std 環境で `FailureDetectorConfig` を `PhiAccrualFailureDetector` 生成へ渡す。
+
+### Non-Goals
+
+- Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) の public API 化。
+- Split Brain Resolver execution actor、provider down execution loop、lease coordination backend の追加。
+- Cluster Singleton、Cluster Client、Receptionist、Distributed Data / CRDT、Pekko public API parity の実装。
+- `MembershipCoordinatorConfig` の timeout / gossip policy を Failure Detector Configuration (故障検出器設定) に移すこと。
+
+## Boundary Commitments
+
+### This Spec Owns
+
+- `FailureDetectorConfig` の public value object、default、builder-style setter、getter、validation。
+- Failure Detector Configuration (故障検出器設定) の Cluster Configuration (クラスタ設定) への保持。
+- Cluster Configuration Validation (クラスタ設定検証) の install / start 境界接続。
+- `cluster.failure-detector` の Join Compatibility (参加互換性) key と Compatibility Mismatch Reason (互換性不一致理由) の field 差分 detail。
+- std 環境で `FailureDetectorConfig` から Phi Accrual detector を生成する bridge。
+- `docs/gap-analysis/cluster-gap-analysis.md` の該当 gap 更新。
+
+### Out of Boundary
+
+- `cluster.failure-detector.choice` を required key にすること。
+- Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) の enum / registry / plugin surface。
+- Failure Detector (故障検出器) に Downing Decision (ダウン判断) や Member Removal (メンバー除去) を持たせること。
+- Membership Coordination Policy (メンバーシップ調停ポリシー) の suspect / dead / quarantine / gossip interval 設計変更。
+- remote watcher 側の detector default 変更。
+
+### Allowed Dependencies
+
+- `cluster-core-kernel` は `core::time::Duration` と `alloc` を使えるが、std 依存を追加しない。
+- `cluster-core-kernel` は cluster-core 内の `FailureDetector` trait / `DefaultFailureDetectorRegistry` / Join Compatibility (参加互換性) infrastructure に依存できる。
+- `cluster-adaptor-std` は `fraktor_remote_core_rs::failure_detector::PhiAccrualFailureDetector` と `fraktor_remote_core_rs::address::Address` に依存できる。
+- 新しい外部 crate は追加しない。
+
+### Revalidation Triggers
+
+- `FailureDetectorConfig` の field、default 値、validation rule、duration 単位が変わる場合。
+- `ClusterCompatibilityKeyCatalog` の `cluster.failure-detector` / `cluster.failure-detector.choice` の分類が変わる場合。
+- `DefaultFailureDetectorRegistry` の factory contract が resource key aware に変わる場合。
+- `MembershipCoordinatorConfig` から `phi_threshold` を削除または意味変更する場合。
+- `PhiAccrualFailureDetector::new` の parameter order / unit が変わる場合。
+
+## Architecture
+
+### Existing Architecture Analysis
+
+cluster-core は portable contract と state coordination を持ち、std adaptor は Tokio や concrete detector binding を持つ。`ClusterExtensionConfig` は既に PubSub と Downing Provider の Join Compatibility (参加互換性) を扱い、`ClusterCompatibilityKeyCatalog` は required / conditional / excluded key を分けている。
+
+現状の `MembershipCoordinatorConfig` は `phi_threshold` と timeout / gossip policy を同じ struct に持つ。この設計では互換性を壊さず、new `FailureDetectorConfig` を Cluster Configuration (クラスタ設定) の source とし、Membership Coordination Policy (メンバーシップ調停ポリシー) への広い移行は行わない。
+
+### Architecture Pattern & Boundary Map
+
+Selected pattern は Hybrid Extension である。Failure Detector Configuration (故障検出器設定) の型と validation は新 component に閉じ、existing cluster config / compatibility / start flow には接続だけを追加する。
+
+```mermaid
+graph TB
+  ClusterConfig[ClusterExtensionConfig] --> DetectorConfig[FailureDetectorConfig]
+  ClusterConfig --> Compatibility[JoinCompatibility]
+  Compatibility --> KeyCatalog[CompatibilityKeyCatalog]
+  Installer[ClusterExtensionInstaller] --> ClusterConfig
+  Installer --> Core[ClusterCore]
+  Core --> DetectorConfig
+  StdBridge[StdDetectorBridge] --> DetectorConfig
+  StdBridge --> PhiDetector[PhiAccrualDetector]
+```
+
+Dependency direction: `FailureDetectorConfig` → `ClusterExtensionConfig` → `ClusterCompatibilityKeyCatalog` / `ClusterCore` → `cluster-adaptor-std bridge`。core layer は std bridge へ依存しない。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Core contract | Rust 2024 / `cluster-core-kernel` | `FailureDetectorConfig`、validation、Join Compatibility (参加互換性) | no_std + alloc を維持 |
+| std adaptor | Rust 2024 / `cluster-adaptor-std` | `FailureDetectorConfig` を Phi Accrual detector へ接続 | 新規外部 crate なし |
+| Remote core | existing `PhiAccrualFailureDetector` | concrete detector implementation | algorithm selection は公開しない |
+| Documentation | Markdown | gap analysis 更新 | `CONTEXT.md` 用語に合わせる |
+
+## File Structure Plan
+
+### Directory Structure
+
+```text
+modules/cluster-core-kernel/src/
+├── failure_detector.rs
+├── failure_detector/
+│   ├── failure_detector_config.rs
+│   ├── failure_detector_config_test.rs
+│   ├── failure_detector_config_error.rs
+│   └── failure_detector_config_error_test.rs
+├── extension/
+│   ├── cluster_extension_config.rs
+│   ├── cluster_extension_config_test.rs
+│   ├── cluster_extension_installer.rs
+│   ├── cluster_extension_installer_test.rs
+│   ├── cluster_core.rs
+│   ├── cluster_core_test.rs
+│   └── cluster_error.rs
+└── topology/
+    ├── cluster_compatibility_key_catalog.rs
+    └── cluster_compatibility_key_catalog_test.rs
+
+modules/cluster-adaptor-std/src/
+└── membership/
+    ├── configured_phi_accrual_detector_factory.rs
+    └── configured_phi_accrual_detector_factory_test.rs
+
+docs/gap-analysis/
+└── cluster-gap-analysis.md
+```
+
+### Modified Files
+
+- `modules/cluster-core-kernel/src/failure_detector.rs` — `FailureDetectorConfig` と `FailureDetectorConfigError` を公開する。
+- `modules/cluster-core-kernel/src/extension/cluster_extension_config.rs` — `failure_detector_config` field、getter、`with_failure_detector_config`、`validate()`、Join Compatibility (参加互換性) check を追加する。
+- `modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs` — install 前に `config.validate()` を実行し、失敗を `ActorSystemBuildError::Configuration` へ変換する。
+- `modules/cluster-core-kernel/src/extension/cluster_core.rs` — `FailureDetectorConfig` を保持し、`start_member` / `start_client` の先頭で validation する。
+- `modules/cluster-core-kernel/src/extension/cluster_error.rs` — Cluster Configuration Validation (クラスタ設定検証) failure を表す variant を追加する。
+- `modules/cluster-core-kernel/src/topology/cluster_compatibility_key_catalog.rs` — required key `cluster.failure-detector` を追加し、`cluster.failure-detector.choice` は excluded のままにする。
+- `modules/cluster-adaptor-std/src/membership.rs` — std bridge helper を公開する。
+- `docs/gap-analysis/cluster-gap-analysis.md` — Failure Detector Configuration (故障検出器設定) gap を完了扱いへ更新し、out-of-boundary 項目を混ぜない。
+
+## System Flows
+
+### Configuration validation flow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Installer
+  participant Config
+  participant Core
+  User->>Installer: install cluster extension
+  Installer->>Config: validate
+  Config-->>Installer: ok or config error
+  Installer->>Core: create core with config
+  User->>Core: start member or client
+  Core->>Config: validate detector config
+  Config-->>Core: ok or config error
+```
+
+validation は provider / pubsub / gossiper start より前に実行する。invalid Failure Detector Configuration (故障検出器設定) は Join Compatibility (参加互換性) へ流さない。
+
+### Join compatibility flow
+
+```mermaid
+sequenceDiagram
+  participant Local
+  participant Joining
+  participant Compat
+  participant Reason
+  Local->>Compat: check join config
+  Joining->>Compat: provide cluster config
+  Compat->>Compat: compare detector config
+  Compat->>Reason: append cluster failure detector key
+  Reason-->>Local: field names in detail
+```
+
+Compatibility Mismatch Reason (互換性不一致理由) の key は `cluster.failure-detector` に固定し、detail に `phi_threshold` など差分 field 名を含める。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | config 保持 | `FailureDetectorConfig`, `ClusterExtensionConfig` | `failure_detector_config()` | Configuration validation flow |
+| 1.2 | default 維持 | `FailureDetectorConfig` | `new()` | Configuration validation flow |
+| 1.3 | 指定値保持 | `FailureDetectorConfig`, `ClusterExtensionConfig` | `with_failure_detector_config`, `with_*` setters | Configuration validation flow |
+| 1.4 | algorithm selection 非要求 | `ClusterCompatibilityKeyCatalog`, std bridge | excluded key guard | Join compatibility flow |
+| 2.1 | Phi Accrual parameters | `FailureDetectorConfig` | field getters | Configuration validation flow |
+| 2.2 | observation fields 区別 | `FailureDetectorConfig` | `difference_field_names()` | Join compatibility flow |
+| 2.3 | policy fields 除外 | `FailureDetectorConfig`, `MembershipCoordinatorConfig` | struct field boundary | N/A |
+| 2.4 | duration semantics | `FailureDetectorConfig`, std bridge | `Duration` getters, millis conversion | Configuration validation flow |
+| 3.1 | install / start validation | `ClusterExtensionInstaller`, `ClusterCore` | `validate()` | Configuration validation flow |
+| 3.2 | phi threshold validation | `FailureDetectorConfigError` | `InvalidPhiThreshold` | Configuration validation flow |
+| 3.3 | max sample size validation | `FailureDetectorConfigError` | `ZeroMaxSampleSize` | Configuration validation flow |
+| 3.4 | duration zero validation | `FailureDetectorConfigError` | `ZeroMinStandardDeviation`, `ZeroFirstHeartbeatEstimate` | Configuration validation flow |
+| 3.5 | acceptable pause zero valid | `FailureDetectorConfig` | `validate()` | Configuration validation flow |
+| 3.6 | validation と compatibility 分離 | `ClusterError`, `ConfigValidation` | `Configuration` error vs incompatible reason | Configuration validation flow |
+| 4.1 | join 対象化 | `ClusterExtensionConfig` | `check_join_compatibility` | Join compatibility flow |
+| 4.2 | 一致時 accept | `ClusterExtensionConfig` | `failure_detector_configs_are_compatible` | Join compatibility flow |
+| 4.3 | 不一致時 reject | `ClusterExtensionConfig` | `ConfigValidation::Incompatible` | Join compatibility flow |
+| 4.4 | single key | `ClusterCompatibilityKeyCatalog` | `FAILURE_DETECTOR` | Join compatibility flow |
+| 4.5 | field names in reason | `FailureDetectorConfig` | `difference_field_names()` | Join compatibility flow |
+| 4.6 | choice key 非必須 | `ClusterCompatibilityKeyCatalog` | `FAILURE_DETECTOR_CHOICE` excluded | Join compatibility flow |
+| 5.1 | std observation reflection | std bridge | `ConfiguredPhiAccrualDetectorFactory` | Configuration validation flow |
+| 5.2 | duration meaning preserved | std bridge | millis conversion from `Duration` | Configuration validation flow |
+| 5.3 | downing / removal 非追加 | boundary guards | no new downing responsibility | N/A |
+| 6.1 | SBR execution 等除外 | boundary guards, docs | docs update | N/A |
+| 6.2 | algorithm selection 除外 | boundary guards, catalog | excluded key guard | Join compatibility flow |
+| 6.3 | gap docs 更新 | docs | `cluster-gap-analysis.md` | N/A |
+| 6.4 | deferred parity 非成果 | docs | scope text | N/A |
+
+## Components and Interfaces
+
+| Component | Domain / Layer | Intent | Req Coverage | Key Dependencies | Contracts |
+|-----------|----------------|--------|--------------|------------------|-----------|
+| `FailureDetectorConfig` | cluster-core / failure_detector | Availability Evidence (可用性観測証拠) の観測パラメータを保持する | 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 2.4, 3.2, 3.3, 3.4, 3.5, 4.5, 5.2 | `core::time::Duration` P0 | Service, State |
+| `FailureDetectorConfigError` | cluster-core / failure_detector | config validation failure を型で表す | 3.2, 3.3, 3.4, 3.6 | none P0 | Service |
+| `ClusterExtensionConfig` integration | cluster-core / extension | Cluster Configuration (クラスタ設定) と Join Compatibility (参加互換性) へ接続する | 1.1, 1.3, 3.1, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6 | `FailureDetectorConfig` P0, key catalog P0 | Service, State |
+| `ClusterCompatibilityKeyCatalog` integration | cluster-core / topology | stable compatibility keys を更新する | 1.4, 4.4, 4.6, 6.2 | `ClusterCompatibilityKey` P0 | State |
+| `ClusterExtensionInstaller` validation | cluster-core / extension | install 境界で validation failure を返す | 3.1, 3.6 | `ClusterExtensionConfig` P0 | Service |
+| `ClusterCore` validation | cluster-core / extension | start 境界で validation failure を返す | 3.1, 3.6 | `FailureDetectorConfig` P0 | Service, State |
+| `ConfiguredPhiAccrualDetectorFactory` | cluster-adaptor-std / membership | std 環境で config を concrete detector 生成へ接続する | 5.1, 5.2, 5.3 | remote-core Phi Accrual P0 | Service |
+| gap analysis docs | docs | feature 完了時の scope を明示する | 6.1, 6.3, 6.4 | `CONTEXT.md` P1 | Documentation |
+
+### cluster-core / failure_detector
+
+#### `FailureDetectorConfig`
+
+| Field | Detail |
+|-------|--------|
+| Intent | Failure Detector Configuration (故障検出器設定) の value object |
+| Requirements | 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 2.4, 3.5, 4.5, 5.2 |
+
+**Responsibilities & Constraints**
+
+- `phi_threshold: f64`、`max_sample_size: usize`、`min_standard_deviation: Duration`、`acceptable_heartbeat_pause: Duration`、`first_heartbeat_estimate: Duration` だけを保持する。
+- default は cluster membership path の既存値に合わせる: `1.0`, `10`, `1ms`, `0ms`, `10ms`。
+- suspect timeout、dead timeout、quarantine ttl、gossip interval を持たない。
+- builder-style setter は値を保持するだけで validation を実行しない。
+
+**Service Interface**
+
+```rust
+pub struct FailureDetectorConfig;
+
+impl FailureDetectorConfig {
+  pub fn new() -> Self;
+  pub fn with_phi_threshold(self, value: f64) -> Self;
+  pub fn with_max_sample_size(self, value: usize) -> Self;
+  pub fn with_min_standard_deviation(self, value: Duration) -> Self;
+  pub fn with_acceptable_heartbeat_pause(self, value: Duration) -> Self;
+  pub fn with_first_heartbeat_estimate(self, value: Duration) -> Self;
+  pub fn validate(&self) -> Result<(), FailureDetectorConfigError>;
+  pub fn difference_field_names(&self, other: &Self) -> Vec<&'static str>;
+}
+```
+
+- Preconditions: none for setters.
+- Postconditions: `validate()` returns success only for a positive finite threshold, nonzero sample size, nonzero min standard deviation, and nonzero first heartbeat estimate.
+- Invariants: `acceptable_heartbeat_pause == 0` is valid.
+
+#### `FailureDetectorConfigError`
+
+| Field | Detail |
+|-------|--------|
+| Intent | Cluster Configuration Validation (クラスタ設定検証) failure の reason を型で表す |
+| Requirements | 3.2, 3.3, 3.4, 3.6 |
+
+**Service Interface**
+
+```rust
+pub enum FailureDetectorConfigError {
+  InvalidPhiThreshold,
+  ZeroMaxSampleSize,
+  ZeroMinStandardDeviation,
+  ZeroFirstHeartbeatEstimate,
+}
+```
+
+- Preconditions: produced only by `FailureDetectorConfig::validate()`.
+- Postconditions: each variant maps to exactly one invalid field category.
+- Invariants: this error is not used for Join Compatibility (参加互換性) mismatch.
+
+### cluster-core / extension
+
+#### `ClusterExtensionConfig` integration
+
+| Field | Detail |
+|-------|--------|
+| Intent | Cluster Configuration (クラスタ設定) aggregate と Join Compatibility (参加互換性) の接続 |
+| Requirements | 1.1, 1.3, 3.1, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6 |
+
+**Responsibilities & Constraints**
+
+- `failure_detector_config: FailureDetectorConfig` を保持し、`new()` で default を設定する。
+- `with_failure_detector_config` と getter を追加する。
+- `validate()` は Failure Detector Configuration (故障検出器設定) の validation を委譲する。
+- Join Compatibility (参加互換性) check は `cluster.failure-detector` key を使い、detail に `difference_field_names()` の結果を含める。
+- `required_join_compatibility_keys()` は Failure Detector Configuration (故障検出器設定) について `cluster.failure-detector` だけを追加し、観測パラメータごとの metadata key は増やさない。
+
+**Service Interface**
+
+```rust
+impl ClusterExtensionConfig {
+  pub fn with_failure_detector_config(self, config: FailureDetectorConfig) -> Self;
+  pub fn failure_detector_config(&self) -> &FailureDetectorConfig;
+  pub fn validate(&self) -> Result<(), FailureDetectorConfigError>;
+}
+```
+
+#### `ClusterExtensionInstaller` and `ClusterCore`
+
+| Field | Detail |
+|-------|--------|
+| Intent | install / start 境界で invalid config を fail fast する |
+| Requirements | 3.1, 3.6 |
+
+**Responsibilities & Constraints**
+
+- `ClusterExtensionInstaller::install` は provider/pubsub/gossiper/identity setup 前に `config.validate()` を呼ぶ。
+- `ClusterCore::new` は `FailureDetectorConfig` clone を保持する。
+- `ClusterCore::start_member` / `start_client` は provider/pubsub/gossiper start 前に validation を呼ぶ。
+- install failure は `ActorSystemBuildError::Configuration(String)`、start failure は `ClusterError::Configuration(FailureDetectorConfigError)` として返す。
+
+### cluster-core / topology
+
+#### `ClusterCompatibilityKeyCatalog` integration
+
+| Field | Detail |
+|-------|--------|
+| Intent | Failure Detector Configuration (故障検出器設定) の stable compatibility key を定義する |
+| Requirements | 1.4, 4.4, 4.6, 6.2 |
+
+**Responsibilities & Constraints**
+
+- `FAILURE_DETECTOR: ClusterCompatibilityKey = required("cluster.failure-detector")` を追加する。
+- `required_keys()` に `FAILURE_DETECTOR` を含める。
+- `FAILURE_DETECTOR_CHOICE` は excluded のままにし、required / conditional に含めない。
+
+### cluster-adaptor-std / membership
+
+#### `ConfiguredPhiAccrualDetectorFactory`
+
+| Field | Detail |
+|-------|--------|
+| Intent | std 環境で FailureDetectorConfig を Phi Accrual detector construction へ接続する |
+| Requirements | 5.1, 5.2, 5.3 |
+
+**Responsibilities & Constraints**
+
+- `FailureDetectorConfig` の duration を millis へ変換して `PhiAccrualFailureDetector::new` に渡す。
+- `PhiAccrualAdapter` は cluster-core の `FailureDetector` trait だけを実装する。
+- helper は fixed Phi Accrual bridge であり、Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を提供しない。
+
+**Service Interface**
+
+```rust
+pub struct ConfiguredPhiAccrualDetectorFactory;
+
+impl ConfiguredPhiAccrualDetectorFactory {
+  pub fn new(config: FailureDetectorConfig, monitored_address: Address) -> Self;
+  pub fn create(&self) -> Box<dyn FailureDetector + Send>;
+}
+```
+
+## Data Models
+
+### Domain Model
+
+- `FailureDetectorConfig` は value object であり、Cluster Configuration (クラスタ設定) の一部として immutable に比較される。
+- `FailureDetectorConfigError` は validation result であり、Compatibility Mismatch Reason (互換性不一致理由) ではない。
+- `ClusterCompatibilityKeyCatalog::FAILURE_DETECTOR` は Join Compatibility (参加互換性) の stable key であり、field-level metadata ではない。
+
+### Logical Data Model
+
+| Field | Type | Default | Validation |
+|-------|------|---------|------------|
+| `phi_threshold` | `f64` | `1.0` | positive finite |
+| `max_sample_size` | `usize` | `10` | nonzero |
+| `min_standard_deviation` | `Duration` | `1ms` | nonzero |
+| `acceptable_heartbeat_pause` | `Duration` | `0ms` | zero allowed |
+| `first_heartbeat_estimate` | `Duration` | `10ms` | nonzero |
+
+## Error Handling
+
+### Error Strategy
+
+- Invalid Failure Detector Configuration (故障検出器設定) は Cluster Configuration Validation (クラスタ設定検証) failure として返す。
+- Join Compatibility (参加互換性) failure は `ConfigValidation::Incompatible { reason }` のまま扱う。
+- std bridge の duration millis conversion は saturating conversion を使い、validation 済みの nonzero duration を zero にしないよう test で確認する。
+
+### Error Categories and Responses
+
+- Configuration error: `FailureDetectorConfigError`。install では actor system build configuration failure、start では `ClusterError` に変換する。
+- Compatibility error: `cluster.failure-detector mismatch: phi_threshold, max_sample_size` のような reason を返す。
+
+## Testing Strategy
+
+### Unit Tests
+
+- `FailureDetectorConfig::new()` が `1.0`, `10`, `1ms`, `0ms`, `10ms` を返すことを検証する。Covers 1.2, 2.1, 2.2.
+- `FailureDetectorConfig::validate()` が invalid threshold、zero sample size、zero min standard deviation、zero first heartbeat estimate を拒否し、zero acceptable pause を許可することを検証する。Covers 3.2, 3.3, 3.4, 3.5.
+- `difference_field_names()` が差分のある観測パラメータ名だけを返すことを検証する。Covers 4.5.
+- `ClusterCompatibilityKeyCatalog` が `cluster.failure-detector` を required に含め、`cluster.failure-detector.choice` を excluded のままにすることを検証する。Covers 1.4, 4.4, 4.6, 6.2.
+
+### Integration Tests
+
+- `ClusterExtensionConfig::new()` が default Failure Detector Configuration (故障検出器設定) を保持し、custom config を `with_failure_detector_config` で保持することを検証する。Covers 1.1, 1.3.
+- local / joining config の Failure Detector Configuration (故障検出器設定) が一致する場合に join compatibility が compatible になることを検証する。Covers 4.1, 4.2.
+- 不一致の場合に `ConfigValidation::Incompatible` となり、reason に `cluster.failure-detector` と差分 field 名が含まれることを検証する。Covers 4.3, 4.4, 4.5.
+- invalid config が installer で `ActorSystemBuildError::Configuration` へ変換され、Join Compatibility (参加互換性) failure にならないことを検証する。Covers 3.1, 3.6.
+- `ClusterCore::start_member` / `start_client` が invalid config を provider/pubsub/gossiper start 前に返すことを検証する。Covers 3.1, 3.6.
+
+### std Bridge Tests
+
+- `ConfiguredPhiAccrualDetectorFactory` が config の threshold、sample size、duration millis を `PhiAccrualFailureDetector` へ渡すことを検証する。Covers 5.1, 5.2.
+- factory helper が Downing Decision (ダウン判断) や Member Removal (メンバー除去) の API を持たないことを public surface で確認する。Covers 5.3.
+
+### Documentation Tests
+
+- `docs/gap-analysis/cluster-gap-analysis.md` の Failure Detector Configuration (故障検出器設定) 項目が完了扱いになり、deferred scope を成果として書かないことを確認する。Covers 6.1, 6.3, 6.4.
+
+## Performance & Scalability
+
+- Join Compatibility (参加互換性) の detector config comparison は fixed field 数の比較であり、member 数に比例しない。
+- `difference_field_names()` は mismatch 時だけ small `Vec<&'static str>` を生成する。
+- std bridge は detector creation 時に duration millis conversion を行い、heartbeat path で configuration lookup を繰り返さない。
+
+## Migration Strategy
+
+- Existing `ClusterExtensionConfig::new()` callers は default `FailureDetectorConfig` により source compatibility を維持する。
+- Existing tests that construct `DefaultFailureDetectorRegistry` manually can migrate from ad hoc Phi Accrual constructor values to `FailureDetectorConfig::new()` where appropriate.
+- `MembershipCoordinatorConfig::phi_threshold` はこの spec では削除しない。後続の policy cleanup が必要な場合は別 spec で revalidation する。

--- a/.kiro/specs/configure-cluster-failure-detector/requirements.md
+++ b/.kiro/specs/configure-cluster-failure-detector/requirements.md
@@ -1,0 +1,66 @@
+# 要件ドキュメント
+
+## 導入
+
+fraktor-rs の cluster 実装者と運用者は、Failure Detector Configuration (故障検出器設定) を Cluster Configuration (クラスタ設定) として明示的に扱い、Availability Evidence (可用性観測証拠) の前提を Join Compatibility (参加互換性) で揃えたい。
+
+現状は Failure Detector (故障検出器) の registry と Phi Accrual 実装はあるが、Cluster Configuration (クラスタ設定) から観測パラメータを設定する contract、Cluster Configuration Validation (クラスタ設定検証)、Join Compatibility (参加互換性) の単一 key、Compatibility Mismatch Reason (互換性不一致理由) が揃っていない。この feature は `FailureDetectorConfig` を導入し、現行の観測挙動を変えずに Phi Accrual 前提の観測パラメータを Cluster Configuration (クラスタ設定) から Failure Detector (故障検出器) の生成へ接続し、gap analysis を完了扱いへ更新する。
+
+## 要件
+
+### 1. Failure Detector Configuration (故障検出器設定)
+**目的:** cluster 実装者として、Availability Evidence (可用性観測証拠) の観測方法を Cluster Configuration (クラスタ設定) として表現し、member 間の運用前提を明示したい。
+
+#### 受け入れ条件
+1. Cluster Configuration (クラスタ設定) が作成されたとき、fraktor-rs cluster は `FailureDetectorConfig` として Failure Detector Configuration (故障検出器設定) を保持しなければならない。
+2. Failure Detector Configuration (故障検出器設定) が明示されない場合、fraktor-rs cluster は既存の Availability Evidence (可用性観測証拠) の観測挙動と同等の default を使わなければならない。
+3. cluster 実装者が Failure Detector Configuration (故障検出器設定) の観測パラメータを指定したとき、fraktor-rs cluster は指定値を Cluster Configuration (クラスタ設定) の一部として保持しなければならない。
+4. Failure Detector Configuration (故障検出器設定) を扱う場合、fraktor-rs cluster は Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を利用者向け公開契約として要求してはならない。
+
+### 2. 観測パラメータの範囲
+**目的:** cluster 運用者として、Availability Evidence (可用性観測証拠) に直接影響する値だけを揃え、Membership Coordination Policy (メンバーシップ調停ポリシー) と混同しないようにしたい。
+
+#### 受け入れ条件
+1. Failure Detector Configuration (故障検出器設定) を含む場合、fraktor-rs cluster は Phi Accrual 前提の観測パラメータを設定対象に含めなければならない。
+2. Phi Accrual 前提の観測パラメータを含む場合、fraktor-rs cluster は phi threshold、max sample size、min standard deviation、acceptable heartbeat pause、first heartbeat estimate を区別して扱わなければならない。
+3. Failure Detector Configuration (故障検出器設定) を扱う場合、fraktor-rs cluster は suspect timeout、dead timeout、quarantine ttl、gossip interval を Failure Detector Configuration (故障検出器設定) に含めてはならない。
+4. Duration を持つ観測パラメータを指定したとき、fraktor-rs cluster は Cluster Configuration (クラスタ設定) 上では単位付きの duration として扱わなければならない。
+
+### 3. Cluster Configuration Validation (クラスタ設定検証)
+**目的:** cluster 実装者として、不成立な Failure Detector Configuration (故障検出器設定) を Join Compatibility (参加互換性) より前に検出し、設定値そのものの誤りとして扱いたい。
+
+#### 受け入れ条件
+1. cluster extension の install / start が要求されたとき、fraktor-rs cluster は Failure Detector Configuration (故障検出器設定) の値を Cluster Configuration Validation (クラスタ設定検証) として検証しなければならない。
+2. phi threshold が正の有限値ではない場合、fraktor-rs cluster は Cluster Configuration Validation (クラスタ設定検証) の失敗として報告しなければならない。
+3. max sample size が 0 の場合、fraktor-rs cluster は Cluster Configuration Validation (クラスタ設定検証) の失敗として報告しなければならない。
+4. min standard deviation または first heartbeat estimate が 0 の場合、fraktor-rs cluster は Cluster Configuration Validation (クラスタ設定検証) の失敗として報告しなければならない。
+5. acceptable heartbeat pause が 0 の場合、fraktor-rs cluster はその値を有効な Failure Detector Configuration (故障検出器設定) として扱わなければならない。
+6. Failure Detector Configuration (故障検出器設定) が不成立の場合、fraktor-rs cluster は Join Compatibility (参加互換性) の失敗ではなく Cluster Configuration Validation (クラスタ設定検証) の失敗として扱わなければならない。
+
+### 4. Join Compatibility (参加互換性)
+**目的:** cluster 運用者として、new Cluster Member (クラスタメンバー) を受け入れる前に Availability Evidence (可用性観測証拠) の前提が既存 member と一致していることを確認したい。
+
+#### 受け入れ条件
+1. new Cluster Member (クラスタメンバー) の join が要求されたとき、fraktor-rs cluster は Failure Detector Configuration (故障検出器設定) を Join Compatibility (参加互換性) の確認対象に含めなければならない。
+2. 既存 member と new Cluster Member (クラスタメンバー) の Failure Detector Configuration (故障検出器設定) が一致する場合、fraktor-rs cluster は Failure Detector Configuration (故障検出器設定) を理由に join を拒否してはならない。
+3. 既存 member と new Cluster Member (クラスタメンバー) の Failure Detector Configuration (故障検出器設定) が一致しない場合、fraktor-rs cluster は Join Compatibility (参加互換性) の失敗として join を拒否しなければならない。
+4. Failure Detector Configuration (故障検出器設定) の不一致で join を拒否する場合、fraktor-rs cluster は Compatibility Mismatch Reason (互換性不一致理由) に単一 key `cluster.failure-detector` を含めなければならない。
+5. Failure Detector Configuration (故障検出器設定) の不一致で join を拒否する場合、fraktor-rs cluster は Compatibility Mismatch Reason (互換性不一致理由) に差分のある観測パラメータ名を含めなければならない。
+6. Join Compatibility (参加互換性) を確認する場合、fraktor-rs cluster は `cluster.failure-detector.choice` を必須 key として扱ってはならない。
+
+### 5. Availability Evidence (可用性観測証拠) への反映
+**目的:** cluster 運用者として、Cluster Configuration (クラスタ設定) に指定した Failure Detector Configuration (故障検出器設定) が実際の Availability Evidence (可用性観測証拠) の観測に反映されることを確認したい。
+
+#### 受け入れ条件
+1. std 環境で Failure Detector (故障検出器) が必要になったとき、fraktor-rs cluster は Cluster Configuration (クラスタ設定) の Failure Detector Configuration (故障検出器設定) に基づいて Availability Evidence (可用性観測証拠) を観測しなければならない。
+2. Duration を持つ観測パラメータが Failure Detector (故障検出器) の観測に使われるとき、fraktor-rs cluster は public な Cluster Configuration (クラスタ設定) 上の duration 意味を維持しなければならない。
+3. Failure Detector Configuration (故障検出器設定) が変更された場合、fraktor-rs cluster は Downing Decision (ダウン判断) や Member Removal (メンバー除去) の責務を Failure Detector (故障検出器) に追加してはならない。
+
+### 6. Scope Boundary (スコープ境界)
+**目的:** cluster 実装者として、この feature が Failure Detector Configuration (故障検出器設定) の公開契約化に閉じていることを確認し、延期スコープと混同しないようにしたい。
+
+#### 受け入れ条件
+1. この feature を含む場合、fraktor-rs cluster は Split Brain Resolver の実行 actor、provider からの実 down execution loop、具体的な lease coordination backend を追加対象に含めてはならない。
+2. この feature を含む場合、fraktor-rs cluster は Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を追加対象に含めてはならない。
+3. この feature が完了したとき、fraktor-rs project docs は cluster gap analysis の該当項目を完了扱いとして示さなければならない。
+4. この feature が完了したとき、fraktor-rs project docs は Cluster Singleton、Cluster Client、Receptionist、Distributed Data / CRDT、Pekko public API parity をこの feature の成果として扱ってはならない。

--- a/.kiro/specs/configure-cluster-failure-detector/research.md
+++ b/.kiro/specs/configure-cluster-failure-detector/research.md
@@ -1,0 +1,295 @@
+# Gap Analysis
+
+## Summary
+
+- **Feature**: `configure-cluster-failure-detector`
+- **Discovery Scope**: Extension / Cluster Configuration (クラスタ設定) contract
+- **Requirements Status**: generated / not approved
+- **Key Findings**:
+  - Failure Detector (故障検出器) の trait、registry、Phi Accrual 実装は存在するが、Cluster Configuration (クラスタ設定) から Failure Detector Configuration (故障検出器設定) を保持・検証・生成へ渡す contract がない。
+  - Join Compatibility (参加互換性) の確認経路と key catalog は存在するため、Compatibility Mismatch Reason (互換性不一致理由) へ `cluster.failure-detector` を追加する拡張点はある。
+  - 現状の `MembershipCoordinatorConfig` は `phi_threshold` と Membership Coordination Policy (メンバーシップ調停ポリシー) の timeout 系を同じ型に持っており、要求上の責務分離とずれている。
+  - 既存テストには複数の Phi Accrual default 値があり、どれを cluster の既存 Availability Evidence (可用性観測証拠) として固定するかは設計フェーズで明示する必要がある。
+
+## Current State Investigation
+
+### Domain assets
+
+- `modules/cluster-core-kernel/src/failure_detector/`
+  - `FailureDetector` trait と `FailureDetectorRegistry` trait がある。
+  - `DefaultFailureDetectorRegistry` は boxed factory から detector を生成できる。
+  - Missing: `FailureDetectorConfig` と validation error はない。
+- `modules/remote-core/src/failure_detector/phi_accrual.rs`
+  - `PhiAccrualFailureDetector::new(address, threshold, max_sample_size, min_std_deviation, acceptable_heartbeat_pause, first_heartbeat_estimate)` がある。
+  - 各観測パラメータの getter がある。
+  - Constraint: Duration を public な Cluster Configuration (クラスタ設定) に置く場合、remote-core 側の primitive 値へ変換する境界が必要。
+- `modules/cluster-core-kernel/src/extension/cluster_extension_config.rs`
+  - `ClusterExtensionConfig` は pubsub、downing provider、role、static topology などを保持する。
+  - `check_join_compatibility` と `JOIN_COMPATIBILITY_CHECKS` に Join Compatibility (参加互換性) の既存拡張点がある。
+  - Missing: Failure Detector Configuration (故障検出器設定) の field、builder、validation、compatibility check がない。
+- `modules/cluster-core-kernel/src/topology/cluster_compatibility_key_catalog.rs`
+  - required key と excluded key の catalog がある。
+  - `cluster.failure-detector.choice` は excluded key として存在する。
+  - Missing: `cluster.failure-detector` の required key がない。
+- `modules/cluster-core-kernel/src/membership/membership_coordinator_config.rs`
+  - `phi_threshold`、`suspect_timeout`、`dead_timeout`、`quarantine_ttl`、`gossip_interval` が同居している。
+  - Constraint: 要件では phi threshold は Failure Detector Configuration (故障検出器設定)、timeout/gossip 系は Membership Coordination Policy (メンバーシップ調停ポリシー) 側に残す。
+- `docs/gap-analysis/cluster-gap-analysis.md`
+  - Failure Detector (故障検出器) の implementation choice config が partial として残っている。
+  - Constraint: 今回は Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を実装しない。
+
+### Conventions
+
+- core crate は no_std 境界を守り、std 依存や actor 実行を持たない。
+- std adaptor は core contract を実行へ接続する。
+- public type は既存ルールに合わせて小さな sibling file に分ける。
+- tests は sibling `tests.rs` や module-local test に置く傾向がある。
+- domain docs は `CONTEXT.md` の用語に合わせ、初出で `English Term (日本語名)` を使う。
+
+### Integration surfaces
+
+- Cluster Configuration (クラスタ設定): `ClusterExtensionConfig`
+- Join Compatibility (参加互換性): `ClusterExtensionConfig::check_join_compatibility`
+- compatibility key catalog: `ClusterCompatibilityKeyCatalog`
+- Availability Evidence (可用性観測証拠) の生成経路: `DefaultFailureDetectorRegistry` と Phi Accrual factory
+- validation reporting: existing `ConfigValidation` は compatibility 用であり、Cluster Configuration Validation (クラスタ設定検証) とは分けて設計する必要がある。
+
+## Requirement-to-Asset Map
+
+| Requirement | Existing Assets | Gap |
+| --- | --- | --- |
+| 1. Failure Detector Configuration (故障検出器設定) を Cluster Configuration (クラスタ設定) に保持する | `ClusterExtensionConfig` | Missing: `FailureDetectorConfig` 型、field、default、builder |
+| 1. Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を公開契約にしない | `ClusterCompatibilityKeyCatalog::FAILURE_DETECTOR_CHOICE` excluded | Constraint: `cluster.failure-detector.choice` を required にしない guard test が必要 |
+| 2. Phi Accrual 観測パラメータを区別する | `PhiAccrualFailureDetector` constructor/getter | Missing: Cluster Configuration (クラスタ設定) 上の typed config と Duration 境界 |
+| 2. suspect/dead/quarantine/gossip を含めない | `MembershipCoordinatorConfig` に timeout/gossip 系が存在 | Constraint: 移動や削除ではなく責務境界を明示する設計が必要 |
+| 3. Cluster Configuration Validation (クラスタ設定検証) | 互換性用 `ConfigValidation` のみ | Missing: install/start 前に呼ぶ validation API と `FailureDetectorConfigError` |
+| 4. Join Compatibility (参加互換性) に含める | `check_join_compatibility`、`JOIN_COMPATIBILITY_CHECKS` | Missing: `cluster.failure-detector` key と field-level diff reason |
+| 5. std 環境で Availability Evidence (可用性観測証拠) へ反映する | `DefaultFailureDetectorRegistry`、Phi Accrual adapter test patterns | Unknown: production path の detector factory 接続点 |
+| 6. gap analysis docs を完了扱いに更新する | `docs/gap-analysis/cluster-gap-analysis.md` | Missing: 実装完了後の該当項目更新 |
+
+## Implementation Approach Options
+
+### Option A: Extend Existing Components
+
+`ClusterExtensionConfig`、`ClusterCompatibilityKeyCatalog`、`ClusterExtensionConfig::check_join_compatibility` を直接拡張し、Failure Detector Configuration (故障検出器設定) の値・validation・Compatibility Mismatch Reason (互換性不一致理由) を既存 file に追加する。
+
+- **Files/modules to extend**:
+  - `modules/cluster-core-kernel/src/extension/cluster_extension_config.rs`
+  - `modules/cluster-core-kernel/src/topology/cluster_compatibility_key_catalog.rs`
+  - existing cluster-core tests
+- **Strengths**:
+  - 変更箇所が少なく、既存 Join Compatibility (参加互換性) の流れに乗せやすい。
+  - backward compatibility の確認対象が限定される。
+- **Risks / Limitations**:
+  - `ClusterExtensionConfig` が validation と field diff formatting まで抱え、責務が増える。
+  - `FailureDetectorConfigError` の置き場所が曖昧になりやすい。
+  - default 値の根拠が file 内で見えにくくなる。
+
+### Option B: Create New Components
+
+`FailureDetectorConfig`、`FailureDetectorConfigError`、差分計算 helper を Failure Detector (故障検出器) 側の独立 component として追加し、既存 config と compatibility catalog は integration のみを持つ。
+
+- **Files/modules to create**:
+  - `modules/cluster-core-kernel/src/failure_detector/failure_detector_config.rs`
+  - `modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error.rs`
+  - 必要に応じて config diff helper
+- **Strengths**:
+  - Failure Detector Configuration (故障検出器設定) の責務が明確になり、単体 test を書きやすい。
+  - Cluster Configuration Validation (クラスタ設定検証) の error taxonomy を config 型の近くに置ける。
+- **Risks / Limitations**:
+  - 新規 file と export が増える。
+  - Join Compatibility (参加互換性) との接続設計を誤ると、config 型が compatibility policy を持ちすぎる。
+  - std 側の factory 接続までは別途 integration が必要。
+
+### Option C: Hybrid Approach
+
+Failure Detector Configuration (故障検出器設定) の型と validation は新 component にし、Cluster Configuration (クラスタ設定) と Join Compatibility (参加互換性) の接続だけを既存 component へ最小追加する。
+
+- **Combination strategy**:
+  - `FailureDetectorConfig` と `FailureDetectorConfigError` は `failure_detector` module に置く。
+  - `ClusterExtensionConfig` は field、default、`with_failure_detector_config`、validation 呼び出しだけを持つ。
+  - `ClusterCompatibilityKeyCatalog` に `cluster.failure-detector` を追加し、`cluster.failure-detector.choice` は excluded のまま保つ。
+  - std adaptor は Cluster Configuration (クラスタ設定) から Phi Accrual factory を作る境界を持つ。
+- **Strengths**:
+  - core/adaptor 分離と one-public-type-per-file の既存規約に合う。
+  - Failure Detector Configuration (故障検出器設定) と Join Compatibility (参加互換性) の責務を分けられる。
+  - 設計フェーズで default と validation の根拠を明示しやすい。
+- **Risks / Limitations**:
+  - 複数 module を触るため、test plan と migration order が必要。
+  - production path の detector factory 接続点が未確認の場合、設計で追加調査が必要。
+
+## Complexity & Risk
+
+- **Effort**: M
+  - core config、validation、Join Compatibility (参加互換性)、std factory 接続、docs 更新、tests にまたがるが、既存の拡張点は明確。
+- **Risk**: Medium
+  - default 値の canonical source と production factory 接続点に不明点がある。Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) へ scope が広がるリスクも guard が必要。
+
+## Recommendations for Design Phase
+
+- **Preferred approach**: Option C を第一候補にする。
+  - `FailureDetectorConfig` は Availability Evidence (可用性観測証拠) の観測パラメータだけを所有する。
+  - `ClusterExtensionConfig` は Cluster Configuration (クラスタ設定) の aggregate として保持・validation 呼び出し・Join Compatibility (参加互換性) への接続を担う。
+  - `PhiAccrualFailureDetector` の selection は固定し、`cluster.failure-detector.choice` を required key にしない。
+- **Key decisions to make**:
+  - canonical default values をどの既存 cluster path から採るか。
+  - `FailureDetectorConfigError` の variant 名と表示文をどうするか。
+  - validation を install/start boundary のどの public API で強制するか。
+  - `required_join_compatibility_keys()` の field-level metadata と `ClusterCompatibilityKeyCatalog` の single key をどう整合させるか。
+  - std adaptor の production factory 接続点をどこに置くか。
+
+## Research Needed
+
+- Existing cluster-path default の特定:
+  - cluster-adaptor tests は `threshold, 10, 1, 0, 10` 系を使う。
+  - cluster-core registry test は `1.5, 4, 1, 0, 10` を使う。
+  - remote watcher の `5.0, 100, 10, 0, 100` は remote-core 側の用途であり、cluster default と混同しない確認が必要。
+- Production detector factory path:
+  - 現状は tests で `DefaultFailureDetectorRegistry` を組み立てる箇所が目立つ。
+  - std 環境で Cluster Configuration (クラスタ設定) から Availability Evidence (可用性観測証拠) へ流す production path を設計前に特定する。
+- Validation boundary:
+  - builder は不変式を強制せず、install/start で Cluster Configuration Validation (クラスタ設定検証) を実行する要求がある。
+  - 実際に install/start を担う API と error propagation を確認する。
+- Join Compatibility (参加互換性) metadata:
+  - 要件は single key `cluster.failure-detector` を Compatibility Mismatch Reason (互換性不一致理由) に出す。
+  - 既存 `required_join_compatibility_keys()` は field-level `fraktor.*` strings を返しているため、公開情報として残すか整理するかを設計で決める。
+
+## Boundary Guards
+
+- Failure Detector Configuration (故障検出器設定) は Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を含めない。
+- `cluster.failure-detector.choice` は required key にしない。
+- Failure Detector (故障検出器) に Downing Decision (ダウン判断) や Member Removal (メンバー除去) の責務を追加しない。
+- Split Brain Resolver execution actor、provider down execution loop、lease coordination backend はこの feature に含めない。
+- Cluster Singleton、Cluster Client、Receptionist、Distributed Data / CRDT、Pekko public API parity はこの feature に含めない。
+- `cluster-core-kernel` に std 依存を入れない。
+
+## References
+
+- `.kiro/specs/configure-cluster-failure-detector/requirements.md` — generated requirements.
+- `CONTEXT.md` — authoritative domain glossary.
+- `docs/adr/0001-failure-detector-configuration-contract.md` — Failure Detector Configuration (故障検出器設定) の contract decision.
+- `docs/gap-analysis/cluster-gap-analysis.md` — source gap.
+- `modules/cluster-core-kernel/src/extension/cluster_extension_config.rs` — Cluster Configuration (クラスタ設定) と Join Compatibility (参加互換性) の既存実装。
+- `modules/cluster-core-kernel/src/topology/cluster_compatibility_key_catalog.rs` — compatibility key catalog.
+- `modules/cluster-core-kernel/src/failure_detector/default_failure_detector_registry.rs` — detector factory registry.
+- `modules/remote-core/src/failure_detector/phi_accrual.rs` — Phi Accrual detector implementation.
+
+---
+
+# Design Discovery & Decisions
+
+## Summary
+
+- **Feature**: `configure-cluster-failure-detector`
+- **Discovery Scope**: Extension / light discovery
+- **Key Findings**:
+  - `ClusterExtensionConfig` と `ClusterCompatibilityKeyCatalog` は Join Compatibility (参加互換性) の拡張点を既に持つため、既存 component へ最小接続する設計で足りる。
+  - `ClusterExtensionInstaller::install` と `ClusterCore::start_member` / `start_client` が Cluster Configuration Validation (クラスタ設定検証) の自然な境界になる。
+  - std 側の Availability Evidence (可用性観測証拠) 反映は、新しい外部依存ではなく `PhiAccrualFailureDetector` を作る小さな factory helper で実現できる。
+
+## Research Log
+
+### Validation boundary
+
+- **Context**: 要件 3.1 は install / start 境界で Failure Detector Configuration (故障検出器設定) を検証することを求める。
+- **Sources Consulted**:
+  - `modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs`
+  - `modules/cluster-core-kernel/src/extension/cluster_core.rs`
+  - `modules/cluster-core-kernel/src/extension/cluster_error.rs`
+- **Findings**:
+  - installer は `ActorSystemBuildError::Configuration(String)` へ設定失敗を写せる。
+  - start member / client は `ClusterError` を返すため、config validation failure を cluster lifecycle error として返せる。
+  - `ClusterCore` は現状 config 全体を保持しないが、start 境界で検証するには Failure Detector Configuration (故障検出器設定) を保持する必要がある。
+- **Implications**:
+  - `ClusterExtensionConfig::validate()` を install 前に呼ぶ。
+  - `ClusterCore` は `FailureDetectorConfig` の clone を保持し、start member / client の最初に検証する。
+  - builder API では validation を強制しない。
+
+### Existing default values
+
+- **Context**: 要件 1.2 は既存 Availability Evidence (可用性観測証拠) の観測挙動と同等の default を求める。
+- **Sources Consulted**:
+  - `modules/cluster-core-kernel/src/membership/membership_coordinator_test.rs`
+  - `modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs`
+  - `modules/cluster-adaptor-std/tests/gossip_tokio_integration.rs`
+  - `modules/remote-core/src/watcher/watcher_state.rs`
+- **Findings**:
+  - cluster membership path は `phi_threshold = 1.0`、`max_sample_size = 10`、`min_std_deviation = 1ms`、`acceptable_heartbeat_pause = 0ms`、`first_heartbeat_estimate = 10ms` を繰り返し使う。
+  - remote watcher path は `5.0, 100, 10ms, 0ms, 100ms` を使うが、remote-core 側の watcher 用であり cluster default とは別の用途である。
+- **Implications**:
+  - `FailureDetectorConfig::new()` は cluster membership path の値を default とする。
+  - remote watcher default はこの spec の default source にしない。
+
+### Join Compatibility metadata
+
+- **Context**: 要件 4.4 と 4.5 は single key `cluster.failure-detector` と差分のある観測パラメータ名を求める。
+- **Sources Consulted**:
+  - `modules/cluster-core-kernel/src/extension/cluster_extension_config.rs`
+  - `modules/cluster-core-kernel/src/topology/cluster_compatibility_key_catalog.rs`
+- **Findings**:
+  - compatibility reason は catalog key と detail string を結合する既存 helper で生成される。
+  - `cluster.failure-detector.choice` は excluded key として既に定義されている。
+  - `required_join_compatibility_keys()` は field-level `fraktor.*` metadata strings を返す既存 API で、catalog の stable key と粒度が異なる。
+- **Implications**:
+  - catalog へ required key `cluster.failure-detector` を追加する。
+  - Failure Detector Configuration (故障検出器設定) は field-level metadata key を増やさず、required metadata も `cluster.failure-detector` に寄せる。Compatibility Mismatch Reason (互換性不一致理由) は同じ key に固定し、detail へ field 名だけを含める。
+  - `cluster.failure-detector.choice` は required / field-level metadata に追加しない。
+
+## Architecture Pattern Evaluation
+
+| Option | Description | Strengths | Risks / Limitations | Notes |
+|--------|-------------|-----------|---------------------|-------|
+| Extend existing components only | `ClusterExtensionConfig` に型・validation・diff を直接追加する | 変更箇所が少ない | config が責務過多になりやすい | 不採用 |
+| New components only | Failure Detector (故障検出器) 側に config と compatibility を閉じる | 単体責務は明確 | Cluster Configuration (クラスタ設定) との接続が遠くなる | 不採用 |
+| Hybrid | config/error は新 component、既存 config/catalog/core/std helper は接続だけ持つ | core/adaptor 境界と one-public-type-per-file に合う | 複数 file にまたがる | 採用 |
+
+## Design Decisions
+
+### Decision: Failure Detector Configuration (故障検出器設定) は focused value object にする
+
+- **Context**: 観測パラメータと Membership Coordination Policy (メンバーシップ調停ポリシー) を分離する必要がある。
+- **Alternatives Considered**:
+  1. `MembershipCoordinatorConfig` の `phi_threshold` 周辺を拡張する。
+  2. `ClusterExtensionConfig` に field を直接並べる。
+  3. `FailureDetectorConfig` を独立 value object にする。
+- **Selected Approach**: `FailureDetectorConfig` を `failure_detector` module に置き、Phi Accrual 前提の観測パラメータだけを所有させる。
+- **Rationale**: `CONTEXT.md` の用語境界と一致し、timeout/gossip policy を混入させない。
+- **Trade-offs**: `ClusterExtensionConfig` と std helper への接続が必要になる。
+- **Follow-up**: `MembershipCoordinatorConfig::phi_threshold` の扱いは実装で互換性を壊さない範囲に留める。
+
+### Decision: validation は builder ではなく install / start 境界で実行する
+
+- **Context**: 要件は Cluster Configuration Validation (クラスタ設定検証) を install / start 境界で扱うことを求める。
+- **Alternatives Considered**:
+  1. `with_*` builder で即時 reject する。
+  2. `ClusterExtensionConfig::validate()` を明示し、installer と core start で呼ぶ。
+- **Selected Approach**: builder は値保持のみ、`validate()` を install / start の先頭で呼ぶ。
+- **Rationale**: 既存 builder style を維持し、設定値そのものの誤りを Join Compatibility (参加互換性) より前に返せる。
+- **Trade-offs**: 無効な config value を一時的に保持できるため、start/install tests が必要。
+- **Follow-up**: install error は `ActorSystemBuildError::Configuration`、start error は `ClusterError::Configuration` 系へ写す。
+
+### Decision: std bridge は Phi Accrual helper に閉じる
+
+- **Context**: std 環境では Cluster Configuration (クラスタ設定) の値を Availability Evidence (可用性観測証拠) の観測に渡す必要がある。
+- **Alternatives Considered**:
+  1. cluster-core が `PhiAccrualFailureDetector` を直接生成する。
+  2. std adaptor に helper を置いて remote-core の detector へ変換する。
+- **Selected Approach**: std adaptor に `ConfiguredPhiAccrualDetectorFactory` を追加し、`FailureDetectorConfig` から `PhiAccrualFailureDetector` を生成する。
+- **Rationale**: cluster-core に concrete detector 依存を増やさず、std 側で remote-core 実装を使える。
+- **Trade-offs**: helper は algorithm selection surface ではなく固定 bridge であることを docs と tests で guard する。
+- **Follow-up**: production assembly が helper を使う箇所は実装タスクで既存 factory flow に沿って接続する。
+
+## Risks & Mitigations
+
+- default 値が意図せず remote watcher default に寄る — cluster membership tests の既存値を `FailureDetectorConfig::new()` の source として固定する。
+- Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) へ scope が広がる — `cluster.failure-detector.choice` を excluded のままにし、std helper 名も choice を示さない。
+- validation failure と Join Compatibility (参加互換性) failure が混ざる — invalid config tests と mismatch config tests を分ける。
+
+## References
+
+- `CONTEXT.md` — domain terminology.
+- `docs/adr/0001-failure-detector-configuration-contract.md` — contract decision.
+- `.kiro/specs/configure-cluster-failure-detector/requirements.md` — accepted requirements for this design.
+- `modules/cluster-core-kernel/src/extension/cluster_extension_config.rs` — Cluster Configuration (クラスタ設定) aggregate and Join Compatibility (参加互換性).
+- `modules/cluster-core-kernel/src/extension/cluster_core.rs` — start member / client validation boundary.
+- `modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs` — existing cluster-path detector parameters.

--- a/.kiro/specs/configure-cluster-failure-detector/spec.json
+++ b/.kiro/specs/configure-cluster-failure-detector/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "configure-cluster-failure-detector",
+  "created_at": "2026-06-08T08:54:59Z",
+  "updated_at": "2026-06-08T11:30:43Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -98,7 +98,7 @@
   - _Depends: 3.2, 4.1_
 
 - [ ] 5. gap analysis と scope guard を更新する
-- [ ] 5.1 cluster gap analysis の該当項目を完了扱いへ更新する
+- [x] 5.1 cluster gap analysis の該当項目を完了扱いへ更新する
   - Failure Detector Configuration (故障検出器設定) の contract、validation、Join Compatibility (参加互換性)、std bridge が揃ったことを反映する。
   - Split Brain Resolver execution actor、provider down execution loop、lease coordination backend はこの成果として書かない。
   - Cluster Singleton、Cluster Client、Receptionist、Distributed Data / CRDT、Pekko public API parity をこの feature の成果として扱わない。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -8,7 +8,7 @@
   - _Requirements: 3.2, 3.3, 3.4, 3.6_
   - _Boundary: FailureDetectorConfigError_
 
-- [ ] 1.2 `FailureDetectorConfig` が観測パラメータと default を保持する
+- [x] 1.2 `FailureDetectorConfig` が観測パラメータと default を保持する
   - phi threshold、max sample size、min standard deviation、acceptable heartbeat pause、first heartbeat estimate を保持する。
   - default は既存 cluster membership path と同等の `1.0`, `10`, `1ms`, `0ms`, `10ms` にする。
   - suspect timeout、dead timeout、quarantine ttl、gossip interval は含めない。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -61,7 +61,7 @@
   - _Boundary: ClusterError_
   - _Depends: 1.1_
 
-- [ ] 3.2 `ClusterCore` が start 前に Failure Detector Configuration (故障検出器設定) を検証する
+- [x] 3.2 `ClusterCore` が start 前に Failure Detector Configuration (故障検出器設定) を検証する
   - `ClusterCore` は start member / client の前提として Failure Detector Configuration (故障検出器設定) を保持する。
   - provider、pubsub、gossiper の start より前に validation failure を返す。
   - validation failure は Join Compatibility (参加互換性) failure ではなく cluster lifecycle error として観測できる。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -108,7 +108,7 @@
   - _Depends: 2.3, 3.2, 3.3, 4.2_
 
 - [ ] 6. feature 全体を検証する
-- [ ] 6.1 対象 crate の単体・統合テストを通す
+- [x] 6.1 対象 crate の単体・統合テストを通す
   - cluster-core の Failure Detector Configuration (故障検出器設定)、Join Compatibility (参加互換性)、install / start validation のテストを実行する。
   - cluster-adaptor-std の std bridge と既存 detector registry 接続のテストを実行する。
   - 完了時点で、対象 test command の成功結果が確認できる。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -70,7 +70,7 @@
   - _Boundary: ClusterCore_
   - _Depends: 2.2, 3.1_
 
-- [ ] 3.3 (P) `ClusterExtensionInstaller` が install 前に Failure Detector Configuration (故障検出器設定) を検証する
+- [x] 3.3 (P) `ClusterExtensionInstaller` が install 前に Failure Detector Configuration (故障検出器設定) を検証する
   - extension install 時に `ClusterExtensionConfig` の validation を実行する。
   - invalid config は actor system build configuration failure として返す。
   - provider、pubsub、identity lookup の組み立て前に failure が観測できるようにする。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -1,0 +1,126 @@
+# 実装タスク
+
+- [ ] 1. Failure Detector Configuration (故障検出器設定) の基盤を作る
+- [x] 1.1 `FailureDetectorConfigError` で Cluster Configuration Validation (クラスタ設定検証) の失敗理由を表現する
+  - phi threshold、max sample size、min standard deviation、first heartbeat estimate の不成立を、それぞれ区別できる error として扱う。
+  - error は Join Compatibility (参加互換性) の不一致理由ではなく、設定値そのものの validation failure として使える状態にする。
+  - 完了時点で、各 invalid field category を単体テストで識別できる。
+  - _Requirements: 3.2, 3.3, 3.4, 3.6_
+  - _Boundary: FailureDetectorConfigError_
+
+- [ ] 1.2 `FailureDetectorConfig` が観測パラメータと default を保持する
+  - phi threshold、max sample size、min standard deviation、acceptable heartbeat pause、first heartbeat estimate を保持する。
+  - default は既存 cluster membership path と同等の `1.0`, `10`, `1ms`, `0ms`, `10ms` にする。
+  - suspect timeout、dead timeout、quarantine ttl、gossip interval は含めない。
+  - 完了時点で、default と custom value が getter から観測でき、Duration を単位付き値として保持していることを単体テストで確認できる。
+  - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 2.4_
+  - _Boundary: FailureDetectorConfig_
+
+- [ ] 1.3 `FailureDetectorConfig` の validation と差分抽出を完成させる
+  - 正の有限値ではない phi threshold、0 の max sample size、0 の min standard deviation、0 の first heartbeat estimate を拒否する。
+  - acceptable heartbeat pause の 0 は valid として扱う。
+  - 差分のある観測パラメータ名だけを Compatibility Mismatch Reason (互換性不一致理由) の detail に使える形で返す。
+  - 完了時点で、valid / invalid の境界と差分 field 名が単体テストで観測できる。
+  - _Requirements: 3.2, 3.3, 3.4, 3.5, 4.5_
+  - _Boundary: FailureDetectorConfig_
+  - _Depends: 1.1, 1.2_
+
+- [ ] 2. Cluster Configuration (クラスタ設定) と Join Compatibility (参加互換性) へ接続する
+- [ ] 2.1 (P) `ClusterCompatibilityKeyCatalog` に `cluster.failure-detector` を追加する
+  - Failure Detector Configuration (故障検出器設定) 用の required key を追加する。
+  - `cluster.failure-detector.choice` は excluded key のまま維持し、required / conditional に入れない。
+  - 完了時点で、required keys と excluded keys の分類を単体テストで確認できる。
+  - _Requirements: 1.4, 4.4, 4.6, 6.2_
+  - _Boundary: ClusterCompatibilityKeyCatalog_
+  - _Depends: 1.1_
+
+- [ ] 2.2 (P) `ClusterExtensionConfig` が Failure Detector Configuration (故障検出器設定) を保持する
+  - Cluster Configuration (クラスタ設定) の一部として `FailureDetectorConfig` を保持する。
+  - 明示指定がない場合は `FailureDetectorConfig` の default を使う。
+  - custom config を builder-style API で設定でき、getter で同じ値を取得できる。
+  - 完了時点で、default config と custom config が `ClusterExtensionConfig` のテストから観測できる。
+  - _Requirements: 1.1, 1.2, 1.3, 3.1_
+  - _Boundary: ClusterExtensionConfig_
+  - _Depends: 1.2_
+
+- [ ] 2.3 `ClusterExtensionConfig` の Join Compatibility (参加互換性) 判定に Failure Detector Configuration (故障検出器設定) を含める
+  - local と joining の Failure Detector Configuration (故障検出器設定) が一致する場合は compatible として扱う。
+  - 不一致の場合は `cluster.failure-detector` の single key で incompatible reason を作る。
+  - reason detail には差分のある観測パラメータ名を含め、`cluster.failure-detector.choice` を必須 key として扱わない。
+  - 完了時点で、一致時 accepted / 不一致時 rejected / choice key excluded が統合テストで確認できる。
+  - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
+  - _Boundary: ClusterExtensionConfig, ClusterCompatibilityKeyCatalog_
+  - _Depends: 1.3, 2.1, 2.2_
+
+- [ ] 3. install / start 境界で Cluster Configuration Validation (クラスタ設定検証) を実行する
+- [ ] 3.1 `ClusterError` が Cluster Configuration Validation (クラスタ設定検証) を表せるようにする
+  - start member / client で返す validation failure を cluster lifecycle error として扱えるようにする。
+  - error は Join Compatibility (参加互換性) failure と区別できる形にする。
+  - 完了時点で、Failure Detector Configuration (故障検出器設定) の validation failure を lifecycle error として比較できる。
+  - _Requirements: 3.1, 3.6_
+  - _Boundary: ClusterError_
+  - _Depends: 1.1_
+
+- [ ] 3.2 `ClusterCore` が start 前に Failure Detector Configuration (故障検出器設定) を検証する
+  - `ClusterCore` は start member / client の前提として Failure Detector Configuration (故障検出器設定) を保持する。
+  - provider、pubsub、gossiper の start より前に validation failure を返す。
+  - validation failure は Join Compatibility (参加互換性) failure ではなく cluster lifecycle error として観測できる。
+  - 完了時点で、invalid config では provider 側 start へ進まないことをテストで確認できる。
+  - _Requirements: 3.1, 3.6_
+  - _Boundary: ClusterCore_
+  - _Depends: 2.2, 3.1_
+
+- [ ] 3.3 (P) `ClusterExtensionInstaller` が install 前に Failure Detector Configuration (故障検出器設定) を検証する
+  - extension install 時に `ClusterExtensionConfig` の validation を実行する。
+  - invalid config は actor system build configuration failure として返す。
+  - provider、pubsub、identity lookup の組み立て前に failure が観測できるようにする。
+  - 完了時点で、invalid config の install が configuration error で止まることをテストで確認できる。
+  - _Requirements: 3.1, 3.6_
+  - _Boundary: ClusterExtensionInstaller_
+  - _Depends: 2.2_
+
+- [ ] 4. std 環境で Availability Evidence (可用性観測証拠) の観測へ接続する
+- [ ] 4.1 (P) `FailureDetectorConfig` から Phi Accrual detector を生成する bridge を追加する
+  - std 側で `FailureDetectorConfig` の値を `PhiAccrualFailureDetector` の constructor へ渡す。
+  - Duration を millis に変換し、public な Cluster Configuration (クラスタ設定) 上の duration 意味を維持する。
+  - bridge は fixed Phi Accrual 生成だけを担い、Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) の API を持たない。
+  - 完了時点で、threshold、sample size、duration millis が生成後の detector から観測できる。
+  - _Requirements: 5.1, 5.2, 5.3, 6.2_
+  - _Boundary: ConfiguredPhiAccrualDetectorFactory_
+  - _Depends: 1.2, 1.3_
+
+- [ ] 4.2 std bridge を既存の detector registry 利用箇所へ接続する
+  - 既存の ad hoc Phi Accrual constructor usage を、Cluster Configuration (クラスタ設定) 由来の bridge を使う形へ置き換える。
+  - `MembershipCoordinatorConfig::phi_threshold` の既存互換性は壊さず、この feature の範囲では policy cleanup をしない。
+  - 完了時点で、std 側の coordinator / gossiper test が Failure Detector Configuration (故障検出器設定) 由来の detector で通る。
+  - _Requirements: 5.1, 5.2, 5.3_
+  - _Boundary: ConfiguredPhiAccrualDetectorFactory, MembershipCoordinator integration_
+  - _Depends: 3.2, 4.1_
+
+- [ ] 5. gap analysis と scope guard を更新する
+- [ ] 5.1 cluster gap analysis の該当項目を完了扱いへ更新する
+  - Failure Detector Configuration (故障検出器設定) の contract、validation、Join Compatibility (参加互換性)、std bridge が揃ったことを反映する。
+  - Split Brain Resolver execution actor、provider down execution loop、lease coordination backend はこの成果として書かない。
+  - Cluster Singleton、Cluster Client、Receptionist、Distributed Data / CRDT、Pekko public API parity をこの feature の成果として扱わない。
+  - 完了時点で、gap analysis からこの feature の完了範囲と延期範囲を区別して読める。
+  - _Requirements: 6.1, 6.3, 6.4_
+  - _Boundary: gap analysis docs_
+  - _Depends: 2.3, 3.2, 3.3, 4.2_
+
+- [ ] 6. feature 全体を検証する
+- [ ] 6.1 対象 crate の単体・統合テストを通す
+  - cluster-core の Failure Detector Configuration (故障検出器設定)、Join Compatibility (参加互換性)、install / start validation のテストを実行する。
+  - cluster-adaptor-std の std bridge と既存 detector registry 接続のテストを実行する。
+  - 完了時点で、対象 test command の成功結果が確認できる。
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2, 5.3_
+  - _Boundary: Verification_
+  - _Depends: 5.1_
+
+- [ ] 6.2 no_std 境界、用語、禁止 scope を確認する
+  - cluster-core に std 依存が増えていないことを確認する。
+  - 禁止された用途語、旧 prefix の failure detector key、`cluster.failure-detector.choice` の required 化が残っていないことを検索で確認する。
+  - docs が `CONTEXT.md` の用語に沿い、Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を成果として扱っていないことを確認する。
+  - 完了時点で、検索結果と targeted verification が scope guard を満たす。
+  - _Requirements: 1.4, 2.3, 4.6, 5.3, 6.1, 6.2, 6.3, 6.4_
+  - _Boundary: Verification_
+  - _Depends: 6.1_

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -80,7 +80,7 @@
   - _Depends: 2.2_
 
 - [ ] 4. std 環境で Availability Evidence (可用性観測証拠) の観測へ接続する
-- [ ] 4.1 (P) `FailureDetectorConfig` から Phi Accrual detector を生成する bridge を追加する
+- [x] 4.1 (P) `FailureDetectorConfig` から Phi Accrual detector を生成する bridge を追加する
   - std 側で `FailureDetectorConfig` の値を `PhiAccrualFailureDetector` の constructor へ渡す。
   - Duration を millis に変換し、public な Cluster Configuration (クラスタ設定) 上の duration 意味を維持する。
   - bridge は fixed Phi Accrual 生成だけを担い、Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) の API を持たない。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -43,7 +43,7 @@
   - _Boundary: ClusterExtensionConfig_
   - _Depends: 1.2_
 
-- [ ] 2.3 `ClusterExtensionConfig` の Join Compatibility (参加互換性) 判定に Failure Detector Configuration (故障検出器設定) を含める
+- [x] 2.3 `ClusterExtensionConfig` の Join Compatibility (参加互換性) 判定に Failure Detector Configuration (故障検出器設定) を含める
   - local と joining の Failure Detector Configuration (故障検出器設定) が一致する場合は compatible として扱う。
   - 不一致の場合は `cluster.failure-detector` の single key で incompatible reason を作る。
   - reason detail には差分のある観測パラメータ名を含め、`cluster.failure-detector.choice` を必須 key として扱わない。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -89,7 +89,7 @@
   - _Boundary: ConfiguredPhiAccrualDetectorFactory_
   - _Depends: 1.2, 1.3_
 
-- [ ] 4.2 std bridge を既存の detector registry 利用箇所へ接続する
+- [x] 4.2 std bridge を既存の detector registry 利用箇所へ接続する
   - 既存の ad hoc Phi Accrual constructor usage を、Cluster Configuration (クラスタ設定) 由来の bridge を使う形へ置き換える。
   - `MembershipCoordinatorConfig::phi_threshold` の既存互換性は壊さず、この feature の範囲では policy cleanup をしない。
   - 完了時点で、std 側の coordinator / gossiper test が Failure Detector Configuration (故障検出器設定) 由来の detector で通る。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -16,7 +16,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 2.4_
   - _Boundary: FailureDetectorConfig_
 
-- [ ] 1.3 `FailureDetectorConfig` の validation と差分抽出を完成させる
+- [x] 1.3 `FailureDetectorConfig` の validation と差分抽出を完成させる
   - 正の有限値ではない phi threshold、0 の max sample size、0 の min standard deviation、0 の first heartbeat estimate を拒否する。
   - acceptable heartbeat pause の 0 は valid として扱う。
   - 差分のある観測パラメータ名だけを Compatibility Mismatch Reason (互換性不一致理由) の detail に使える形で返す。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -34,7 +34,7 @@
   - _Boundary: ClusterCompatibilityKeyCatalog_
   - _Depends: 1.1_
 
-- [ ] 2.2 (P) `ClusterExtensionConfig` が Failure Detector Configuration (故障検出器設定) を保持する
+- [x] 2.2 (P) `ClusterExtensionConfig` が Failure Detector Configuration (故障検出器設定) を保持する
   - Cluster Configuration (クラスタ設定) の一部として `FailureDetectorConfig` を保持する。
   - 明示指定がない場合は `FailureDetectorConfig` の default を使う。
   - custom config を builder-style API で設定でき、getter で同じ値を取得できる。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -53,7 +53,7 @@
   - _Depends: 1.3, 2.1, 2.2_
 
 - [ ] 3. install / start 境界で Cluster Configuration Validation (クラスタ設定検証) を実行する
-- [ ] 3.1 `ClusterError` が Cluster Configuration Validation (クラスタ設定検証) を表せるようにする
+- [x] 3.1 `ClusterError` が Cluster Configuration Validation (クラスタ設定検証) を表せるようにする
   - start member / client で返す validation failure を cluster lifecycle error として扱えるようにする。
   - error は Join Compatibility (参加互換性) failure と区別できる形にする。
   - 完了時点で、Failure Detector Configuration (故障検出器設定) の validation failure を lifecycle error として比較できる。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -116,7 +116,7 @@
   - _Boundary: Verification_
   - _Depends: 5.1_
 
-- [ ] 6.2 no_std 境界、用語、禁止 scope を確認する
+- [x] 6.2 no_std 境界、用語、禁止 scope を確認する
   - cluster-core に std 依存が増えていないことを確認する。
   - 禁止された用途語、旧 prefix の failure detector key、`cluster.failure-detector.choice` の required 化が残っていないことを検索で確認する。
   - docs が `CONTEXT.md` の用語に沿い、Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) を成果として扱っていないことを確認する。

--- a/.kiro/specs/configure-cluster-failure-detector/tasks.md
+++ b/.kiro/specs/configure-cluster-failure-detector/tasks.md
@@ -26,7 +26,7 @@
   - _Depends: 1.1, 1.2_
 
 - [ ] 2. Cluster Configuration (クラスタ設定) と Join Compatibility (参加互換性) へ接続する
-- [ ] 2.1 (P) `ClusterCompatibilityKeyCatalog` に `cluster.failure-detector` を追加する
+- [x] 2.1 (P) `ClusterCompatibilityKeyCatalog` に `cluster.failure-detector` を追加する
   - Failure Detector Configuration (故障検出器設定) 用の required key を追加する。
   - `cluster.failure-detector.choice` は excluded key のまま維持し、required / conditional に入れない。
   - 完了時点で、required keys と excluded keys の分類を単体テストで確認できる。

--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -63,13 +63,13 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 294 件 (core-kerne
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象概念 | 約 121 |
-| fraktor-rs 固定スコープ対応概念 | 約 72 |
-| 固定スコープ概念カバレッジ | 約 72/121 (60%) |
+| fraktor-rs 固定スコープ対応概念 | 約 73 |
+| 固定スコープ概念カバレッジ | 約 73/121 (60%) |
 | raw public type declarations | 294 (core-kernel: 263, core-typed: 9, std: 22) |
 | raw public method declarations | 825 (core-kernel: 714, core-typed: 32, std: 79) |
 | hard gap | 16 |
 | medium gap | 16 |
-| easy gap | 9 |
+| easy gap | 8 |
 | trivial gap | 2 |
 | panic 系スタブ | 0 件 |
 | 機能 placeholder / TODO | 0 件 |
@@ -105,7 +105,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 
 実装済みとして扱うもの: cluster extension、join/leave/down、event stream subscription、current state snapshot、member/up/removed callback、roles/app_version 設定、leader/role leader 算出、startup/shutdown event。
 
-### 2. Gossip / reachability / failure detection　✅ 実装済み 14/15 (93%)
+### 2. Gossip / reachability / failure detection　✅ 実装済み 15/15 (100%)
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
@@ -116,7 +116,7 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | `CrossDcClusterHeartbeat` | `CrossDcClusterHeartbeat.scala:230` | core evidence 実装済み | core/membership | hard | `CrossDcHeartbeat` が data center pair、cross-DC request/response、target add/remove/retain、timeout evidence を扱う。routing、discovery、downing strategy は決定しない。tests: `cross_dc_*` |
 | `SeedNodeProcess` | `SeedNodeProcess.scala:22` | core + std provider boundary 実装済み | core/cluster_provider + std/provider | medium | `SeedNodeInput` と `SeedNodeProcess` が empty seed、self filtering、duplicate seed、invalid authority、client start、shutdown 後停止を扱う。`ProviderLifecycleBridge` が seed input を topology update に接続する。tests: `seed_node_process_*`, `provider_lifecycle_bridge_seed_input_publishes_topology_update`, `provider_lifecycle_bridge_shutdown_stops_seed_and_discovery_lifecycle` |
 | config compatibility full key set | `JoinConfigCompatChecker.scala:25`, `JoinConfigCompatCheckCluster.scala:27` | baseline 実装済み | core/config | easy | `ClusterCompatibilityKeyCatalog` が required/excluded key を公開し、`JoinCompatibilityComposition` と `ClusterExtensionConfig::check_join_compatibility` が pubsub、downing provider、SBR settings の mismatch reason を合成する。`cluster_compatibility_key` / `join_compatibility` tests で確認 |
-| failure detector implementation choice | `Cluster.scala:124`, `Cluster.scala:131` | 部分実装 | core/failure_detector | easy | registry はあるが cluster config から deadline/phi などを選ぶ設定 contract がない |
+| Failure Detector Configuration (故障検出器設定) | `Cluster.scala:124`, `Cluster.scala:131` | contract 実装済み | core/failure_detector + config + std/membership | easy | `FailureDetectorConfig` が Phi Accrual 前提の Availability Evidence (可用性観測証拠) 観測パラメータを Cluster Configuration (クラスタ設定) として保持する。Cluster Configuration Validation (クラスタ設定検証) は install / start 境界で不成立値を Join Compatibility (参加互換性) より前に拒否する。Join Compatibility (参加互換性) は single key `cluster.failure-detector` で Compatibility Mismatch Reason (互換性不一致理由) を作り、detail に差分 field を含める。`cluster.failure-detector.choice` は required key ではなく excluded key のまま維持する。std bridge は `ConfiguredPhiAccrualDetectorFactory` で config を concrete detector 生成へ接続する |
 
 実装済みとして扱うもの: `MembershipTable`、`MembershipDelta`、`MembershipVersion`、`VectorClock`、`DefaultFailureDetectorRegistry`、`MembershipCoordinator::poll` による suspect/dead 遷移、`GossipEnvelope`、`GossipStateModel`、`HeartbeatProtocolState`、`CrossDcHeartbeat`、logical envelope handoff、`TokioGossipTransport`。
 
@@ -307,6 +307,14 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 
 この completed table は `cluster-message-serialization-contract` の serializer bridge evidence だけを表す。gossip merge / heartbeat / reachability semantics、pubsub mediator state / delivery / registry semantics、remote transport lifecycle、Pekko/protobuf 完全バイナリ互換は scope 外のまま残す。
 
+### Completed active follow-up: Failure Detector Configuration (故障検出器設定)
+
+| 項目 | 実装先層 | 状態 | 根拠 / evidence |
+|------|----------|------|-----------------|
+| Failure Detector Configuration (故障検出器設定) | core/failure_detector + config + std/membership | contract evidence 実装済み | `FailureDetectorConfig` が Phi Accrual 前提の観測パラメータを Cluster Configuration (クラスタ設定) として保持し、Cluster Configuration Validation (クラスタ設定検証) が install / start 境界で不成立値を拒否する。Join Compatibility (参加互換性) は `cluster.failure-detector` single key を使い、Compatibility Mismatch Reason (互換性不一致理由) の detail に差分 field を含める。`cluster.failure-detector.choice` は required key ではなく excluded key のまま維持する。std bridge は `ConfiguredPhiAccrualDetectorFactory` で `FailureDetectorConfig` を concrete Phi Accrual detector 生成へ接続する |
+
+この completed table は `configure-cluster-failure-detector` の Failure Detector Configuration (故障検出器設定) contract evidence だけを表す。Split Brain Resolver execution actor、provider down execution loop、concrete lease coordination backend、Cluster Singleton、Cluster Client、Receptionist、Distributed Data / CRDT、Pekko public API parity、Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) はこの feature の成果として扱わず、延期 scope のまま残す。
+
 ### Completed active follow-up: distributed pubsub / topic registry
 
 | 項目 | 実装先層 | 状態 | 根拠 / evidence |
@@ -323,12 +331,6 @@ cluster は、membership table、gossip dissemination、full gossip state merge 
 | 項目 | 実装先層 | 根拠 |
 |------|----------|------|
 | `PrepareForFullClusterShutdown` command path | core/typed + std | カテゴリ1 / カテゴリ5 |
-
-### Active comparison follow-up: easy
-
-| 項目 | 実装先層 | 根拠 |
-|------|----------|------|
-| failure detector implementation choice config | core/failure_detector + config | カテゴリ2 |
 
 ### Deferred Pekko concepts: trivial / easy
 

--- a/modules/cluster-adaptor-std/src/membership.rs
+++ b/modules/cluster-adaptor-std/src/membership.rs
@@ -1,5 +1,6 @@
 //! Tokio-backed membership and gossip adaptors.
 
+mod configured_phi_accrual_detector_factory;
 mod gossip_wire_delta_v1;
 mod gossip_wire_node_record;
 mod membership_coordinator_driver;
@@ -8,6 +9,7 @@ mod tokio_gossip_transport_config;
 mod tokio_gossiper;
 mod tokio_gossiper_config;
 
+pub use configured_phi_accrual_detector_factory::ConfiguredPhiAccrualDetectorFactory;
 pub use tokio_gossip_transport::TokioGossipTransport;
 pub use tokio_gossip_transport_config::TokioGossipTransportConfig;
 pub use tokio_gossiper::TokioGossiper;

--- a/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory.rs
+++ b/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory.rs
@@ -1,0 +1,61 @@
+//! Configured Phi Accrual detector bridge.
+
+use core::time::Duration;
+
+use fraktor_cluster_core_kernel_rs::failure_detector::{FailureDetector, FailureDetectorConfig};
+use fraktor_remote_core_rs::{address::Address, failure_detector::PhiAccrualFailureDetector};
+
+#[cfg(test)]
+#[path = "configured_phi_accrual_detector_factory_test.rs"]
+mod tests;
+
+/// Creates Phi Accrual failure detectors from cluster failure detector configuration.
+pub struct ConfiguredPhiAccrualDetectorFactory {
+  config:            FailureDetectorConfig,
+  monitored_address: Address,
+}
+
+impl ConfiguredPhiAccrualDetectorFactory {
+  /// Creates a configured Phi Accrual detector factory.
+  #[must_use]
+  pub const fn new(config: FailureDetectorConfig, monitored_address: Address) -> Self {
+    Self { config, monitored_address }
+  }
+
+  /// Creates a cluster-core failure detector.
+  #[must_use]
+  pub fn create(&self) -> Box<dyn FailureDetector + Send> {
+    Box::new(PhiAccrualAdapter(self.create_phi_accrual_detector()))
+  }
+
+  fn create_phi_accrual_detector(&self) -> PhiAccrualFailureDetector {
+    PhiAccrualFailureDetector::new(
+      self.monitored_address.clone(),
+      self.config.phi_threshold(),
+      self.config.max_sample_size(),
+      millis_u64(self.config.min_standard_deviation()),
+      millis_u64(self.config.acceptable_heartbeat_pause()),
+      millis_u64(self.config.first_heartbeat_estimate()),
+    )
+  }
+}
+
+struct PhiAccrualAdapter(PhiAccrualFailureDetector);
+
+impl FailureDetector for PhiAccrualAdapter {
+  fn is_available(&self, now_ms: u64) -> bool {
+    self.0.is_available(now_ms)
+  }
+
+  fn is_monitoring(&self) -> bool {
+    self.0.is_monitoring()
+  }
+
+  fn heartbeat(&mut self, now_ms: u64) {
+    self.0.heartbeat(now_ms);
+  }
+}
+
+fn millis_u64(value: Duration) -> u64 {
+  u64::try_from(value.as_millis()).unwrap_or(u64::MAX)
+}

--- a/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory.rs
+++ b/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory.rs
@@ -57,5 +57,10 @@ impl FailureDetector for PhiAccrualAdapter {
 }
 
 fn millis_u64(value: Duration) -> u64 {
-  u64::try_from(value.as_millis()).unwrap_or(u64::MAX)
+  let millis = value.as_millis();
+  if millis == 0 && value > Duration::ZERO {
+    return 1;
+  }
+
+  u64::try_from(millis).unwrap_or(u64::MAX)
 }

--- a/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory_test.rs
@@ -1,0 +1,41 @@
+use core::time::Duration;
+
+use fraktor_cluster_core_kernel_rs::failure_detector::{FailureDetector, FailureDetectorConfig};
+use fraktor_remote_core_rs::address::Address;
+
+use super::ConfiguredPhiAccrualDetectorFactory;
+
+fn address() -> Address {
+  Address::new("cluster-test", "127.0.0.1", 2552)
+}
+
+#[test]
+fn creates_phi_accrual_detector_from_failure_detector_config() {
+  let config = FailureDetectorConfig::new()
+    .with_phi_threshold(8.5)
+    .with_max_sample_size(64)
+    .with_min_standard_deviation(Duration::from_millis(250))
+    .with_acceptable_heartbeat_pause(Duration::from_secs(3))
+    .with_first_heartbeat_estimate(Duration::from_millis(750));
+  let factory = ConfiguredPhiAccrualDetectorFactory::new(config, address());
+
+  let detector = factory.create_phi_accrual_detector();
+
+  assert_eq!(detector.threshold(), 8.5);
+  assert_eq!(detector.max_sample_size(), 64);
+  assert_eq!(detector.min_std_deviation(), 250);
+  assert_eq!(detector.acceptable_heartbeat_pause(), 3_000);
+  assert_eq!(detector.first_heartbeat_estimate(), 750);
+}
+
+#[test]
+fn create_returns_cluster_core_failure_detector_trait_object() {
+  let factory = ConfiguredPhiAccrualDetectorFactory::new(FailureDetectorConfig::new(), address());
+
+  let mut detector: Box<dyn FailureDetector + Send> = factory.create();
+
+  assert!(detector.is_available(0));
+  assert!(!detector.is_monitoring());
+  detector.heartbeat(100);
+  assert!(detector.is_monitoring());
+}

--- a/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/configured_phi_accrual_detector_factory_test.rs
@@ -29,6 +29,21 @@ fn creates_phi_accrual_detector_from_failure_detector_config() {
 }
 
 #[test]
+fn creates_phi_accrual_detector_without_truncating_sub_millisecond_durations_to_zero() {
+  let config = FailureDetectorConfig::new()
+    .with_min_standard_deviation(Duration::from_nanos(1))
+    .with_acceptable_heartbeat_pause(Duration::from_nanos(1))
+    .with_first_heartbeat_estimate(Duration::from_nanos(1));
+  let factory = ConfiguredPhiAccrualDetectorFactory::new(config, address());
+
+  let detector = factory.create_phi_accrual_detector();
+
+  assert_eq!(detector.min_std_deviation(), 1);
+  assert_eq!(detector.acceptable_heartbeat_pause(), 1);
+  assert_eq!(detector.first_heartbeat_estimate(), 1);
+}
+
+#[test]
 fn create_returns_cluster_core_failure_detector_trait_object() {
   let factory = ConfiguredPhiAccrualDetectorFactory::new(FailureDetectorConfig::new(), address());
 

--- a/modules/cluster-adaptor-std/src/membership/membership_coordinator_driver_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/membership_coordinator_driver_test.rs
@@ -7,16 +7,17 @@ use std::{
 use fraktor_actor_core_kernel_rs::event::stream::EventStreamShared;
 use fraktor_cluster_core_kernel_rs::{
   extension::ClusterExtensionConfig,
-  failure_detector::{DefaultFailureDetectorRegistry, FailureDetector},
+  failure_detector::{DefaultFailureDetectorRegistry, FailureDetectorConfig},
   membership::{
     GossipOutbound, GossipTransport, GossipTransportError, MembershipCoordinator, MembershipCoordinatorConfig,
     MembershipCoordinatorShared, MembershipDelta, MembershipSnapshot, MembershipTable, NodeStatus,
   },
 };
-use fraktor_remote_core_rs::{address::Address, failure_detector::PhiAccrualFailureDetector};
+use fraktor_remote_core_rs::address::Address;
 use fraktor_utils_core_rs::{sync::SharedAccess, time::TimerInstant};
 
 use super::MembershipCoordinatorDriver;
+use crate::membership::ConfiguredPhiAccrualDetectorFactory;
 
 impl<TTransport: GossipTransport> MembershipCoordinatorDriver<TTransport> {
   const fn coordinator(&self) -> &MembershipCoordinatorShared {
@@ -43,24 +44,6 @@ impl<TTransport: GossipTransport> MembershipCoordinatorDriver<TTransport> {
       .with_write(|coordinator| coordinator.handle_heartbeat(authority, now))
       .expect("handle_heartbeat");
     self.apply_outcome(outcome).expect("apply handle_heartbeat outcome");
-  }
-}
-
-/// Test-only adapter that bridges the remote-core detector to the
-/// cluster-core `FailureDetector` trait.
-struct PhiAccrualAdapter(PhiAccrualFailureDetector);
-
-impl FailureDetector for PhiAccrualAdapter {
-  fn is_available(&self, now_ms: u64) -> bool {
-    self.0.is_available(now_ms)
-  }
-
-  fn is_monitoring(&self) -> bool {
-    self.0.is_monitoring()
-  }
-
-  fn heartbeat(&mut self, now_ms: u64) {
-    self.0.heartbeat(now_ms);
   }
 }
 
@@ -124,7 +107,8 @@ impl GossipTransport for DemoTransport {
 }
 
 struct DemoNode {
-  driver: MembershipCoordinatorDriver<DemoTransport>,
+  driver:        MembershipCoordinatorDriver<DemoTransport>,
+  phi_threshold: f64,
 }
 
 impl DemoNode {
@@ -135,27 +119,30 @@ impl DemoNode {
     event_stream: EventStreamShared,
   ) -> Self {
     let table = MembershipTable::new(3);
-    let threshold = config.phi_threshold;
+    let phi_threshold = config.phi_threshold;
     let cluster_config = ClusterExtensionConfig::new()
       .with_advertised_address(authority)
       .with_app_version("1.0.0")
-      .with_roles(vec![String::from("member")]);
+      .with_roles(vec![String::from("member")])
+      .with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(phi_threshold));
+    let detector_config = *cluster_config.failure_detector_config();
     let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
-      Box::new(PhiAccrualAdapter(PhiAccrualFailureDetector::new(detector_address(), threshold, 10, 1, 0, 10)))
+      ConfiguredPhiAccrualDetectorFactory::new(detector_config, detector_address()).create()
     }));
     let mut coordinator = MembershipCoordinator::new(config, cluster_config, table, registry);
     coordinator.start_member().expect("start_member");
     let shared = MembershipCoordinatorShared::new(coordinator);
     let transport = DemoTransport::new(authority, bus);
     let driver = MembershipCoordinatorDriver::new(shared, transport, event_stream);
-    Self { driver }
+    Self { driver, phi_threshold }
   }
 
   fn handle_join(&mut self, node_id: &str, authority: &str, now: TimerInstant) {
     let joining_config = ClusterExtensionConfig::new()
       .with_advertised_address(authority)
       .with_app_version("1.0.0")
-      .with_roles(vec![String::from("member")]);
+      .with_roles(vec![String::from("member")])
+      .with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(self.phi_threshold));
     self.driver.handle_join(node_id, authority, &joining_config, now);
   }
 

--- a/modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs
@@ -3,33 +3,18 @@ use core::time::Duration;
 use fraktor_actor_core_kernel_rs::event::stream::EventStreamShared;
 use fraktor_cluster_core_kernel_rs::{
   extension::ClusterExtensionConfig,
-  failure_detector::{DefaultFailureDetectorRegistry, FailureDetector},
+  failure_detector::{DefaultFailureDetectorRegistry, FailureDetectorConfig},
   membership::{
     Gossiper, MembershipCoordinator, MembershipCoordinatorConfig, MembershipCoordinatorShared, MembershipTable,
   },
 };
-use fraktor_remote_core_rs::{address::Address, failure_detector::PhiAccrualFailureDetector};
+use fraktor_remote_core_rs::address::Address;
 use tokio::runtime::Handle;
 
-use crate::membership::{TokioGossipTransport, TokioGossipTransportConfig, TokioGossiper, TokioGossiperConfig};
-
-/// Test-only adapter that bridges the remote-core detector to the
-/// cluster-core `FailureDetector` trait.
-struct PhiAccrualAdapter(PhiAccrualFailureDetector);
-
-impl FailureDetector for PhiAccrualAdapter {
-  fn is_available(&self, now_ms: u64) -> bool {
-    self.0.is_available(now_ms)
-  }
-
-  fn is_monitoring(&self) -> bool {
-    self.0.is_monitoring()
-  }
-
-  fn heartbeat(&mut self, now_ms: u64) {
-    self.0.heartbeat(now_ms);
-  }
-}
+use crate::membership::{
+  ConfiguredPhiAccrualDetectorFactory, TokioGossipTransport, TokioGossipTransportConfig, TokioGossiper,
+  TokioGossiperConfig,
+};
 
 fn build_coordinator() -> MembershipCoordinatorShared {
   let config = MembershipCoordinatorConfig {
@@ -42,11 +27,13 @@ fn build_coordinator() -> MembershipCoordinatorShared {
     topology_emit_interval: Duration::from_millis(50),
   };
   let table = MembershipTable::new(3);
-  let threshold = config.phi_threshold;
+  let cluster_config = ClusterExtensionConfig::new()
+    .with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(config.phi_threshold));
+  let detector_config = *cluster_config.failure_detector_config();
   let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
-    Box::new(PhiAccrualAdapter(PhiAccrualFailureDetector::new(detector_address(), threshold, 10, 1, 0, 10)))
+    ConfiguredPhiAccrualDetectorFactory::new(detector_config, detector_address()).create()
   }));
-  let mut coordinator = MembershipCoordinator::new(config, ClusterExtensionConfig::new(), table, registry);
+  let mut coordinator = MembershipCoordinator::new(config, cluster_config, table, registry);
   coordinator.start_member().expect("start_member");
   MembershipCoordinatorShared::new(coordinator)
 }

--- a/modules/cluster-adaptor-std/tests/gossip_tokio_integration.rs
+++ b/modules/cluster-adaptor-std/tests/gossip_tokio_integration.rs
@@ -5,38 +5,21 @@ use fraktor_actor_core_kernel_rs::event::stream::{
   EventStreamEvent, EventStreamShared, EventStreamSubscriber, EventStreamSubscriberShared,
 };
 use fraktor_cluster_adaptor_std_rs::membership::{
-  TokioGossipTransport, TokioGossipTransportConfig, TokioGossiper, TokioGossiperConfig,
+  ConfiguredPhiAccrualDetectorFactory, TokioGossipTransport, TokioGossipTransportConfig, TokioGossiper,
+  TokioGossiperConfig,
 };
 use fraktor_cluster_core_kernel_rs::{
   extension::ClusterExtensionConfig,
-  failure_detector::{DefaultFailureDetectorRegistry, FailureDetector},
+  failure_detector::{DefaultFailureDetectorRegistry, FailureDetectorConfig},
   membership::{
     GossipOutbound, GossipTransport, Gossiper, MembershipCoordinator, MembershipCoordinatorConfig,
     MembershipCoordinatorShared, MembershipDelta, MembershipTable, MembershipVersion, NodeRecord, NodeStatus,
   },
   topology::ClusterEvent,
 };
-use fraktor_remote_core_rs::{address::Address, failure_detector::PhiAccrualFailureDetector};
+use fraktor_remote_core_rs::address::Address;
 use fraktor_utils_core_rs::sync::{SharedLock, SpinSyncMutex};
 use tokio::runtime::Handle;
-
-/// Test-only adapter that bridges the remote-core detector to the
-/// cluster-core `FailureDetector` trait.
-struct PhiAccrualAdapter(PhiAccrualFailureDetector);
-
-impl FailureDetector for PhiAccrualAdapter {
-  fn is_available(&self, now_ms: u64) -> bool {
-    self.0.is_available(now_ms)
-  }
-
-  fn is_monitoring(&self) -> bool {
-    self.0.is_monitoring()
-  }
-
-  fn heartbeat(&mut self, now_ms: u64) {
-    self.0.heartbeat(now_ms);
-  }
-}
 
 struct EventSink {
   events: Arc<Mutex<Vec<ClusterEvent>>>,
@@ -71,14 +54,15 @@ fn build_coordinator() -> MembershipCoordinatorShared {
     topology_emit_interval: Duration::from_millis(20),
   };
   let table = MembershipTable::new(3);
-  let threshold = config.phi_threshold;
-  let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
-    Box::new(PhiAccrualAdapter(PhiAccrualFailureDetector::new(detector_address(), threshold, 10, 1, 0, 10)))
-  }));
   let cluster_config = ClusterExtensionConfig::new()
     .with_advertised_address("127.0.0.1:22110")
     .with_app_version("1.0.0")
-    .with_roles(vec![String::from("member")]);
+    .with_roles(vec![String::from("member")])
+    .with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(config.phi_threshold));
+  let detector_config = *cluster_config.failure_detector_config();
+  let registry = DefaultFailureDetectorRegistry::new(Box::new(move || {
+    ConfiguredPhiAccrualDetectorFactory::new(detector_config, detector_address()).create()
+  }));
   let mut coordinator = MembershipCoordinator::new(config, cluster_config, table, registry);
   coordinator.start_member().expect("start_member");
   MembershipCoordinatorShared::new(coordinator)

--- a/modules/cluster-core-kernel/src/extension/cluster_core.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_core.rs
@@ -29,6 +29,7 @@ use crate::{
     ActivatedKind, IdentityLookupShared, IdentitySetupError, LookupError, PidCache, PlacementEvent, PlacementResolution,
   },
   downing_provider::{DowningDecision, DowningInput, DowningProvider},
+  failure_detector::FailureDetectorConfig,
   grain::{GrainKey, KindRegistry},
   membership::{CurrentClusterState, GossiperShared, MembershipVersion, NodeRecord, NodeStatus},
   pub_sub::ClusterPubSubShared,
@@ -36,25 +37,26 @@ use crate::{
 
 /// Aggregates configuration and shared dependencies for cluster runtime flows.
 pub struct ClusterCore {
-  provider:            ClusterProviderShared,
-  block_list_provider: ArcShared<dyn BlockListProvider>,
-  event_stream:        EventStreamShared,
-  downing_provider:    SharedLock<Box<dyn DowningProvider>>,
-  gossiper:            GossiperShared,
-  pub_sub:             ClusterPubSubShared,
-  startup_state:       ClusterStartupState,
-  metrics_enabled:     bool,
-  kind_registry:       KindRegistry,
-  identity_lookup:     IdentityLookupShared,
-  virtual_actor_count: i64,
-  mode:                Option<StartupMode>,
-  metrics:             Option<ClusterMetrics>,
-  blocked_members:     Vec<String>,
-  member_count:        usize,
-  pid_cache:           Option<PidCache>,
-  last_topology_hash:  Option<u64>,
-  current_members:     Vec<String>,
-  observed_at:         TimerInstant,
+  provider:                ClusterProviderShared,
+  block_list_provider:     ArcShared<dyn BlockListProvider>,
+  event_stream:            EventStreamShared,
+  downing_provider:        SharedLock<Box<dyn DowningProvider>>,
+  gossiper:                GossiperShared,
+  pub_sub:                 ClusterPubSubShared,
+  failure_detector_config: FailureDetectorConfig,
+  startup_state:           ClusterStartupState,
+  metrics_enabled:         bool,
+  kind_registry:           KindRegistry,
+  identity_lookup:         IdentityLookupShared,
+  virtual_actor_count:     i64,
+  mode:                    Option<StartupMode>,
+  metrics:                 Option<ClusterMetrics>,
+  blocked_members:         Vec<String>,
+  member_count:            usize,
+  pid_cache:               Option<PidCache>,
+  last_topology_hash:      Option<u64>,
+  current_members:         Vec<String>,
+  observed_at:             TimerInstant,
 }
 
 impl ClusterCore {
@@ -84,6 +86,7 @@ impl ClusterCore {
       downing_provider,
       gossiper,
       pub_sub: pubsub,
+      failure_detector_config: *config.failure_detector_config(),
       startup_state,
       metrics_enabled,
       kind_registry,
@@ -223,8 +226,9 @@ impl ClusterCore {
   ///
   /// # Errors
   ///
-  /// Returns an error if pub/sub, gossiper, or provider startup fails.
+  /// Returns an error if configuration validation, pub/sub, gossiper, or provider startup fails.
   pub fn start_member(&mut self) -> Result<(), ClusterError> {
+    self.failure_detector_config.validate().map_err(ClusterError::from)?;
     let address = self.startup_address();
     self.refresh_blocked_members();
 
@@ -272,8 +276,9 @@ impl ClusterCore {
   ///
   /// # Errors
   ///
-  /// Returns an error if pub/sub or provider startup fails.
+  /// Returns an error if configuration validation, pub/sub, gossiper, or provider startup fails.
   pub fn start_client(&mut self) -> Result<(), ClusterError> {
+    self.failure_detector_config.validate().map_err(ClusterError::from)?;
     let address = self.startup_address();
     self.refresh_blocked_members();
 

--- a/modules/cluster-core-kernel/src/extension/cluster_core.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_core.rs
@@ -228,8 +228,15 @@ impl ClusterCore {
   ///
   /// Returns an error if configuration validation, pub/sub, gossiper, or provider startup fails.
   pub fn start_member(&mut self) -> Result<(), ClusterError> {
-    self.failure_detector_config.validate().map_err(ClusterError::from)?;
     let address = self.startup_address();
+    self.failure_detector_config.validate().map_err(|error| {
+      self.publish_cluster_event(ClusterEvent::StartupFailed {
+        address: address.clone(),
+        mode:    StartupMode::Member,
+        reason:  error.to_string(),
+      });
+      ClusterError::from(error)
+    })?;
     self.refresh_blocked_members();
 
     self.pub_sub.with_write(|pub_sub| pub_sub.start()).map_err(ClusterError::from).map_err(|error| {
@@ -278,8 +285,15 @@ impl ClusterCore {
   ///
   /// Returns an error if configuration validation, pub/sub, gossiper, or provider startup fails.
   pub fn start_client(&mut self) -> Result<(), ClusterError> {
-    self.failure_detector_config.validate().map_err(ClusterError::from)?;
     let address = self.startup_address();
+    self.failure_detector_config.validate().map_err(|error| {
+      self.publish_cluster_event(ClusterEvent::StartupFailed {
+        address: address.clone(),
+        mode:    StartupMode::Client,
+        reason:  error.to_string(),
+      });
+      ClusterError::from(error)
+    })?;
     self.refresh_blocked_members();
 
     self.pub_sub.with_write(|pub_sub| pub_sub.start()).map_err(ClusterError::from).map_err(|error| {

--- a/modules/cluster-core-kernel/src/extension/cluster_core_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_core_test.rs
@@ -15,14 +15,15 @@ use fraktor_utils_core_rs::{
 
 use super::*;
 use crate::{
-  BlockListProvider, ClusterEvent, ClusterProviderError, ClusterProviderShared, ClusterTopology, MetricsError,
-  StartupMode, TopologyUpdate,
+  BlockListProvider, ClusterError, ClusterEvent, ClusterProviderError, ClusterProviderShared, ClusterTopology,
+  MetricsError, StartupMode, TopologyUpdate,
   activation::{
     ActivatedKind, IdentityLookup, IdentityLookupShared, IdentitySetupError, LookupError, PidCache, PidCacheEvent,
     PlacementResolution,
   },
   cluster_provider::ClusterProvider,
   downing_provider::{DowningDecision, DowningInput, DowningProvider, NoopDowningProvider},
+  failure_detector::{FailureDetectorConfig, FailureDetectorConfigError},
   grain::{GrainKey, KindRegistry, TOPIC_ACTOR_KIND},
   membership::{Gossiper, GossiperShared},
   pub_sub::{
@@ -68,6 +69,49 @@ impl ClusterProvider for StubProvider {
   }
 
   fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+#[derive(Clone)]
+struct RecordingProvider {
+  member_started: ArcShared<SpinSyncMutex<bool>>,
+  client_started: ArcShared<SpinSyncMutex<bool>>,
+}
+
+impl RecordingProvider {
+  fn new() -> Self {
+    Self {
+      member_started: ArcShared::new(SpinSyncMutex::new(false)),
+      client_started: ArcShared::new(SpinSyncMutex::new(false)),
+    }
+  }
+}
+
+impl ClusterProvider for RecordingProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    *self.member_started.lock() = true;
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    *self.client_started.lock() = true;
     Ok(())
   }
 
@@ -921,6 +965,80 @@ fn start_member_fails_when_pubsub_start_fails() {
     ClusterEvent::StartupFailed { address, mode, reason }
       if address == "proto://member" && *mode == StartupMode::Member && reason.contains("pubsub")
   )));
+}
+
+#[test]
+fn start_member_rejects_invalid_failure_detector_config_before_starting_dependencies() {
+  let provider_impl = RecordingProvider::new();
+  let member_started = provider_impl.member_started.clone();
+  let provider = wrap_provider(provider_impl);
+  let block_list_provider = ArcShared::new(StubBlockListProvider::new(vec![]));
+  let event_stream = EventStreamShared::default();
+  let kind_registry = KindRegistry::new();
+  let identity_lookup = wrap_identity_lookup(StubIdentityLookup::new());
+  let gossiper_impl = StubGossiper::new();
+  let gossiper_started = gossiper_impl.started.clone();
+  let gossiper = wrap_gossiper(gossiper_impl);
+  let pubsub_impl = StubPubSub::new();
+  let pubsub_started = pubsub_impl.started.clone();
+  let pubsub = wrap_pubsub(pubsub_impl);
+  let config =
+    ClusterExtensionConfig::new().with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(0.0));
+  let mut core = ClusterCore::new(
+    &config,
+    provider,
+    block_list_provider,
+    event_stream,
+    wrap_downing_provider(NoopDowningProvider::new()),
+    gossiper,
+    pubsub,
+    kind_registry,
+    identity_lookup,
+  );
+
+  let result = core.start_member();
+
+  assert_eq!(Err(ClusterError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold)), result);
+  assert!(!*member_started.lock());
+  assert!(!*pubsub_started.lock());
+  assert!(!*gossiper_started.lock());
+}
+
+#[test]
+fn start_client_rejects_invalid_failure_detector_config_before_starting_dependencies() {
+  let provider_impl = RecordingProvider::new();
+  let client_started = provider_impl.client_started.clone();
+  let provider = wrap_provider(provider_impl);
+  let block_list_provider = ArcShared::new(StubBlockListProvider::new(vec![]));
+  let event_stream = EventStreamShared::default();
+  let kind_registry = KindRegistry::new();
+  let identity_lookup = wrap_identity_lookup(StubIdentityLookup::new());
+  let gossiper_impl = StubGossiper::new();
+  let gossiper_started = gossiper_impl.started.clone();
+  let gossiper = wrap_gossiper(gossiper_impl);
+  let pubsub_impl = StubPubSub::new();
+  let pubsub_started = pubsub_impl.started.clone();
+  let pubsub = wrap_pubsub(pubsub_impl);
+  let config =
+    ClusterExtensionConfig::new().with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(0.0));
+  let mut core = ClusterCore::new(
+    &config,
+    provider,
+    block_list_provider,
+    event_stream,
+    wrap_downing_provider(NoopDowningProvider::new()),
+    gossiper,
+    pubsub,
+    kind_registry,
+    identity_lookup,
+  );
+
+  let result = core.start_client();
+
+  assert_eq!(Err(ClusterError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold)), result);
+  assert!(!*client_started.lock());
+  assert!(!*pubsub_started.lock());
+  assert!(!*gossiper_started.lock());
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/extension/cluster_core_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_core_test.rs
@@ -988,7 +988,7 @@ fn start_member_rejects_invalid_failure_detector_config_before_starting_dependen
     &config,
     provider,
     block_list_provider,
-    event_stream,
+    event_stream.clone(),
     wrap_downing_provider(NoopDowningProvider::new()),
     gossiper,
     pubsub,
@@ -996,12 +996,19 @@ fn start_member_rejects_invalid_failure_detector_config_before_starting_dependen
     identity_lookup,
   );
 
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+
   let result = core.start_member();
 
   assert_eq!(Err(ClusterError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold)), result);
   assert!(!*member_started.lock());
   assert!(!*pubsub_started.lock());
   assert!(!*gossiper_started.lock());
+  let events = subscriber_impl.events();
+  assert!(events.iter().any(|event| matches!(event,
+    ClusterEvent::StartupFailed { address, mode, reason }
+      if address == "" && *mode == StartupMode::Member && reason.contains("phi threshold")
+  )));
 }
 
 #[test]
@@ -1025,7 +1032,7 @@ fn start_client_rejects_invalid_failure_detector_config_before_starting_dependen
     &config,
     provider,
     block_list_provider,
-    event_stream,
+    event_stream.clone(),
     wrap_downing_provider(NoopDowningProvider::new()),
     gossiper,
     pubsub,
@@ -1033,12 +1040,19 @@ fn start_client_rejects_invalid_failure_detector_config_before_starting_dependen
     identity_lookup,
   );
 
+  let (subscriber_impl, _subscription) = subscribe_recorder(&event_stream);
+
   let result = core.start_client();
 
   assert_eq!(Err(ClusterError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold)), result);
   assert!(!*client_started.lock());
   assert!(!*pubsub_started.lock());
   assert!(!*gossiper_started.lock());
+  let events = subscriber_impl.events();
+  assert!(events.iter().any(|event| matches!(event,
+    ClusterEvent::StartupFailed { address, mode, reason }
+      if address == "" && *mode == StartupMode::Client && reason.contains("phi threshold")
+  )));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/extension/cluster_error.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_error.rs
@@ -2,10 +2,15 @@
 
 extern crate alloc;
 
+#[cfg(test)]
+#[path = "cluster_error_test.rs"]
+mod tests;
+
 use alloc::string::String;
 
 use crate::{
-  ClusterProviderError, activation::IdentitySetupError, downing_provider::DowningDecision, pub_sub::PubSubError,
+  ClusterProviderError, activation::IdentitySetupError, downing_provider::DowningDecision,
+  failure_detector::FailureDetectorConfigError, pub_sub::PubSubError,
 };
 
 /// Error type returned by cluster lifecycle operations.
@@ -13,6 +18,8 @@ use crate::{
 pub enum ClusterError {
   /// Provider-related failure.
   Provider(ClusterProviderError),
+  /// Cluster configuration validation failure.
+  Configuration(FailureDetectorConfigError),
   /// Downing strategy did not allow an explicit down command.
   DowningRejected {
     /// Authority that was requested to be downed.
@@ -31,6 +38,12 @@ pub enum ClusterError {
 impl From<ClusterProviderError> for ClusterError {
   fn from(value: ClusterProviderError) -> Self {
     Self::Provider(value)
+  }
+}
+
+impl From<FailureDetectorConfigError> for ClusterError {
+  fn from(value: FailureDetectorConfigError) -> Self {
+    Self::Configuration(value)
   }
 }
 

--- a/modules/cluster-core-kernel/src/extension/cluster_error_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_error_test.rs
@@ -1,0 +1,16 @@
+use super::ClusterError;
+use crate::failure_detector::FailureDetectorConfigError;
+
+#[test]
+fn configuration_validation_failure_is_lifecycle_error() {
+  let error = ClusterError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold);
+
+  assert_eq!(ClusterError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold), error);
+}
+
+#[test]
+fn converts_failure_detector_config_error_to_cluster_error() {
+  let error: ClusterError = FailureDetectorConfigError::InvalidPhiThreshold.into();
+
+  assert_eq!(ClusterError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold), error);
+}

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
@@ -10,6 +10,7 @@ use core::time::Duration;
 use crate::{
   ClusterTopology, ConfigValidation, JoinConfigCompatChecker,
   downing_provider::DowningProviderCompatibility,
+  failure_detector::FailureDetectorConfig,
   pub_sub::PubSubConfig,
   topology::{ClusterCompatibilityKey, ClusterCompatibilityKeyCatalog},
 };
@@ -66,15 +67,16 @@ const JOIN_COMPATIBILITY_CHECKS: &[JoinCompatibilityCheck] = &[
 ];
 
 /// Configuration applied when installing the cluster extension.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ClusterExtensionConfig {
-  advertised_address: String,
-  metrics_enabled:    bool,
-  static_topology:    Option<ClusterTopology>,
-  pubsub_config:      PubSubConfig,
-  app_version:        String,
-  roles:              Vec<String>,
-  downing_provider:   DowningProviderCompatibility,
+  advertised_address:      String,
+  metrics_enabled:         bool,
+  static_topology:         Option<ClusterTopology>,
+  pubsub_config:           PubSubConfig,
+  failure_detector_config: FailureDetectorConfig,
+  app_version:             String,
+  roles:                   Vec<String>,
+  downing_provider:        DowningProviderCompatibility,
 }
 
 impl ClusterExtensionConfig {
@@ -86,13 +88,14 @@ impl ClusterExtensionConfig {
   #[must_use]
   pub fn new() -> Self {
     Self {
-      advertised_address: String::new(),
-      metrics_enabled:    false,
-      static_topology:    None,
-      pubsub_config:      PubSubConfig::new(Duration::from_secs(3), Duration::from_secs(60)),
-      app_version:        String::from(env!("CARGO_PKG_VERSION")),
-      roles:              Vec::new(),
-      downing_provider:   DowningProviderCompatibility::noop(),
+      advertised_address:      String::new(),
+      metrics_enabled:         false,
+      static_topology:         None,
+      pubsub_config:           PubSubConfig::new(Duration::from_secs(3), Duration::from_secs(60)),
+      failure_detector_config: FailureDetectorConfig::new(),
+      app_version:             String::from(env!("CARGO_PKG_VERSION")),
+      roles:                   Vec::new(),
+      downing_provider:        DowningProviderCompatibility::noop(),
     }
   }
 
@@ -138,6 +141,13 @@ impl ClusterExtensionConfig {
     self
   }
 
+  /// Sets the failure detector configuration.
+  #[must_use]
+  pub const fn with_failure_detector_config(mut self, config: FailureDetectorConfig) -> Self {
+    self.failure_detector_config = config;
+    self
+  }
+
   /// Sets cluster roles advertised by this node.
   #[must_use]
   pub fn with_roles(mut self, roles: Vec<String>) -> Self {
@@ -169,6 +179,12 @@ impl ClusterExtensionConfig {
   #[must_use]
   pub const fn pubsub_config(&self) -> &PubSubConfig {
     &self.pubsub_config
+  }
+
+  /// Returns the failure detector configuration.
+  #[must_use]
+  pub const fn failure_detector_config(&self) -> &FailureDetectorConfig {
+    &self.failure_detector_config
   }
 
   /// Returns advertised application version.

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
@@ -10,7 +10,7 @@ use core::time::Duration;
 use crate::{
   ClusterTopology, ConfigValidation, JoinConfigCompatChecker,
   downing_provider::DowningProviderCompatibility,
-  failure_detector::FailureDetectorConfig,
+  failure_detector::{FailureDetectorConfig, FailureDetectorConfigError},
   pub_sub::PubSubConfig,
   topology::{ClusterCompatibilityKey, ClusterCompatibilityKeyCatalog},
 };
@@ -233,6 +233,16 @@ impl ClusterExtensionConfig {
   #[must_use]
   pub fn is_sensitive_join_compatibility_key(key: &str) -> bool {
     SENSITIVE_JOIN_COMPATIBILITY_KEYS.contains(&key)
+  }
+
+  /// Validates cluster extension configuration values.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`FailureDetectorConfigError`] when the configured failure detector
+  /// observation parameters are outside the accepted range.
+  pub fn validate(&self) -> Result<(), FailureDetectorConfigError> {
+    self.failure_detector_config.validate()
   }
 }
 

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config.rs
@@ -22,47 +22,41 @@ const SPLIT_BRAIN_RESOLVER_PROVIDER_KEY: &str = "split-brain-resolver";
 const PUBSUB_SUBSCRIBER_TIMEOUT_KEY: &str = "fraktor.cluster.pubsub.subscriber-timeout";
 const PUBSUB_SUSPENDED_TTL_KEY: &str = "fraktor.cluster.pubsub.suspended-ttl";
 const DOWNING_PROVIDER_KEY: &str = "fraktor.cluster.downing-provider.provider-key";
+const FAILURE_DETECTOR_KEY: &str = ClusterCompatibilityKeyCatalog::FAILURE_DETECTOR.name();
 const SBR_STABLE_AFTER_KEY: &str = "fraktor.cluster.downing-provider.split-brain-resolver.stable-after";
 const SBR_ACTIVE_STRATEGY_KEY: &str = "fraktor.cluster.downing-provider.split-brain-resolver.active-strategy";
 const SBR_DOWN_ALL_WHEN_UNSTABLE_KEY: &str =
   "fraktor.cluster.downing-provider.split-brain-resolver.down-all-when-unstable";
 const REQUIRED_JOIN_COMPATIBILITY_KEYS: &[&str] =
-  &[PUBSUB_SUBSCRIBER_TIMEOUT_KEY, PUBSUB_SUSPENDED_TTL_KEY, DOWNING_PROVIDER_KEY];
+  &[PUBSUB_SUBSCRIBER_TIMEOUT_KEY, PUBSUB_SUSPENDED_TTL_KEY, DOWNING_PROVIDER_KEY, FAILURE_DETECTOR_KEY];
 const CONDITIONAL_JOIN_COMPATIBILITY_KEYS: &[&str] =
   &[SBR_STABLE_AFTER_KEY, SBR_ACTIVE_STRATEGY_KEY, SBR_DOWN_ALL_WHEN_UNSTABLE_KEY];
 const SENSITIVE_JOIN_COMPATIBILITY_KEYS: &[&str] = &[];
 
 struct JoinCompatibilityCheck {
-  key:           ClusterCompatibilityKey,
-  reason:        &'static str,
-  is_compatible: fn(&ClusterExtensionConfig, &ClusterExtensionConfig) -> bool,
+  key:             ClusterCompatibilityKey,
+  mismatch_detail: fn(&ClusterExtensionConfig, &ClusterExtensionConfig) -> Option<String>,
 }
 
 impl JoinCompatibilityCheck {
   const fn new(
     key: ClusterCompatibilityKey,
-    reason: &'static str,
-    is_compatible: fn(&ClusterExtensionConfig, &ClusterExtensionConfig) -> bool,
+    mismatch_detail: fn(&ClusterExtensionConfig, &ClusterExtensionConfig) -> Option<String>,
   ) -> Self {
-    Self { key, reason, is_compatible }
+    Self { key, mismatch_detail }
   }
 }
 
 const JOIN_COMPATIBILITY_CHECKS: &[JoinCompatibilityCheck] = &[
-  JoinCompatibilityCheck::new(
-    ClusterCompatibilityKeyCatalog::PUBSUB,
-    PUBSUB_CONFIGURATION_MISMATCH_REASON,
-    pubsub_configs_are_compatible,
-  ),
-  JoinCompatibilityCheck::new(
-    ClusterCompatibilityKeyCatalog::DOWNING_PROVIDER,
-    DOWNING_PROVIDER_KEY_MISMATCH_REASON,
-    downing_provider_keys_are_compatible,
-  ),
+  JoinCompatibilityCheck::new(ClusterCompatibilityKeyCatalog::PUBSUB, pubsub_config_mismatch_detail),
+  JoinCompatibilityCheck::new(ClusterCompatibilityKeyCatalog::DOWNING_PROVIDER, downing_provider_key_mismatch_detail),
   JoinCompatibilityCheck::new(
     ClusterCompatibilityKeyCatalog::SPLIT_BRAIN_RESOLVER_SETTINGS,
-    SBR_SETTINGS_MISMATCH_REASON,
-    split_brain_resolver_settings_are_compatible,
+    split_brain_resolver_settings_mismatch_detail,
+  ),
+  JoinCompatibilityCheck::new(
+    ClusterCompatibilityKeyCatalog::FAILURE_DETECTOR,
+    failure_detector_config_mismatch_detail,
   ),
 ];
 
@@ -253,8 +247,8 @@ impl JoinConfigCompatChecker for ClusterExtensionConfig {
     let mut reason = String::new();
 
     for check in JOIN_COMPATIBILITY_CHECKS {
-      if !(check.is_compatible)(self, joining) {
-        append_mismatch_reason(&mut reason, check.key, check.reason);
+      if let Some(detail) = (check.mismatch_detail)(self, joining) {
+        append_mismatch_reason(&mut reason, check.key, &detail);
       }
     }
 
@@ -275,8 +269,27 @@ fn pubsub_configs_are_compatible(local: &ClusterExtensionConfig, joining: &Clust
   local.pubsub_config == joining.pubsub_config
 }
 
+fn pubsub_config_mismatch_detail(local: &ClusterExtensionConfig, joining: &ClusterExtensionConfig) -> Option<String> {
+  if pubsub_configs_are_compatible(local, joining) {
+    None
+  } else {
+    Some(String::from(PUBSUB_CONFIGURATION_MISMATCH_REASON))
+  }
+}
+
 fn downing_provider_keys_are_compatible(local: &ClusterExtensionConfig, joining: &ClusterExtensionConfig) -> bool {
   local.downing_provider.provider_key() == joining.downing_provider.provider_key()
+}
+
+fn downing_provider_key_mismatch_detail(
+  local: &ClusterExtensionConfig,
+  joining: &ClusterExtensionConfig,
+) -> Option<String> {
+  if downing_provider_keys_are_compatible(local, joining) {
+    None
+  } else {
+    Some(String::from(DOWNING_PROVIDER_KEY_MISMATCH_REASON))
+  }
 }
 
 fn split_brain_resolver_settings_are_compatible(
@@ -286,6 +299,25 @@ fn split_brain_resolver_settings_are_compatible(
   local.downing_provider.provider_key() != SPLIT_BRAIN_RESOLVER_PROVIDER_KEY
     || joining.downing_provider.provider_key() != SPLIT_BRAIN_RESOLVER_PROVIDER_KEY
     || local.downing_provider.sbr_settings_identity() == joining.downing_provider.sbr_settings_identity()
+}
+
+fn split_brain_resolver_settings_mismatch_detail(
+  local: &ClusterExtensionConfig,
+  joining: &ClusterExtensionConfig,
+) -> Option<String> {
+  if split_brain_resolver_settings_are_compatible(local, joining) {
+    None
+  } else {
+    Some(String::from(SBR_SETTINGS_MISMATCH_REASON))
+  }
+}
+
+fn failure_detector_config_mismatch_detail(
+  local: &ClusterExtensionConfig,
+  joining: &ClusterExtensionConfig,
+) -> Option<String> {
+  let field_names = local.failure_detector_config.difference_field_names(&joining.failure_detector_config);
+  if field_names.is_empty() { None } else { Some(field_names.join(", ")) }
 }
 
 fn normalize_roles(mut roles: Vec<String>) -> Vec<String> {

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::{
   ClusterTopology, ConfigValidation, JoinConfigCompatChecker,
   downing_provider::{DowningProviderCompatibility, SplitBrainResolverSettings, SplitBrainResolverStrategy},
-  failure_detector::FailureDetectorConfig,
+  failure_detector::{FailureDetectorConfig, FailureDetectorConfigError},
   pub_sub::PubSubConfig,
 };
 
@@ -87,7 +87,7 @@ fn validate_delegates_to_failure_detector_config() {
   let config =
     ClusterExtensionConfig::new().with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(0.0));
 
-  assert_eq!(config.validate(), Err(crate::failure_detector::FailureDetectorConfigError::InvalidPhiThreshold));
+  assert_eq!(config.validate(), Err(FailureDetectorConfigError::InvalidPhiThreshold));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
@@ -83,6 +83,36 @@ fn custom_failure_detector_config_is_preserved() {
 }
 
 #[test]
+fn join_compatibility_accepts_same_failure_detector_config() {
+  let failure_detector_config = FailureDetectorConfig::new()
+    .with_phi_threshold(8.0)
+    .with_max_sample_size(128)
+    .with_min_standard_deviation(Duration::from_millis(500))
+    .with_acceptable_heartbeat_pause(Duration::from_secs(2))
+    .with_first_heartbeat_estimate(Duration::from_secs(1));
+  let local = ClusterExtensionConfig::new().with_failure_detector_config(failure_detector_config);
+  let joining = ClusterExtensionConfig::new().with_failure_detector_config(failure_detector_config);
+
+  let validation = local.check_join_compatibility(&joining);
+
+  assert_eq!(validation, ConfigValidation::Compatible);
+}
+
+#[test]
+fn join_compatibility_reports_failure_detector_config_mismatch_with_different_fields() {
+  let local = ClusterExtensionConfig::new()
+    .with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(8.0).with_max_sample_size(128));
+  let joining = ClusterExtensionConfig::new()
+    .with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(10.0).with_max_sample_size(256));
+
+  let validation = local.check_join_compatibility(&joining);
+
+  assert_eq!(validation, ConfigValidation::Incompatible {
+    reason: "cluster.failure-detector mismatch: phi_threshold, max_sample_size".to_string(),
+  });
+}
+
+#[test]
 fn join_compatibility_key_manifest_separates_required_and_conditional_non_sensitive_keys() {
   let required_keys = ClusterExtensionConfig::required_join_compatibility_keys();
   let conditional_keys = ClusterExtensionConfig::conditional_join_compatibility_keys();
@@ -91,6 +121,7 @@ fn join_compatibility_key_manifest_separates_required_and_conditional_non_sensit
     "fraktor.cluster.pubsub.subscriber-timeout",
     "fraktor.cluster.pubsub.suspended-ttl",
     "fraktor.cluster.downing-provider.provider-key",
+    "cluster.failure-detector",
   ]);
   assert_eq!(conditional_keys, &[
     "fraktor.cluster.downing-provider.split-brain-resolver.stable-after",
@@ -98,6 +129,9 @@ fn join_compatibility_key_manifest_separates_required_and_conditional_non_sensit
     "fraktor.cluster.downing-provider.split-brain-resolver.down-all-when-unstable",
   ]);
   assert!(ClusterExtensionConfig::is_required_join_compatibility_key("fraktor.cluster.downing-provider.provider-key"));
+  assert!(ClusterExtensionConfig::is_required_join_compatibility_key("cluster.failure-detector"));
+  assert!(!ClusterExtensionConfig::is_required_join_compatibility_key("cluster.failure-detector.choice"));
+  assert!(!ClusterExtensionConfig::is_required_join_compatibility_key("cluster.failure-detector.phi-threshold"));
   assert!(!ClusterExtensionConfig::is_required_join_compatibility_key(
     "fraktor.cluster.downing-provider.split-brain-resolver.stable-after"
   ));

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
@@ -83,6 +83,14 @@ fn custom_failure_detector_config_is_preserved() {
 }
 
 #[test]
+fn validate_delegates_to_failure_detector_config() {
+  let config =
+    ClusterExtensionConfig::new().with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(0.0));
+
+  assert_eq!(config.validate(), Err(crate::failure_detector::FailureDetectorConfigError::InvalidPhiThreshold));
+}
+
+#[test]
 fn join_compatibility_accepts_same_failure_detector_config() {
   let failure_detector_config = FailureDetectorConfig::new()
     .with_phi_threshold(8.0)

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_config_test.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::{
   ClusterTopology, ConfigValidation, JoinConfigCompatChecker,
   downing_provider::{DowningProviderCompatibility, SplitBrainResolverSettings, SplitBrainResolverStrategy},
+  failure_detector::FailureDetectorConfig,
   pub_sub::PubSubConfig,
 };
 
@@ -58,6 +59,27 @@ fn downing_provider_compatibility_is_preserved() {
   let config = ClusterExtensionConfig::new().with_downing_provider_compatibility(compatibility.clone());
 
   assert_eq!(config.downing_provider_compatibility(), &compatibility);
+}
+
+#[test]
+fn default_failure_detector_config_is_preserved() {
+  let config = ClusterExtensionConfig::new();
+
+  assert_eq!(config.failure_detector_config(), &FailureDetectorConfig::default());
+}
+
+#[test]
+fn custom_failure_detector_config_is_preserved() {
+  let failure_detector_config = FailureDetectorConfig::new()
+    .with_phi_threshold(8.0)
+    .with_max_sample_size(128)
+    .with_min_standard_deviation(Duration::from_millis(500))
+    .with_acceptable_heartbeat_pause(Duration::from_secs(2))
+    .with_first_heartbeat_estimate(Duration::from_secs(1));
+
+  let config = ClusterExtensionConfig::new().with_failure_detector_config(failure_detector_config);
+
+  assert_eq!(config.failure_detector_config(), &failure_detector_config);
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs
@@ -238,6 +238,7 @@ impl ClusterExtensionInstaller {
         alloc::format!("{}:{}", remoting_config.canonical_host(), remoting_config.canonical_port().unwrap_or(0));
       config = config.with_advertised_address(addr);
     }
+    config.validate().map_err(|error| ActorSystemBuildError::Configuration(alloc::format!("{error:?}")))?;
 
     // デフォルト実装を使用（未指定の場合）
     let block_list_provider: ArcShared<dyn BlockListProvider> =

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_installer.rs
@@ -45,7 +45,7 @@ pub type ClusterProviderFactory = ArcShared<
 >;
 
 /// Factory function type for creating a `Gossiper`.
-type GossiperFactory = ArcShared<dyn Fn() -> Box<dyn Gossiper> + Send + Sync>;
+type GossiperFactory = ArcShared<dyn Fn(&ClusterExtensionConfig) -> Box<dyn Gossiper> + Send + Sync>;
 /// Factory function type for creating a `DowningProvider`.
 type DowningProviderFactory = ArcShared<dyn Fn() -> Box<dyn DowningProvider> + Send + Sync>;
 
@@ -169,11 +169,12 @@ impl ClusterExtensionInstaller {
 
   /// Sets a custom gossiper factory.
   ///
-  /// The factory is called during installation to create a fresh `Gossiper` instance.
+  /// The factory receives the validated cluster configuration and is called
+  /// during installation to create a fresh `Gossiper` instance.
   #[must_use]
   pub fn with_gossiper_factory<F>(mut self, factory: F) -> Self
   where
-    F: Fn() -> Box<dyn Gossiper> + Send + Sync + 'static, {
+    F: Fn(&ClusterExtensionConfig) -> Box<dyn Gossiper> + Send + Sync + 'static, {
     self.gossiper_f = Some(ArcShared::new(factory));
     self
   }
@@ -246,7 +247,8 @@ impl ClusterExtensionInstaller {
     let downing_provider: Box<dyn DowningProvider> =
       self.downing_provider_f.as_ref().map(|f| f()).unwrap_or_else(|| Box::new(NoopDowningProvider::new()));
     // Gossiper はファクトリ経由で作成（Clone できないため）
-    let gossiper: Box<dyn Gossiper> = self.gossiper_f.as_ref().map(|f| f()).unwrap_or_else(|| Box::new(NoopGossiper));
+    let gossiper: Box<dyn Gossiper> =
+      self.gossiper_f.as_ref().map(|f| f(&config)).unwrap_or_else(|| Box::new(NoopGossiper));
     // ClusterPubSub はファクトリ経由で作成（Clone できないため）
     let pubsub: Box<dyn ClusterPubSub> =
       self.pubsub_f.as_ref().map(|f| f(&config)).unwrap_or_else(|| Box::new(NoopClusterPubSub));

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_installer_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_installer_test.rs
@@ -17,19 +17,28 @@ use crate::{
   cluster_provider::NoopClusterProvider,
   downing_provider::{DowningDecision, DowningInput, DowningProvider, DowningProviderCompatibility},
   failure_detector::FailureDetectorConfig,
+  membership::NoopGossiper,
   pub_sub::{NoopClusterPubSub, cluster_pub_sub::ClusterPubSub},
 };
 
 #[test]
 fn with_downing_provider_factory_propagates_compatibility_key_to_install_config() {
   let observed_key = ArcShared::new(SpinSyncMutex::new(Option::<String>::None));
+  let observed_phi_threshold = ArcShared::new(SpinSyncMutex::new(Option::<f64>::None));
   let observed_key_for_pubsub = observed_key.clone();
+  let observed_phi_threshold_for_gossiper = observed_phi_threshold.clone();
   let compatibility = DowningProviderCompatibility::new("recording-downing-provider");
-  let cluster_config = ClusterExtensionConfig::new().with_advertised_address("node1:8080");
+  let cluster_config = ClusterExtensionConfig::new()
+    .with_advertised_address("node1:8080")
+    .with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(9.0));
   let cluster_installer = ClusterExtensionInstaller::new(cluster_config, |_event_stream, _block_list, _address| {
     Box::new(NoopClusterProvider::new())
   })
   .with_downing_provider_factory(compatibility, || Box::new(RecordingDowningProvider))
+  .with_gossiper_factory(move |config| {
+    *observed_phi_threshold_for_gossiper.lock() = Some(config.failure_detector_config().phi_threshold());
+    Box::new(NoopGossiper)
+  })
   .with_pubsub_factory(move |config| {
     *observed_key_for_pubsub.lock() = Some(String::from(config.downing_provider_compatibility().provider_key()));
     Box::new(NoopClusterPubSub::new()) as Box<dyn ClusterPubSub>
@@ -40,14 +49,17 @@ fn with_downing_provider_factory_propagates_compatibility_key_to_install_config(
   let _system = ActorSystem::create_from_props(&props, config).expect("build system");
 
   assert_eq!(observed_key.lock().clone(), Some(String::from("recording-downing-provider")));
+  assert_eq!(*observed_phi_threshold.lock(), Some(9.0));
 }
 
 #[test]
 fn install_rejects_invalid_failure_detector_config_before_building_components() {
   let provider_calls = ArcShared::new(SpinSyncMutex::new(0usize));
+  let gossiper_calls = ArcShared::new(SpinSyncMutex::new(0usize));
   let pubsub_calls = ArcShared::new(SpinSyncMutex::new(0usize));
   let identity_lookup_calls = ArcShared::new(SpinSyncMutex::new(0usize));
   let provider_calls_for_factory = provider_calls.clone();
+  let gossiper_calls_for_factory = gossiper_calls.clone();
   let pubsub_calls_for_factory = pubsub_calls.clone();
   let identity_lookup_calls_for_factory = identity_lookup_calls.clone();
   let cluster_config =
@@ -56,6 +68,10 @@ fn install_rejects_invalid_failure_detector_config_before_building_components() 
     ClusterExtensionInstaller::new(cluster_config, move |_event_stream, _block_list, _address| {
       *provider_calls_for_factory.lock() += 1;
       Box::new(NoopClusterProvider::new())
+    })
+    .with_gossiper_factory(move |_config| {
+      *gossiper_calls_for_factory.lock() += 1;
+      Box::new(NoopGossiper)
     })
     .with_pubsub_factory(move |_config| {
       *pubsub_calls_for_factory.lock() += 1;
@@ -76,6 +92,7 @@ fn install_rejects_invalid_failure_detector_config_before_building_components() 
   };
   assert!(reason.contains("InvalidPhiThreshold"));
   assert_eq!(*provider_calls.lock(), 0);
+  assert_eq!(*gossiper_calls.lock(), 0);
   assert_eq!(*pubsub_calls.lock(), 0);
   assert_eq!(*identity_lookup_calls.lock(), 0);
 }

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_installer_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_installer_test.rs
@@ -6,15 +6,17 @@ use fraktor_actor_core_kernel_rs::{
     Actor, ActorContext, error::ActorError, extension::ExtensionInstallers, messaging::AnyMessageView, props::Props,
     setup::ActorSystemConfig,
   },
-  system::ActorSystem,
+  system::{ActorSystem, ActorSystemBuildError},
 };
 use fraktor_utils_core_rs::sync::{ArcShared, SpinSyncMutex};
 
 use super::ClusterExtensionInstaller;
 use crate::{
   ClusterExtensionConfig, ClusterProviderError,
+  activation::NoopIdentityLookup,
   cluster_provider::NoopClusterProvider,
   downing_provider::{DowningDecision, DowningInput, DowningProvider, DowningProviderCompatibility},
+  failure_detector::FailureDetectorConfig,
   pub_sub::{NoopClusterPubSub, cluster_pub_sub::ClusterPubSub},
 };
 
@@ -38,6 +40,44 @@ fn with_downing_provider_factory_propagates_compatibility_key_to_install_config(
   let _system = ActorSystem::create_from_props(&props, config).expect("build system");
 
   assert_eq!(observed_key.lock().clone(), Some(String::from("recording-downing-provider")));
+}
+
+#[test]
+fn install_rejects_invalid_failure_detector_config_before_building_components() {
+  let provider_calls = ArcShared::new(SpinSyncMutex::new(0usize));
+  let pubsub_calls = ArcShared::new(SpinSyncMutex::new(0usize));
+  let identity_lookup_calls = ArcShared::new(SpinSyncMutex::new(0usize));
+  let provider_calls_for_factory = provider_calls.clone();
+  let pubsub_calls_for_factory = pubsub_calls.clone();
+  let identity_lookup_calls_for_factory = identity_lookup_calls.clone();
+  let cluster_config =
+    ClusterExtensionConfig::new().with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(0.0));
+  let cluster_installer =
+    ClusterExtensionInstaller::new(cluster_config, move |_event_stream, _block_list, _address| {
+      *provider_calls_for_factory.lock() += 1;
+      Box::new(NoopClusterProvider::new())
+    })
+    .with_pubsub_factory(move |_config| {
+      *pubsub_calls_for_factory.lock() += 1;
+      Box::new(NoopClusterPubSub::new()) as Box<dyn ClusterPubSub>
+    })
+    .with_identity_lookup_factory(move || {
+      *identity_lookup_calls_for_factory.lock() += 1;
+      Box::new(NoopIdentityLookup::new())
+    });
+  let props = Props::from_fn(|| TestGuardian);
+  let system = ActorSystem::create_from_props(&props, ActorSystemConfig::new(TestTickDriver::default()))
+    .expect("build actor system");
+
+  let result = cluster_installer.install(&system);
+
+  let Err(ActorSystemBuildError::Configuration(reason)) = result else {
+    panic!("invalid failure detector config should reject actor system build");
+  };
+  assert!(reason.contains("InvalidPhiThreshold"));
+  assert_eq!(*provider_calls.lock(), 0);
+  assert_eq!(*pubsub_calls.lock(), 0);
+  assert_eq!(*identity_lookup_calls.lock(), 0);
 }
 
 struct RecordingDowningProvider;

--- a/modules/cluster-core-kernel/src/failure_detector.rs
+++ b/modules/cluster-core-kernel/src/failure_detector.rs
@@ -8,8 +8,10 @@
 mod default_failure_detector_registry;
 #[allow(clippy::module_inception)]
 mod failure_detector;
+mod failure_detector_config_error;
 mod failure_detector_registry;
 
 pub use default_failure_detector_registry::DefaultFailureDetectorRegistry;
 pub use failure_detector::FailureDetector;
+pub use failure_detector_config_error::FailureDetectorConfigError;
 pub use failure_detector_registry::FailureDetectorRegistry;

--- a/modules/cluster-core-kernel/src/failure_detector.rs
+++ b/modules/cluster-core-kernel/src/failure_detector.rs
@@ -8,10 +8,12 @@
 mod default_failure_detector_registry;
 #[allow(clippy::module_inception)]
 mod failure_detector;
+mod failure_detector_config;
 mod failure_detector_config_error;
 mod failure_detector_registry;
 
 pub use default_failure_detector_registry::DefaultFailureDetectorRegistry;
 pub use failure_detector::FailureDetector;
+pub use failure_detector_config::FailureDetectorConfig;
 pub use failure_detector_config_error::FailureDetectorConfigError;
 pub use failure_detector_registry::FailureDetectorRegistry;

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config.rs
@@ -1,0 +1,102 @@
+//! Failure detector observation configuration.
+
+use core::time::Duration;
+
+#[cfg(test)]
+#[path = "failure_detector_config_test.rs"]
+mod tests;
+
+/// Failure detector observation configuration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FailureDetectorConfig {
+  phi_threshold:              f64,
+  max_sample_size:            usize,
+  min_standard_deviation:     Duration,
+  acceptable_heartbeat_pause: Duration,
+  first_heartbeat_estimate:   Duration,
+}
+
+impl FailureDetectorConfig {
+  /// Creates a failure detector configuration with defaults.
+  #[must_use]
+  pub const fn new() -> Self {
+    Self {
+      phi_threshold:              1.0,
+      max_sample_size:            10,
+      min_standard_deviation:     Duration::from_millis(1),
+      acceptable_heartbeat_pause: Duration::from_millis(0),
+      first_heartbeat_estimate:   Duration::from_millis(10),
+    }
+  }
+
+  /// Sets the phi threshold.
+  #[must_use]
+  pub const fn with_phi_threshold(mut self, value: f64) -> Self {
+    self.phi_threshold = value;
+    self
+  }
+
+  /// Sets the maximum sample size.
+  #[must_use]
+  pub const fn with_max_sample_size(mut self, value: usize) -> Self {
+    self.max_sample_size = value;
+    self
+  }
+
+  /// Sets the minimum standard deviation.
+  #[must_use]
+  pub const fn with_min_standard_deviation(mut self, value: Duration) -> Self {
+    self.min_standard_deviation = value;
+    self
+  }
+
+  /// Sets the acceptable heartbeat pause.
+  #[must_use]
+  pub const fn with_acceptable_heartbeat_pause(mut self, value: Duration) -> Self {
+    self.acceptable_heartbeat_pause = value;
+    self
+  }
+
+  /// Sets the first heartbeat estimate.
+  #[must_use]
+  pub const fn with_first_heartbeat_estimate(mut self, value: Duration) -> Self {
+    self.first_heartbeat_estimate = value;
+    self
+  }
+
+  /// Returns the phi threshold.
+  #[must_use]
+  pub const fn phi_threshold(&self) -> f64 {
+    self.phi_threshold
+  }
+
+  /// Returns the maximum sample size.
+  #[must_use]
+  pub const fn max_sample_size(&self) -> usize {
+    self.max_sample_size
+  }
+
+  /// Returns the minimum standard deviation.
+  #[must_use]
+  pub const fn min_standard_deviation(&self) -> Duration {
+    self.min_standard_deviation
+  }
+
+  /// Returns the acceptable heartbeat pause.
+  #[must_use]
+  pub const fn acceptable_heartbeat_pause(&self) -> Duration {
+    self.acceptable_heartbeat_pause
+  }
+
+  /// Returns the first heartbeat estimate.
+  #[must_use]
+  pub const fn first_heartbeat_estimate(&self) -> Duration {
+    self.first_heartbeat_estimate
+  }
+}
+
+impl Default for FailureDetectorConfig {
+  fn default() -> Self {
+    Self::new()
+  }
+}

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config.rs
@@ -1,6 +1,9 @@
 //! Failure detector observation configuration.
 
+use alloc::vec::Vec;
 use core::time::Duration;
+
+use super::FailureDetectorConfigError;
 
 #[cfg(test)]
 #[path = "failure_detector_config_test.rs"]
@@ -92,6 +95,53 @@ impl FailureDetectorConfig {
   #[must_use]
   pub const fn first_heartbeat_estimate(&self) -> Duration {
     self.first_heartbeat_estimate
+  }
+
+  /// Validates this failure detector configuration.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`FailureDetectorConfigError`] when an observation parameter is
+  /// outside the accepted configuration range.
+  pub fn validate(&self) -> Result<(), FailureDetectorConfigError> {
+    if !self.phi_threshold.is_finite() || self.phi_threshold <= 0.0 {
+      return Err(FailureDetectorConfigError::InvalidPhiThreshold);
+    }
+    if self.max_sample_size == 0 {
+      return Err(FailureDetectorConfigError::ZeroMaxSampleSize);
+    }
+    if self.min_standard_deviation == Duration::ZERO {
+      return Err(FailureDetectorConfigError::ZeroMinStandardDeviation);
+    }
+    if self.first_heartbeat_estimate == Duration::ZERO {
+      return Err(FailureDetectorConfigError::ZeroFirstHeartbeatEstimate);
+    }
+
+    Ok(())
+  }
+
+  /// Returns observation parameter names whose values differ from another configuration.
+  #[must_use]
+  pub fn difference_field_names(&self, other: &Self) -> Vec<&'static str> {
+    let mut names = Vec::new();
+
+    if self.phi_threshold.to_bits() != other.phi_threshold.to_bits() {
+      names.push("phi_threshold");
+    }
+    if self.max_sample_size != other.max_sample_size {
+      names.push("max_sample_size");
+    }
+    if self.min_standard_deviation != other.min_standard_deviation {
+      names.push("min_standard_deviation");
+    }
+    if self.acceptable_heartbeat_pause != other.acceptable_heartbeat_pause {
+      names.push("acceptable_heartbeat_pause");
+    }
+    if self.first_heartbeat_estimate != other.first_heartbeat_estimate {
+      names.push("first_heartbeat_estimate");
+    }
+
+    names
   }
 }
 

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error.rs
@@ -1,5 +1,10 @@
 //! Failure detector configuration validation errors.
 
+use core::{
+  error::Error,
+  fmt::{self, Formatter, Result as FmtResult},
+};
+
 #[cfg(test)]
 #[path = "failure_detector_config_error_test.rs"]
 mod tests;
@@ -19,3 +24,16 @@ pub enum FailureDetectorConfigError {
   /// First heartbeat estimate is zero.
   ZeroFirstHeartbeatEstimate,
 }
+
+impl fmt::Display for FailureDetectorConfigError {
+  fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+    match self {
+      | Self::InvalidPhiThreshold => f.write_str("phi threshold must be a positive finite value"),
+      | Self::ZeroMaxSampleSize => f.write_str("max sample size must be greater than zero"),
+      | Self::ZeroMinStandardDeviation => f.write_str("min standard deviation must be greater than zero"),
+      | Self::ZeroFirstHeartbeatEstimate => f.write_str("first heartbeat estimate must be greater than zero"),
+    }
+  }
+}
+
+impl Error for FailureDetectorConfigError {}

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error.rs
@@ -1,0 +1,21 @@
+//! Failure detector configuration validation errors.
+
+#[cfg(test)]
+#[path = "failure_detector_config_error_test.rs"]
+mod tests;
+
+/// Failure detector configuration validation errors.
+///
+/// These errors describe invalid configuration values and are not join
+/// compatibility mismatch reasons.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureDetectorConfigError {
+  /// Phi threshold is not a positive finite value.
+  InvalidPhiThreshold,
+  /// Max sample size is zero.
+  ZeroMaxSampleSize,
+  /// Min standard deviation is zero.
+  ZeroMinStandardDeviation,
+  /// First heartbeat estimate is zero.
+  ZeroFirstHeartbeatEstimate,
+}

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error_test.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error_test.rs
@@ -1,29 +1,32 @@
+use core::time::Duration;
+
 use super::FailureDetectorConfigError;
+use crate::failure_detector::FailureDetectorConfig;
 
 #[test]
 fn identifies_phi_threshold_validation_failure() {
-  let error = FailureDetectorConfigError::InvalidPhiThreshold;
+  let config = FailureDetectorConfig::new().with_phi_threshold(0.0);
 
-  assert!(matches!(error, FailureDetectorConfigError::InvalidPhiThreshold));
+  assert_eq!(config.validate(), Err(FailureDetectorConfigError::InvalidPhiThreshold));
 }
 
 #[test]
 fn identifies_max_sample_size_validation_failure() {
-  let error = FailureDetectorConfigError::ZeroMaxSampleSize;
+  let config = FailureDetectorConfig::new().with_max_sample_size(0);
 
-  assert!(matches!(error, FailureDetectorConfigError::ZeroMaxSampleSize));
+  assert_eq!(config.validate(), Err(FailureDetectorConfigError::ZeroMaxSampleSize));
 }
 
 #[test]
 fn identifies_min_standard_deviation_validation_failure() {
-  let error = FailureDetectorConfigError::ZeroMinStandardDeviation;
+  let config = FailureDetectorConfig::new().with_min_standard_deviation(Duration::ZERO);
 
-  assert!(matches!(error, FailureDetectorConfigError::ZeroMinStandardDeviation));
+  assert_eq!(config.validate(), Err(FailureDetectorConfigError::ZeroMinStandardDeviation));
 }
 
 #[test]
 fn identifies_first_heartbeat_estimate_validation_failure() {
-  let error = FailureDetectorConfigError::ZeroFirstHeartbeatEstimate;
+  let config = FailureDetectorConfig::new().with_first_heartbeat_estimate(Duration::ZERO);
 
-  assert!(matches!(error, FailureDetectorConfigError::ZeroFirstHeartbeatEstimate));
+  assert_eq!(config.validate(), Err(FailureDetectorConfigError::ZeroFirstHeartbeatEstimate));
 }

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error_test.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_error_test.rs
@@ -1,0 +1,29 @@
+use super::FailureDetectorConfigError;
+
+#[test]
+fn identifies_phi_threshold_validation_failure() {
+  let error = FailureDetectorConfigError::InvalidPhiThreshold;
+
+  assert!(matches!(error, FailureDetectorConfigError::InvalidPhiThreshold));
+}
+
+#[test]
+fn identifies_max_sample_size_validation_failure() {
+  let error = FailureDetectorConfigError::ZeroMaxSampleSize;
+
+  assert!(matches!(error, FailureDetectorConfigError::ZeroMaxSampleSize));
+}
+
+#[test]
+fn identifies_min_standard_deviation_validation_failure() {
+  let error = FailureDetectorConfigError::ZeroMinStandardDeviation;
+
+  assert!(matches!(error, FailureDetectorConfigError::ZeroMinStandardDeviation));
+}
+
+#[test]
+fn identifies_first_heartbeat_estimate_validation_failure() {
+  let error = FailureDetectorConfigError::ZeroFirstHeartbeatEstimate;
+
+  assert!(matches!(error, FailureDetectorConfigError::ZeroFirstHeartbeatEstimate));
+}

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_test.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_test.rs
@@ -1,6 +1,7 @@
 use core::time::Duration;
 
 use super::FailureDetectorConfig;
+use crate::failure_detector::FailureDetectorConfigError;
 
 #[test]
 fn default_config_keeps_existing_observation_parameters() {
@@ -38,4 +39,60 @@ fn default_trait_uses_existing_observation_parameters() {
   assert_eq!(config.min_standard_deviation(), Duration::from_millis(1));
   assert_eq!(config.acceptable_heartbeat_pause(), Duration::from_millis(0));
   assert_eq!(config.first_heartbeat_estimate(), Duration::from_millis(10));
+}
+
+#[test]
+fn validate_rejects_invalid_observation_parameters_but_allows_zero_acceptable_pause() {
+  assert_eq!(FailureDetectorConfig::new().validate(), Ok(()));
+  assert_eq!(
+    FailureDetectorConfig::new().with_phi_threshold(0.0).validate(),
+    Err(FailureDetectorConfigError::InvalidPhiThreshold)
+  );
+  assert_eq!(
+    FailureDetectorConfig::new().with_phi_threshold(-1.0).validate(),
+    Err(FailureDetectorConfigError::InvalidPhiThreshold)
+  );
+  assert_eq!(
+    FailureDetectorConfig::new().with_phi_threshold(f64::NAN).validate(),
+    Err(FailureDetectorConfigError::InvalidPhiThreshold)
+  );
+  assert_eq!(
+    FailureDetectorConfig::new().with_phi_threshold(f64::INFINITY).validate(),
+    Err(FailureDetectorConfigError::InvalidPhiThreshold)
+  );
+  assert_eq!(
+    FailureDetectorConfig::new().with_max_sample_size(0).validate(),
+    Err(FailureDetectorConfigError::ZeroMaxSampleSize)
+  );
+  assert_eq!(
+    FailureDetectorConfig::new().with_min_standard_deviation(Duration::ZERO).validate(),
+    Err(FailureDetectorConfigError::ZeroMinStandardDeviation)
+  );
+  assert_eq!(
+    FailureDetectorConfig::new().with_first_heartbeat_estimate(Duration::ZERO).validate(),
+    Err(FailureDetectorConfigError::ZeroFirstHeartbeatEstimate)
+  );
+  assert_eq!(FailureDetectorConfig::new().with_acceptable_heartbeat_pause(Duration::ZERO).validate(), Ok(()));
+}
+
+#[test]
+fn difference_field_names_returns_only_changed_observation_parameter_names() {
+  let base = FailureDetectorConfig::new();
+  let changed = FailureDetectorConfig::new()
+    .with_phi_threshold(8.5)
+    .with_max_sample_size(42)
+    .with_min_standard_deviation(Duration::from_millis(3))
+    .with_acceptable_heartbeat_pause(Duration::from_millis(250))
+    .with_first_heartbeat_estimate(Duration::from_millis(30));
+  let max_sample_size_changed = FailureDetectorConfig::new().with_max_sample_size(42);
+
+  assert!(base.difference_field_names(&base).is_empty());
+  assert_eq!(max_sample_size_changed.difference_field_names(&base).as_slice(), ["max_sample_size"]);
+  assert_eq!(changed.difference_field_names(&base).as_slice(), [
+    "phi_threshold",
+    "max_sample_size",
+    "min_standard_deviation",
+    "acceptable_heartbeat_pause",
+    "first_heartbeat_estimate",
+  ]);
 }

--- a/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_test.rs
+++ b/modules/cluster-core-kernel/src/failure_detector/failure_detector_config_test.rs
@@ -1,0 +1,41 @@
+use core::time::Duration;
+
+use super::FailureDetectorConfig;
+
+#[test]
+fn default_config_keeps_existing_observation_parameters() {
+  let config = FailureDetectorConfig::new();
+
+  assert_eq!(config.phi_threshold(), 1.0);
+  assert_eq!(config.max_sample_size(), 10);
+  assert_eq!(config.min_standard_deviation(), Duration::from_millis(1));
+  assert_eq!(config.acceptable_heartbeat_pause(), Duration::from_millis(0));
+  assert_eq!(config.first_heartbeat_estimate(), Duration::from_millis(10));
+}
+
+#[test]
+fn custom_config_keeps_builder_style_observation_parameters() {
+  let config = FailureDetectorConfig::new()
+    .with_phi_threshold(8.5)
+    .with_max_sample_size(42)
+    .with_min_standard_deviation(Duration::from_millis(3))
+    .with_acceptable_heartbeat_pause(Duration::from_millis(250))
+    .with_first_heartbeat_estimate(Duration::from_millis(30));
+
+  assert_eq!(config.phi_threshold(), 8.5);
+  assert_eq!(config.max_sample_size(), 42);
+  assert_eq!(config.min_standard_deviation(), Duration::from_millis(3));
+  assert_eq!(config.acceptable_heartbeat_pause(), Duration::from_millis(250));
+  assert_eq!(config.first_heartbeat_estimate(), Duration::from_millis(30));
+}
+
+#[test]
+fn default_trait_uses_existing_observation_parameters() {
+  let config = FailureDetectorConfig::default();
+
+  assert_eq!(config.phi_threshold(), 1.0);
+  assert_eq!(config.max_sample_size(), 10);
+  assert_eq!(config.min_standard_deviation(), Duration::from_millis(1));
+  assert_eq!(config.acceptable_heartbeat_pause(), Duration::from_millis(0));
+  assert_eq!(config.first_heartbeat_estimate(), Duration::from_millis(10));
+}

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator.rs
@@ -77,7 +77,8 @@ impl MembershipCoordinator {
   /// # Errors
   ///
   /// Returns an error when the coordinator cannot transition to member mode.
-  pub const fn start_member(&mut self) -> Result<(), MembershipCoordinatorError> {
+  pub fn start_member(&mut self) -> Result<(), MembershipCoordinatorError> {
+    self.cluster_config.validate().map_err(MembershipCoordinatorError::Configuration)?;
     self.state = MembershipCoordinatorState::Member;
     Ok(())
   }
@@ -87,7 +88,8 @@ impl MembershipCoordinator {
   /// # Errors
   ///
   /// Returns an error when the coordinator cannot transition to client mode.
-  pub const fn start_client(&mut self) -> Result<(), MembershipCoordinatorError> {
+  pub fn start_client(&mut self) -> Result<(), MembershipCoordinatorError> {
+    self.cluster_config.validate().map_err(MembershipCoordinatorError::Configuration)?;
     self.state = MembershipCoordinatorState::Client;
     Ok(())
   }

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator.rs
@@ -153,6 +153,8 @@ impl MembershipCoordinator {
       return Err(MembershipCoordinatorError::Membership(MembershipError::Quarantined { authority, reason }));
     }
 
+    joining_config.validate().map_err(MembershipCoordinatorError::Configuration)?;
+
     if let ConfigValidation::Incompatible { reason } = self.cluster_config.check_join_compatibility(joining_config) {
       return Err(MembershipCoordinatorError::Membership(MembershipError::IncompatibleConfig { reason }));
     }

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator_error.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator_error.rs
@@ -1,6 +1,7 @@
 //! Membership coordinator error types.
 
 use super::{GossipTransportError, MembershipCoordinatorState, MembershipError};
+use crate::failure_detector::FailureDetectorConfigError;
 
 /// Errors returned by the membership coordinator.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,6 +15,8 @@ pub enum MembershipCoordinatorError {
   },
   /// Membership table error.
   Membership(MembershipError),
+  /// Cluster configuration validation failure.
+  Configuration(FailureDetectorConfigError),
   /// Gossip transport error.
   Transport(GossipTransportError),
 }

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator_test.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator_test.rs
@@ -379,6 +379,22 @@ fn join_rejects_incompatible_cluster_config() {
 }
 
 #[test]
+fn join_rejects_invalid_joining_failure_detector_config_before_compatibility_check() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let joining =
+    joining_cluster_config().with_failure_detector_config(FailureDetectorConfig::new().with_max_sample_size(0));
+
+  let err = coordinator
+    .handle_join("node-1".to_string(), "node-a".to_string(), &joining, now(1))
+    .expect_err("invalid joining failure detector config must be rejected");
+  assert_eq!(err, MembershipCoordinatorError::Configuration(FailureDetectorConfigError::ZeroMaxSampleSize));
+}
+
+#[test]
 fn join_uses_joining_config_metadata() {
   let table = MembershipTable::new(3);
   let config = base_config();

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator_test.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator_test.rs
@@ -10,7 +10,9 @@ use fraktor_utils_core_rs::time::TimerInstant;
 use super::MembershipCoordinator;
 use crate::{
   ClusterEvent, ClusterExtensionConfig,
-  failure_detector::{DefaultFailureDetectorRegistry, FailureDetector},
+  failure_detector::{
+    DefaultFailureDetectorRegistry, FailureDetector, FailureDetectorConfig, FailureDetectorConfigError,
+  },
   membership::{
     DataCenter, MembershipCoordinatorConfig, MembershipCoordinatorError, MembershipCoordinatorState, MembershipDelta,
     MembershipError, MembershipEvent, MembershipTable, MembershipVersion, NodeRecord, NodeStatus, QuarantineEvent,
@@ -102,6 +104,21 @@ fn client_rejects_join_and_leave() {
 
   let err = coordinator.handle_leave("node-a", now(1)).unwrap_err();
   assert_eq!(err, MembershipCoordinatorError::InvalidState { state: MembershipCoordinatorState::Client });
+}
+
+#[test]
+fn start_member_rejects_invalid_failure_detector_config_before_running() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let cluster_config =
+    local_cluster_config().with_failure_detector_config(FailureDetectorConfig::new().with_phi_threshold(0.0));
+  let mut coordinator = MembershipCoordinator::new(config, cluster_config, table, registry(1.0));
+
+  assert_eq!(
+    coordinator.start_member().unwrap_err(),
+    MembershipCoordinatorError::Configuration(FailureDetectorConfigError::InvalidPhiThreshold)
+  );
+  assert_eq!(coordinator.state(), MembershipCoordinatorState::Stopped);
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/topology/cluster_compatibility_key_catalog.rs
+++ b/modules/cluster-core-kernel/src/topology/cluster_compatibility_key_catalog.rs
@@ -8,8 +8,11 @@ const SENSITIVE_PROVIDER_FACTORY_REASON: &str =
 const UNOWNED_FAILURE_DETECTOR_CHOICE_REASON: &str =
   "failure detector implementation choice is not compared until cluster config owns detector selection";
 
-static REQUIRED_KEYS: [ClusterCompatibilityKey; 2] =
-  [ClusterCompatibilityKeyCatalog::PUBSUB, ClusterCompatibilityKeyCatalog::DOWNING_PROVIDER];
+static REQUIRED_KEYS: [ClusterCompatibilityKey; 3] = [
+  ClusterCompatibilityKeyCatalog::PUBSUB,
+  ClusterCompatibilityKeyCatalog::DOWNING_PROVIDER,
+  ClusterCompatibilityKeyCatalog::FAILURE_DETECTOR,
+];
 
 static CONDITIONAL_KEYS: [ClusterCompatibilityKey; 1] = [ClusterCompatibilityKeyCatalog::SPLIT_BRAIN_RESOLVER_SETTINGS];
 
@@ -31,6 +34,8 @@ impl ClusterCompatibilityKeyCatalog {
   /// Downing provider factory key excluded because implementation identity is local and sensitive.
   pub const DOWNING_PROVIDER_FACTORY: ClusterCompatibilityKey =
     ClusterCompatibilityKey::excluded("cluster.downing-provider.factory", SENSITIVE_PROVIDER_FACTORY_REASON);
+  /// Failure detector configuration compatibility key.
+  pub const FAILURE_DETECTOR: ClusterCompatibilityKey = ClusterCompatibilityKey::required("cluster.failure-detector");
   /// Failure detector implementation choice vocabulary key.
   pub const FAILURE_DETECTOR_CHOICE: ClusterCompatibilityKey =
     ClusterCompatibilityKey::excluded("cluster.failure-detector.choice", UNOWNED_FAILURE_DETECTOR_CHOICE_REASON);

--- a/modules/cluster-core-kernel/src/topology/cluster_compatibility_key_test.rs
+++ b/modules/cluster-core-kernel/src/topology/cluster_compatibility_key_test.rs
@@ -4,7 +4,7 @@ use crate::topology::ClusterCompatibilityKeyCatalog;
 fn catalog_exposes_required_stable_key_names() {
   let required_names: Vec<_> = ClusterCompatibilityKeyCatalog::required_keys().iter().map(|key| key.name()).collect();
 
-  assert_eq!(required_names, vec!["cluster.pubsub", "cluster.downing-provider"]);
+  assert_eq!(required_names, vec!["cluster.pubsub", "cluster.downing-provider", "cluster.failure-detector"]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add the Kiro spec artifacts for `configure-cluster-failure-detector`.
- Add `FailureDetectorConfig` and validation errors to configure Phi Accrual failure detector parameters.
- Include failure detector configuration in cluster extension validation and Join Compatibility (参加互換性).
- Wire the std membership bridge to build a configured Phi Accrual detector factory.
- Update cluster gap analysis and add scope guard tests for deferred work.

## Validation

- `CI_CHECK_ALLOW_RERUN_AFTER_HANG=1 CARGO_TARGET_DIR=target/codex-final-ci ./scripts/ci-check.sh ai test`
- `CARGO_TARGET_DIR=target/codex-cluster-core-no-std cargo check -p fraktor-cluster-core-kernel-rs --lib --no-default-features`

## Notes

Uncommitted local changes that are unrelated to this feature were intentionally left out of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster install/start and join compatibility paths; invalid configs now fail earlier. Production runtime wiring of the new factory may still rely on custom gossiper factories—verify non-test assembly uses `FailureDetectorConfig`.
> 
> **Overview**
> Introduces **`FailureDetectorConfig`** as a first-class cluster setting for Phi Accrual observation parameters (threshold, sample size, durations), with defaults aligned to the existing membership path and **`FailureDetectorConfigError`** for invalid values.
> 
> **Cluster integration:** `ClusterExtensionConfig` holds the config, delegates **`validate()`**, and compares it on join under required key **`cluster.failure-detector`**, reporting differing field names in mismatch reasons. **`cluster.failure-detector.choice`** stays excluded. Validation runs at **extension install** (before building provider/pubsub/gossiper) and at **`ClusterCore` / `MembershipCoordinator` start and join**, surfaced as **`ClusterError::Configuration`** / build configuration errors—not join incompatibility.
> 
> **Std adaptor:** Adds **`ConfiguredPhiAccrualDetectorFactory`** to build `PhiAccrualFailureDetector` from cluster config (duration → millis); membership tests and coordinator/gossip tests use it instead of ad-hoc constructors. **`with_gossiper_factory`** now receives **`&ClusterExtensionConfig`**.
> 
> Also adds Kiro spec artifacts and marks the failure-detector configuration gap **complete** in **`cluster-gap-analysis.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a41b862108007bda24396c75b9c441f6972d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フェイルディテクタの設定機能を実装完了。閾値、サンプルサイズ、標準偏差などのパラメータをカスタマイズ可能に。
  * クラスター参加時の互換性確認にフェイルディテクタ設定を追加。

* **改善**
  * メンバー・クライアント起動時に設定検証を実施。不正な設定は起動前にエラーで検出。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->