### PR TITLE
refactor: complete settings-to-config rename for remaining API surface

### DIFF
--- a/.kiro/specs/cluster-singleton-settings-contract/tasks.md
+++ b/.kiro/specs/cluster-singleton-settings-contract/tasks.md
@@ -8,7 +8,7 @@
   - _Boundary:_ singleton モジュール wiring, ClusterSingletonConfigError
   - _Depends:_ none
 
-- [ ] 2. コア: 設定契約
+- [x] 2. コア: 設定契約
 - [x] 2.1 lease 設定スロットを実装する
   - lease 実装の識別名と lease リトライ間隔の 2 項目のみを保持する設定型を定義する（SBR の lease 語彙とは結合しない）
   - 空の実装名とゼロ以下のリトライ間隔を検証で拒否する
@@ -50,7 +50,7 @@
   - _Boundary:_ ClusterSingletonConfig
   - _Depends:_ 2.2, 2.3
 
-- [ ] 3. 観測契約
+- [x] 3. 観測契約
 - [x] 3.1 (P) stuck 局面の語彙を定義する
   - 停滞の局面（oldest への昇格待ち / handover 実行中）を表す 2 値 enum を singleton モジュールに追加する
   - 完了条件: 2 variant の等価比較テストが通り、singleton モジュールから公開される
@@ -68,7 +68,7 @@
   - _Boundary:_ ClusterEvent / ClusterEventType 拡張
   - _Depends:_ 3.1
 
-- [ ] 4. 統合: 検証境界と参加互換性
+- [x] 4. 統合: 検証境界と参加互換性
 - [x] 4.1 (P) 互換キーカタログに singleton キーを追加する
   - cluster.singleton を required キーとしてカタログに追加し、required キー一覧に組み込む
   - カタログには sibling テストファイルが未存在のため、新規作成してテスト紐づけを追加する

--- a/modules/actor-adaptor-embassy/src/actor.rs
+++ b/modules/actor-adaptor-embassy/src/actor.rs
@@ -24,15 +24,15 @@ pub fn embassy_actor_system_config<const N: usize>(
   executor_factory: &EmbassyExecutorFactory<N>,
   spawner: SendSpawner,
 ) -> ActorSystemConfig {
-  let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
+  let default_config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
   let default_executor = executor_factory.create(DEFAULT_DISPATCHER_ID);
   let default_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
+    Box::new(DefaultDispatcherFactory::new(&default_config, default_executor));
 
-  let blocking_settings = DispatcherConfig::with_defaults(DEFAULT_BLOCKING_DISPATCHER_ID);
+  let blocking_config = DispatcherConfig::with_defaults(DEFAULT_BLOCKING_DISPATCHER_ID);
   let blocking_executor = executor_factory.create(DEFAULT_BLOCKING_DISPATCHER_ID);
   let blocking_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(DefaultDispatcherFactory::new(&blocking_settings, blocking_executor));
+    Box::new(DefaultDispatcherFactory::new(&blocking_config, blocking_executor));
 
   ActorSystemConfig::new(EmbassyTickDriver::new(Duration::from_millis(10), spawner))
     .with_mailbox_clock(embassy_monotonic_mailbox_clock())

--- a/modules/actor-adaptor-std/benches/actor_baseline.rs
+++ b/modules/actor-adaptor-std/benches/actor_baseline.rs
@@ -137,9 +137,10 @@ impl TokioBenchSystem {
     let handle = runtime.handle().clone();
     let system = runtime.block_on(async {
       let config = ActorSystemConfig::new(TokioTickDriver::default());
-      let config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
+      let dispatcher_config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
       let executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
-      let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&config, executor));
+      let configurator: Box<dyn MessageDispatcherFactory> =
+        Box::new(DefaultDispatcherFactory::new(&dispatcher_config, executor));
       let config = config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(configurator));
       ActorSystem::create_from_props(props, config).expect("actor system")
     });

--- a/modules/actor-adaptor-std/benches/actor_baseline.rs
+++ b/modules/actor-adaptor-std/benches/actor_baseline.rs
@@ -137,10 +137,9 @@ impl TokioBenchSystem {
     let handle = runtime.handle().clone();
     let system = runtime.block_on(async {
       let config = ActorSystemConfig::new(TokioTickDriver::default());
-      let settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
+      let config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
       let executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
-      let configurator: Box<dyn MessageDispatcherFactory> =
-        Box::new(DefaultDispatcherFactory::new(&settings, executor));
+      let configurator: Box<dyn MessageDispatcherFactory> = Box::new(DefaultDispatcherFactory::new(&config, executor));
       let config = config.with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(configurator));
       ActorSystem::create_from_props(props, config).expect("actor system")
     });

--- a/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
+++ b/modules/actor-adaptor-std/benches/balancing_dispatcher.rs
@@ -123,16 +123,16 @@ impl DispatcherBenchSystem {
     let handle = runtime.handle().clone();
     let system = runtime.block_on(async {
       let config = ActorSystemConfig::new(TokioTickDriver::default());
-      let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
+      let default_config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
       let default_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle.clone())), TrampolineState::new());
       let default_configurator: Box<dyn MessageDispatcherFactory> =
-        Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
+        Box::new(DefaultDispatcherFactory::new(&default_config, default_executor));
 
-      let balancing_settings = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
+      let balancing_config = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
       let balancing_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
       let shared_queue = SharedMessageQueue::new();
       let balancing_configurator: Box<dyn MessageDispatcherFactory> =
-        Box::new(BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue));
+        Box::new(BalancingDispatcherFactory::new(&balancing_config, balancing_executor, shared_queue));
 
       let config = config
         .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))

--- a/modules/actor-adaptor-std/src/actor.rs
+++ b/modules/actor-adaptor-std/src/actor.rs
@@ -46,15 +46,15 @@ pub fn install_panic_invoke_guard(config: ActorSystemConfig) -> ActorSystemConfi
 #[cfg(feature = "tokio-executor")]
 #[must_use]
 pub fn tokio_actor_system_config(handle: Handle) -> ActorSystemConfig {
-  let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
+  let default_config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
   let default_executor = TokioTaskExecutorFactory::new(handle.clone()).create(DEFAULT_DISPATCHER_ID);
   let default_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
+    Box::new(DefaultDispatcherFactory::new(&default_config, default_executor));
 
-  let blocking_settings = DispatcherConfig::with_defaults(DEFAULT_BLOCKING_DISPATCHER_ID);
+  let blocking_config = DispatcherConfig::with_defaults(DEFAULT_BLOCKING_DISPATCHER_ID);
   let blocking_executor = TokioExecutorFactory::new(handle).create(DEFAULT_BLOCKING_DISPATCHER_ID);
   let blocking_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(DefaultDispatcherFactory::new(&blocking_settings, blocking_executor));
+    Box::new(DefaultDispatcherFactory::new(&blocking_config, blocking_executor));
 
   ActorSystemConfig::new(TokioTickDriver::default())
     .with_mailbox_clock(std_monotonic_mailbox_clock())

--- a/modules/actor-adaptor-std/src/dispatch/dispatcher_test.rs
+++ b/modules/actor-adaptor-std/src/dispatch/dispatcher_test.rs
@@ -112,16 +112,16 @@ fn build_system() -> ActorSystem {
   // batch drains correctly even though each `mailbox.run` invocation only
   // processes a small slice.
   let config = ActorSystemConfig::new(TokioTickDriver::default());
-  let default_settings = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
+  let default_config = DispatcherConfig::with_defaults(DEFAULT_DISPATCHER_ID);
   let default_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle.clone())), TrampolineState::new());
   let default_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(DefaultDispatcherFactory::new(&default_settings, default_executor));
+    Box::new(DefaultDispatcherFactory::new(&default_config, default_executor));
 
-  let balancing_settings = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
+  let balancing_config = DispatcherConfig::with_defaults(BALANCING_DISPATCHER_ID);
   let balancing_executor = ExecutorShared::new(Box::new(TokioExecutor::new(handle)), TrampolineState::new());
   let shared_queue = SharedMessageQueue::new();
   let balancing_configurator: Box<dyn MessageDispatcherFactory> =
-    Box::new(BalancingDispatcherFactory::new(&balancing_settings, balancing_executor, shared_queue));
+    Box::new(BalancingDispatcherFactory::new(&balancing_config, balancing_executor, shared_queue));
 
   let config = config
     .with_dispatcher_factory(DEFAULT_DISPATCHER_ID, ArcShared::new(default_configurator))

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/balancing_dispatcher.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/balancing_dispatcher.rs
@@ -36,8 +36,8 @@ impl BalancingDispatcher {
   /// attaches via
   /// [`MessageDispatcher::try_create_shared_mailbox`].
   #[must_use]
-  pub fn new(settings: &DispatcherConfig, executor: ExecutorShared, shared_queue: SharedMessageQueue) -> Self {
-    Self { core: DispatcherCore::new(settings, executor), shared_queue, team: Vec::new() }
+  pub fn new(config: &DispatcherConfig, executor: ExecutorShared, shared_queue: SharedMessageQueue) -> Self {
+    Self { core: DispatcherCore::new(config, executor), shared_queue, team: Vec::new() }
   }
 
   /// Returns a clone of the shared message queue used by team members.

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/balancing_dispatcher_factory.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/balancing_dispatcher_factory.rs
@@ -18,10 +18,10 @@ pub struct BalancingDispatcherFactory {
 }
 
 impl BalancingDispatcherFactory {
-  /// Builds a new configurator from the supplied settings and executor.
+  /// Builds a new configurator from the supplied configuration and executor.
   #[must_use]
-  pub fn new(settings: &DispatcherConfig, executor: ExecutorShared, shared_queue: SharedMessageQueue) -> Self {
-    let dispatcher = BalancingDispatcher::new(settings, executor, shared_queue);
+  pub fn new(config: &DispatcherConfig, executor: ExecutorShared, shared_queue: SharedMessageQueue) -> Self {
+    let dispatcher = BalancingDispatcher::new(config, executor, shared_queue);
     Self { shared: MessageDispatcherShared::new(Box::new(dispatcher)) }
   }
 }

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/default_dispatcher.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/default_dispatcher.rs
@@ -19,10 +19,10 @@ pub struct DefaultDispatcher {
 }
 
 impl DefaultDispatcher {
-  /// Constructs a new `DefaultDispatcher` with the given settings and executor.
+  /// Constructs a new `DefaultDispatcher` with the given configuration and executor.
   #[must_use]
-  pub fn new(settings: &DispatcherConfig, executor: ExecutorShared) -> Self {
-    Self { core: DispatcherCore::new(settings, executor) }
+  pub fn new(config: &DispatcherConfig, executor: ExecutorShared) -> Self {
+    Self { core: DispatcherCore::new(config, executor) }
   }
 }
 

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/default_dispatcher_factory.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/default_dispatcher_factory.rs
@@ -16,10 +16,10 @@ pub struct DefaultDispatcherFactory {
 }
 
 impl DefaultDispatcherFactory {
-  /// Builds a new configurator from the supplied settings and executor.
+  /// Builds a new configurator from the supplied configuration and executor.
   #[must_use]
-  pub fn new(settings: &DispatcherConfig, executor: ExecutorShared) -> Self {
-    let dispatcher = DefaultDispatcher::new(settings, executor);
+  pub fn new(config: &DispatcherConfig, executor: ExecutorShared) -> Self {
+    let dispatcher = DefaultDispatcher::new(config, executor);
     Self { shared: MessageDispatcherShared::new(Box::new(dispatcher)) }
   }
 }

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/default_dispatcher_test.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/default_dispatcher_test.rs
@@ -27,7 +27,7 @@ fn make_dispatcher() -> DefaultDispatcher {
 }
 
 #[test]
-fn new_initialises_core_from_settings() {
+fn new_initialises_core_from_config() {
   let dispatcher = make_dispatcher();
   assert_eq!(dispatcher.id(), "default-id");
   assert_eq!(dispatcher.throughput(), nz(7));

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/dispatcher_core.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/dispatcher_core.rs
@@ -29,14 +29,14 @@ pub struct DispatcherCore {
 }
 
 impl DispatcherCore {
-  /// Constructs the core from an immutable settings bundle and an executor.
+  /// Constructs the core from an immutable configuration bundle and an executor.
   #[must_use]
-  pub fn new(settings: &DispatcherConfig, executor: ExecutorShared) -> Self {
+  pub fn new(config: &DispatcherConfig, executor: ExecutorShared) -> Self {
     Self {
-      id: settings.id().to_string(),
-      throughput: settings.throughput(),
-      throughput_deadline: settings.throughput_deadline(),
-      shutdown_timeout: settings.shutdown_timeout(),
+      id: config.id().to_string(),
+      throughput: config.throughput(),
+      throughput_deadline: config.throughput_deadline(),
+      shutdown_timeout: config.shutdown_timeout(),
       executor,
       inhabitants: 0,
       shutdown_schedule: ShutdownSchedule::Unscheduled,

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/pinned_dispatcher.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/pinned_dispatcher.rs
@@ -46,15 +46,15 @@ pub struct PinnedDispatcher {
 }
 
 impl PinnedDispatcher {
-  /// Constructs a new `PinnedDispatcher` from the supplied settings and executor.
+  /// Constructs a new `PinnedDispatcher` from the supplied configuration and executor.
   ///
-  /// The settings are normalised to `throughput = usize::MAX`,
+  /// The configuration are normalised to `throughput = usize::MAX`,
   /// `throughput_deadline = None` before being handed to [`DispatcherCore`].
   #[must_use]
-  pub fn new(settings: &DispatcherConfig, executor: ExecutorShared) -> Self {
+  pub fn new(config: &DispatcherConfig, executor: ExecutorShared) -> Self {
     // SAFETY: `usize::MAX` is non-zero on every supported target.
     let max_throughput = unsafe { NonZeroUsize::new_unchecked(usize::MAX) };
-    let normalised = settings.clone().with_throughput(max_throughput).with_throughput_deadline(None);
+    let normalised = config.clone().with_throughput(max_throughput).with_throughput_deadline(None);
     Self { core: DispatcherCore::new(&normalised, executor), owner: None }
   }
 

--- a/modules/actor-core-kernel/src/dispatch/dispatcher/pinned_dispatcher.rs
+++ b/modules/actor-core-kernel/src/dispatch/dispatcher/pinned_dispatcher.rs
@@ -48,7 +48,7 @@ pub struct PinnedDispatcher {
 impl PinnedDispatcher {
   /// Constructs a new `PinnedDispatcher` from the supplied configuration and executor.
   ///
-  /// The configuration are normalised to `throughput = usize::MAX`,
+  /// The configuration is normalised to `throughput = usize::MAX`,
   /// `throughput_deadline = None` before being handed to [`DispatcherCore`].
   #[must_use]
   pub fn new(config: &DispatcherConfig, executor: ExecutorShared) -> Self {

--- a/modules/actor-core-typed/src/delivery/consumer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/consumer_controller.rs
@@ -31,7 +31,7 @@ where
 struct ConsumerControllerState<A>
 where
   A: Clone + Send + Sync + 'static, {
-  settings:            ConsumerControllerConfig,
+  config:              ConsumerControllerConfig,
   received_seq_nr:     SeqNr,
   delivered_seq_nr:    SeqNr,
   confirmed_seq_nr:    SeqNr,
@@ -47,9 +47,9 @@ impl<A> ConsumerControllerState<A>
 where
   A: Clone + Send + Sync + 'static,
 {
-  const fn new(settings: ConsumerControllerConfig) -> Self {
+  const fn new(config: ConsumerControllerConfig) -> Self {
     Self {
-      settings,
+      config,
       received_seq_nr: 0,
       delivered_seq_nr: 0,
       confirmed_seq_nr: 0,
@@ -68,7 +68,7 @@ where
 
   fn should_request_more(&self) -> bool {
     let remaining = self.requested_seq_nr.saturating_sub(self.received_seq_nr);
-    let window = u64::from(self.settings.flow_control_window());
+    let window = u64::from(self.config.flow_control_window());
     remaining <= window / 2
   }
 
@@ -120,20 +120,20 @@ impl ConsumerController {
     ConsumerControllerCommand::deliver_then_stop()
   }
 
-  /// Creates the consumer controller behavior with default settings.
+  /// Creates the consumer controller behavior with default configuration.
   #[must_use]
   pub fn behavior<A>() -> Behavior<ConsumerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
-    Self::behavior_with_settings(ConsumerControllerConfig::new())
+    Self::behavior_with_config(ConsumerControllerConfig::new())
   }
 
-  /// Creates the consumer controller behavior with custom settings.
+  /// Creates the consumer controller behavior with custom configuration.
   #[must_use]
-  pub fn behavior_with_settings<A>(settings: ConsumerControllerConfig) -> Behavior<ConsumerControllerCommand<A>>
+  pub fn behavior_with_config<A>(config: ConsumerControllerConfig) -> Behavior<ConsumerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
-    let state = SharedLock::new_with_driver::<DefaultMutex<_>>(ConsumerControllerState::<A>::new(settings));
+    let state = SharedLock::new_with_driver::<DefaultMutex<_>>(ConsumerControllerState::<A>::new(config));
 
     Behaviors::setup(move |ctx| {
       let self_ref = ctx.self_ref();
@@ -220,7 +220,7 @@ fn collect_on_sequenced_message<A>(
   }
 
   if !is_first && !state.is_within_requested_window(seq_nr) {
-    if !state.settings.only_flow_control()
+    if !state.config.only_flow_control()
       && let Some(pc) = state.producer_controller.clone()
     {
       deferred.push(DeferredAction::SendToProducer(pc, ProducerControllerCommand::resend(state.received_seq_nr + 1)));
@@ -245,7 +245,7 @@ fn collect_on_sequenced_message<A>(
     if !state.stashed.iter().any(|stashed| stashed.seq_nr() == seq_nr) {
       state.stashed.push(seq_msg);
     }
-    if !state.settings.only_flow_control()
+    if !state.config.only_flow_control()
       && let Some(pc) = state.producer_controller.clone()
     {
       deferred.push(DeferredAction::SendToProducer(pc, ProducerControllerCommand::resend(state.received_seq_nr + 1)));
@@ -321,13 +321,13 @@ fn collect_send_request<A>(
   deferred: &mut Vec<DeferredAction<A>>,
 ) where
   A: Clone + Send + Sync + 'static, {
-  let window = u64::from(state.settings.flow_control_window());
+  let window = u64::from(state.config.flow_control_window());
   let new_requested = state.received_seq_nr + window;
   if new_requested > state.requested_seq_nr
     && let Some(pc) = state.producer_controller.clone()
   {
     state.requested_seq_nr = new_requested;
-    let support_resend = !state.settings.only_flow_control();
+    let support_resend = !state.config.only_flow_control();
     deferred.push(DeferredAction::SendToProducer(
       pc,
       ProducerControllerCommand::request(state.confirmed_seq_nr, state.requested_seq_nr, support_resend),

--- a/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
@@ -143,12 +143,12 @@ impl ProducerController {
     ProducerControllerCommand::register_consumer(consumer_controller)
   }
 
-  /// Creates the producer controller behavior with default settings.
+  /// Creates the producer controller behavior with default configuration.
   #[must_use]
   pub fn behavior<A>(producer_id: impl Into<String>) -> Behavior<ProducerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
-    Self::behavior_with_settings(producer_id, &ProducerControllerConfig::new(), None)
+    Self::behavior_with_config(producer_id, &ProducerControllerConfig::new(), None)
   }
 
   /// Creates the producer controller behavior with an optional durable
@@ -171,20 +171,20 @@ impl ProducerController {
   ) -> Behavior<ProducerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
-    Self::behavior_with_settings(producer_id, &ProducerControllerConfig::new(), durable_queue)
+    Self::behavior_with_config(producer_id, &ProducerControllerConfig::new(), durable_queue)
   }
 
-  /// Creates the producer controller behavior with custom settings.
+  /// Creates the producer controller behavior with custom configuration.
   #[must_use]
-  pub fn behavior_with_settings<A>(
+  pub fn behavior_with_config<A>(
     producer_id: impl Into<String>,
-    settings: &ProducerControllerConfig,
+    config: &ProducerControllerConfig,
     durable_queue_behavior: Option<Behavior<DurableProducerQueueCommand<A>>>,
   ) -> Behavior<ProducerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
     let producer_id = producer_id.into();
-    let settings = settings.clone();
+    let config = config.clone();
 
     Behaviors::setup(move |ctx| {
       let self_ref = ctx.self_ref();
@@ -256,7 +256,7 @@ impl ProducerController {
         return Behaviors::stopped();
       } else if state.with_lock(|state| state.awaiting_load)
         && let Err(error) = ctx.schedule_once(
-          settings.durable_queue_request_timeout(),
+          config.durable_queue_request_timeout(),
           self_ref.clone(),
           ProducerControllerCommand::durable_queue_load_timed_out(1),
         )
@@ -265,11 +265,11 @@ impl ProducerController {
         ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
       }
 
-      let runtime_settings = settings.clone();
+      let runtime_settings = config.clone();
       let runtime_load_state_adapter = load_state_adapter;
       Behaviors::receive_message(move |ctx, command: &ProducerControllerCommand<A>| {
         let command_context = ProducerCommandContext {
-          settings:           &runtime_settings,
+          config:             &runtime_settings,
           self_ref:           &self_ref,
           load_state_adapter: &runtime_load_state_adapter,
         };
@@ -282,7 +282,7 @@ impl ProducerController {
 struct ProducerCommandContext<'a, A>
 where
   A: Clone + Send + Sync + 'static, {
-  settings:           &'a ProducerControllerConfig,
+  config:             &'a ProducerControllerConfig,
   self_ref:           &'a TypedActorRef<ProducerControllerCommand<A>>,
   load_state_adapter: &'a Option<TypedActorRef<DurableProducerQueueState<A>>>,
 }
@@ -301,10 +301,10 @@ where
   let deferred = state.with_lock(|state| {
     let mut deferred = Vec::new();
     collect_producer_deferred_for_command(state, command, command_context, &mut deferred, &mut stop_self);
-    maybe_schedule_resend_first(state, command_context.settings, command_context.self_ref, ctx);
+    maybe_schedule_resend_first(state, command_context.config, command_context.self_ref, ctx);
     deferred
   });
-  execute_deferred(ctx, deferred, command_context.settings, command_context.self_ref);
+  execute_deferred(ctx, deferred, command_context.config, command_context.self_ref);
   stop_producer_after_timeout(ctx, stop_self);
   Behaviors::same()
 }
@@ -346,14 +346,14 @@ fn collect_producer_deferred_for_command<A>(
       collect_producer_load_timeout(
         state,
         *attempt,
-        command_context.settings,
+        command_context.config,
         command_context.load_state_adapter,
         deferred,
         stop_self,
       );
     },
     | ProducerControllerCommandKind::DurableQueueStoreTimedOut { seq_nr, attempt } => {
-      collect_producer_store_timeout(state, *seq_nr, *attempt, command_context.settings, deferred, stop_self);
+      collect_producer_store_timeout(state, *seq_nr, *attempt, command_context.config, deferred, stop_self);
     },
     | ProducerControllerCommandKind::ResendFirstUnconfirmed { seq_nr } => {
       collect_producer_resend_first_unconfirmed(state, *seq_nr, deferred);
@@ -435,7 +435,7 @@ fn collect_producer_durable_queue_loaded<A>(
 fn collect_producer_load_timeout<A>(
   state: &mut ProducerControllerState<A>,
   attempt: u32,
-  settings: &ProducerControllerConfig,
+  config: &ProducerControllerConfig,
   load_state_adapter: &Option<TypedActorRef<DurableProducerQueueState<A>>>,
   deferred: &mut Vec<DeferredAction<A>>,
   stop_self: &mut Option<String>,
@@ -444,7 +444,7 @@ fn collect_producer_load_timeout<A>(
   if !state.awaiting_load {
     return;
   }
-  if attempt >= settings.durable_queue_retry_attempts() {
+  if attempt >= config.durable_queue_retry_attempts() {
     *stop_self = Some(alloc::format!("ProducerController durable queue load timed out after {} attempts", attempt));
   } else if let (Some(durable_queue), Some(load_state_adapter)) =
     (state.durable_queue.clone(), load_state_adapter.clone())
@@ -461,7 +461,7 @@ fn collect_producer_store_timeout<A>(
   state: &mut ProducerControllerState<A>,
   seq_nr: SeqNr,
   attempt: u32,
-  settings: &ProducerControllerConfig,
+  config: &ProducerControllerConfig,
   deferred: &mut Vec<DeferredAction<A>>,
   stop_self: &mut Option<String>,
 ) where
@@ -472,7 +472,7 @@ fn collect_producer_store_timeout<A>(
   if pending_delivery.sequenced.seq_nr() != seq_nr {
     return;
   }
-  if attempt >= settings.durable_queue_retry_attempts() {
+  if attempt >= config.durable_queue_retry_attempts() {
     *stop_self = Some(alloc::format!(
       "ProducerController durable queue store timed out for seq_nr {} after {} attempts",
       seq_nr,
@@ -530,7 +530,7 @@ fn stop_producer_after_timeout<A>(
 
 fn maybe_schedule_resend_first<A>(
   state: &mut ProducerControllerState<A>,
-  settings: &ProducerControllerConfig,
+  config: &ProducerControllerConfig,
   self_ref: &TypedActorRef<ProducerControllerCommand<A>>,
   ctx: &TypedActorContext<'_, ProducerControllerCommand<A>>,
 ) where
@@ -547,7 +547,7 @@ fn maybe_schedule_resend_first<A>(
     return;
   }
   match ctx.schedule_once(
-    settings.durable_queue_resend_first_interval(),
+    config.durable_queue_resend_first_interval(),
     self_ref.clone(),
     ProducerControllerCommand::resend_first_unconfirmed(first_seq_nr),
   ) {
@@ -690,7 +690,7 @@ pub(crate) fn collect_on_durable_queue_message_stored<A>(
 fn execute_deferred<A>(
   ctx: &mut TypedActorContext<'_, ProducerControllerCommand<A>>,
   actions: Vec<DeferredAction<A>>,
-  settings: &ProducerControllerConfig,
+  config: &ProducerControllerConfig,
   self_ref: &TypedActorRef<ProducerControllerCommand<A>>,
 ) where
   A: Clone + Send + Sync + 'static, {
@@ -724,7 +724,7 @@ fn execute_deferred<A>(
               ProducerControllerCommand::durable_queue_store_timed_out(seq_nr, attempt)
             },
           };
-          if let Err(error) = ctx.schedule_once(settings.durable_queue_request_timeout(), self_ref.clone(), command) {
+          if let Err(error) = ctx.schedule_once(config.durable_queue_request_timeout(), self_ref.clone(), command) {
             let message = alloc::format!("ProducerController failed to schedule durable queue timeout: {:?}", error);
             ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
           }

--- a/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/internal/producer_controller.rs
@@ -265,11 +265,11 @@ impl ProducerController {
         ctx.system().emit_log(LogLevel::Warn, message, Some(ctx.pid()), None);
       }
 
-      let runtime_settings = config.clone();
+      let runtime_config = config.clone();
       let runtime_load_state_adapter = load_state_adapter;
       Behaviors::receive_message(move |ctx, command: &ProducerControllerCommand<A>| {
         let command_context = ProducerCommandContext {
-          config:             &runtime_settings,
+          config:             &runtime_config,
           self_ref:           &self_ref,
           load_state_adapter: &runtime_load_state_adapter,
         };

--- a/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller.rs
+++ b/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller.rs
@@ -67,10 +67,10 @@ where
   StopWorkerPc(TypedActorRef<ProducerControllerCommand<A>>),
   /// Spawn a per-worker ProducerController and wire it up.
   SpawnWorker {
-    worker_ref:                   ActorRef,
-    producer_id:                  String,
-    demand_adapter:               TypedActorRef<ProducerControllerRequestNext<A>>,
-    producer_controller_settings: ProducerControllerConfig,
+    worker_ref:                 ActorRef,
+    producer_id:                String,
+    demand_adapter:             TypedActorRef<ProducerControllerRequestNext<A>>,
+    producer_controller_config: ProducerControllerConfig,
   },
   LogDropped {
     total_seq_nr: u64,
@@ -257,7 +257,7 @@ impl WorkPullingProducerController {
   ) -> Behavior<WorkPullingProducerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
-    Self::behavior_with_settings(
+    Self::behavior_with_config(
       producer_id,
       worker_service_key,
       &WorkPullingProducerControllerConfig::new(),
@@ -266,7 +266,7 @@ impl WorkPullingProducerController {
   }
 
   /// Creates the work-pulling producer controller behavior with default
-  /// settings.
+  /// configuration.
   #[must_use]
   pub fn behavior<A>(
     producer_id: impl Into<String>,
@@ -274,25 +274,25 @@ impl WorkPullingProducerController {
   ) -> Behavior<WorkPullingProducerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
-    Self::behavior_with_settings(producer_id, worker_service_key, &WorkPullingProducerControllerConfig::new(), None)
+    Self::behavior_with_config(producer_id, worker_service_key, &WorkPullingProducerControllerConfig::new(), None)
   }
 
   /// Creates the work-pulling producer controller behavior with custom
-  /// settings.
+  /// configuration.
   #[must_use]
-  pub fn behavior_with_settings<A>(
+  pub fn behavior_with_config<A>(
     producer_id: impl Into<String>,
     worker_service_key: ServiceKey<ConsumerControllerCommand<A>>,
-    settings: &WorkPullingProducerControllerConfig,
+    config: &WorkPullingProducerControllerConfig,
     durable_queue_behavior: Option<Behavior<DurableProducerQueueCommand<A>>>,
   ) -> Behavior<WorkPullingProducerControllerCommand<A>>
   where
     A: Clone + Send + Sync + 'static, {
     let producer_id = producer_id.into();
-    let buffer_size = settings.buffer_size();
-    let internal_ask_timeout = settings.internal_ask_timeout();
-    let producer_controller_settings = settings.producer_controller_settings().clone();
-    let durable_queue_request_timeout = producer_controller_settings.durable_queue_request_timeout();
+    let buffer_size = config.buffer_size();
+    let internal_ask_timeout = config.internal_ask_timeout();
+    let producer_controller_config = config.producer_controller_config().clone();
+    let durable_queue_request_timeout = producer_controller_config.durable_queue_request_timeout();
 
     Behaviors::setup(move |ctx| {
       let self_ref = ctx.self_ref();
@@ -403,13 +403,13 @@ impl WorkPullingProducerController {
 
       let producer_id_inner = producer_id.clone();
       let runtime_load_state_adapter = load_state_adapter;
-      let runtime_producer_controller_settings = producer_controller_settings.clone();
+      let runtime_producer_controller_config = producer_controller_config.clone();
       let runtime_durable_queue_request_timeout = durable_queue_request_timeout;
       Behaviors::receive_message(move |ctx, command: &WorkPullingProducerControllerCommand<A>| {
         let command_context = WorkPullingCommandContext {
           producer_id: &producer_id_inner,
           self_ref: &self_ref,
-          producer_controller_settings: &runtime_producer_controller_settings,
+          producer_controller_config: &runtime_producer_controller_config,
           load_state_adapter: &runtime_load_state_adapter,
           internal_ask_timeout,
           durable_queue_request_timeout: runtime_durable_queue_request_timeout,
@@ -484,7 +484,7 @@ where
   A: Clone + Send + Sync + 'static, {
   producer_id: &'a str,
   self_ref: &'a TypedActorRef<WorkPullingProducerControllerCommand<A>>,
-  producer_controller_settings: &'a ProducerControllerConfig,
+  producer_controller_config: &'a ProducerControllerConfig,
   load_state_adapter: &'a Option<TypedActorRef<DurableProducerQueueState<A>>>,
   internal_ask_timeout: Duration,
   durable_queue_request_timeout: Duration,
@@ -546,7 +546,7 @@ fn collect_wppc_deferred_for_command<A>(
         listing,
         command_context.producer_id,
         command_context.self_ref,
-        command_context.producer_controller_settings,
+        command_context.producer_controller_config,
         deferred,
       );
     },
@@ -563,7 +563,7 @@ fn collect_wppc_deferred_for_command<A>(
       collect_wppc_load_timeout(
         state,
         *attempt,
-        command_context.producer_controller_settings,
+        command_context.producer_controller_config,
         command_context.load_state_adapter,
         deferred,
         stop_self,
@@ -574,7 +574,7 @@ fn collect_wppc_deferred_for_command<A>(
         state,
         *seq_nr,
         *attempt,
-        command_context.producer_controller_settings,
+        command_context.producer_controller_config,
         deferred,
         stop_self,
       );
@@ -618,7 +618,7 @@ fn collect_wppc_durable_queue_loaded<A>(
 fn collect_wppc_load_timeout<A>(
   state: &mut WorkPullingState<A>,
   attempt: u32,
-  producer_controller_settings: &ProducerControllerConfig,
+  producer_controller_config: &ProducerControllerConfig,
   load_state_adapter: &Option<TypedActorRef<DurableProducerQueueState<A>>>,
   deferred: &mut Vec<WppcDeferredAction<A>>,
   stop_self: &mut Option<String>,
@@ -627,7 +627,7 @@ fn collect_wppc_load_timeout<A>(
   if !state.awaiting_load {
     return;
   }
-  if attempt >= producer_controller_settings.durable_queue_retry_attempts() {
+  if attempt >= producer_controller_config.durable_queue_retry_attempts() {
     *stop_self =
       Some(alloc::format!("WorkPullingProducerController durable queue load timed out after {} attempts", attempt));
   } else if let (Some(durable_queue), Some(load_state_adapter)) =
@@ -645,7 +645,7 @@ fn collect_wppc_store_timeout<A>(
   state: &mut WorkPullingState<A>,
   seq_nr: u64,
   attempt: u32,
-  producer_controller_settings: &ProducerControllerConfig,
+  producer_controller_config: &ProducerControllerConfig,
   deferred: &mut Vec<WppcDeferredAction<A>>,
   stop_self: &mut Option<String>,
 ) where
@@ -653,7 +653,7 @@ fn collect_wppc_store_timeout<A>(
   let Some(pending) = state.pending_stores.get(&seq_nr) else {
     return;
   };
-  if attempt >= producer_controller_settings.durable_queue_retry_attempts() {
+  if attempt >= producer_controller_config.durable_queue_retry_attempts() {
     *stop_self = Some(alloc::format!(
       "WorkPullingProducerController durable queue store timed out for seq_nr {} after {} attempts",
       seq_nr,
@@ -760,7 +760,7 @@ pub(crate) fn collect_on_worker_listing<A>(
   listing: &Listing,
   producer_id: &str,
   self_ref: &TypedActorRef<WorkPullingProducerControllerCommand<A>>,
-  producer_controller_settings: &ProducerControllerConfig,
+  producer_controller_config: &ProducerControllerConfig,
   deferred: &mut Vec<WppcDeferredAction<A>>,
 ) where
   A: Clone + Send + Sync + 'static, {
@@ -794,10 +794,10 @@ pub(crate) fn collect_on_worker_listing<A>(
       let pc_producer_id = alloc::format!("{}-worker-{}", producer_id, actor_ref.pid());
 
       deferred.push(WppcDeferredAction::SpawnWorker {
-        worker_ref:                   actor_ref.clone(),
-        producer_id:                  pc_producer_id,
-        demand_adapter:               demand_adapter.clone(),
-        producer_controller_settings: producer_controller_settings.clone(),
+        worker_ref:                 actor_ref.clone(),
+        producer_id:                pc_producer_id,
+        demand_adapter:             demand_adapter.clone(),
+        producer_controller_config: producer_controller_config.clone(),
       });
     }
   }
@@ -1115,7 +1115,7 @@ fn execute_wppc_action<A>(
       worker_ref,
       producer_id: pc_producer_id,
       demand_adapter,
-      producer_controller_settings,
+      producer_controller_config,
     } => {
       execute_wppc_spawn_worker(
         ctx,
@@ -1124,7 +1124,7 @@ fn execute_wppc_action<A>(
         &worker_ref,
         &pc_producer_id,
         demand_adapter,
-        &producer_controller_settings,
+        &producer_controller_config,
       );
     },
     | WppcDeferredAction::LogDropped { total_seq_nr, buffered_len, buffer_size, message_type } => {
@@ -1259,14 +1259,13 @@ fn execute_wppc_spawn_worker<A>(
   worker_ref: &ActorRef,
   pc_producer_id: &str,
   demand_adapter: TypedActorRef<ProducerControllerRequestNext<A>>,
-  producer_controller_settings: &ProducerControllerConfig,
+  producer_controller_config: &ProducerControllerConfig,
 ) where
   A: Clone + Send + Sync + 'static, {
   // ワーカー PC を生成し、先に state に登録してから tell() する。
   // インラインディスパッチで InternalDemand が即座に返るため、
   // 登録前に tell() すると demand シグナルが消失する。
-  if let Some((entry, pc_ref)) = spawn_worker_actor::<A>(ctx, worker_ref, pc_producer_id, producer_controller_settings)
-  {
+  if let Some((entry, pc_ref)) = spawn_worker_actor::<A>(ctx, worker_ref, pc_producer_id, producer_controller_config) {
     // 1 回目の state.with_lock は spawn_worker_actor の結果を登録するためだけに使う。
     // start_spawned_worker_pc のインラインディスパッチで InternalDemand
     // が同期的に返る可能性があるため、 collect_after_worker_spawn の 2 回目の state.with_lock で
@@ -1352,15 +1351,15 @@ fn spawn_worker_actor<A>(
   ctx: &mut TypedActorContext<'_, WorkPullingProducerControllerCommand<A>>,
   worker_ref: &ActorRef,
   pc_producer_id: &str,
-  producer_controller_settings: &ProducerControllerConfig,
+  producer_controller_config: &ProducerControllerConfig,
 ) -> Option<SpawnedWorker<A>>
 where
   A: Clone + Send + Sync + 'static, {
   let pc_id = pc_producer_id.to_string();
-  let producer_controller_settings = producer_controller_settings.clone();
+  let producer_controller_config = producer_controller_config.clone();
 
   let pc_props = TypedProps::<ProducerControllerCommand<A>>::from_behavior_factory(move || {
-    ProducerController::behavior_with_settings::<A>(pc_id.clone(), &producer_controller_settings, None)
+    ProducerController::behavior_with_config::<A>(pc_id.clone(), &producer_controller_config, None)
   });
 
   let pc_ref = match ctx.spawn_child(&pc_props) {

--- a/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller_test.rs
+++ b/modules/actor-core-typed/src/delivery/internal/work_pulling_producer_controller_test.rs
@@ -80,10 +80,10 @@ fn work_pulling_producer_controller_factory_methods_compile() {
 }
 
 #[test]
-fn work_pulling_producer_controller_with_settings_compiles() {
+fn work_pulling_producer_controller_with_config_compiles() {
   let key = ServiceKey::<ConsumerControllerCommand<u32>>::new("test-workers");
   let settings = WorkPullingProducerControllerConfig::new();
-  let _behavior = WorkPullingProducerController::behavior_with_settings::<u32>("test-producer", key, &settings, None);
+  let _behavior = WorkPullingProducerController::behavior_with_config::<u32>("test-producer", key, &settings, None);
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn worker_removal_replays_unconfirmed_messages_to_self() {
 }
 
 #[test]
-fn worker_spawn_propagates_nested_producer_controller_settings() {
+fn worker_spawn_propagates_nested_producer_controller_config() {
   let mut state = WorkPullingState::<u32>::new("test-producer".to_string(), 16);
   state.demand_adapter = Some(make_typed_ref::<ProducerControllerRequestNext<u32>>());
   let self_ref = make_typed_ref::<WorkPullingProducerControllerCommand<u32>>();
@@ -333,8 +333,8 @@ fn worker_spawn_propagates_nested_producer_controller_settings() {
 
   assert!(matches!(
     deferred.last(),
-    Some(WppcDeferredAction::SpawnWorker { producer_controller_settings, .. })
-      if producer_controller_settings.durable_queue_retry_attempts() == 3
+    Some(WppcDeferredAction::SpawnWorker { producer_controller_config, .. })
+      if producer_controller_config.durable_queue_retry_attempts() == 3
   ));
 }
 
@@ -362,7 +362,7 @@ fn durable_queue_send_failure_stops_work_pulling_controller() {
   let command_context = WorkPullingCommandContext {
     producer_id: "test-producer",
     self_ref: &self_ref,
-    producer_controller_settings: &producer_settings,
+    producer_controller_config: &producer_settings,
     load_state_adapter: &load_state_adapter,
     internal_ask_timeout: Duration::from_millis(1),
     durable_queue_request_timeout: Duration::from_millis(1),

--- a/modules/actor-core-typed/src/delivery/work_pulling_producer_controller_config.rs
+++ b/modules/actor-core-typed/src/delivery/work_pulling_producer_controller_config.rs
@@ -20,9 +20,9 @@ const DEFAULT_INTERNAL_ASK_TIMEOUT: Duration = Duration::from_secs(60);
 /// Corresponds to Pekko's `WorkPullingProducerController.Settings`.
 #[derive(Debug, Clone)]
 pub struct WorkPullingProducerControllerConfig {
-  buffer_size:                  u32,
-  internal_ask_timeout:         Duration,
-  producer_controller_settings: ProducerControllerConfig,
+  buffer_size:                u32,
+  internal_ask_timeout:       Duration,
+  producer_controller_config: ProducerControllerConfig,
 }
 
 impl WorkPullingProducerControllerConfig {
@@ -30,9 +30,9 @@ impl WorkPullingProducerControllerConfig {
   #[must_use]
   pub const fn new() -> Self {
     Self {
-      buffer_size:                  DEFAULT_BUFFER_SIZE,
-      internal_ask_timeout:         DEFAULT_INTERNAL_ASK_TIMEOUT,
-      producer_controller_settings: ProducerControllerConfig::new(),
+      buffer_size:                DEFAULT_BUFFER_SIZE,
+      internal_ask_timeout:       DEFAULT_INTERNAL_ASK_TIMEOUT,
+      producer_controller_config: ProducerControllerConfig::new(),
     }
   }
 
@@ -70,14 +70,14 @@ impl WorkPullingProducerControllerConfig {
   /// Returns the nested producer-controller config applied to spawned worker
   /// controllers and durable-queue retries.
   #[must_use]
-  pub const fn producer_controller_settings(&self) -> &ProducerControllerConfig {
-    &self.producer_controller_settings
+  pub const fn producer_controller_config(&self) -> &ProducerControllerConfig {
+    &self.producer_controller_config
   }
 
   /// Returns a new config with the given nested producer-controller config.
   #[must_use]
-  pub const fn with_producer_controller_settings(self, settings: ProducerControllerConfig) -> Self {
-    Self { producer_controller_settings: settings, ..self }
+  pub const fn with_producer_controller_config(self, config: ProducerControllerConfig) -> Self {
+    Self { producer_controller_config: config, ..self }
   }
 }
 

--- a/modules/actor-core-typed/src/delivery/work_pulling_producer_controller_config_test.rs
+++ b/modules/actor-core-typed/src/delivery/work_pulling_producer_controller_config_test.rs
@@ -35,7 +35,7 @@ fn default_internal_ask_timeout() {
 
   // Then: internal_ask_timeout matches Pekko's default (60 seconds)
   assert_eq!(config.internal_ask_timeout(), Duration::from_secs(60));
-  assert_eq!(config.producer_controller_settings().durable_queue_retry_attempts(), 10);
+  assert_eq!(config.producer_controller_config().durable_queue_retry_attempts(), 10);
 }
 
 #[test]
@@ -89,18 +89,18 @@ fn with_buffer_size_preserves_internal_ask_timeout() {
 }
 
 #[test]
-fn with_producer_controller_settings_overrides_nested_config() {
+fn with_producer_controller_config_overrides_nested_config() {
   let producer_config = ProducerControllerConfig::new()
     .with_durable_queue_retry_attempts(3)
     .with_durable_queue_request_timeout(Duration::from_millis(75));
-  let config = WorkPullingProducerControllerConfig::new().with_producer_controller_settings(producer_config.clone());
+  let config = WorkPullingProducerControllerConfig::new().with_producer_controller_config(producer_config.clone());
 
   assert_eq!(
-    config.producer_controller_settings().durable_queue_retry_attempts(),
+    config.producer_controller_config().durable_queue_retry_attempts(),
     producer_config.durable_queue_retry_attempts()
   );
   assert_eq!(
-    config.producer_controller_settings().durable_queue_request_timeout(),
+    config.producer_controller_config().durable_queue_request_timeout(),
     producer_config.durable_queue_request_timeout()
   );
 }

--- a/modules/actor-core-typed/src/delivery_test.rs
+++ b/modules/actor-core-typed/src/delivery_test.rs
@@ -360,7 +360,7 @@ fn consumer_controller_settings_accessors() {
 }
 
 #[test]
-fn producer_controller_settings_accessors() {
+fn producer_controller_config_accessors() {
   let settings = ProducerControllerConfig::new()
     .with_durable_queue_request_timeout(Duration::from_millis(15))
     .with_durable_queue_retry_attempts(2)
@@ -372,27 +372,27 @@ fn producer_controller_settings_accessors() {
 }
 
 #[test]
-fn producer_controller_behavior_with_settings_is_publicly_usable() {
+fn producer_controller_behavior_with_config_is_publicly_usable() {
   let settings = ProducerControllerConfig::new();
-  let _behavior = ProducerController::behavior_with_settings::<u32>("public-producer", &settings, None);
+  let _behavior = ProducerController::behavior_with_config::<u32>("public-producer", &settings, None);
 }
 
 #[test]
-fn work_pulling_producer_controller_settings_accessors() {
+fn work_pulling_producer_controller_config_accessors() {
   let settings = WorkPullingProducerControllerConfig::new()
     .with_internal_ask_timeout(Duration::from_millis(21))
-    .with_producer_controller_settings(ProducerControllerConfig::new().with_durable_queue_retry_attempts(4));
+    .with_producer_controller_config(ProducerControllerConfig::new().with_durable_queue_retry_attempts(4));
   assert_eq!(settings.buffer_size(), 1000);
   assert_eq!(settings.internal_ask_timeout(), Duration::from_millis(21));
-  assert_eq!(settings.producer_controller_settings().durable_queue_retry_attempts(), 4);
+  assert_eq!(settings.producer_controller_config().durable_queue_retry_attempts(), 4);
 }
 
 #[test]
-fn work_pulling_behavior_with_settings_is_publicly_usable() {
+fn work_pulling_behavior_with_config_is_publicly_usable() {
   let worker_key = ServiceKey::<ConsumerControllerCommand<u32>>::new("public-workers");
   let settings = WorkPullingProducerControllerConfig::new().with_buffer_size(8);
   let _behavior =
-    WorkPullingProducerController::behavior_with_settings::<u32>("public-wppc", worker_key, &settings, None);
+    WorkPullingProducerController::behavior_with_config::<u32>("public-wppc", worker_key, &settings, None);
 }
 
 #[test]
@@ -581,7 +581,7 @@ fn work_pulling_durable_queue_timeout_uses_nested_producer_settings() {
   let durable_events = ArcShared::new(SpinSyncMutex::new(Vec::<&'static str>::new()));
   let settings = WorkPullingProducerControllerConfig::new()
     .with_internal_ask_timeout(Duration::from_millis(10))
-    .with_producer_controller_settings(
+    .with_producer_controller_config(
       ProducerControllerConfig::new()
         .with_durable_queue_request_timeout(Duration::from_millis(30))
         .with_durable_queue_retry_attempts(1),
@@ -592,7 +592,7 @@ fn work_pulling_durable_queue_timeout_uses_nested_producer_settings() {
     let durable_events = durable_events.clone();
     let settings = settings.clone();
     move || {
-      WorkPullingProducerController::behavior_with_settings(
+      WorkPullingProducerController::behavior_with_config(
         "durable-timeout-wppc",
         worker_key.clone(),
         &settings,

--- a/modules/actor-core-typed/src/system.rs
+++ b/modules/actor-core-typed/src/system.rs
@@ -429,7 +429,7 @@ where
   ///
   /// Corresponds to Pekko's `ActorSystem.settings`.
   #[must_use]
-  pub fn settings(&self) -> TypedActorSystemConfig {
+  pub fn config(&self) -> TypedActorSystemConfig {
     TypedActorSystemConfig::new(self.inner.name(), self.inner.start_time())
   }
 
@@ -437,13 +437,13 @@ where
   ///
   /// Corresponds to Pekko's `ActorSystem.logConfiguration()`.
   pub fn log_configuration(&self) {
-    let settings = self.settings();
+    let config = self.config();
     self.log().emit(
       LogLevel::Info,
       format!(
         "typed actor system configuration: system_name={}, start_time={:?}",
-        settings.system_name(),
-        settings.start_time()
+        config.system_name(),
+        config.start_time()
       ),
     );
   }

--- a/modules/actor-core-typed/src/system_test.rs
+++ b/modules/actor-core-typed/src/system_test.rs
@@ -449,12 +449,12 @@ fn settings_returns_snapshot_preserved_through_from_untyped() {
   });
   let system = TypedActorSystem::<u32>::from_untyped(untyped);
 
-  // When: settings() is called on the typed wrapper
-  let settings = system.settings();
+  // When: config() is called on the typed wrapper
+  let config = system.config();
 
   // Then: the immutable snapshot preserves the source configuration
-  assert_eq!(settings.system_name(), "wrapped-system");
-  assert_eq!(settings.start_time(), expected_start_time);
+  assert_eq!(config.system_name(), "wrapped-system");
+  assert_eq!(config.start_time(), expected_start_time);
 }
 
 #[test]

--- a/modules/remote-core/src/config/remote_compression_config.rs
+++ b/modules/remote-core/src/config/remote_compression_config.rs
@@ -1,4 +1,4 @@
-//! Typed compression settings carried by `RemoteConfig`.
+//! Typed compression configuration carried by `RemoteConfig`.
 
 use core::{num::NonZeroUsize, time::Duration};
 
@@ -10,7 +10,7 @@ const fn default_compression_max() -> NonZeroUsize {
   unsafe { NonZeroUsize::new_unchecked(DEFAULT_COMPRESSION_MAX) }
 }
 
-/// Compression table settings for actor refs and serializer manifests.
+/// Compression table configuration for actor refs and serializer manifests.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RemoteCompressionConfig {
   actor_ref_max:                    Option<NonZeroUsize>,
@@ -20,7 +20,7 @@ pub struct RemoteCompressionConfig {
 }
 
 impl RemoteCompressionConfig {
-  /// Creates compression settings with Pekko-compatible defaults.
+  /// Creates compression configuration with Pekko-compatible defaults.
   #[must_use]
   pub const fn new() -> Self {
     Self {

--- a/modules/remote-core/src/config/remote_config.rs
+++ b/modules/remote-core/src/config/remote_config.rs
@@ -479,7 +479,7 @@ impl RemoteConfig {
     self
   }
 
-  /// Returns a copy with the given compression settings.
+  /// Returns a copy with the given compression configuration.
   #[must_use]
   pub const fn with_compression_config(mut self, compression_config: RemoteCompressionConfig) -> Self {
     self.compression_config = compression_config;
@@ -756,7 +756,7 @@ impl RemoteConfig {
     self.outbound_max_restarts
   }
 
-  /// Returns the compression settings surface.
+  /// Returns the compression configuration surface.
   #[must_use]
   pub const fn compression_config(&self) -> &RemoteCompressionConfig {
     &self.compression_config

--- a/modules/remote-core/src/config_test.rs
+++ b/modules/remote-core/src/config_test.rs
@@ -50,7 +50,7 @@ fn new_uses_defaults_for_optional_fields() {
 }
 
 #[test]
-fn advanced_artery_settings_use_pekko_compatible_defaults() {
+fn advanced_artery_config_uses_pekko_compatible_defaults() {
   // Given: デフォルト構成
   let s = RemoteConfig::new("localhost");
 
@@ -136,7 +136,7 @@ fn method_chain_applies_all_changes() {
 }
 
 #[test]
-fn advanced_artery_settings_method_chain_applies_all_changes() {
+fn advanced_artery_config_method_chain_applies_all_changes() {
   // Given: advanced 設定をすべて上書きした構成
   let destinations = LargeMessageDestinations::new()
     .with_pattern(LargeMessageDestinationPattern::new("/user/large"))
@@ -360,7 +360,7 @@ fn with_remove_quarantined_association_after_rejects_zero() {
 }
 
 #[test]
-fn restart_timing_settings_reject_zero_duration() {
+fn restart_timing_config_rejects_zero_duration() {
   let outbound_backoff =
     std::panic::catch_unwind(|| RemoteConfig::new("localhost").with_outbound_restart_backoff(Duration::ZERO));
   let outbound_timeout =
@@ -452,7 +452,7 @@ fn remote_compression_config_rejects_zero_advertisement_interval() {
 }
 
 #[test]
-fn advanced_settings_sources_keep_no_std_boundary() {
+fn advanced_config_sources_keep_no_std_boundary() {
   let sources = [
     include_str!("config/remote_config.rs"),
     include_str!("config/large_message_destination_pattern.rs"),
@@ -461,6 +461,6 @@ fn advanced_settings_sources_keep_no_std_boundary() {
   ];
 
   for source in sources {
-    assert!(!source.contains("use std::"), "remote-core config advanced settings must remain no_std");
+    assert!(!source.contains("use std::"), "remote-core advanced config sources must remain no_std");
   }
 }

--- a/modules/stream-core-kernel/src/dsl/flow.rs
+++ b/modules/stream-core-kernel/src/dsl/flow.rs
@@ -772,10 +772,10 @@ where
     self.restart_flow_with_backoff(min_backoff_ticks, max_restarts)
   }
 
-  /// Enables restart semantics by explicit restart settings.
+  /// Enables restart semantics by explicit restart configuration.
   #[must_use]
-  pub fn restart_flow_with_settings(mut self, settings: RestartConfig) -> Flow<In, Out, Mat> {
-    self.graph.set_flow_restart(&Some(RestartBackoff::from_settings(settings)));
+  pub fn restart_flow_with_config(mut self, config: RestartConfig) -> Flow<In, Out, Mat> {
+    self.graph.set_flow_restart(&Some(RestartBackoff::from_config(config)));
     self
   }
 

--- a/modules/stream-core-kernel/src/dsl/flow_test.rs
+++ b/modules/stream-core-kernel/src/dsl/flow_test.rs
@@ -2421,13 +2421,13 @@ fn with_backoff_and_context_alias_keeps_single_path_behavior() {
 }
 
 #[test]
-fn restart_flow_with_settings_keeps_single_path_behavior() {
+fn restart_flow_with_config_keeps_single_path_behavior() {
   let settings = RestartConfig::new(1, 4, 3)
     .with_random_factor_permille(250)
     .with_max_restarts_within_ticks(16)
     .with_jitter_seed(17);
   let values = Source::single(7_u32)
-    .via(Flow::new().restart_flow_with_settings(settings))
+    .via(Flow::new().restart_flow_with_config(settings))
     .run_with_collect_sink()
     .expect("run_with_collect_sink");
   assert_eq!(values, vec![7_u32]);

--- a/modules/stream-core-kernel/src/dsl/restart_flow.rs
+++ b/modules/stream-core-kernel/src/dsl/restart_flow.rs
@@ -10,7 +10,7 @@ use super::{RestartConfig, flow::Flow};
 pub struct RestartFlow;
 
 impl RestartFlow {
-  /// Applies restart-on-failure backoff settings to a flow.
+  /// Applies restart-on-failure backoff configuration to a flow.
   #[must_use]
   pub fn with_backoff<In, Out, Mat>(
     flow: Flow<In, Out, Mat>,
@@ -23,12 +23,12 @@ impl RestartFlow {
     flow.restart_flow_with_backoff(min_backoff_ticks, max_restarts)
   }
 
-  /// Applies restart settings to a flow.
+  /// Applies restart configuration to a flow.
   #[must_use]
-  pub fn with_settings<In, Out, Mat>(flow: Flow<In, Out, Mat>, settings: RestartConfig) -> Flow<In, Out, Mat>
+  pub fn with_config<In, Out, Mat>(flow: Flow<In, Out, Mat>, config: RestartConfig) -> Flow<In, Out, Mat>
   where
     In: Send + Sync + 'static,
     Out: Send + Sync + 'static, {
-    flow.restart_flow_with_settings(settings)
+    flow.restart_flow_with_config(config)
   }
 }

--- a/modules/stream-core-kernel/src/dsl/restart_flow_test.rs
+++ b/modules/stream-core-kernel/src/dsl/restart_flow_test.rs
@@ -22,9 +22,9 @@ fn restart_flow_with_backoff_keeps_data_path_behavior() {
 }
 
 #[test]
-fn restart_flow_with_settings_keeps_data_path_behavior() {
+fn restart_flow_with_config_keeps_data_path_behavior() {
   let settings = RestartConfig::new(1, 2, 3);
-  let flow = RestartFlow::with_settings(Flow::new().map(|value: u32| value + 1), settings);
+  let flow = RestartFlow::with_config(Flow::new().map(|value: u32| value + 1), settings);
   let values = Source::single(2_u32).via(flow).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![3_u32]);
 }

--- a/modules/stream-core-kernel/src/dsl/restart_sink.rs
+++ b/modules/stream-core-kernel/src/dsl/restart_sink.rs
@@ -10,7 +10,7 @@ use super::{RestartConfig, sink::Sink};
 pub struct RestartSink;
 
 impl RestartSink {
-  /// Applies restart-on-failure backoff settings to a sink.
+  /// Applies restart-on-failure backoff configuration to a sink.
   #[must_use]
   pub fn with_backoff<In, Mat>(sink: Sink<In, Mat>, min_backoff_ticks: u32, max_restarts: usize) -> Sink<In, Mat>
   where
@@ -18,11 +18,11 @@ impl RestartSink {
     sink.restart_sink_with_backoff(min_backoff_ticks, max_restarts)
   }
 
-  /// Applies restart settings to a sink.
+  /// Applies restart configuration to a sink.
   #[must_use]
-  pub fn with_settings<In, Mat>(sink: Sink<In, Mat>, settings: RestartConfig) -> Sink<In, Mat>
+  pub fn with_config<In, Mat>(sink: Sink<In, Mat>, config: RestartConfig) -> Sink<In, Mat>
   where
     In: Send + Sync + 'static, {
-    sink.restart_sink_with_settings(settings)
+    sink.restart_sink_with_config(config)
   }
 }

--- a/modules/stream-core-kernel/src/dsl/restart_sink_test.rs
+++ b/modules/stream-core-kernel/src/dsl/restart_sink_test.rs
@@ -22,9 +22,9 @@ fn restart_sink_with_backoff_keeps_data_path_behavior() {
 }
 
 #[test]
-fn restart_sink_with_settings_keeps_data_path_behavior() {
+fn restart_sink_with_config_keeps_data_path_behavior() {
   let settings = RestartConfig::new(1, 2, 3);
-  let sink = RestartSink::with_settings(Sink::<u32, _>::ignore(), settings);
+  let sink = RestartSink::with_config(Sink::<u32, _>::ignore(), settings);
   let graph = Source::single(2_u32).into_mat(sink, KeepRight);
   let (plan, completion) = graph.into_parts();
   let mut interpreter = GraphInterpreter::new(plan, StreamBufferConfig::default());

--- a/modules/stream-core-kernel/src/dsl/restart_source.rs
+++ b/modules/stream-core-kernel/src/dsl/restart_source.rs
@@ -10,7 +10,7 @@ use super::{RestartConfig, source::Source};
 pub struct RestartSource;
 
 impl RestartSource {
-  /// Applies restart-on-failure backoff settings to a source.
+  /// Applies restart-on-failure backoff configuration to a source.
   #[must_use]
   pub fn with_backoff<Out, Mat>(
     source: Source<Out, Mat>,
@@ -22,11 +22,11 @@ impl RestartSource {
     source.restart_source_with_backoff(min_backoff_ticks, max_restarts)
   }
 
-  /// Applies restart settings to a source.
+  /// Applies restart configuration to a source.
   #[must_use]
-  pub fn with_settings<Out, Mat>(source: Source<Out, Mat>, settings: RestartConfig) -> Source<Out, Mat>
+  pub fn with_config<Out, Mat>(source: Source<Out, Mat>, config: RestartConfig) -> Source<Out, Mat>
   where
     Out: Send + Sync + 'static, {
-    source.restart_source_with_settings(settings)
+    source.restart_source_with_config(config)
   }
 }

--- a/modules/stream-core-kernel/src/dsl/restart_source_test.rs
+++ b/modules/stream-core-kernel/src/dsl/restart_source_test.rs
@@ -12,9 +12,9 @@ fn restart_source_with_backoff_keeps_data_path_behavior() {
 }
 
 #[test]
-fn restart_source_with_settings_keeps_data_path_behavior() {
+fn restart_source_with_config_keeps_data_path_behavior() {
   let settings = RestartConfig::new(1, 2, 3);
-  let source = RestartSource::with_settings(Source::from_array([1_u32, 2]), settings);
+  let source = RestartSource::with_config(Source::from_array([1_u32, 2]), settings);
   let values = source.run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![1_u32, 2_u32]);
 }

--- a/modules/stream-core-kernel/src/dsl/sink.rs
+++ b/modules/stream-core-kernel/src/dsl/sink.rs
@@ -504,10 +504,10 @@ where
     self
   }
 
-  /// Enables restart semantics by explicit restart settings.
+  /// Enables restart semantics by explicit restart configuration.
   #[must_use]
-  pub fn restart_sink_with_settings(mut self, settings: RestartConfig) -> Self {
-    self.graph.set_sink_restart(&Some(RestartBackoff::from_settings(settings)));
+  pub fn restart_sink_with_config(mut self, config: RestartConfig) -> Self {
+    self.graph.set_sink_restart(&Some(RestartBackoff::from_config(config)));
     self
   }
 

--- a/modules/stream-core-kernel/src/dsl/source.rs
+++ b/modules/stream-core-kernel/src/dsl/source.rs
@@ -1963,10 +1963,10 @@ where
     self.restart_source_with_backoff(min_backoff_ticks, max_restarts)
   }
 
-  /// Enables restart semantics by explicit restart settings.
+  /// Enables restart semantics by explicit restart configuration.
   #[must_use]
-  pub fn restart_source_with_settings(mut self, settings: RestartConfig) -> Source<Out, Mat> {
-    self.graph.set_source_restart(&Some(RestartBackoff::from_settings(settings)));
+  pub fn restart_source_with_config(mut self, config: RestartConfig) -> Source<Out, Mat> {
+    self.graph.set_source_restart(&Some(RestartBackoff::from_config(config)));
     self
   }
 

--- a/modules/stream-core-kernel/src/dsl/source_test.rs
+++ b/modules/stream-core-kernel/src/dsl/source_test.rs
@@ -2452,15 +2452,13 @@ fn source_with_backoff_and_context_alias_keeps_single_path_behavior() {
 }
 
 #[test]
-fn source_restart_with_settings_keeps_single_path_behavior() {
+fn source_restart_with_config_keeps_single_path_behavior() {
   let settings = RestartConfig::new(1, 4, 3)
     .with_random_factor_permille(250)
     .with_max_restarts_within_ticks(16)
     .with_jitter_seed(11);
-  let values = Source::single(5_u32)
-    .restart_source_with_settings(settings)
-    .run_with_collect_sink()
-    .expect("run_with_collect_sink");
+  let values =
+    Source::single(5_u32).restart_source_with_config(settings).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 

--- a/modules/stream-core-kernel/src/dsl/source_test.rs
+++ b/modules/stream-core-kernel/src/dsl/source_test.rs
@@ -2453,12 +2453,12 @@ fn source_with_backoff_and_context_alias_keeps_single_path_behavior() {
 
 #[test]
 fn source_restart_with_config_keeps_single_path_behavior() {
-  let settings = RestartConfig::new(1, 4, 3)
+  let config = RestartConfig::new(1, 4, 3)
     .with_random_factor_permille(250)
     .with_max_restarts_within_ticks(16)
     .with_jitter_seed(11);
   let values =
-    Source::single(5_u32).restart_source_with_config(settings).run_with_collect_sink().expect("run_with_collect_sink");
+    Source::single(5_u32).restart_source_with_config(config).run_with_collect_sink().expect("run_with_collect_sink");
   assert_eq!(values, vec![5_u32]);
 }
 

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter.rs
@@ -94,11 +94,11 @@ impl GraphInterpreter {
     plan: StreamPlan,
     buffer_config: StreamBufferConfig,
     actor_system: Option<&ActorSystem>,
-    stream_ref_settings: &StreamRefConfig,
+    stream_ref_config: &StreamRefConfig,
   ) -> Self {
     let compiled = CompiledGraphPlan::compile(plan, buffer_config);
     let mut stages = compiled.stages;
-    Self::attach_materializer_context(&mut stages, actor_system, stream_ref_settings);
+    Self::attach_materializer_context(&mut stages, actor_system, stream_ref_config);
     let stage_count = stages.len();
     let flow_count = compiled.flow_order.len();
     let source_indices_len = compiled.source_indices.len();
@@ -132,7 +132,7 @@ impl GraphInterpreter {
   fn attach_materializer_context(
     stages: &mut [StageDefinition],
     actor_system: Option<&ActorSystem>,
-    stream_ref_settings: &StreamRefConfig,
+    stream_ref_config: &StreamRefConfig,
   ) {
     for stage in stages {
       match stage {
@@ -140,7 +140,7 @@ impl GraphInterpreter {
           if let Some(system) = actor_system {
             source.logic.attach_actor_system(system.clone());
           }
-          source.logic.attach_stream_ref_settings(stream_ref_settings.clone());
+          source.logic.attach_stream_ref_config(stream_ref_config.clone());
         },
         | StageDefinition::Flow(flow) => {
           if let Some(system) = actor_system {
@@ -151,7 +151,7 @@ impl GraphInterpreter {
           if let Some(system) = actor_system {
             sink.logic.attach_actor_system(system.clone());
           }
-          sink.logic.attach_stream_ref_settings(stream_ref_settings.clone());
+          sink.logic.attach_stream_ref_config(stream_ref_config.clone());
         },
       };
     }

--- a/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter_test.rs
+++ b/modules/stream-core-kernel/src/impl/interpreter/graph_interpreter_test.rs
@@ -319,7 +319,7 @@ fn source_completion_fails_when_restart_budget_exhaustion_is_configured_to_fail(
     mat_combine: MatCombine::Right,
     logic:       Box::new(EmptyTestSourceLogic),
     supervision: SupervisionStrategy::Stop,
-    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 0).with_complete_on_max_restarts(false))),
+    restart:     Some(RestartBackoff::from_config(RestartConfig::new(0, 0, 0).with_complete_on_max_restarts(false))),
     attributes:  Attributes::new(),
   };
   let sink = collect_u32_sequence_sink(sink_inlet, StreamFuture::new());
@@ -385,7 +385,7 @@ fn flow_input_rejects_type_mismatch_before_applying_logic() {
 
 #[test]
 fn flow_failure_complete_updates_step_and_closes_sources() {
-  let restart = RestartBackoff::from_settings(RestartConfig::new(0, 0, 0));
+  let restart = RestartBackoff::from_config(RestartConfig::new(0, 0, 0));
   let (mut interpreter, _, flow_index, _) =
     single_flow_interpreter_with_logic(Box::new(DrainFailingFlowLogic), Some(restart));
   let mut step = FlowStageStep::default();
@@ -430,7 +430,7 @@ fn flow_async_restart_exhaustion_skips_timer_callback() {
   assert_eq!(coverage_logic.on_timer().expect("timer output").len(), 1);
   assert_eq!(*coverage_timer_calls.lock(), 1);
 
-  let restart = RestartBackoff::from_settings(RestartConfig::new(0, 0, 0));
+  let restart = RestartBackoff::from_config(RestartConfig::new(0, 0, 0));
   let (mut interpreter, _, flow_index, _) = single_flow_interpreter_with_logic(
     Box::new(AsyncRestartExhaustedFlowLogic { timer_calls: timer_calls.clone() }),
     Some(restart),
@@ -444,7 +444,7 @@ fn flow_async_restart_exhaustion_skips_timer_callback() {
 
 #[test]
 fn flow_drain_failure_complete_finishes_flow_without_failing_stream() {
-  let restart = RestartBackoff::from_settings(RestartConfig::new(0, 0, 0));
+  let restart = RestartBackoff::from_config(RestartConfig::new(0, 0, 0));
   let (mut interpreter, _, flow_index, _) =
     single_flow_interpreter_with_logic(Box::new(DrainFailingFlowLogic), Some(restart));
   assert!(!interpreter.all_sources_done());
@@ -548,7 +548,7 @@ fn sink_failure_completes_when_restart_budget_is_exhausted() {
     mat_combine: MatCombine::Right,
     logic:       Box::new(AlwaysFailCollectSinkLogic { completion }),
     supervision: SupervisionStrategy::Stop,
-    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 0))),
+    restart:     Some(RestartBackoff::from_config(RestartConfig::new(0, 0, 0))),
     attributes:  Attributes::new(),
   };
   let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
@@ -616,7 +616,7 @@ fn sink_drive_returns_after_tick_completes_sink() {
     mat_combine: MatCombine::Right,
     logic:       Box::new(CompletingTickSinkLogic { can_accept_calls: can_accept_calls.clone() }),
     supervision: SupervisionStrategy::Stop,
-    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 0))),
+    restart:     Some(RestartBackoff::from_config(RestartConfig::new(0, 0, 0))),
     attributes:  Attributes::new(),
   };
   let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(
@@ -2634,7 +2634,7 @@ fn source_restart_with_backoff_fails_on_budget_exhaustion_when_configured() {
     mat_combine: MatCombine::Right,
     logic:       Box::new(AlwaysFailSourceLogic),
     supervision: SupervisionStrategy::Stop,
-    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 1).with_complete_on_max_restarts(false))),
+    restart:     Some(RestartBackoff::from_config(RestartConfig::new(0, 0, 1).with_complete_on_max_restarts(false))),
     attributes:  Attributes::new(),
   };
   let sink = collect_u32_sequence_sink(sink_inlet, completion.clone());
@@ -2741,7 +2741,7 @@ fn flow_restart_with_backoff_fails_on_budget_exhaustion_when_configured() {
     mat_combine: MatCombine::Left,
     logic:       Box::new(RestartCounterFlowLogic { restart_calls: ArcShared::new(SpinSyncMutex::new(0_u32)) }),
     supervision: SupervisionStrategy::Stop,
-    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 1).with_complete_on_max_restarts(false))),
+    restart:     Some(RestartBackoff::from_config(RestartConfig::new(0, 0, 1).with_complete_on_max_restarts(false))),
     attributes:  Attributes::new(),
   };
   let sink = collect_u32_sequence_sink(sink_inlet, completion.clone());
@@ -2805,7 +2805,7 @@ fn sink_restart_with_backoff_fails_on_budget_exhaustion_when_configured() {
     mat_combine: MatCombine::Right,
     logic:       Box::new(AlwaysFailCollectSinkLogic { completion: completion.clone() }),
     supervision: SupervisionStrategy::Stop,
-    restart:     Some(RestartBackoff::from_settings(RestartConfig::new(0, 0, 1).with_complete_on_max_restarts(false))),
+    restart:     Some(RestartBackoff::from_config(RestartConfig::new(0, 0, 1).with_complete_on_max_restarts(false))),
     attributes:  Attributes::new(),
   };
   let plan = stream_plan(vec![StageDefinition::Source(source), StageDefinition::Sink(sink)], vec![(

--- a/modules/stream-core-kernel/src/impl/materialization/stream.rs
+++ b/modules/stream-core-kernel/src/impl/materialization/stream.rs
@@ -48,7 +48,7 @@ impl Stream {
     buffer_config: StreamBufferConfig,
     kill_switch_state: KillSwitchStateHandle,
     actor_system: Option<&ActorSystem>,
-    stream_ref_settings: &StreamRefConfig,
+    stream_ref_config: &StreamRefConfig,
   ) -> Self {
     let linked_kill_switch_states = plan.shared_kill_switch_states().to_vec();
     Self {
@@ -57,7 +57,7 @@ impl Stream {
         plan,
         buffer_config,
         actor_system,
-        stream_ref_settings,
+        stream_ref_config,
       ),
       kill_switch_state,
       linked_kill_switch_states,

--- a/modules/stream-core-kernel/src/impl/restart_backoff.rs
+++ b/modules/stream-core-kernel/src/impl/restart_backoff.rs
@@ -1,5 +1,9 @@
 use crate::RestartConfig;
 
+#[cfg(test)]
+#[path = "restart_backoff_test.rs"]
+mod tests;
+
 #[derive(Debug, Clone)]
 pub(crate) struct RestartBackoff {
   config:                RestartConfig,

--- a/modules/stream-core-kernel/src/impl/restart_backoff.rs
+++ b/modules/stream-core-kernel/src/impl/restart_backoff.rs
@@ -2,7 +2,7 @@ use crate::RestartConfig;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RestartBackoff {
-  settings:              RestartConfig,
+  config:                RestartConfig,
   restart_count:         usize,
   cooldown_ticks:        u32,
   pending:               bool,
@@ -13,14 +13,14 @@ pub(crate) struct RestartBackoff {
 
 impl RestartBackoff {
   pub(crate) fn new(min_backoff_ticks: u32, max_restarts: usize) -> Self {
-    Self::from_settings(RestartConfig::new(min_backoff_ticks, min_backoff_ticks, max_restarts))
+    Self::from_config(RestartConfig::new(min_backoff_ticks, min_backoff_ticks, max_restarts))
   }
 
-  pub(crate) const fn from_settings(settings: RestartConfig) -> Self {
-    let min_backoff_ticks = settings.min_backoff_ticks();
-    let jitter_seed = settings.jitter_seed();
+  pub(crate) const fn from_config(config: RestartConfig) -> Self {
+    let min_backoff_ticks = config.min_backoff_ticks();
+    let jitter_seed = config.jitter_seed();
     Self {
-      settings,
+      config,
       restart_count: 0,
       cooldown_ticks: 0,
       pending: false,
@@ -35,12 +35,12 @@ impl RestartBackoff {
   }
 
   pub(crate) const fn complete_on_max_restarts(&self) -> bool {
-    self.settings.complete_on_max_restarts()
+    self.config.complete_on_max_restarts()
   }
 
   pub(crate) fn schedule(&mut self, now_tick: u64) -> bool {
     self.reset_backoff_if_window_elapsed(now_tick);
-    if self.restart_count >= self.settings.max_restarts() {
+    if self.restart_count >= self.config.max_restarts() {
       return false;
     }
     self.restart_count = self.restart_count.saturating_add(1);
@@ -64,8 +64,8 @@ impl RestartBackoff {
   }
 
   fn next_cooldown_ticks(&mut self) -> u32 {
-    let min_ticks = self.settings.min_backoff_ticks();
-    let max_ticks = self.settings.max_backoff_ticks();
+    let min_ticks = self.config.min_backoff_ticks();
+    let max_ticks = self.config.max_backoff_ticks();
     let base = self.current_backoff_ticks.max(min_ticks).min(max_ticks);
     let jitter_ticks = self.compute_jitter_ticks(base);
     self.current_backoff_ticks = base.saturating_mul(2).min(max_ticks).max(min_ticks);
@@ -73,17 +73,17 @@ impl RestartBackoff {
   }
 
   fn reset_backoff_if_window_elapsed(&mut self, now_tick: u64) {
-    let window = u64::from(self.settings.max_restarts_within_ticks());
+    let window = u64::from(self.config.max_restarts_within_ticks());
     if window == 0 {
       return;
     }
     if now_tick.saturating_sub(self.last_schedule_tick) > window {
-      self.current_backoff_ticks = self.settings.min_backoff_ticks();
+      self.current_backoff_ticks = self.config.min_backoff_ticks();
     }
   }
 
   fn compute_jitter_ticks(&mut self, base_ticks: u32) -> u32 {
-    let factor = u32::from(self.settings.random_factor_permille());
+    let factor = u32::from(self.config.random_factor_permille());
     if factor == 0 || base_ticks == 0 {
       return 0;
     }

--- a/modules/stream-core-kernel/src/impl/restart_backoff_test.rs
+++ b/modules/stream-core-kernel/src/impl/restart_backoff_test.rs
@@ -1,0 +1,40 @@
+use super::RestartBackoff;
+use crate::RestartConfig;
+
+#[test]
+fn reset_backoff_skips_when_restart_window_is_disabled() {
+  // max_restarts_within_ticks = 0 はウィンドウ無効を意味し、リセットしない
+  let config = RestartConfig::new(2, 16, 3).with_max_restarts_within_ticks(0);
+  let mut backoff = RestartBackoff::from_config(config);
+  backoff.current_backoff_ticks = 8;
+
+  backoff.reset_backoff_if_window_elapsed(100);
+
+  assert_eq!(backoff.current_backoff_ticks, 8);
+}
+
+#[test]
+fn reset_backoff_restores_min_backoff_after_window_elapsed() {
+  // 最終スケジュールからウィンドウを超えた場合、バックオフを最小値へ戻す
+  let config = RestartConfig::new(2, 16, 3).with_max_restarts_within_ticks(4);
+  let mut backoff = RestartBackoff::from_config(config);
+  backoff.current_backoff_ticks = 8;
+  backoff.last_schedule_tick = 1;
+
+  backoff.reset_backoff_if_window_elapsed(10);
+
+  assert_eq!(backoff.current_backoff_ticks, 2);
+}
+
+#[test]
+fn reset_backoff_keeps_current_backoff_within_window() {
+  // ウィンドウ内では現在のバックオフを維持する
+  let config = RestartConfig::new(2, 16, 3).with_max_restarts_within_ticks(4);
+  let mut backoff = RestartBackoff::from_config(config);
+  backoff.current_backoff_ticks = 8;
+  backoff.last_schedule_tick = 1;
+
+  backoff.reset_backoff_if_window_elapsed(3);
+
+  assert_eq!(backoff.current_backoff_ticks, 8);
+}

--- a/modules/stream-core-kernel/src/impl/streamref/stream_ref_sink_logic.rs
+++ b/modules/stream-core-kernel/src/impl/streamref/stream_ref_sink_logic.rs
@@ -37,7 +37,7 @@ pub(crate) struct StreamRefSinkLogic<T> {
   endpoint:        Option<StreamRefEndpointSlot>,
   subscription:    StreamRefSinkSubscription,
   completion:      Option<StreamFuture<StreamDone>>,
-  settings:        StreamRefConfig,
+  config:          StreamRefConfig,
   demand_started:  bool,
   terminal_queued: bool,
   waiting_ticks:   u64,
@@ -73,7 +73,7 @@ impl<T> StreamRefSinkLogic<T> {
       endpoint,
       subscription,
       completion,
-      settings: StreamRefConfig::new(),
+      config: StreamRefConfig::new(),
       demand_started: false,
       terminal_queued: false,
       waiting_ticks: 0,
@@ -98,7 +98,7 @@ impl<T> StreamRefSinkLogic<T> {
       return Ok(());
     }
     self.waiting_ticks = self.waiting_ticks.saturating_add(1);
-    if self.waiting_ticks >= u64::from(self.settings.subscription_timeout_ticks()) {
+    if self.waiting_ticks >= u64::from(self.config.subscription_timeout_ticks()) {
       return Err(StreamRefHandoff::<T>::subscription_timeout_error());
     }
     Ok(())
@@ -294,9 +294,9 @@ where
     self.terminal_queued && self.handoff.has_pending_protocols()
   }
 
-  fn attach_stream_ref_settings(&mut self, settings: StreamRefConfig) {
-    self.handoff.configure_buffer_capacity(settings.buffer_capacity());
-    self.settings = settings;
+  fn attach_stream_ref_config(&mut self, config: StreamRefConfig) {
+    self.handoff.configure_buffer_capacity(config.buffer_capacity());
+    self.config = config;
   }
 
   fn attach_actor_system(&mut self, system: ActorSystem) {

--- a/modules/stream-core-kernel/src/impl/streamref/stream_ref_sink_logic_test.rs
+++ b/modules/stream-core-kernel/src/impl/streamref/stream_ref_sink_logic_test.rs
@@ -92,7 +92,7 @@ fn awaiting_remote_subscription_rejects_push_before_subscribe() {
 fn awaiting_remote_subscription_fails_after_configured_ticks() {
   let handoff = StreamRefHandoff::<u32>::new();
   let mut logic = StreamRefSinkLogic::awaiting_remote_subscription(handoff);
-  logic.attach_stream_ref_settings(StreamRefConfig::new().with_subscription_timeout_ticks(1));
+  logic.attach_stream_ref_config(StreamRefConfig::new().with_subscription_timeout_ticks(1));
   let mut demand = DemandTracker::new();
 
   let error = logic.on_tick(&mut demand).expect_err("subscription timeout");
@@ -131,7 +131,7 @@ fn subscribed_sink_respects_configured_buffer_capacity() {
   let handoff = StreamRefHandoff::<u32>::new();
   handoff.subscribe();
   let mut logic = StreamRefSinkLogic::subscribed(handoff, None);
-  logic.attach_stream_ref_settings(StreamRefConfig::new().with_buffer_capacity(1));
+  logic.attach_stream_ref_config(StreamRefConfig::new().with_buffer_capacity(1));
   let mut demand = DemandTracker::new();
 
   let first: DynValue = Box::new(10_u32);

--- a/modules/stream-core-kernel/src/impl/streamref/stream_ref_source_logic.rs
+++ b/modules/stream-core-kernel/src/impl/streamref/stream_ref_source_logic.rs
@@ -34,7 +34,7 @@ pub(crate) struct StreamRefSourceLogic<T> {
   handoff:       StreamRefHandoff<T>,
   endpoint:      Option<StreamRefEndpointSlot>,
   subscription:  StreamRefSourceSubscription,
-  settings:      StreamRefConfig,
+  config:        StreamRefConfig,
   waiting_ticks: u64,
   _pd:           PhantomData<fn() -> T>,
 }
@@ -62,7 +62,7 @@ impl<T> StreamRefSourceLogic<T> {
     endpoint: Option<StreamRefEndpointSlot>,
     subscription: StreamRefSourceSubscription,
   ) -> Self {
-    Self { handoff, endpoint, subscription, settings: StreamRefConfig::new(), waiting_ticks: 0, _pd: PhantomData }
+    Self { handoff, endpoint, subscription, config: StreamRefConfig::new(), waiting_ticks: 0, _pd: PhantomData }
   }
 
   fn await_subscription(&mut self) -> Result<(), StreamError> {
@@ -70,7 +70,7 @@ impl<T> StreamRefSourceLogic<T> {
       return Ok(());
     }
     self.waiting_ticks = self.waiting_ticks.saturating_add(1);
-    if self.waiting_ticks >= u64::from(self.settings.subscription_timeout_ticks()) {
+    if self.waiting_ticks >= u64::from(self.config.subscription_timeout_ticks()) {
       return Err(StreamRefHandoff::<T>::subscription_timeout_error());
     }
     Err(StreamError::WouldBlock)
@@ -211,9 +211,9 @@ where
     false
   }
 
-  fn attach_stream_ref_settings(&mut self, settings: StreamRefConfig) {
-    self.handoff.configure_buffer_capacity(settings.buffer_capacity());
-    self.settings = settings;
+  fn attach_stream_ref_config(&mut self, config: StreamRefConfig) {
+    self.handoff.configure_buffer_capacity(config.buffer_capacity());
+    self.config = config;
   }
 
   fn attach_actor_system(&mut self, system: ActorSystem) {

--- a/modules/stream-core-kernel/src/impl/streamref/stream_ref_source_logic_test.rs
+++ b/modules/stream-core-kernel/src/impl/streamref/stream_ref_source_logic_test.rs
@@ -112,7 +112,7 @@ fn temp_demand_failing_actor(system: &ActorSystem) -> ActorRef {
 fn awaiting_remote_subscription_fails_after_configured_ticks() {
   let handoff = StreamRefHandoff::<u32>::new();
   let mut logic = StreamRefSourceLogic::awaiting_remote_subscription(handoff);
-  logic.attach_stream_ref_settings(StreamRefConfig::new().with_subscription_timeout_ticks(1));
+  logic.attach_stream_ref_config(StreamRefConfig::new().with_subscription_timeout_ticks(1));
 
   let error = logic.pull().expect_err("subscription timeout");
 

--- a/modules/stream-core-kernel/src/materialization/actor_materializer.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer.rs
@@ -191,7 +191,7 @@ impl ActorMaterializer {
     system: &ActorSystem,
     buffer_config: StreamBufferConfig,
     kill_switch_state: KillSwitchStateHandle,
-    stream_ref_settings: &StreamRefConfig,
+    stream_ref_config: &StreamRefConfig,
   ) -> Result<(StreamShared, Option<String>), StreamError> {
     let dispatcher = island.dispatcher().map(String::from);
     let stream_plan = island.into_stream_plan();
@@ -200,7 +200,7 @@ impl ActorMaterializer {
       buffer_config,
       kill_switch_state,
       Some(system),
-      stream_ref_settings,
+      stream_ref_config,
     );
     stream.start()?;
     Ok((StreamShared::new(stream), dispatcher))
@@ -648,7 +648,7 @@ impl Materializer for ActorMaterializer {
     let actor_system = self.system()?;
     let (plan, materialized) = graph.into_parts();
     let island_plan = IslandSplitter::split(plan);
-    let stream_ref_settings = self.config.stream_ref_settings();
+    let stream_ref_config = self.config.stream_ref_config();
     let (mut islands, crossings) = island_plan.into_parts();
     let graph_kill_switch_state = Stream::new_running_kill_switch_state();
     let mut downstream_cancellation_boundaries = Vec::new();
@@ -679,7 +679,7 @@ impl Materializer for ActorMaterializer {
         &actor_system,
         self.config.buffer_config(),
         graph_kill_switch_state.clone(),
-        &stream_ref_settings,
+        &stream_ref_config,
       ) {
         | Ok((stream, dispatcher)) => {
           streams.push(stream);

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_config.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_config.rs
@@ -16,7 +16,7 @@ pub struct ActorMaterializerConfig {
   debug_logging:         bool,
   output_burst_limit:    usize,
   max_fixed_buffer_size: usize,
-  stream_ref_settings:   StreamRefConfig,
+  stream_ref_config:     StreamRefConfig,
 }
 
 impl ActorMaterializerConfig {
@@ -31,7 +31,7 @@ impl ActorMaterializerConfig {
       debug_logging:         false,
       output_burst_limit:    1000,
       max_fixed_buffer_size: 1_000_000_000,
-      stream_ref_settings:   StreamRefConfig::new(),
+      stream_ref_config:     StreamRefConfig::new(),
     }
   }
 
@@ -79,8 +79,8 @@ impl ActorMaterializerConfig {
 
   /// Returns the configured stream reference settings.
   #[must_use]
-  pub fn stream_ref_settings(&self) -> StreamRefConfig {
-    self.stream_ref_settings.clone()
+  pub fn stream_ref_config(&self) -> StreamRefConfig {
+    self.stream_ref_config.clone()
   }
 
   /// Updates the drive interval.
@@ -134,8 +134,8 @@ impl ActorMaterializerConfig {
 
   /// Updates the stream reference settings.
   #[must_use]
-  pub const fn with_stream_ref_settings(mut self, stream_ref_settings: StreamRefConfig) -> Self {
-    self.stream_ref_settings = stream_ref_settings;
+  pub const fn with_stream_ref_config(mut self, stream_ref_config: StreamRefConfig) -> Self {
+    self.stream_ref_config = stream_ref_config;
     self
   }
 }

--- a/modules/stream-core-kernel/src/materialization/actor_materializer_config_test.rs
+++ b/modules/stream-core-kernel/src/materialization/actor_materializer_config_test.rs
@@ -109,45 +109,45 @@ fn default_matches_new() {
 // --- StreamRefConfig 連携 ---
 
 #[test]
-fn new_returns_default_stream_ref_settings() {
+fn new_returns_default_stream_ref_config() {
   // Given/When: materializer config を default で構築する
   let config = ActorMaterializerConfig::new();
 
   // Then: StreamRefConfig の reference.conf 相当 default が含まれる
-  assert_eq!(config.stream_ref_settings(), StreamRefConfig::new());
+  assert_eq!(config.stream_ref_config(), StreamRefConfig::new());
 }
 
 #[test]
-fn with_stream_ref_settings_round_trip() {
+fn with_stream_ref_config_round_trip() {
   // Given: 明示的な StreamRefConfig
-  let stream_ref_settings = StreamRefConfig::new()
+  let stream_ref_config = StreamRefConfig::new()
     .with_buffer_capacity(64)
     .with_demand_redelivery_interval_ticks(2)
     .with_subscription_timeout_ticks(45)
     .with_termination_received_before_completion_leeway_ticks(5);
 
   // When: ActorMaterializerConfig に設定する
-  let config = ActorMaterializerConfig::new().with_stream_ref_settings(stream_ref_settings.clone());
+  let config = ActorMaterializerConfig::new().with_stream_ref_config(stream_ref_config.clone());
 
   // Then: 同じ設定値が取得できる
-  assert_eq!(config.stream_ref_settings(), stream_ref_settings);
+  assert_eq!(config.stream_ref_config(), stream_ref_config);
 }
 
 #[test]
-fn with_stream_ref_settings_preserves_existing_materializer_fields() {
+fn with_stream_ref_config_preserves_existing_materializer_fields() {
   // Given: 既存 materializer fields を設定済みにする
-  let stream_ref_settings = StreamRefConfig::new().with_buffer_capacity(64);
+  let stream_ref_config = StreamRefConfig::new().with_buffer_capacity(64);
   let config = ActorMaterializerConfig::new()
     .with_drive_interval(Duration::from_millis(50))
     .with_debug_logging(true)
     .with_output_burst_limit(500)
-    .with_stream_ref_settings(stream_ref_settings.clone());
+    .with_stream_ref_config(stream_ref_config.clone());
 
   // Then: StreamRef settings 追加後も既存 fields は保持される
   assert_eq!(config.drive_interval(), Duration::from_millis(50));
   assert!(config.debug_logging());
   assert_eq!(config.output_burst_limit(), 500);
-  assert_eq!(config.stream_ref_settings(), stream_ref_settings);
+  assert_eq!(config.stream_ref_config(), stream_ref_config);
 }
 
 // --- SubscriptionTimeoutConfig のテスト ---

--- a/modules/stream-core-kernel/src/restart_config.rs
+++ b/modules/stream-core-kernel/src/restart_config.rs
@@ -22,7 +22,7 @@ pub struct RestartConfig {
   complete_on_max_restarts:  bool,
   jitter_seed:               u64,
   restart_on:                Option<ArcShared<RestartPredicate>>,
-  log_settings:              RestartLogConfig,
+  log_config:                RestartLogConfig,
 }
 
 // PartialEq/Eq は restart_on (クロージャ) を含むため正確な等値比較ができず削除。
@@ -39,13 +39,13 @@ impl fmt::Debug for RestartConfig {
       .field("complete_on_max_restarts", &self.complete_on_max_restarts)
       .field("jitter_seed", &self.jitter_seed)
       .field("restart_on", &self.restart_on.as_ref().map(|_| ".."))
-      .field("log_settings", &self.log_settings)
+      .field("log_config", &self.log_config)
       .finish()
   }
 }
 
 impl RestartConfig {
-  /// Creates restart settings with required fields.
+  /// Creates restart configuration with required fields.
   #[must_use]
   pub fn new(min_backoff_ticks: u32, max_backoff_ticks: u32, max_restarts: usize) -> Self {
     let normalized_max_backoff =
@@ -59,7 +59,7 @@ impl RestartConfig {
       complete_on_max_restarts: true,
       jitter_seed: 0,
       restart_on: None,
-      log_settings: RestartLogConfig::default(),
+      log_config: RestartLogConfig::default(),
     }
   }
 
@@ -140,10 +140,10 @@ impl RestartConfig {
     self
   }
 
-  /// Sets log settings for restart event diagnostics.
+  /// Sets log configuration for restart event diagnostics.
   #[must_use]
-  pub const fn with_log_settings(mut self, log_settings: RestartLogConfig) -> Self {
-    self.log_settings = log_settings;
+  pub const fn with_log_config(mut self, log_config: RestartLogConfig) -> Self {
+    self.log_config = log_config;
     self
   }
 
@@ -200,9 +200,9 @@ impl RestartConfig {
     self.jitter_seed
   }
 
-  /// Returns log settings for restart event diagnostics.
+  /// Returns log configuration for restart event diagnostics.
   #[must_use]
-  pub const fn log_settings(&self) -> &RestartLogConfig {
-    &self.log_settings
+  pub const fn log_config(&self) -> &RestartLogConfig {
+    &self.log_config
   }
 }

--- a/modules/stream-core-kernel/src/restart_config_test.rs
+++ b/modules/stream-core-kernel/src/restart_config_test.rs
@@ -115,6 +115,18 @@ fn restart_config_with_log_config_replaces_defaults() {
 }
 
 #[test]
+fn restart_config_debug_formats_all_fields() {
+  // 手書き Debug 実装が全フィールドを描画することを確認する
+  let config = RestartConfig::new(1, 8, 3);
+
+  let rendered = format!("{config:?}");
+
+  assert!(rendered.contains("min_backoff_ticks"));
+  assert!(rendered.contains("restart_on"));
+  assert!(rendered.contains("log_config"));
+}
+
+#[test]
 fn restart_log_level_equality() {
   // Given: RestartLogLevel variants
   // Then: equality works correctly

--- a/modules/stream-core-kernel/src/restart_config_test.rs
+++ b/modules/stream-core-kernel/src/restart_config_test.rs
@@ -66,28 +66,28 @@ fn restart_config_with_restart_on_is_cloneable() {
   assert_eq!(settings.should_restart(&error), cloned.should_restart(&error));
 }
 
-// --- log_settings tests ---
+// --- log_config tests ---
 
 #[test]
 fn restart_log_config_default_values() {
   // Given: default RestartLogConfig
-  let log_settings = RestartLogConfig::default();
+  let log_config = RestartLogConfig::default();
 
   // Then: defaults match Pekko convention
-  assert_eq!(log_settings.log_level(), RestartLogLevel::Warning);
-  assert_eq!(log_settings.critical_log_level(), RestartLogLevel::Error);
-  assert_eq!(log_settings.critical_log_level_after(), usize::MAX);
+  assert_eq!(log_config.log_level(), RestartLogLevel::Warning);
+  assert_eq!(log_config.critical_log_level(), RestartLogLevel::Error);
+  assert_eq!(log_config.critical_log_level_after(), usize::MAX);
 }
 
 #[test]
 fn restart_log_config_with_custom_values() {
   // Given: custom log settings
-  let log_settings = RestartLogConfig::new(RestartLogLevel::Debug, RestartLogLevel::Warning, 5);
+  let log_config = RestartLogConfig::new(RestartLogLevel::Debug, RestartLogLevel::Warning, 5);
 
   // Then: custom values are preserved
-  assert_eq!(log_settings.log_level(), RestartLogLevel::Debug);
-  assert_eq!(log_settings.critical_log_level(), RestartLogLevel::Warning);
-  assert_eq!(log_settings.critical_log_level_after(), 5);
+  assert_eq!(log_config.log_level(), RestartLogLevel::Debug);
+  assert_eq!(log_config.critical_log_level(), RestartLogLevel::Warning);
+  assert_eq!(log_config.critical_log_level_after(), 5);
 }
 
 #[test]
@@ -95,10 +95,10 @@ fn restart_config_default_log_config() {
   // Given: default RestartConfig
   let settings = RestartConfig::new(1, 8, 3);
 
-  // Then: log_settings uses default values
-  let log_settings = settings.log_settings();
-  assert_eq!(log_settings.log_level(), RestartLogLevel::Warning);
-  assert_eq!(log_settings.critical_log_level(), RestartLogLevel::Error);
+  // Then: log_config uses default values
+  let log_config = settings.log_config();
+  assert_eq!(log_config.log_level(), RestartLogLevel::Warning);
+  assert_eq!(log_config.critical_log_level(), RestartLogLevel::Error);
 }
 
 #[test]
@@ -107,11 +107,11 @@ fn restart_config_with_log_config_replaces_defaults() {
   let custom_log = RestartLogConfig::new(RestartLogLevel::Info, RestartLogLevel::Error, 10);
 
   // When: applying custom log settings
-  let settings = RestartConfig::new(1, 8, 3).with_log_settings(custom_log);
+  let settings = RestartConfig::new(1, 8, 3).with_log_config(custom_log);
 
   // Then: custom log settings are used
-  assert_eq!(settings.log_settings().log_level(), RestartLogLevel::Info);
-  assert_eq!(settings.log_settings().critical_log_level_after(), 10);
+  assert_eq!(settings.log_config().log_level(), RestartLogLevel::Info);
+  assert_eq!(settings.log_config().critical_log_level_after(), 10);
 }
 
 #[test]

--- a/modules/stream-core-kernel/src/sink_logic.rs
+++ b/modules/stream-core-kernel/src/sink_logic.rs
@@ -75,7 +75,7 @@ pub trait SinkLogic: Send {
   }
 
   /// Attaches stream reference configuration resolved by the materializer.
-  fn attach_stream_ref_config(&mut self, _settings: StreamRefConfig) {}
+  fn attach_stream_ref_config(&mut self, _config: StreamRefConfig) {}
 
   /// Attaches the actor system resolved by the materializer.
   fn attach_actor_system(&mut self, system: ActorSystem) {

--- a/modules/stream-core-kernel/src/sink_logic.rs
+++ b/modules/stream-core-kernel/src/sink_logic.rs
@@ -74,8 +74,8 @@ pub trait SinkLogic: Send {
     Ok(())
   }
 
-  /// Attaches stream reference settings resolved by the materializer.
-  fn attach_stream_ref_settings(&mut self, _settings: StreamRefConfig) {}
+  /// Attaches stream reference configuration resolved by the materializer.
+  fn attach_stream_ref_config(&mut self, _settings: StreamRefConfig) {}
 
   /// Attaches the actor system resolved by the materializer.
   fn attach_actor_system(&mut self, system: ActorSystem) {

--- a/modules/stream-core-kernel/src/source_logic.rs
+++ b/modules/stream-core-kernel/src/source_logic.rs
@@ -55,8 +55,8 @@ pub trait SourceLogic: Send {
     Ok(())
   }
 
-  /// Attaches stream reference settings resolved by the materializer.
-  fn attach_stream_ref_settings(&mut self, _settings: StreamRefConfig) {}
+  /// Attaches stream reference configuration resolved by the materializer.
+  fn attach_stream_ref_config(&mut self, _settings: StreamRefConfig) {}
 
   /// Attaches the actor system resolved by the materializer.
   fn attach_actor_system(&mut self, system: ActorSystem) {

--- a/modules/stream-core-kernel/src/source_logic.rs
+++ b/modules/stream-core-kernel/src/source_logic.rs
@@ -56,7 +56,7 @@ pub trait SourceLogic: Send {
   }
 
   /// Attaches stream reference configuration resolved by the materializer.
-  fn attach_stream_ref_config(&mut self, _settings: StreamRefConfig) {}
+  fn attach_stream_ref_config(&mut self, _config: StreamRefConfig) {}
 
   /// Attaches the actor system resolved by the materializer.
   fn attach_actor_system(&mut self, system: ActorSystem) {

--- a/modules/stream-core-kernel/src/stream_ref/source_ref.rs
+++ b/modules/stream-core-kernel/src/stream_ref/source_ref.rs
@@ -98,7 +98,7 @@ struct ActorBackedSourceRefLogic<T> {
   endpoint_actor: Option<StageActor>,
   startup_error:  Option<StreamError>,
   waiting_ticks:  u64,
-  settings:       StreamRefConfig,
+  config:         StreamRefConfig,
   _pd:            PhantomData<fn() -> T>,
 }
 
@@ -110,7 +110,7 @@ impl<T> ActorBackedSourceRefLogic<T> {
       endpoint_actor: None,
       startup_error: None,
       waiting_ticks: 0,
-      settings: StreamRefConfig::new(),
+      config: StreamRefConfig::new(),
       _pd: PhantomData,
     }
   }
@@ -139,7 +139,7 @@ impl<T> ActorBackedSourceRefLogic<T> {
       return Ok(());
     }
     self.waiting_ticks = self.waiting_ticks.saturating_add(1);
-    if self.waiting_ticks >= u64::from(self.settings.subscription_timeout_ticks()) {
+    if self.waiting_ticks >= u64::from(self.config.subscription_timeout_ticks()) {
       return Err(StreamRefHandoff::<T>::subscription_timeout_error());
     }
     Err(StreamError::WouldBlock)
@@ -212,9 +212,9 @@ where
     false
   }
 
-  fn attach_stream_ref_settings(&mut self, settings: StreamRefConfig) {
-    self.handoff.configure_buffer_capacity(settings.buffer_capacity());
-    self.settings = settings;
+  fn attach_stream_ref_config(&mut self, config: StreamRefConfig) {
+    self.handoff.configure_buffer_capacity(config.buffer_capacity());
+    self.config = config;
   }
 
   fn attach_actor_system(&mut self, system: ActorSystem) {

--- a/modules/stream-core-kernel/src/stream_ref/source_ref_test.rs
+++ b/modules/stream-core-kernel/src/stream_ref/source_ref_test.rs
@@ -117,7 +117,7 @@ fn actor_backed_source_ref_fails_when_partner_never_subscribes_before_timeout() 
   let system = build_system();
   let (target, _system_messages, _user_messages) = temp_recording_actor(&system);
   let mut logic = ActorBackedSourceRefLogic::<u32>::new(target);
-  logic.attach_stream_ref_settings(StreamRefConfig::new().with_subscription_timeout_ticks(1));
+  logic.attach_stream_ref_config(StreamRefConfig::new().with_subscription_timeout_ticks(1));
 
   let error = logic.pull().expect_err("subscription timeout");
 
@@ -143,7 +143,7 @@ fn actor_backed_source_ref_reports_startup_and_missing_endpoint_errors() {
 #[test]
 fn actor_backed_source_ref_waits_before_timeout_and_reports_handoff_failure() {
   let mut waiting = ActorBackedSourceRefLogic::<u32>::new(ActorRef::null());
-  waiting.attach_stream_ref_settings(StreamRefConfig::new().with_subscription_timeout_ticks(2));
+  waiting.attach_stream_ref_config(StreamRefConfig::new().with_subscription_timeout_ticks(2));
 
   assert_eq!(waiting.pull().expect_err("waiting should block"), StreamError::WouldBlock);
 

--- a/modules/stream-core-kernel/tests/requirement_traceability.rs
+++ b/modules/stream-core-kernel/tests/requirement_traceability.rs
@@ -436,7 +436,7 @@ fn verify_restart_supervision_surface() {
     .with_jitter_seed(31);
 
   let source_values = Source::single(1_u32)
-    .restart_source_with_settings(settings.clone())
+    .restart_source_with_config(settings.clone())
     .supervision_resume()
     .supervision_restart()
     .supervision_stop()
@@ -447,7 +447,7 @@ fn verify_restart_supervision_surface() {
   let flow_values = Source::single(1_u32)
     .via(
       Flow::<u32, u32, StreamNotUsed>::new()
-        .restart_flow_with_settings(settings.clone())
+        .restart_flow_with_config(settings.clone())
         .supervision_resume()
         .supervision_restart()
         .supervision_stop(),
@@ -457,7 +457,7 @@ fn verify_restart_supervision_surface() {
   assert_eq!(flow_values, vec![1_u32]);
 
   let sink = Sink::<u32, _>::head()
-    .restart_sink_with_settings(settings)
+    .restart_sink_with_config(settings)
     .supervision_resume()
     .supervision_restart()
     .supervision_stop();

--- a/modules/stream-core-kernel/tests/stream_ref_config_public.rs
+++ b/modules/stream-core-kernel/tests/stream_ref_config_public.rs
@@ -11,7 +11,7 @@ use fraktor_stream_core_kernel_rs::{
 };
 
 #[test]
-fn stream_ref_settings_are_reachable_from_public_core_api() {
+fn stream_ref_config_are_reachable_from_public_core_api() {
   // Given/When: crate public API から StreamRefConfig を構築する
   let settings = StreamRefConfig::new();
 
@@ -51,19 +51,19 @@ fn stream_ref_buffer_capacity_public_factory_rejects_zero() {
 }
 
 #[test]
-fn actor_materializer_config_exposes_stream_ref_settings() {
+fn actor_materializer_config_exposes_stream_ref_config() {
   // Given: StreamRef settings を明示的に差し替える
-  let stream_ref_settings = StreamRefConfig::new()
+  let stream_ref_config = StreamRefConfig::new()
     .with_buffer_capacity(64)
     .with_demand_redelivery_interval_ticks(2)
     .with_subscription_timeout_ticks(45)
     .with_termination_received_before_completion_leeway_ticks(5);
 
   // When: ActorMaterializerConfig に設定する
-  let config = ActorMaterializerConfig::new().with_stream_ref_settings(stream_ref_settings.clone());
+  let config = ActorMaterializerConfig::new().with_stream_ref_config(stream_ref_config.clone());
 
   // Then: config 経由で同じ設定が取得できる
-  assert_eq!(config.stream_ref_settings(), stream_ref_settings);
+  assert_eq!(config.stream_ref_config(), stream_ref_config);
 }
 
 #[test]

--- a/modules/stream-core-kernel/tests/stream_ref_public.rs
+++ b/modules/stream-core-kernel/tests/stream_ref_public.rs
@@ -110,7 +110,7 @@ fn sink_ref_source_fails_when_remote_sink_never_subscribes_before_timeout() {
   // Given: subscription timeout を 1 tick に縮めた materializer
   let settings = StreamRefConfig::new().with_subscription_timeout_ticks(1);
   let config =
-    ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)).with_stream_ref_settings(settings);
+    ActorMaterializerConfig::default().with_drive_interval(Duration::from_millis(1)).with_stream_ref_config(settings);
   let mut materializer = build_materializer_with_config(config);
   let graph = StreamRefs::sink_ref::<u32>().into_mat(collect_sink(), KeepBoth);
 


### PR DESCRIPTION
## 概要

Closes #1984

PR #1983 で導入した `*Config` 命名規約（`.agents/rules/rust/naming-conventions.md`）に対し、差分外に残っていた `settings` 名のフィールド・アクセサ・メソッド・引数を `config` 系へ統一する。

## 変更内容

- **actor-core-typed**: `TypedActorSystem::settings()` → `config()`（rustdoc の「Corresponds to Pekko's `ActorSystem.settings`」は事実参照として維持）、delivery 系の `settings` フィールド・`behavior_with_settings` → `behavior_with_config`・`producer_controller_settings` 系アクセサ
- **stream-core-kernel**:
  - restart 系: `RestartBackoff::from_settings` → `from_config`、`RestartSource/Sink/Flow::with_settings` → `with_config`、DSL の `restart_*_with_settings` → `restart_*_with_config`、`RestartConfig::log_settings` → `log_config`
  - stream ref 系: `stream_ref_settings` 系アクセサ → `stream_ref_config`、`attach_stream_ref_settings` → `attach_stream_ref_config`、`settings` フィールド、統合テストファイル名 `stream_ref_settings_public.rs` → `stream_ref_config_public.rs`
- **actor-core-kernel / adaptors**: dispatcher 系コンストラクタの `settings` 引数と adaptor のローカル変数を `config` へ
- **remote-core**: doc 文言・テスト名を config 語彙へ
- **spec 記帳**: `cluster-singleton-settings-contract/tasks.md` の完了済み親タスクのチェックボックスを更新

## スコープ外（意図的に残置）

- 無関係なテスト本体のローカル変数 `let settings = ...`（規約の対象は互換キー文字列・フィールド名・アクセサ名）
- 挙動を記述するテスト関数名の一般的な "settings" 表現（`pool_settings_store_values` 等）
- `SchedulerCapacityProfile` の doc 文言（`*Config` 型ではないため対象外）

## 検証

- `./scripts/ci-check.sh ai fmt dylint clippy` 通過
- 影響5パッケージ（stream-core-kernel / actor-core-typed / actor-core-kernel / remote-core / actor-adaptor-std）の `cargo test` 全53スイート合格

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide public API renames (`settings` → `config`, `*_with_settings` → `*_with_config`) break downstream callers; runtime behavior is intended to be unchanged.
> 
> **Overview**
> Completes the **settings → config** naming pass from #1983 across the remaining public and internal API surface, aligning with the `*Config` convention.
> 
> **Typed actor system & delivery:** `TypedActorSystem::settings()` becomes **`config()`**; consumer/producer/work-pulling controllers use **`config`** fields, **`behavior_with_config`**, and **`producer_controller_config`** accessors (replacing `behavior_with_settings` / `producer_controller_settings`).
> 
> **Dispatch & adaptors:** Dispatcher factories and cores take a **`config`** argument (was `settings`); adaptor helpers and benches use **`default_config` / `dispatcher_config`** locals.
> 
> **Streams:** Restart DSL and internals use **`from_config`**, **`restart_*_with_config`**, **`RestartConfig::log_config`**, and **`RestartBackoff`** tests for window reset; stream-ref plumbing uses **`stream_ref_config`**, **`attach_stream_ref_config`**, and materializer **`with_stream_ref_config`**.
> 
> **Remote & spec:** Remote-core docs/tests use config wording; cluster singleton spec **tasks.md** marks parent tasks 2–4 complete.
> 
> This is a **breaking rename** for callers still using the old method/field names; behavior is unchanged aside from added **`restart_backoff`** unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 669e7a74d1b21150924e1a7803e8ca9721834eff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 設定関連API表記を大規模に統一し、名称を「settings」から「config」へ変更。ストリーム／再起動／マテリアライザ／ストリーム参照／ディスパッチャ周りなどで一貫性を向上。
* **Tests**
  * 再起動バックオフのリセット挙動など、バックオフ関連の追加テストを導入。既存テスト名・呼び出しも対応して更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->