### PR TITLE
docs(roadmap): mark merged cluster specs as done

### DIFF
--- a/.kiro/steering/roadmap.md
+++ b/.kiro/steering/roadmap.md
@@ -46,8 +46,8 @@
 - [x] cluster-pubsub-mediator-protocol -- DistributedPubSubMediator、settings、Send / SendToAll path semantics、topic registry gossip / delta collection を定義する。Dependencies: cluster-membership-reachability-model, cluster-gossip-heartbeat-protocol
 - [x] cluster-message-serialization-contract -- cluster message serializer contract を std/wire と actor-core serialization の境界で定義する。Dependencies: cluster-gossip-heartbeat-protocol, cluster-pubsub-mediator-protocol
 - [x] cluster-membership-event-surface -- Member ordering 公開契約、shutdown 進行 / DC reachability の membership イベント variant、cluster lifecycle 構造化 tracing field 契約を定義する。Dependencies: cluster-membership-reachability-model（2026-06-11 完了、PR #1982）
-- [ ] cluster-singleton-settings-contract -- Cluster Singleton の設定契約（classic/typed settings、setup、stuck 検知契約）を config validation / join compatibility に接続して定義する。Dependencies: cluster-active-compatibility-baseline
-- [ ] cluster-grain-typed-entity-facade -- GrainKey / GrainRef の typed wrapper（EntityTypeKey / EntityRef 相当）と typed ActorSystem setup 統合を定義する。Dependencies: none
+- [x] cluster-singleton-settings-contract -- Cluster Singleton の設定契約（classic/typed settings、setup、stuck 検知契約）を config validation / join compatibility に接続して定義する。Dependencies: cluster-active-compatibility-baseline
+- [x] cluster-grain-typed-entity-facade -- GrainKey / GrainRef の typed wrapper（EntityTypeKey / EntityRef 相当）と typed ActorSystem setup 統合を定義する。Dependencies: none
 - [ ] cluster-sharding-extractor-contract -- ShardingEnvelope / ShardingMessageExtractor SPI と HashCode / Murmur2 標準実装群を定義する。Dependencies: cluster-grain-typed-entity-facade
 - [ ] cluster-sharding-health-and-join-compat -- grain/placement の readiness check（std）と sharding join compatibility key（core/config）を定義する。Dependencies: cluster-active-compatibility-baseline
 - [ ] cluster-ddata-core-types -- ReplicatedData 基底 SPI、Key、SelfUniqueAddress、基本 CRDT（Flag / GCounter / PNCounter / PNCounterMap）、consistency levels、補助 protocol 型を新設 ddata モジュールに定義する。Dependencies: none


### PR DESCRIPTION
マージ済みの 2 spec を roadmap に記帳する。

- cluster-singleton-settings-contract（PR #1983 / #1985 で完了・マージ済み）
- cluster-grain-typed-entity-facade（PR #1987 で完了・マージ済み）

ドキュメントのみの変更。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only roadmap checkbox updates with no behavioral or deployment impact.
> 
> **Overview**
> Updates **`.kiro/steering/roadmap.md`** so two cluster specs are marked **done** (`[x]`): **`cluster-singleton-settings-contract`** and **`cluster-grain-typed-entity-facade`**, matching work already merged (PRs #1983/#1985 and #1987). No runtime, config, or test changes—roadmap tracking only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 329f3cd9e0e651891686b23a57d9f2bc50dd2b74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->