### PR TITLE
[codex] Fix grain readiness self status observation

### DIFF
--- a/modules/cluster-core-kernel/src/extension/cluster_core.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_core.rs
@@ -121,6 +121,12 @@ impl ClusterCore {
     self.mode
   }
 
+  /// Returns true when the current topology still contains the self authority.
+  #[must_use]
+  pub(crate) fn has_current_self_member(&self) -> bool {
+    self.current_members.iter().any(|authority| authority == &self.startup_state.address)
+  }
+
   /// Returns true if the given kind is registered.
   #[must_use]
   pub fn is_kind_registered(&self, kind: &str) -> bool {
@@ -216,6 +222,15 @@ impl ClusterCore {
     let (state, _) = self.current_cluster_state_snapshot();
     let self_address = self.startup_address();
     let self_status = state.members.iter().find(|record| record.authority == self_address).map(|record| record.status);
+    self.grain_readiness_snapshot_with_self_status(self_status)
+  }
+
+  /// Builds a readiness snapshot using the provided observed self-node status.
+  #[must_use]
+  pub(crate) fn grain_readiness_snapshot_with_self_status(
+    &self,
+    self_status: Option<NodeStatus>,
+  ) -> GrainReadinessSnapshot {
     let placement_state = self.identity_lookup.with_read(|lookup| lookup.placement_state());
     let registered_kinds = self.kind_registry.all().into_iter().map(|kind| kind.name().to_string()).collect();
     GrainReadinessSnapshot::new(self_status, placement_state, registered_kinds)

--- a/modules/cluster-core-kernel/src/extension/cluster_extension.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension.rs
@@ -176,6 +176,10 @@ fn is_topology_absent_identity(
     .with_lock(|absent_identities| absent_identities.iter().any(|absent| identity_matches(absent, identity)))
 }
 
+const fn is_rejoin_transition(from: NodeStatus, to: NodeStatus) -> bool {
+  matches!((from, to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining))
+}
+
 fn can_accept_retired_self_status(
   identity: &SelfMemberIdentity,
   from: NodeStatus,
@@ -191,7 +195,7 @@ fn can_accept_retired_self_status(
   let is_starting_identity = starting_identity.with_lock(|starting_identity| {
     starting_identity.as_ref().is_some_and(|starting| identity_matches(starting, identity))
   });
-  if matches!((from, to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining)) {
+  if is_rejoin_transition(from, to) {
     return is_starting_identity;
   }
   is_starting_identity
@@ -264,8 +268,11 @@ fn clear_self_observation_if_absent(
     return;
   }
   let previous_identity = self_identity.with_lock(|identity| identity.take());
+  let previous_status = self_status.with_lock(|status| status.clone());
   starting_identity.with_lock(|identity| *identity = None);
-  self_status.with_lock(|status| *status = None);
+  if !previous_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed) {
+    self_status.with_lock(|status| *status = None);
+  }
   if let Some(identity) = previous_identity {
     remember_unique_identity(topology_absent_identities, identity);
   }
@@ -318,9 +325,8 @@ impl EventStreamSubscriber for SelfMemberStatusTrackerSubscriber {
       let is_terminated = self.terminated.with_lock(|terminated| *terminated);
       let identity = SelfMemberIdentity { node_id: node_id.clone(), authority: authority.clone() };
       let is_topology_absent = is_topology_absent_identity(&self.topology_absent_identities, &identity);
-      let can_rejoin_from_absent =
-        matches!((*from, *to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining));
-      if is_topology_absent && *to != NodeStatus::Removed && !can_rejoin_from_absent {
+      let can_rejoin = is_rejoin_transition(*from, *to);
+      if is_topology_absent && *to != NodeStatus::Removed && !can_rejoin {
         return;
       }
       let is_retired_identity = is_suppressed_retired_identity(&self.suppressed_retired_identities, &identity);
@@ -339,7 +345,6 @@ impl EventStreamSubscriber for SelfMemberStatusTrackerSubscriber {
         return;
       }
       let current_status = self.self_status.with_lock(|self_status| self_status.clone());
-      let mut keep_retired_identity = false;
       if let Some(current) = self.self_identity.with_lock(|self_identity| self_identity.clone())
         && (current.node_id != identity.node_id || current.authority != identity.authority)
       {
@@ -349,8 +354,16 @@ impl EventStreamSubscriber for SelfMemberStatusTrackerSubscriber {
             .as_ref()
             .is_some_and(|starting| identity_matches(starting, &current) && !is_retired_identity)
         });
-        let can_replace_removed_identity =
+        let incoming_is_starting_identity = self.starting_identity.with_lock(|starting_identity| {
+          starting_identity.as_ref().is_some_and(|starting| identity_matches(starting, &identity))
+        });
+        // Removed / 退役済みの self を別 identity で置換できるのは、終端を巻き戻さない Removed イベント、
+        // 正規の再参加遷移、開始対象 identity の 3 ケースに限る。古い incarnation の遅延 Up で
+        // observed status を非終端へ巻き戻さない。
+        let current_is_terminal =
           current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed) || current_is_retired;
+        let can_replace_removed_identity =
+          current_is_terminal && (*to == NodeStatus::Removed || can_rejoin || incoming_is_starting_identity);
         if !can_replace_starting_identity && !can_replace_removed_identity {
           return;
         }
@@ -359,15 +372,13 @@ impl EventStreamSubscriber for SelfMemberStatusTrackerSubscriber {
         && identity_matches(&current, &identity)
         && current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed)
         && *to != NodeStatus::Removed
-        && !matches!((*from, *to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining))
+        && !can_rejoin
       {
-        remember_retired_identity(&self.suppressed_retired_identities, identity.clone());
-        keep_retired_identity = true;
+        remember_retired_identity(&self.suppressed_retired_identities, identity);
+        return;
       }
       let status = SelfMemberStatus { node_id: node_id.clone(), authority: authority.clone(), status: *to };
-      if !keep_retired_identity {
-        retain_non_matching_identity(&self.suppressed_retired_identities, &identity);
-      }
+      retain_non_matching_identity(&self.suppressed_retired_identities, &identity);
       if !is_topology_absent || *to != NodeStatus::Removed {
         retain_non_matching_identity(&self.topology_absent_identities, &identity);
       }
@@ -417,9 +428,8 @@ where
         return;
       }
       let is_topology_absent = is_topology_absent_identity(&self.lifecycle.topology_absent_identities, &identity);
-      let can_rejoin_from_absent =
-        matches!((*from, *to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining));
-      if is_topology_absent && *to != NodeStatus::Removed && !can_rejoin_from_absent {
+      let can_rejoin = is_rejoin_transition(*from, *to);
+      if is_topology_absent && *to != NodeStatus::Removed && !can_rejoin {
         return;
       }
       let is_retired_identity =
@@ -438,7 +448,26 @@ where
       let current_status = self.lifecycle.self_status.with_lock(|self_status| self_status.clone());
       if let Some(current) = self.lifecycle.self_identity.with_lock(|self_identity| self_identity.clone())
         && !identity_matches(&current, &identity)
-        && !current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed)
+      {
+        let current_is_removed = current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed);
+        let current_is_retired =
+          is_suppressed_retired_identity(&self.lifecycle.suppressed_retired_identities, &current);
+        let incoming_is_starting_identity = self.lifecycle.starting_identity.with_lock(|starting_identity| {
+          starting_identity.as_ref().is_some_and(|starting| identity_matches(starting, &identity))
+        });
+        // alive な self は別 identity で置換しない。退役済み self を非 Removed の別 identity で
+        // 巻き戻すのは再参加遷移か開始対象 identity に限り、古い incarnation の遅延 Up では発火させない。
+        let retired_blocks_non_removed =
+          current_is_retired && *to != NodeStatus::Removed && !can_rejoin && !incoming_is_starting_identity;
+        if !current_is_removed || retired_blocks_non_removed {
+          return;
+        }
+      }
+      if let Some(current) = self.lifecycle.self_identity.with_lock(|self_identity| self_identity.clone())
+        && identity_matches(&current, &identity)
+        && current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed)
+        && *to != NodeStatus::Removed
+        && !can_rejoin
       {
         return;
       }

--- a/modules/cluster-core-kernel/src/extension/cluster_extension.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension.rs
@@ -27,13 +27,26 @@ const CLUSTER_EVENT_STREAM_NAME: &str = "cluster";
 
 /// Internal subscriber that applies topology updates to ClusterCore.
 struct ClusterTopologySubscriber {
-  core:         SharedLock<ClusterCore>,
+  core: SharedLock<ClusterCore>,
   event_stream: EventStreamShared,
+  self_address: String,
+  self_status: SharedLock<Option<SelfMemberStatus>>,
+  self_identity: SharedLock<Option<SelfMemberIdentity>>,
+  starting_identity: SharedLock<Option<SelfMemberIdentity>>,
+  topology_absent_identities: SharedLock<Vec<SelfMemberIdentity>>,
 }
 
 impl ClusterTopologySubscriber {
-  const fn new(core: SharedLock<ClusterCore>, event_stream: EventStreamShared) -> Self {
-    Self { core, event_stream }
+  const fn new(
+    core: SharedLock<ClusterCore>,
+    event_stream: EventStreamShared,
+    self_address: String,
+    self_status: SharedLock<Option<SelfMemberStatus>>,
+    self_identity: SharedLock<Option<SelfMemberIdentity>>,
+    starting_identity: SharedLock<Option<SelfMemberIdentity>>,
+    topology_absent_identities: SharedLock<Vec<SelfMemberIdentity>>,
+  ) -> Self {
+    Self { core, event_stream, self_address, self_status, self_identity, starting_identity, topology_absent_identities }
   }
 }
 
@@ -46,6 +59,16 @@ impl EventStreamSubscriber for ClusterTopologySubscriber {
       && let Some(ClusterEvent::TopologyUpdated { update }) = payload.payload().downcast_ref::<ClusterEvent>()
     {
       let result = self.core.with_lock(|core| core.try_apply_topology(update));
+      if matches!(result.as_ref(), Ok(Some(_))) {
+        clear_self_observation_if_absent(
+          update,
+          &self.self_address,
+          &self.self_status,
+          &self.self_identity,
+          &self.starting_identity,
+          &self.topology_absent_identities,
+        );
+      }
       if let Err(error) = result {
         let reason = format!("{error:?}");
         let failed = ClusterEvent::TopologyApplyFailed { reason, observed_at: update.observed_at };
@@ -103,14 +126,184 @@ struct SelfMemberStatus {
   status:    NodeStatus,
 }
 
+#[derive(Clone)]
+struct SelfMemberIdentity {
+  node_id:   String,
+  authority: String,
+}
+
+fn remember_retired_identity(
+  suppressed_retired_identities: &SharedLock<Vec<SelfMemberIdentity>>,
+  identity: SelfMemberIdentity,
+) {
+  suppressed_retired_identities.with_lock(|retired_identities| {
+    if retired_identities
+      .iter()
+      .any(|retired| retired.node_id == identity.node_id && retired.authority == identity.authority)
+    {
+      return;
+    }
+    retired_identities.push(identity);
+  });
+}
+
+fn remember_unique_identity(identities: &SharedLock<Vec<SelfMemberIdentity>>, identity: SelfMemberIdentity) {
+  identities.with_lock(|identities| {
+    if identities.iter().any(|current| current.node_id == identity.node_id && current.authority == identity.authority) {
+      return;
+    }
+    identities.push(identity);
+  });
+}
+
+fn identity_matches(left: &SelfMemberIdentity, right: &SelfMemberIdentity) -> bool {
+  left.node_id == right.node_id && left.authority == right.authority
+}
+
+fn is_suppressed_retired_identity(
+  suppressed_retired_identities: &SharedLock<Vec<SelfMemberIdentity>>,
+  identity: &SelfMemberIdentity,
+) -> bool {
+  suppressed_retired_identities
+    .with_lock(|retired_identities| retired_identities.iter().any(|retired| identity_matches(retired, identity)))
+}
+
+fn is_topology_absent_identity(
+  topology_absent_identities: &SharedLock<Vec<SelfMemberIdentity>>,
+  identity: &SelfMemberIdentity,
+) -> bool {
+  topology_absent_identities
+    .with_lock(|absent_identities| absent_identities.iter().any(|absent| identity_matches(absent, identity)))
+}
+
+fn can_accept_retired_self_status(
+  identity: &SelfMemberIdentity,
+  from: NodeStatus,
+  to: NodeStatus,
+  self_identity: &SharedLock<Option<SelfMemberIdentity>>,
+  starting_identity: &SharedLock<Option<SelfMemberIdentity>>,
+  start_in_progress: &SharedLock<bool>,
+) -> bool {
+  let current_identity = self_identity.with_lock(|self_identity| self_identity.clone());
+  if current_identity.is_some() {
+    return false;
+  }
+  let is_starting_identity = starting_identity.with_lock(|starting_identity| {
+    starting_identity.as_ref().is_some_and(|starting| identity_matches(starting, identity))
+  });
+  if matches!((from, to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining)) {
+    return is_starting_identity;
+  }
+  is_starting_identity
+    && start_in_progress.with_lock(|start_in_progress| *start_in_progress)
+    && to != NodeStatus::Removed
+}
+
+fn retain_non_matching_identity(
+  suppressed_retired_identities: &SharedLock<Vec<SelfMemberIdentity>>,
+  identity: &SelfMemberIdentity,
+) {
+  suppressed_retired_identities.with_lock(|retired_identities| {
+    retired_identities.retain(|retired| !identity_matches(retired, identity));
+  });
+}
+
+fn clear_starting_identity_if_replaced(
+  starting_identity: &SharedLock<Option<SelfMemberIdentity>>,
+  identity: &SelfMemberIdentity,
+) {
+  starting_identity.with_lock(|starting_identity| {
+    if starting_identity.as_ref().is_some_and(|starting| !identity_matches(starting, identity)) {
+      *starting_identity = None;
+    }
+  });
+}
+
+#[derive(Clone)]
+struct SelfMemberLifecycle {
+  self_status:                   SharedLock<Option<SelfMemberStatus>>,
+  self_identity:                 SharedLock<Option<SelfMemberIdentity>>,
+  terminated:                    SharedLock<bool>,
+  suppressed_retired_identities: SharedLock<Vec<SelfMemberIdentity>>,
+  starting_identity:             SharedLock<Option<SelfMemberIdentity>>,
+  start_in_progress:             SharedLock<bool>,
+  topology_absent_identities:    SharedLock<Vec<SelfMemberIdentity>>,
+}
+
+impl SelfMemberLifecycle {
+  const fn new(
+    self_status: SharedLock<Option<SelfMemberStatus>>,
+    self_identity: SharedLock<Option<SelfMemberIdentity>>,
+    terminated: SharedLock<bool>,
+    suppressed_retired_identities: SharedLock<Vec<SelfMemberIdentity>>,
+    starting_identity: SharedLock<Option<SelfMemberIdentity>>,
+    start_in_progress: SharedLock<bool>,
+    topology_absent_identities: SharedLock<Vec<SelfMemberIdentity>>,
+  ) -> Self {
+    Self {
+      self_status,
+      self_identity,
+      terminated,
+      suppressed_retired_identities,
+      starting_identity,
+      start_in_progress,
+      topology_absent_identities,
+    }
+  }
+}
+
+fn clear_self_observation_if_absent(
+  update: &TopologyUpdate,
+  self_address: &str,
+  self_status: &SharedLock<Option<SelfMemberStatus>>,
+  self_identity: &SharedLock<Option<SelfMemberIdentity>>,
+  starting_identity: &SharedLock<Option<SelfMemberIdentity>>,
+  topology_absent_identities: &SharedLock<Vec<SelfMemberIdentity>>,
+) {
+  if update.members.iter().any(|member| member == self_address) {
+    return;
+  }
+  let previous_identity = self_identity.with_lock(|identity| identity.take());
+  starting_identity.with_lock(|identity| *identity = None);
+  self_status.with_lock(|status| *status = None);
+  if let Some(identity) = previous_identity {
+    remember_unique_identity(topology_absent_identities, identity);
+  }
+}
+
 struct SelfMemberStatusTrackerSubscriber {
-  self_address: String,
-  self_status:  SharedLock<Option<SelfMemberStatus>>,
+  self_address:                  String,
+  self_status:                   SharedLock<Option<SelfMemberStatus>>,
+  self_identity:                 SharedLock<Option<SelfMemberIdentity>>,
+  terminated:                    SharedLock<bool>,
+  suppressed_retired_identities: SharedLock<Vec<SelfMemberIdentity>>,
+  starting_identity:             SharedLock<Option<SelfMemberIdentity>>,
+  start_in_progress:             SharedLock<bool>,
+  topology_absent_identities:    SharedLock<Vec<SelfMemberIdentity>>,
 }
 
 impl SelfMemberStatusTrackerSubscriber {
-  const fn new(self_address: String, self_status: SharedLock<Option<SelfMemberStatus>>) -> Self {
-    Self { self_address, self_status }
+  #[allow(clippy::too_many_arguments)]
+  const fn new(
+    self_address: String,
+    self_status: SharedLock<Option<SelfMemberStatus>>,
+    self_identity: SharedLock<Option<SelfMemberIdentity>>,
+    terminated: SharedLock<bool>,
+    suppressed_retired_identities: SharedLock<Vec<SelfMemberIdentity>>,
+    starting_identity: SharedLock<Option<SelfMemberIdentity>>,
+    start_in_progress: SharedLock<bool>,
+    topology_absent_identities: SharedLock<Vec<SelfMemberIdentity>>,
+  ) -> Self {
+    Self {
+      self_address,
+      self_status,
+      self_identity,
+      terminated,
+      suppressed_retired_identities,
+      starting_identity,
+      start_in_progress,
+      topology_absent_identities,
+    }
   }
 }
 
@@ -118,12 +311,69 @@ impl EventStreamSubscriber for SelfMemberStatusTrackerSubscriber {
   fn on_event(&mut self, event: &EventStreamEvent) {
     if let EventStreamEvent::Extension { name, payload } = event
       && name == CLUSTER_EVENT_STREAM_NAME
-      && let Some(ClusterEvent::MemberStatusChanged { node_id, authority, to, .. }) =
+      && let Some(ClusterEvent::MemberStatusChanged { node_id, authority, from, to, .. }) =
         payload.payload().downcast_ref::<ClusterEvent>()
       && authority == &self.self_address
     {
+      let is_terminated = self.terminated.with_lock(|terminated| *terminated);
+      let identity = SelfMemberIdentity { node_id: node_id.clone(), authority: authority.clone() };
+      let is_topology_absent = is_topology_absent_identity(&self.topology_absent_identities, &identity);
+      let can_rejoin_from_absent =
+        matches!((*from, *to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining));
+      if is_topology_absent && *to != NodeStatus::Removed && !can_rejoin_from_absent {
+        return;
+      }
+      let is_retired_identity = is_suppressed_retired_identity(&self.suppressed_retired_identities, &identity);
+      let can_rejoin_with_same_identity = can_accept_retired_self_status(
+        &identity,
+        *from,
+        *to,
+        &self.self_identity,
+        &self.starting_identity,
+        &self.start_in_progress,
+      );
+      if is_retired_identity && !can_rejoin_with_same_identity {
+        return;
+      }
+      if is_terminated && *to != NodeStatus::Removed {
+        return;
+      }
+      let current_status = self.self_status.with_lock(|self_status| self_status.clone());
+      let mut keep_retired_identity = false;
+      if let Some(current) = self.self_identity.with_lock(|self_identity| self_identity.clone())
+        && (current.node_id != identity.node_id || current.authority != identity.authority)
+      {
+        let current_is_retired = is_suppressed_retired_identity(&self.suppressed_retired_identities, &current);
+        let can_replace_starting_identity = self.starting_identity.with_lock(|starting_identity| {
+          starting_identity
+            .as_ref()
+            .is_some_and(|starting| identity_matches(starting, &current) && !is_retired_identity)
+        });
+        let can_replace_removed_identity =
+          current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed) || current_is_retired;
+        if !can_replace_starting_identity && !can_replace_removed_identity {
+          return;
+        }
+      }
+      if let Some(current) = self.self_identity.with_lock(|self_identity| self_identity.clone())
+        && identity_matches(&current, &identity)
+        && current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed)
+        && *to != NodeStatus::Removed
+        && !matches!((*from, *to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining))
+      {
+        remember_retired_identity(&self.suppressed_retired_identities, identity.clone());
+        keep_retired_identity = true;
+      }
       let status = SelfMemberStatus { node_id: node_id.clone(), authority: authority.clone(), status: *to };
+      if !keep_retired_identity {
+        retain_non_matching_identity(&self.suppressed_retired_identities, &identity);
+      }
+      if !is_topology_absent || *to != NodeStatus::Removed {
+        retain_non_matching_identity(&self.topology_absent_identities, &identity);
+      }
+      clear_starting_identity_if_replaced(&self.starting_identity, &identity);
       self.self_status.with_lock(|self_status| *self_status = Some(status));
+      self.self_identity.with_lock(|self_identity| *self_identity = Some(identity));
     }
   }
 }
@@ -134,6 +384,7 @@ struct MemberStatusSubscriber<F: FnMut(&str, &str) + Send + Sync + 'static> {
   callback_state: SharedLock<MemberStatusCallbackState<F>>,
   state:          SharedLock<MemberStatusSubscriberState>,
   event_stream:   EventStreamShared,
+  lifecycle:      SelfMemberLifecycle,
 }
 
 impl<F: FnMut(&str, &str) + Send + Sync + 'static> MemberStatusSubscriber<F> {
@@ -143,8 +394,9 @@ impl<F: FnMut(&str, &str) + Send + Sync + 'static> MemberStatusSubscriber<F> {
     callback_state: SharedLock<MemberStatusCallbackState<F>>,
     state: SharedLock<MemberStatusSubscriberState>,
     event_stream: EventStreamShared,
+    lifecycle: SelfMemberLifecycle,
   ) -> Self {
-    Self { target, self_address, callback_state, state, event_stream }
+    Self { target, self_address, callback_state, state, event_stream, lifecycle }
   }
 }
 
@@ -156,11 +408,43 @@ where
     if let EventStreamEvent::Extension { name, payload } = event
       && name == CLUSTER_EVENT_STREAM_NAME
       && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
-      && let ClusterEvent::MemberStatusChanged { node_id, authority, to, .. } = cluster_event
+      && let ClusterEvent::MemberStatusChanged { node_id, authority, from, to, .. } = cluster_event
       && authority == &self.self_address
       && *to == self.target
-      && trigger_member_status_callback::<F>(&self.callback_state, node_id, authority)
     {
+      let identity = SelfMemberIdentity { node_id: node_id.clone(), authority: authority.clone() };
+      if self.lifecycle.terminated.with_lock(|terminated| *terminated) && *to != NodeStatus::Removed {
+        return;
+      }
+      let is_topology_absent = is_topology_absent_identity(&self.lifecycle.topology_absent_identities, &identity);
+      let can_rejoin_from_absent =
+        matches!((*from, *to), (NodeStatus::Removed | NodeStatus::Dead, NodeStatus::Joining));
+      if is_topology_absent && *to != NodeStatus::Removed && !can_rejoin_from_absent {
+        return;
+      }
+      let is_retired_identity =
+        is_suppressed_retired_identity(&self.lifecycle.suppressed_retired_identities, &identity);
+      let can_rejoin_with_same_identity = can_accept_retired_self_status(
+        &identity,
+        *from,
+        *to,
+        &self.lifecycle.self_identity,
+        &self.lifecycle.starting_identity,
+        &self.lifecycle.start_in_progress,
+      );
+      if is_retired_identity && !can_rejoin_with_same_identity {
+        return;
+      }
+      let current_status = self.lifecycle.self_status.with_lock(|self_status| self_status.clone());
+      if let Some(current) = self.lifecycle.self_identity.with_lock(|self_identity| self_identity.clone())
+        && !identity_matches(&current, &identity)
+        && !current_status.as_ref().is_some_and(|status| status.status == NodeStatus::Removed)
+      {
+        return;
+      }
+      if !trigger_member_status_callback::<F>(&self.callback_state, node_id, authority) {
+        return;
+      }
       let subscription_id = self.state.with_lock(|state| {
         state.unsubscribe_requested = true;
         state.subscription_id
@@ -186,6 +470,11 @@ pub struct ClusterExtension {
   subscription: SharedLock<Option<EventStreamSubscription>>,
   terminated: SharedLock<bool>,
   self_member_status: SharedLock<Option<SelfMemberStatus>>,
+  self_member_identity: SharedLock<Option<SelfMemberIdentity>>,
+  suppressed_retired_identities: SharedLock<Vec<SelfMemberIdentity>>,
+  starting_identity: SharedLock<Option<SelfMemberIdentity>>,
+  start_in_progress: SharedLock<bool>,
+  topology_absent_identities: SharedLock<Vec<SelfMemberIdentity>>,
   _self_member_status_subscription: EventStreamSubscription,
   _system: ActorSystemWeak,
 }
@@ -200,12 +489,25 @@ impl ClusterExtension {
     let self_address = core.startup_address();
     let grain_metrics = if core.metrics_enabled() { Some(GrainMetricsShared::new(GrainMetrics::new())) } else { None };
     let self_member_status = SharedLock::new_with_driver::<DefaultMutex<_>>(None);
-    let status_subscriber =
-      subscriber_handle(SelfMemberStatusTrackerSubscriber::new(self_address, self_member_status.clone()));
+    let self_member_identity = SharedLock::new_with_driver::<DefaultMutex<_>>(None);
+    let suppressed_retired_identities = SharedLock::new_with_driver::<DefaultMutex<_>>(Vec::new());
+    let starting_identity = SharedLock::new_with_driver::<DefaultMutex<_>>(None);
+    let start_in_progress = SharedLock::new_with_driver::<DefaultMutex<_>>(false);
+    let topology_absent_identities = SharedLock::new_with_driver::<DefaultMutex<_>>(Vec::new());
+    let terminated = SharedLock::new_with_driver::<DefaultMutex<_>>(false);
+    let status_subscriber = subscriber_handle(SelfMemberStatusTrackerSubscriber::new(
+      self_address,
+      self_member_status.clone(),
+      self_member_identity.clone(),
+      terminated.clone(),
+      suppressed_retired_identities.clone(),
+      starting_identity.clone(),
+      start_in_progress.clone(),
+      topology_absent_identities.clone(),
+    ));
     let self_member_status_subscription = event_stream.subscribe_no_replay(&status_subscriber);
     let locked = SharedLock::new_with_driver::<DefaultMutex<_>>(core);
     let subscription = SharedLock::new_with_driver::<DefaultMutex<_>>(None);
-    let terminated = SharedLock::new_with_driver::<DefaultMutex<_>>(false);
     Self {
       core: locked,
       event_stream,
@@ -213,6 +515,11 @@ impl ClusterExtension {
       subscription,
       terminated,
       self_member_status,
+      self_member_identity,
+      suppressed_retired_identities,
+      starting_identity,
+      start_in_progress,
+      topology_absent_identities,
       _self_member_status_subscription: self_member_status_subscription,
       _system: system.downgrade(),
     }
@@ -244,8 +551,16 @@ impl ClusterExtension {
     }
 
     // ClusterCore への共有参照を持つ subscriber を作成
-    let subscriber: ClusterTopologySubscriber =
-      ClusterTopologySubscriber::new(self.core.clone(), self.event_stream.clone());
+    let self_address = self.core.with_lock(|core| core.startup_address());
+    let subscriber: ClusterTopologySubscriber = ClusterTopologySubscriber::new(
+      self.core.clone(),
+      self.event_stream.clone(),
+      self_address,
+      self.self_member_status.clone(),
+      self.self_member_identity.clone(),
+      self.starting_identity.clone(),
+      self.topology_absent_identities.clone(),
+    );
     let subscriber_handle = subscriber_handle(subscriber);
     let sub = self.event_stream.subscribe(&subscriber_handle);
     self.subscription.with_lock(|subscription| *subscription = Some(sub));
@@ -257,11 +572,40 @@ impl ClusterExtension {
   ///
   /// Returns an error if pub/sub, gossiper, or provider startup fails.
   pub fn start_member(&self) -> Result<(), ClusterError> {
+    let previous_status = self.self_member_status.with_lock(|self_member_status| self_member_status.clone());
+    let previous_identity = self.self_member_identity.with_lock(|self_member_identity| self_member_identity.clone());
     self.self_member_status.with_lock(|self_member_status| *self_member_status = None);
+    self.self_member_identity.with_lock(|self_member_identity| *self_member_identity = None);
+    self.starting_identity.with_lock(|starting_identity| *starting_identity = previous_identity.clone());
+    if let Some(previous_identity) = previous_identity.clone() {
+      remember_retired_identity(&self.suppressed_retired_identities, previous_identity);
+    }
+    let was_terminated = self.terminated.with_lock(|terminated| {
+      let was_terminated = *terminated;
+      *terminated = false;
+      was_terminated
+    });
+    self.start_in_progress.with_lock(|start_in_progress| *start_in_progress = true);
     let result = self.core.with_lock(|core| core.start_member());
+    self.start_in_progress.with_lock(|start_in_progress| *start_in_progress = false);
     if result.is_ok() {
-      self.terminated.with_lock(|terminated| *terminated = false);
       self.subscribe_topology_events();
+    } else {
+      let failed_identity = self.self_member_identity.with_lock(|self_member_identity| self_member_identity.clone());
+      if let Some(failed_identity) = failed_identity
+        && previous_identity.as_ref().is_none_or(|previous| !identity_matches(previous, &failed_identity))
+      {
+        remember_retired_identity(&self.suppressed_retired_identities, failed_identity);
+      }
+      self.self_member_status.with_lock(|self_member_status| *self_member_status = previous_status);
+      self.self_member_identity.with_lock(|self_member_identity| *self_member_identity = previous_identity.clone());
+      if let Some(previous_identity) = previous_identity {
+        retain_non_matching_identity(&self.suppressed_retired_identities, &previous_identity);
+      }
+      if was_terminated {
+        self.terminated.with_lock(|terminated| *terminated = true);
+      }
+      self.starting_identity.with_lock(|starting_identity| *starting_identity = None);
     }
     result
   }
@@ -272,11 +616,40 @@ impl ClusterExtension {
   ///
   /// Returns an error if pub/sub or provider startup fails.
   pub fn start_client(&self) -> Result<(), ClusterError> {
+    let previous_status = self.self_member_status.with_lock(|self_member_status| self_member_status.clone());
+    let previous_identity = self.self_member_identity.with_lock(|self_member_identity| self_member_identity.clone());
     self.self_member_status.with_lock(|self_member_status| *self_member_status = None);
+    self.self_member_identity.with_lock(|self_member_identity| *self_member_identity = None);
+    self.starting_identity.with_lock(|starting_identity| *starting_identity = previous_identity.clone());
+    if let Some(previous_identity) = previous_identity.clone() {
+      remember_retired_identity(&self.suppressed_retired_identities, previous_identity);
+    }
+    let was_terminated = self.terminated.with_lock(|terminated| {
+      let was_terminated = *terminated;
+      *terminated = false;
+      was_terminated
+    });
+    self.start_in_progress.with_lock(|start_in_progress| *start_in_progress = true);
     let result = self.core.with_lock(|core| core.start_client());
+    self.start_in_progress.with_lock(|start_in_progress| *start_in_progress = false);
     if result.is_ok() {
-      self.terminated.with_lock(|terminated| *terminated = false);
       self.subscribe_topology_events();
+    } else {
+      let failed_identity = self.self_member_identity.with_lock(|self_member_identity| self_member_identity.clone());
+      if let Some(failed_identity) = failed_identity
+        && previous_identity.as_ref().is_none_or(|previous| !identity_matches(previous, &failed_identity))
+      {
+        remember_retired_identity(&self.suppressed_retired_identities, failed_identity);
+      }
+      self.self_member_status.with_lock(|self_member_status| *self_member_status = previous_status);
+      self.self_member_identity.with_lock(|self_member_identity| *self_member_identity = previous_identity.clone());
+      if let Some(previous_identity) = previous_identity {
+        retain_non_matching_identity(&self.suppressed_retired_identities, &previous_identity);
+      }
+      if was_terminated {
+        self.terminated.with_lock(|terminated| *terminated = true);
+      }
+      self.starting_identity.with_lock(|starting_identity| *starting_identity = None);
     }
     result
   }
@@ -292,6 +665,7 @@ impl ClusterExtension {
     let result = self.core.with_lock(|core| core.shutdown(graceful));
     if result.is_ok() {
       self.terminated.with_lock(|terminated| *terminated = true);
+      self.self_member_status.with_lock(|self_member_status| *self_member_status = None);
     }
     result
   }
@@ -349,6 +723,17 @@ impl ClusterExtension {
     // ロックを保持したまま publish するとデッドロックするため、
     // イベントを取得してからロックを解放し、その後に publish する
     let result = self.core.with_lock(|core| core.try_apply_topology(update));
+    if matches!(result.as_ref(), Ok(Some(_))) {
+      let self_address = self.core.with_lock(|core| core.startup_address());
+      clear_self_observation_if_absent(
+        update,
+        &self_address,
+        &self.self_member_status,
+        &self.self_member_identity,
+        &self.starting_identity,
+        &self.topology_absent_identities,
+      );
+    }
 
     match result {
       | Ok(Some(event)) => {
@@ -383,8 +768,13 @@ impl ClusterExtension {
     if self.terminated.with_lock(|terminated| *terminated) {
       let self_address = self.core.with_lock(|core| core.startup_address());
       let node_id = {
-        let current = self.self_member_status.with_lock(|self_member_status| self_member_status.clone());
-        if let Some(status) = current.as_ref() { status.node_id.clone() } else { self_address.clone() }
+        let current = self.self_member_identity.with_lock(|self_member_identity| self_member_identity.clone());
+        if let Some(identity) = current.as_ref() {
+          debug_assert_eq!(identity.authority, self_address);
+          identity.node_id.clone()
+        } else {
+          self_address.clone()
+        }
       };
       let mut immediate = callback;
       immediate(&node_id, &self_address);
@@ -427,7 +817,14 @@ impl ClusterExtension {
   /// wiring (HTTP servers etc.) is out of scope and owned by the caller.
   #[must_use]
   pub fn grain_readiness_snapshot(&self) -> GrainReadinessSnapshot {
-    self.core.with_lock(|core| core.grain_readiness_snapshot())
+    let observed_self_status =
+      self.self_member_status.with_lock(|self_status| self_status.as_ref().map(|status| status.status));
+    self.core.with_lock(|core| {
+      if core.mode().is_some() && core.has_current_self_member() && observed_self_status.is_some() {
+        return core.grain_readiness_snapshot_with_self_status(observed_self_status);
+      }
+      core.grain_readiness_snapshot()
+    })
   }
 
   /// Returns blocked members cache.
@@ -442,12 +839,22 @@ impl ClusterExtension {
     let self_address = self.core.with_lock(|core| core.startup_address());
     let state = SharedLock::new_with_driver::<DefaultMutex<_>>(MemberStatusSubscriberState::new());
     let callback_state = SharedLock::new_with_driver::<DefaultMutex<_>>(MemberStatusCallbackState::new(callback));
+    let lifecycle = SelfMemberLifecycle::new(
+      self.self_member_status.clone(),
+      self.self_member_identity.clone(),
+      self.terminated.clone(),
+      self.suppressed_retired_identities.clone(),
+      self.starting_identity.clone(),
+      self.start_in_progress.clone(),
+      self.topology_absent_identities.clone(),
+    );
     let subscriber = subscriber_handle(MemberStatusSubscriber::new(
       target,
       self_address.clone(),
       callback_state.clone(),
       state.clone(),
       self.event_stream.clone(),
+      lifecycle,
     ));
     let subscription = self.event_stream.subscribe_no_replay(&subscriber);
     let subscription_id = subscription.id();
@@ -457,6 +864,10 @@ impl ClusterExtension {
     if let Some(current) = self.self_member_status.with_lock(|self_member_status| self_member_status.clone())
       && current.authority == self_address.as_str()
       && current.status == target
+      && !is_suppressed_retired_identity(&self.suppressed_retired_identities, &SelfMemberIdentity {
+        node_id:   current.node_id.clone(),
+        authority: current.authority.clone(),
+      })
       && trigger_member_status_callback::<F>(&callback_state, &current.node_id, &current.authority)
     {
       state.with_lock(|state| state.unsubscribe_requested = true);

--- a/modules/cluster-core-kernel/src/extension/cluster_extension.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension.rs
@@ -349,11 +349,15 @@ impl EventStreamSubscriber for SelfMemberStatusTrackerSubscriber {
         && (current.node_id != identity.node_id || current.authority != identity.authority)
       {
         let current_is_retired = is_suppressed_retired_identity(&self.suppressed_retired_identities, &current);
-        let can_replace_starting_identity = self.starting_identity.with_lock(|starting_identity| {
-          starting_identity
-            .as_ref()
-            .is_some_and(|starting| identity_matches(starting, &current) && !is_retired_identity)
-        });
+        // 開始対象 identity の置換は start window 中に限る。完了後に starting_identity == current の間へ
+        // 別 identity の遅延イベントが届いても self_member_identity を上書きさせない。
+        let in_start_window = self.start_in_progress.with_lock(|start_in_progress| *start_in_progress);
+        let can_replace_starting_identity = in_start_window
+          && self.starting_identity.with_lock(|starting_identity| {
+            starting_identity
+              .as_ref()
+              .is_some_and(|starting| identity_matches(starting, &current) && !is_retired_identity)
+          });
         let incoming_is_starting_identity = self.starting_identity.with_lock(|starting_identity| {
           starting_identity.as_ref().is_some_and(|starting| identity_matches(starting, &identity))
         });

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_test.rs
@@ -1195,6 +1195,41 @@ fn grain_readiness_snapshot_accepts_same_node_id_rejoin_during_restart_start_win
 }
 
 #[test]
+fn grain_readiness_snapshot_ignores_foreign_identity_up_after_restart_start_window() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(RestartEmitsSameIdentityJoiningProvider::new(
+      event_stream.clone(),
+      authority.clone(),
+      String::from("node-self"),
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+
+  // restart-with-same-identity は starting_identity == current（node-self/Joining）の状態を残す。
+  // start window 完了後に別 identity の遅延 Up が届いても observed self を上書きしてはならない。
+  publish_member_status(&event_stream, "node-foreign", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
 fn grain_readiness_snapshot_accepts_same_node_id_up_during_restart_start_window() {
   let system = create_noop_actor_system();
   let event_stream = system.event_stream();

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_test.rs
@@ -100,22 +100,358 @@ struct StartAndEmitSelfUpProvider {
   event_stream: EventStreamShared,
   authority:    String,
   node_id:      String,
+  status:       NodeStatus,
 }
 
 impl StartAndEmitSelfUpProvider {
   const fn new(event_stream: EventStreamShared, authority: String, node_id: String) -> Self {
-    Self { event_stream, authority, node_id }
+    Self { event_stream, authority, node_id, status: NodeStatus::Up }
+  }
+
+  const fn with_status(
+    event_stream: EventStreamShared,
+    authority: String,
+    node_id: String,
+    status: NodeStatus,
+  ) -> Self {
+    Self { event_stream, authority, node_id, status }
   }
 }
 
 impl ClusterProvider for StartAndEmitSelfUpProvider {
   fn start_member(&mut self) -> Result<(), ClusterProviderError> {
-    publish_member_status(&self.event_stream, &self.node_id, &self.authority, NodeStatus::Joining, NodeStatus::Up);
+    publish_member_status(&self.event_stream, &self.node_id, &self.authority, NodeStatus::Joining, self.status);
     Ok(())
   }
 
   fn start_client(&mut self) -> Result<(), ClusterProviderError> {
-    publish_member_status(&self.event_stream, &self.node_id, &self.authority, NodeStatus::Joining, NodeStatus::Up);
+    publish_member_status(&self.event_stream, &self.node_id, &self.authority, NodeStatus::Joining, self.status);
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct StartAndEmitRestartSelfUpProvider {
+  event_stream:      EventStreamShared,
+  authority:         String,
+  first_node_id:     String,
+  restarted_node_id: String,
+  start_count:       usize,
+}
+
+impl StartAndEmitRestartSelfUpProvider {
+  fn new(event_stream: EventStreamShared, authority: String, first_node_id: String, restarted_node_id: String) -> Self {
+    Self { event_stream, authority, first_node_id, restarted_node_id, start_count: 0 }
+  }
+
+  fn current_node_id(&mut self) -> String {
+    let node_id = if self.start_count == 0 { self.first_node_id.clone() } else { self.restarted_node_id.clone() };
+    self.start_count += 1;
+    node_id
+  }
+}
+
+impl ClusterProvider for StartAndEmitRestartSelfUpProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    let node_id = self.current_node_id();
+    publish_member_status(&self.event_stream, &node_id, &self.authority, NodeStatus::Joining, NodeStatus::Up);
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    let node_id = self.current_node_id();
+    publish_member_status(&self.event_stream, &node_id, &self.authority, NodeStatus::Joining, NodeStatus::Up);
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct RestartEmitsSameIdentityJoiningProvider {
+  event_stream: EventStreamShared,
+  authority:    String,
+  node_id:      String,
+  start_count:  usize,
+}
+
+impl RestartEmitsSameIdentityJoiningProvider {
+  const fn new(event_stream: EventStreamShared, authority: String, node_id: String) -> Self {
+    Self { event_stream, authority, node_id, start_count: 0 }
+  }
+
+  fn publish_start_status(&mut self) {
+    if self.start_count == 0 {
+      publish_member_status(&self.event_stream, &self.node_id, &self.authority, NodeStatus::Joining, NodeStatus::Up);
+    } else {
+      publish_member_status(
+        &self.event_stream,
+        &self.node_id,
+        &self.authority,
+        NodeStatus::Removed,
+        NodeStatus::Joining,
+      );
+    }
+    self.start_count += 1;
+  }
+}
+
+impl ClusterProvider for RestartEmitsSameIdentityJoiningProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    self.publish_start_status();
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    self.publish_start_status();
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct RestartEmitsRetiredThenCurrentProvider {
+  event_stream:    EventStreamShared,
+  authority:       String,
+  retired_node_id: String,
+  current_node_id: String,
+  started_member:  bool,
+}
+
+impl RestartEmitsRetiredThenCurrentProvider {
+  const fn new(
+    event_stream: EventStreamShared,
+    authority: String,
+    retired_node_id: String,
+    current_node_id: String,
+  ) -> Self {
+    Self { event_stream, authority, retired_node_id, current_node_id, started_member: false }
+  }
+}
+
+impl ClusterProvider for RestartEmitsRetiredThenCurrentProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    if self.started_member {
+      publish_member_status(
+        &self.event_stream,
+        &self.retired_node_id,
+        &self.authority,
+        NodeStatus::Joining,
+        NodeStatus::Up,
+      );
+      publish_member_status(
+        &self.event_stream,
+        &self.current_node_id,
+        &self.authority,
+        NodeStatus::Joining,
+        NodeStatus::Joining,
+      );
+    } else {
+      self.started_member = true;
+      publish_member_status(
+        &self.event_stream,
+        &self.retired_node_id,
+        &self.authority,
+        NodeStatus::Joining,
+        NodeStatus::Up,
+      );
+    }
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct StartFirstOnlyEmitSelfUpProvider {
+  event_stream:   EventStreamShared,
+  authority:      String,
+  node_id:        String,
+  started_member: bool,
+}
+
+impl StartFirstOnlyEmitSelfUpProvider {
+  const fn new(event_stream: EventStreamShared, authority: String, node_id: String) -> Self {
+    Self { event_stream, authority, node_id, started_member: false }
+  }
+}
+
+impl ClusterProvider for StartFirstOnlyEmitSelfUpProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    if !self.started_member {
+      self.started_member = true;
+      publish_member_status(&self.event_stream, &self.node_id, &self.authority, NodeStatus::Joining, NodeStatus::Up);
+    }
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct StartOnceThenFailProvider {
+  started_member: bool,
+  started_client: bool,
+}
+
+impl StartOnceThenFailProvider {
+  const fn new() -> Self {
+    Self { started_member: false, started_client: false }
+  }
+}
+
+impl ClusterProvider for StartOnceThenFailProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    if self.started_member {
+      return Err(ClusterProviderError::start_member("restart failed"));
+    }
+    self.started_member = true;
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    if self.started_client {
+      return Err(ClusterProviderError::start_client("restart failed"));
+    }
+    self.started_client = true;
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct StartEmitThenFailOnceProvider {
+  event_stream: EventStreamShared,
+  authority:    String,
+  failed_node:  String,
+  member_calls: usize,
+  client_calls: usize,
+}
+
+impl StartEmitThenFailOnceProvider {
+  const fn new(event_stream: EventStreamShared, authority: String, failed_node: String) -> Self {
+    Self { event_stream, authority, failed_node, member_calls: 0, client_calls: 0 }
+  }
+}
+
+impl ClusterProvider for StartEmitThenFailOnceProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    self.member_calls += 1;
+    if self.member_calls == 2 {
+      publish_member_status(
+        &self.event_stream,
+        &self.failed_node,
+        &self.authority,
+        NodeStatus::Joining,
+        NodeStatus::Up,
+      );
+      return Err(ClusterProviderError::start_member("restart failed"));
+    }
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    self.client_calls += 1;
+    if self.client_calls == 2 {
+      publish_member_status(
+        &self.event_stream,
+        &self.failed_node,
+        &self.authority,
+        NodeStatus::Joining,
+        NodeStatus::Up,
+      );
+      return Err(ClusterProviderError::start_client("restart failed"));
+    }
     Ok(())
   }
 
@@ -263,6 +599,656 @@ fn grain_readiness_snapshot_transitions_from_not_ready_to_ready() {
 }
 
 #[test]
+fn grain_readiness_snapshot_uses_observed_self_status() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitSelfUpProvider::with_status(
+      event_stream,
+      authority,
+      String::from("node-self"),
+      NodeStatus::Joining,
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_clears_observed_self_status_after_shutdown() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitSelfUpProvider::new(event_stream, authority, String::from("node-self"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  ext_shared.shutdown(true).expect("shutdown");
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: None }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_late_observed_self_status_after_shutdown() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-self"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  ext_shared.shutdown(true).expect("shutdown");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: None }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_observed_self_status_when_self_leaves_topology() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitSelfUpProvider::new(event_stream, authority.clone(), String::from("node-self"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  ext_shared.on_topology(&build_update(20, Vec::new(), Vec::new(), vec![authority], Vec::new()));
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: None }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_accepts_observed_status_when_self_rejoins_topology() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  publish_member_status(&event_stream, "node-self", "fraktor://demo", NodeStatus::Joining, NodeStatus::Up);
+  ext_shared.on_topology(&build_update(2, Vec::new(), Vec::new(), vec![String::from("fraktor://demo")], Vec::new()));
+  ext_shared.on_topology(&build_update(
+    3,
+    vec![String::from("fraktor://demo")],
+    vec![String::from("fraktor://demo")],
+    Vec::new(),
+    Vec::new(),
+  ));
+
+  publish_member_status(&event_stream, "node-self", "fraktor://demo", NodeStatus::Removed, NodeStatus::Joining);
+
+  match ext_shared.grain_readiness_snapshot().readiness(&expected) {
+    | GrainReadiness::NotReady { reasons } => {
+      assert!(
+        reasons.contains(&GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }),
+        "rejoined self status should remain observed as Joining"
+      );
+    },
+    | GrainReadiness::Ready => panic!("rejoined self should not be ready while Joining"),
+  }
+}
+
+#[test]
+fn grain_readiness_snapshot_accepts_up_after_removed_rejoin_from_topology_absent() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+  ext_shared.on_topology(&build_update(2, Vec::new(), Vec::new(), vec![authority.clone()], Vec::new()));
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+  ext_shared.on_topology(&build_update(3, vec![authority.clone()], vec![authority.clone()], Vec::new(), Vec::new()));
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Removed, NodeStatus::Joining);
+
+  match ext_shared.grain_readiness_snapshot().readiness(&expected) {
+    | GrainReadiness::NotReady { reasons } => {
+      assert!(reasons.contains(&GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }));
+    },
+    | GrainReadiness::Ready => panic!("rejoined self should not be ready while Joining"),
+  }
+
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  if let GrainReadiness::NotReady { reasons } = ext_shared.grain_readiness_snapshot().readiness(&expected) {
+    assert!(
+      !reasons.iter().any(|reason| matches!(reason, GrainUnreadyReason::SelfNodeNotUp { .. })),
+      "self Up should clear the self-node readiness blocker"
+    );
+  }
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_old_up_before_fresh_rejoin_status() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  publish_member_status(&event_stream, "node-old", "fraktor://demo", NodeStatus::Joining, NodeStatus::Up);
+  ext_shared.on_topology(&build_update(2, Vec::new(), Vec::new(), vec![String::from("fraktor://demo")], Vec::new()));
+  ext_shared.on_topology(&build_update(
+    3,
+    vec![String::from("fraktor://demo")],
+    vec![String::from("fraktor://demo")],
+    Vec::new(),
+    Vec::new(),
+  ));
+
+  publish_member_status(&event_stream, "node-old", "fraktor://demo", NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-new", "fraktor://demo", NodeStatus::Joining, NodeStatus::Joining);
+
+  match ext_shared.grain_readiness_snapshot().readiness(&expected) {
+    | GrainReadiness::NotReady { reasons } => {
+      assert!(
+        reasons.contains(&GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }),
+        "fresh rejoin status should win over old Up"
+      );
+    },
+    | GrainReadiness::Ready => panic!("fresh rejoin should not be ready while Joining"),
+  }
+}
+
+#[test]
+fn grain_readiness_snapshot_drops_stale_observed_status_when_self_rejoins_topology() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-self"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Up, NodeStatus::Joining);
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+
+  ext_shared.on_topology(&build_update(20, Vec::new(), Vec::new(), vec![authority.clone()], Vec::new()));
+  ext_shared.on_topology(&build_update(21, vec![authority], Vec::new(), Vec::new(), Vec::new()));
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+}
+
+#[test]
+fn grain_readiness_snapshot_keeps_observed_status_on_deduped_topology() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-self"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.on_topology(&build_update(20, vec![authority.clone()], Vec::new(), Vec::new(), Vec::new()));
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Up, NodeStatus::Joining);
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+
+  ext_shared.on_topology(&build_update(20, Vec::new(), Vec::new(), vec![authority], Vec::new()));
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_late_removed_from_previous_lifecycle_after_restart() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitRestartSelfUpProvider::new(
+      event_stream.clone(),
+      authority.clone(),
+      String::from("node-old"),
+      String::from("node-new"),
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_late_removed_before_restart_identity_is_observed() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-old"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_late_non_removed_then_removed_before_restart_identity_is_observed() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-old"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_late_non_removed_from_older_retired_lifecycle_before_restart_identity_is_observed()
+{
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(
+      event_stream.clone(),
+      authority.clone(),
+      String::from("node-first"),
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown first lifecycle");
+  ext_shared.start_member().expect("start second lifecycle");
+  publish_member_status(&event_stream, "node-second", &authority, NodeStatus::Joining, NodeStatus::Up);
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+  ext_shared.shutdown(true).expect("shutdown second lifecycle");
+  ext_shared.start_member().expect("start third lifecycle");
+
+  publish_member_status(&event_stream, "node-first", &authority, NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-third", &authority, NodeStatus::Joining, NodeStatus::Joining);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_old_removed_to_joining_from_older_retired_lifecycle() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(
+      event_stream.clone(),
+      authority.clone(),
+      String::from("node-first"),
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown first lifecycle");
+  ext_shared.start_member().expect("start second lifecycle");
+  publish_member_status(&event_stream, "node-second", &authority, NodeStatus::Joining, NodeStatus::Up);
+  ext_shared.shutdown(true).expect("shutdown second lifecycle");
+  ext_shared.start_member().expect("start third lifecycle");
+
+  publish_member_status(&event_stream, "node-first", &authority, NodeStatus::Removed, NodeStatus::Joining);
+  publish_member_status(&event_stream, "node-third", &authority, NodeStatus::Joining, NodeStatus::Joining);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_retired_identity_arriving_during_restart_start_window() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(RestartEmitsRetiredThenCurrentProvider::new(
+      event_stream,
+      authority.clone(),
+      String::from("node-old"),
+      String::from("node-new"),
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_accepts_same_node_id_rejoin_after_restart_start_window() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-self"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Removed, NodeStatus::Joining);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-self"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn grain_readiness_snapshot_accepts_same_node_id_rejoin_during_restart_start_window() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(RestartEmitsSameIdentityJoiningProvider::new(event_stream, authority.clone(), String::from("node-self"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_accepts_same_node_id_up_during_restart_start_window() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitRestartSelfUpProvider::new(
+      event_stream,
+      authority.clone(),
+      String::from("node-self"),
+      String::from("node-self"),
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-self"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn grain_readiness_snapshot_accepts_removed_from_new_lifecycle_before_restart_identity_is_observed() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-old"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::Ready);
+
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Removed) }],
+  });
+}
+
+#[test]
+fn grain_readiness_snapshot_ignores_late_non_removed_from_previous_lifecycle_after_restart_identity_is_observed() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-old"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(PartitionIdentityLookup::with_defaults()),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Joining, NodeStatus::Joining);
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  assert_eq!(ext_shared.grain_readiness_snapshot().readiness(&expected), GrainReadiness::NotReady {
+    reasons: vec![GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Joining) }],
+  });
+}
+
+#[test]
 fn register_on_member_up_invokes_callback_for_up_transition() {
   let system = create_noop_actor_system();
   let event_stream = system.event_stream();
@@ -366,6 +1352,51 @@ fn register_on_member_up_invokes_callback_when_status_arrives_during_start_clien
   run_member_up_during_start_test(|ext| ext.start_client());
 }
 
+fn run_member_up_during_restart_test(start_fn: impl Fn(&ClusterExtension) -> Result<(), ClusterError>) {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartAndEmitRestartSelfUpProvider::new(
+      event_stream.clone(),
+      authority.clone(),
+      String::from("node-old"),
+      String::from("node-new"),
+    )),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(StubIdentity),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  start_fn(&ext_shared).expect("start");
+  ext_shared.shutdown(true).expect("shutdown");
+  start_fn(&ext_shared).expect("restart");
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-new"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_up_invokes_callback_when_status_arrives_during_restart_member() {
+  run_member_up_during_restart_test(|ext| ext.start_member());
+}
+
+#[test]
+fn register_on_member_up_invokes_callback_when_status_arrives_during_restart_client() {
+  run_member_up_during_restart_test(|ext| ext.start_client());
+}
+
 #[test]
 fn register_on_member_removed_invokes_callback_immediately_when_self_already_removed() {
   let system = create_noop_actor_system();
@@ -410,6 +1441,137 @@ fn register_on_member_removed_invokes_callback_immediately_after_shutdown() {
 }
 
 #[test]
+fn register_on_member_removed_after_shutdown_ignores_late_non_removed_identity() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  ext_shared.start_member().expect("start member");
+  publish_member_status(&event_stream, "node-removed", "fraktor://demo", NodeStatus::Exiting, NodeStatus::Removed);
+  ext_shared.shutdown(true).expect("shutdown");
+  publish_member_status(&event_stream, "node-late", "fraktor://demo", NodeStatus::Joining, NodeStatus::Up);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_removed(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-removed"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_removed_after_shutdown_ignores_late_removed_from_previous_lifecycle() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-old"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(StubIdentity),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Joining, NodeStatus::Up);
+  ext_shared.shutdown(true).expect("shutdown again");
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_removed(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-new"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_removed_after_shutdown_ignores_retired_removed_when_current_identity_unknown() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-old"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(StubIdentity),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+  ext_shared.shutdown(true).expect("shutdown again");
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_removed(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("fraktor://demo"), String::from("fraktor://demo"))]);
+}
+
+fn run_failed_restart_preserves_removed_identity_test(
+  start_fn: impl Fn(&ClusterExtension) -> Result<(), ClusterError>,
+) {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address("fraktor://demo"),
+    Box::new(StartOnceThenFailProvider::new()),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(StubIdentity),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  start_fn(&ext_shared).expect("start");
+  publish_member_status(&event_stream, "node-removed", "fraktor://demo", NodeStatus::Exiting, NodeStatus::Removed);
+  ext_shared.shutdown(true).expect("shutdown");
+  assert!(start_fn(&ext_shared).is_err());
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_removed(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-removed"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_removed_after_failed_member_restart_preserves_removed_identity() {
+  run_failed_restart_preserves_removed_identity_test(|ext| ext.start_member());
+}
+
+#[test]
+fn register_on_member_removed_after_failed_client_restart_preserves_removed_identity() {
+  run_failed_restart_preserves_removed_identity_test(|ext| ext.start_client());
+}
+
+#[test]
 fn register_on_member_removed_after_shutdown_falls_back_to_authority_when_node_id_is_unknown() {
   let system = create_noop_actor_system();
 
@@ -451,6 +1613,213 @@ fn register_on_member_up_does_not_fire_for_buffered_old_up_events() {
 
   let recorded = calls.lock().clone();
   assert_eq!(recorded, vec![(String::from("node-new"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_up_does_not_fire_for_retired_up_after_restart() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartFirstOnlyEmitSelfUpProvider::new(event_stream.clone(), authority.clone(), String::from("node-old"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(StubIdentity),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.shutdown(true).expect("shutdown");
+  ext_shared.start_member().expect("restart member");
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Joining, NodeStatus::Up);
+  assert!(calls.lock().is_empty());
+
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-new"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_up_does_not_fire_after_shutdown() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  ext_shared.start_member().expect("start member");
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  ext_shared.shutdown(true).expect("shutdown");
+  publish_member_status(&event_stream, "node-late", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  assert!(calls.lock().is_empty());
+}
+
+#[test]
+fn register_on_member_up_does_not_fire_after_topology_absent_removed() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  ext_shared.start_member().expect("start member");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+  ext_shared.on_topology(&build_update(2, Vec::new(), Vec::new(), vec![authority.clone()], Vec::new()));
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  assert!(calls.lock().is_empty());
+}
+
+#[test]
+fn register_on_member_up_does_not_fire_for_identity_mismatched_up() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Joining, NodeStatus::Joining);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Joining, NodeStatus::Up);
+  assert!(calls.lock().is_empty());
+
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-new"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_removed_fires_after_self_leaves_topology() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  ext_shared.start_member().expect("start member");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_removed(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  ext_shared.on_topology(&build_update(2, Vec::new(), Vec::new(), vec![authority.clone()], Vec::new()));
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-self"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_removed_does_not_fire_for_identity_mismatched_removed() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_removed(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+  assert!(calls.lock().is_empty());
+
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-new"), String::from("fraktor://demo"))]);
+}
+
+fn run_failed_restart_retires_failed_start_identity_test(
+  start_fn: impl Fn(&ClusterExtension) -> Result<(), ClusterError>,
+) {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = ClusterExtensionId::new(
+    ClusterExtensionConfig::new().with_advertised_address(&authority),
+    Box::new(StartEmitThenFailOnceProvider::new(event_stream.clone(), authority.clone(), String::from("node-failed"))),
+    ArcShared::new(StubBlockList),
+    Box::new(NoopDowningProvider::new()),
+    Box::new(StubGossiper),
+    Box::new(StubPubSub),
+    Box::new(StubIdentity),
+  );
+  let ext_shared = system.extended().register_extension(&ext_id);
+
+  start_fn(&ext_shared).expect("start");
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Joining, NodeStatus::Up);
+  ext_shared.shutdown(true).expect("shutdown");
+  assert!(start_fn(&ext_shared).is_err());
+  start_fn(&ext_shared).expect("restart");
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  publish_member_status(&event_stream, "node-failed", &authority, NodeStatus::Joining, NodeStatus::Up);
+  assert!(calls.lock().is_empty());
+
+  publish_member_status(&event_stream, "node-new", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-new"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_up_ignores_failed_member_start_identity_after_retry() {
+  run_failed_restart_retires_failed_start_identity_test(|ext| ext.start_member());
+}
+
+#[test]
+fn register_on_member_up_ignores_failed_client_start_identity_after_retry() {
+  run_failed_restart_retires_failed_start_identity_test(|ext| ext.start_client());
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/extension/cluster_extension_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension_test.rs
@@ -783,6 +783,54 @@ fn grain_readiness_snapshot_accepts_up_after_removed_rejoin_from_topology_absent
 }
 
 #[test]
+fn grain_readiness_snapshot_keeps_removed_after_late_same_identity_up() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  match ext_shared.grain_readiness_snapshot().readiness(&expected) {
+    | GrainReadiness::NotReady { reasons } => {
+      assert!(reasons.contains(&GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Removed) }));
+    },
+    | GrainReadiness::Ready => panic!("late Up after Removed should not make readiness Ready"),
+  }
+}
+
+#[test]
+fn grain_readiness_snapshot_does_not_replace_removed_with_different_identity_up() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  let expected = vec![String::from("grain-kind")];
+
+  ext_shared.start_member().expect("start member");
+  ext_shared.setup_member_kinds(vec![ActivatedKind::new("grain-kind")]).expect("setup kinds");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  match ext_shared.grain_readiness_snapshot().readiness(&expected) {
+    | GrainReadiness::NotReady { reasons } => {
+      assert!(reasons.contains(&GrainUnreadyReason::SelfNodeNotUp { status: Some(NodeStatus::Removed) }));
+    },
+    | GrainReadiness::Ready => panic!("different identity late Up after Removed should not make readiness Ready"),
+  }
+}
+
+#[test]
 fn grain_readiness_snapshot_ignores_old_up_before_fresh_rejoin_status() {
   let system = create_noop_actor_system();
   let event_stream = system.event_stream();
@@ -1698,6 +1746,30 @@ fn register_on_member_up_does_not_fire_after_topology_absent_removed() {
 }
 
 #[test]
+fn register_on_member_up_does_not_fire_for_late_up_after_removed() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  ext_shared.start_member().expect("start member");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_up(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
+
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-old", &authority, NodeStatus::Joining, NodeStatus::Up);
+
+  assert!(calls.lock().is_empty());
+}
+
+#[test]
 fn register_on_member_up_does_not_fire_for_identity_mismatched_up() {
   let system = create_noop_actor_system();
   let event_stream = system.event_stream();
@@ -1742,6 +1814,29 @@ fn register_on_member_removed_fires_after_self_leaves_topology() {
 
   ext_shared.on_topology(&build_update(2, Vec::new(), Vec::new(), vec![authority.clone()], Vec::new()));
   publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+
+  let recorded = calls.lock().clone();
+  assert_eq!(recorded, vec![(String::from("node-self"), String::from("fraktor://demo"))]);
+}
+
+#[test]
+fn register_on_member_removed_invokes_immediately_after_removed_then_topology_absent() {
+  let system = create_noop_actor_system();
+  let event_stream = system.event_stream();
+  let authority = String::from("fraktor://demo");
+
+  let ext_id = stub_extension_id(ClusterExtensionConfig::new().with_advertised_address(&authority));
+  let ext_shared = system.extended().register_extension(&ext_id);
+  ext_shared.start_member().expect("start member");
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Joining, NodeStatus::Up);
+  publish_member_status(&event_stream, "node-self", &authority, NodeStatus::Exiting, NodeStatus::Removed);
+  ext_shared.on_topology(&build_update(2, Vec::new(), Vec::new(), vec![authority], Vec::new()));
+
+  let calls = ArcShared::new(SpinSyncMutex::new(Vec::<(String, String)>::new()));
+  let calls_for_callback = calls.clone();
+  let _subscription = ext_shared.register_on_member_removed(move |node_id, authority| {
+    calls_for_callback.lock().push((String::from(node_id), String::from(authority)));
+  });
 
   let recorded = calls.lock().clone();
   assert_eq!(recorded, vec![(String::from("node-self"), String::from("fraktor://demo"))]);


### PR DESCRIPTION
## Summary

- Use the `ClusterExtension` self member status tracker when building grain readiness snapshots.
- Keep the existing `ClusterCore` synthetic snapshot path as a fallback when no status event has been observed.
- Add regression tests proving an observed `Joining` self status stays `NotReady` and shutdown clears readiness status while retaining removed-callback identity.

## Root Cause

`ClusterCore::current_cluster_state_snapshot()` currently synthesizes `NodeStatus::Up` for entries in `current_members`. `ClusterExtension::grain_readiness_snapshot()` delegated directly to that path, so an observed non-up self member status could be ignored.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-kernel-rs grain_readiness_snapshot --no-default-features`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test -p fraktor-cluster-core-kernel-rs register_on_member_removed_invokes_callback_immediately_after_shutdown --lib`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo test --workspace --lib --bins --features test-support`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo fmt --check --all`
- `MISE_TRUSTED_CONFIG_PATHS=$PWD/mise.toml mise exec -- cargo clippy -p fraktor-cluster-core-kernel-rs --no-default-features --lib --tests -- -D warnings`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster membership observation, readiness probes, and callback firing—incorrect filtering could block legitimate rejoins or misreport readiness, but changes are heavily regression-tested.
> 
> **Overview**
> **Grain readiness** now prefers the extension’s **observed** self `MemberStatusChanged` state when the cluster is running, the self authority is still in the current topology, and a status has been tracked—via `grain_readiness_snapshot_with_self_status`—instead of `ClusterCore`’s synthetic **Up** snapshot. Shutdown, topology removal, and absent-self topology updates clear or ignore stale observed status so probes do not stay **Ready** on late events.
> 
> **Self-member lifecycle** tracking adds node identity, start/restart windows, retired-identity suppression, and topology-absent identities. Status subscribers and **Up**/**Removed** callbacks filter delayed or foreign incarnation events, failed-start rollbacks, and rejoin transitions so readiness and hooks stay aligned with the current lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01dcbe576b9e6ec0d29dfbb50f1644bb0062f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 自ノードの識別情報・開始状態・退役抑止リストを追跡し、開始／再参加／シャットダウンのライフサイクルを自己管理
* **Bug Fixes**
  * 準備性評価が自己観測状態と整合するよう改善し、遅延イベントや再起動境界での誤判定を抑止
  * 起動失敗時の状態退避とロールバックを明確化し、退役／トポロジ不在時の扱いを修正
* **Tests**
  * 再起動・退役・遅延到達・起動失敗など多岐のシナリオを網羅するテストを大幅拡充
<!-- end of auto-generated comment: release notes by coderabbit.ai -->