### PR TITLE
kiro-impl スキルを ai-tools の標準内容へ戻す

### DIFF
--- a/.agents/skills/kiro-impl/SKILL.md
+++ b/.agents/skills/kiro-impl/SKILL.md
@@ -1,17 +1,15 @@
 ---
 name: kiro-impl
-description: Implement approved tasks using TDD with an independent reviewer gate per task. Executes directly in the main context (default) or via sub-agent dispatch for parallelizable task groups.
+description: Implement approved tasks using TDD with subagent dispatch. Runs all pending tasks autonomously or selected tasks manually.
 ---
 
 
 # kiro-impl Skill
 
 <background_information>
-You operate in two execution engines (the per-task quality gate is identical in both):
-- **Direct mode**: The controller implements each task in the main context with TDD, gated by a fresh independent reviewer sub-agent before completion. Default for serial task queues on high-capability host models.
-- **Dispatch mode**: A fresh implementer sub-agent per task, with independent review after each. Reserve for parallelizable `(P)` task groups with isolation, or when main-context budget is constrained.
-
-In BOTH engines: the independent reviewer gate per task and parent-owned selective commits are mandatory and non-negotiable.
+You operate in two modes:
+- **Autonomous mode** (no task numbers): Dispatch a fresh sub-agent per task, with independent review after each
+- **Manual mode** (task numbers provided): Execute selected tasks directly in the main context
 
 - **Success Criteria**:
   - All tests written before implementation code
@@ -59,17 +57,8 @@ After all parallel research completes, synthesize implementation brief before st
 
 **Parse arguments**:
 - Extract feature name from `$1`
-- If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **direct mode** on the selected tasks only
-- If no task numbers: all pending tasks; choose the execution engine with the decision flow below
-
-**Execution engine decision flow** (no task numbers):
-1. Are there 3+ unblocked `(P)` tasks touching disjoint boundaries that genuinely benefit from parallel implementation, AND does the host support isolated parallel write-agents (e.g., git worktree isolation)? → **dispatch mode** for that group, direct mode for the serial remainder
-2. Is main-context budget at risk (very large feature, heavy exploration expected per task)? → **dispatch mode**
-3. Otherwise → **direct mode** (default). Serial sub-agent dispatch adds orchestration latency (per-dispatch context rebuild, per-edit hook runs, handoff parsing and re-dispatch on protocol violations) without a quality gain when the controller model is high-capability — the quality lever is the independent reviewer gate, not the implementer dispatch.
-
-**Dispatch-mode handoff rule**: when the host supports schema-enforced structured outputs (e.g., workflow `agent({schema})` or structured-output sub-agents), use them for implementer status and reviewer verdicts instead of prose-block parsing. Prompt-based `## Status Report` / `## Review Verdict` blocks are the fallback only.
-
-**Read-only fan-out**: regardless of engine, review and validation steps may fan out as parallel read-only sub-agents (or a workflow). Repo-serialized build/lint constraints apply to write work, not to read-only review.
+- If task numbers provided in `$2` (e.g., "1.1" or "1,2,3"): **manual mode**
+- If no task numbers: **autonomous mode** (all pending tasks)
 
 **Build task queue**:
 - Read tasks.md, identify actionable sub-tasks (X.Y numbering like 1.1, 2.3)
@@ -81,7 +70,7 @@ After all parallel research completes, synthesize implementation brief before st
 
 ## Step 3: Execute Implementation
 
-### Dispatch Mode (sub-agent per task)
+### Autonomous Mode (sub-agent dispatch)
 
 **Iteration discipline**: Process exactly ONE sub-task (e.g., 1.1) per iteration. Do NOT batch multiple sub-tasks into a single sub-agent dispatch. Each iteration follows the full cycle: dispatch implementer → review → commit → re-read tasks.md → next.
 
@@ -160,11 +149,11 @@ The debug subagent runs in a **fresh context** — it receives only the error in
 - **Max 2 debug rounds per task**. Each round: fresh debug subagent → fresh implementer. If still failing after 2 rounds, the task is blocked.
 - Record debug findings in `## Implementation Notes` (this helps subsequent tasks avoid the same issue)
 
-**`(P)` markers**: Tasks marked `(P)` in tasks.md have no inter-dependencies. In direct mode they are still processed sequentially. In dispatch mode they may run in parallel ONLY with per-agent isolation (e.g., git worktrees) and awareness of repo-serialized build/lint constraints (hooks or CI scripts that forbid concurrent runs); without isolation, process them sequentially to avoid git and build-lock conflicts.
+**`(P)` markers**: Tasks marked `(P)` in tasks.md indicate they have no inter-dependencies and could theoretically run in parallel. However, kiro-impl processes them sequentially (one at a time) to avoid git conflicts and simplify review. The `(P)` marker is informational for task planning, not an execution directive.
 
-**Fallback**: If multi-agent is not available, fall back to direct mode execution for all tasks (reviewer runs inline using the `kiro-review` protocol).
+**Fallback**: If multi-agent is not available, fall back to manual mode execution for all tasks.
 
-### Direct Mode (main context)
+### Manual Mode (main context)
 
 For each selected task:
 
@@ -180,15 +169,12 @@ Before writing any code, read the relevant sections of requirements.md and desig
 - **GREEN**: Implement simplest solution to make test pass, following the design constraints.
 - **REFACTOR**: Improve code structure, remove duplication. All tests must still pass.
 - **VERIFY**: All tests pass (new and existing), no regressions. Confirm verification method passes.
-- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh sub-agents, ALWAYS use a fresh reviewer sub-agent (the independence of the reviewer is the primary quality lever of this skill — the author must not be the sole judge of their own work); fall back to an inline `kiro-review` only when sub-agents are unavailable. Pre-screening by the controller (doc links, fmt, known failure classes) before dispatching the reviewer is encouraged. Do NOT continue until the verdict is parseably `APPROVED`.
+- **REVIEW**: Apply `kiro-review` before marking the task complete. If the host supports fresh sub-agents in manual mode, use a fresh reviewer; otherwise perform the review in the main context using the `kiro-review` protocol. Do NOT continue until the verdict is parseably `APPROVED`.
 - **MARK COMPLETE**: Only after review returns `APPROVED`, apply `kiro-verify-completion`, then update the checkbox from `- [ ]` to `- [x]` in tasks.md.
-- **COMMIT** (selective staging): Stage only the files changed for this task plus tasks.md with explicit paths (`git add <file1> <file2> ...`). NEVER `git add -A` or `git add .`. Commit message format: `feat(<feature-name>): <task description>` (or `test(...)`/`docs(...)` as appropriate).
-
-**Hook reconciliation note**: if the host runs long validation hooks on every file edit and the user has authorized temporarily disabling them, the controller may do so for an editing burst, but MUST then run the equivalent checks manually (fmt, lint, targeted tests) before committing, and restore the hooks immediately after. Never leave hooks disabled past the editing burst, and never commit the hook-config change.
 
 ## Step 4: Final Validation
 
-**Full-feature run (all pending tasks, either engine)**:
+**Autonomous mode**:
 - After all tasks complete, run `$kiro-validate-impl $1` as a GO/NO-GO gate
 - If validation returns GO → before reporting feature success, apply `kiro-verify-completion` to the feature-level claim using the validation result and fresh supporting evidence
 - If validation returns NO-GO:
@@ -196,7 +182,7 @@ Before writing any code, read the relevant sections of requirements.md and desig
   - Cap remediation at 3 rounds; if still NO-GO, stop and report remaining findings
 - If validation returns MANUAL_VERIFY_REQUIRED → stop and report the missing verification step
 
-**Partial run (explicit task numbers)**:
+**Manual mode**:
 - Suggest running `$kiro-validate-impl $1` but do not auto-execute
 
 ## Feature Flag Protocol
@@ -222,9 +208,9 @@ For tasks that add or change behavior, enforce RED → GREEN with a feature flag
 
 ## Output Description
 
-**Dispatch mode**: For each task, report: task ID, implementer status, reviewer verdict, files changed, commit hash. After all tasks: final validation result.
+**Autonomous mode**: For each task, report: task ID, implementer status, reviewer verdict, files changed, commit hash. After all tasks: final validation result.
 
-**Direct mode**: For each task, report: task ID, test results, reviewer verdict, files changed, commit hash. After all tasks: final validation result (full-feature run) or remaining-task status (partial run).
+**Manual mode**: Tasks executed with test results. Status of completed/remaining tasks.
 
 **Format**: Concise, in the language specified in spec.json.
 

--- a/.agents/skills/kiro-impl/templates/implementer-prompt.md
+++ b/.agents/skills/kiro-impl/templates/implementer-prompt.md
@@ -68,12 +68,6 @@ If any of these cannot be determined from the spec — the requirements are too 
 - Do NOT stop at a mock, stub, placeholder, fake, or TODO-only implementation unless the task explicitly requires it
 - Prefer the minimal implementation that satisfies the Task Brief and tests
 
-## Turn Discipline (MANDATORY)
-
-- Your final message MUST end with the `## Status Report` block. Ending your turn with a narration of intent (e.g., "次に実装します", "I will now add the method") is a protocol violation — perform the action instead of announcing it, and keep working until the report can be emitted.
-- PostToolUse hooks in this repository run long validation (several minutes of fmt/lint/clippy) after each file edit and inject their results as feedback. This is normal and expected. Treat hook output as input: read it, fix any reported errors, and CONTINUE working in the same turn. Hook feedback is never a reason to stop.
-- If you genuinely cannot finish (missing context, hard blocker), still end with the `## Status Report` block using `NEEDS_CONTEXT` or `BLOCKED` — never end without the block.
-
 ## Status Report
 
 End your response with this structured status block:


### PR DESCRIPTION
## 概要

`.agents/skills/kiro-impl` に入っていた Claude Fable 5 / Claude Code 文脈の最適化を戻し、`ai-tools/main` の標準内容に合わせます。

## 背景

`kiro-impl` の実行モード説明と implementer prompt に、host-specific な運用指示が混入していました。fraktor-rs 側では `ai-tools/main` の `.agents/skills` を想定元として扱うため、ローカル drift を解消します。

## 変更内容

- `.agents/skills/kiro-impl/SKILL.md` を `ai-tools/main` の内容へ復元
- `.agents/skills/kiro-impl/templates/implementer-prompt.md` から Fable 5 向けの Turn Discipline 指示を除去

## 確認

- `git diff --check`
- 対象 2 ファイルが `ai-tools/main` の同一ファイルと一致することを `diff -q` で確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only skill template changes with no runtime or application code impact.
> 
> **Overview**
> Reverts **local drift** in `.agents/skills/kiro-impl` so it matches `ai-tools/main`, removing Claude Fable 5 / Claude Code–specific execution guidance.
> 
> **`SKILL.md`** replaces the dual **direct vs dispatch** engine (parallel `(P)` groups, worktrees, main-context budget heuristics, structured-output handoffs, hook-reconciliation notes) with the simpler **autonomous** (sub-agent per task) vs **manual** (selected tasks in main context) model. `(P)` tasks are documented as **sequential only**; fallback when multi-agent is unavailable is **manual mode**, not inline direct implementation.
> 
> **`templates/implementer-prompt.md`** drops the **Turn Discipline** block (mandatory `## Status Report` ending, PostToolUse hook / long validation behavior after edits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd17e8a3327cf1fa40564e14a6dcf31f30945fc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション

* スキル実行プロトコルを「Autonomous/Manual モード」体系へ整理しました
* タスク実行の解釈および検証手順を明確化しました
* マルチエージェント非対応時は manual mode へフォールバックするよう統一しました
* 実行結果出力フォーマットを新体系に対応させました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->