### PR TITLE
docs(roadmap): mark cluster-sharding-extractor-contract as done

### DIFF
--- a/.kiro/steering/roadmap.md
+++ b/.kiro/steering/roadmap.md
@@ -48,7 +48,7 @@
 - [x] cluster-membership-event-surface -- Member ordering 公開契約、shutdown 進行 / DC reachability の membership イベント variant、cluster lifecycle 構造化 tracing field 契約を定義する。Dependencies: cluster-membership-reachability-model（2026-06-11 完了、PR #1982）
 - [x] cluster-singleton-settings-contract -- Cluster Singleton の設定契約（classic/typed settings、setup、stuck 検知契約）を config validation / join compatibility に接続して定義する。Dependencies: cluster-active-compatibility-baseline
 - [x] cluster-grain-typed-entity-facade -- GrainKey / GrainRef の typed wrapper（EntityTypeKey / EntityRef 相当）と typed ActorSystem setup 統合を定義する。Dependencies: none
-- [ ] cluster-sharding-extractor-contract -- ShardingEnvelope / ShardingMessageExtractor SPI と HashCode / Murmur2 標準実装群を定義する。Dependencies: cluster-grain-typed-entity-facade
+- [x] cluster-sharding-extractor-contract -- ShardingEnvelope / ShardingMessageExtractor SPI と HashCode / Murmur2 標準実装群を定義する。Dependencies: cluster-grain-typed-entity-facade（2026-06-13 完了、PR #1990）
 - [ ] cluster-sharding-health-and-join-compat -- grain/placement の readiness check（std）と sharding join compatibility key（core/config）を定義する。Dependencies: cluster-active-compatibility-baseline
 - [ ] cluster-ddata-core-types -- ReplicatedData 基底 SPI、Key、SelfUniqueAddress、基本 CRDT（Flag / GCounter / PNCounter / PNCounterMap）、consistency levels、補助 protocol 型を新設 ddata モジュールに定義する。Dependencies: none
 


### PR DESCRIPTION
cluster-sharding-extractor-contract が PR #1990 でマージ完了したため、roadmap のエントリをチェックする。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only roadmap checkbox update with no code or configuration impact.
> 
> **Overview**
> Updates `.kiro/steering/roadmap.md` so **cluster-sharding-extractor-contract** is marked done after merge of PR #1990.
> 
> The spec line switches from `[ ]` to `[x]` and adds the same completion annotation used elsewhere: `（2026-06-13 完了、PR #1990）`. No runtime or spec code changes—only roadmap status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83bcb01d032b8c9cd7b8ac90da437bce9f4d101d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->