### PR TITLE
docs(roadmap): cluster-sharding-health-and-join-compat を完了に更新

### DIFF
--- a/.kiro/steering/roadmap.md
+++ b/.kiro/steering/roadmap.md
@@ -49,7 +49,7 @@
 - [x] cluster-singleton-settings-contract -- Cluster Singleton の設定契約（classic/typed settings、setup、stuck 検知契約）を config validation / join compatibility に接続して定義する。Dependencies: cluster-active-compatibility-baseline
 - [x] cluster-grain-typed-entity-facade -- GrainKey / GrainRef の typed wrapper（EntityTypeKey / EntityRef 相当）と typed ActorSystem setup 統合を定義する。Dependencies: none
 - [x] cluster-sharding-extractor-contract -- ShardingEnvelope / ShardingMessageExtractor SPI と HashCode / Murmur2 標準実装群を定義する。Dependencies: cluster-grain-typed-entity-facade（2026-06-13 完了、PR #1990）
-- [ ] cluster-sharding-health-and-join-compat -- grain/placement の readiness check（std）と sharding join compatibility key（core/config）を定義する。Dependencies: cluster-active-compatibility-baseline
+- [x] cluster-sharding-health-and-join-compat -- grain/placement の readiness check（core 完結の純粋判定 + 公開アクセサ）と sharding join compatibility の除外キー整備（required key の追加は config 所有化とともに後続スペックへ委譲）を定義する。Dependencies: cluster-active-compatibility-baseline（2026-06-13 完了、PR #1993）
 - [ ] cluster-ddata-core-types -- ReplicatedData 基底 SPI、Key、SelfUniqueAddress、基本 CRDT（Flag / GCounter / PNCounter / PNCounterMap）、consistency levels、補助 protocol 型を新設 ddata モジュールに定義する。Dependencies: none
 
 ## Existing Spec Updates


### PR DESCRIPTION
## 概要

PR #1993（`cluster-sharding-health-and-join-compat` 実装）のマージに伴い、roadmap の当該行を完了に更新する docs-only PR。

## 変更内容

- `.kiro/steering/roadmap.md` の `cluster-sharding-health-and-join-compat` 行を `[ ]` → `[x]`、完了日 + PR #1993 を付記
- 記述を実装の実態に補正:
  - 「readiness check（std）」→「readiness check（**core 完結の純粋判定 + 公開アクセサ**）」— readiness は core で完結し、std 便宜層は設けなかった（core が契約を定義しホストが従う依存方向の原則）
  - 「sharding join compatibility key（core/config）」→「sharding join compatibility の**除外キー整備**（required key の追加は config 所有化とともに後続スペックへ委譲）」— 調査の結果、現行 grain/placement 設定には join-required な値がないため除外キー整備に限定した実態を反映

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only roadmap tracking; no runtime or config behavior changes.
> 
> **Overview**
> Marks **`cluster-sharding-health-and-join-compat`** as done in `.kiro/steering/roadmap.md` after PR #1993 (2026-06-13).
> 
> The line text is **corrected** to match what shipped: readiness is described as **core-only pure checks + public accessors** (not a std convenience layer), and join compatibility as **exclusion-key cleanup** with required-key additions deferred to a later config-owned spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde6cbd21570376bfe746c950048fb296c28c58c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->