### PR TITLE
cluster gap analysis Phase 1 を実装

### DIFF
--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -58,27 +58,27 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象公開契約グループ | 151 |
-| fraktor-rs 固定スコープ対応公開契約グループ（実装済み） | 97 |
-| 固定スコープカバレッジ | 97/151 (64%) |
-| 部分実装 | 15 |
-| 未対応 | 39（ギャップ表上は32行。カテゴリ9の13行が20未対応公開契約グループを集約） |
+| fraktor-rs 固定スコープ対応公開契約グループ（実装済み） | 102 |
+| 固定スコープカバレッジ | 102/151 (68%) |
+| 部分実装 | 11 |
+| 未対応 | 38（ギャップ表上は31行。カテゴリ9の13行が20未対応公開契約グループを集約） |
 | raw public type declarations | 297 (core-kernel: 265, core-typed: 9, std: 23) |
 | raw public method declarations | 843 (core-kernel: 730, core-typed: 32, std: 81) |
-| hard / medium / easy / trivial gap | 11 / 32 / 10 / 1 |
+| hard / medium / easy / trivial gap | 11 / 30 / 8 / 0 |
 | panic 系スタブ | 0 件 |
 | 機能 placeholder / TODO | 0 件 |
 
 注: `raw public` は `pub(crate)` など内部到達可能な `pub` を含む参考値であり、crate 外から到達可能な外部公開 API 数ではない。
-注: `実装済み` / `部分実装` / `未対応` / 難易度内訳は、この台帳で定義した公開契約グループ単位で数える。ギャップ表は47行（部分実装15行、未対応32行）だが、カテゴリ9の protocol / CRDT 行は複数の公開契約グループを1行に集約している。raw 型名やメソッド名の個数を個別加算するものではない。
+注: `実装済み` / `部分実装` / `未対応` / 難易度内訳は、この台帳で定義した公開契約グループ単位で数える。ギャップ表は42行（部分実装11行、未対応31行）だが、カテゴリ9の protocol / CRDT 行は複数の公開契約グループを1行に集約している。raw 型名やメソッド名の個数を個別加算するものではない。
 
 ### 前回 (2026-06-05) からの判定変更
 
 | 項目 | 旧判定 | 新判定 | 根拠 |
 |------|--------|--------|------|
 | std `ClusterApi` wrapper parity | 部分実装（get/request/down のみ） | 実装済み | `ClusterApi`（core-kernel）に `join` / `leave` / `subscribe` / `subscribe_no_replay` / `unsubscribe` / `current_state` / `self_authority` / `remote_path_of` / `down` / `get` / `request` / `request_future` がフルセットで存在。std は core API を直接使う設計で独自 wrapper は不要 |
-| membership-driven routee add/remove | 実装済み (core policy) | 部分実装 | core policy（`ClusterRouterPool::update_from_members`）は完了だが、ClusterEvent 購読 → routee 更新の std 配線が未実装で end-to-end では動かない |
+| membership-driven routee add/remove | 実装済み (core policy) | 実装済み | core policy（`ClusterRouterPool::update_from_members`）に加え、std `ClusterRouterPoolRouteeSubscriber` が ClusterEvent 購読 → routee 更新を接続 |
 | `SubscriptionInitialStateMode` | 分母外 | 実装済み | `ClusterSubscriptionInitialStateMode` が extension モジュールに存在 |
-| pub-sub query | mediator protocol に包含 | 概念分離して実装済み/部分実装 | `MediatorQuery::CurrentTopics` / `SubscriberCount` は実装済み。mediator 全体の `Count`（トピック横断 subscriber 総数）のみ未対応 |
+| pub-sub query | mediator protocol に包含 | 実装済み | `MediatorQuery::CurrentTopics` / `SubscriberCount` / `Count` を実装済み。`Count` は active owner の delivery view からトピック横断 subscriber 登録総数を返す |
 | `MembershipCoordinatorDriver` | 実装済み概念として列挙 | 公開型ではない | `pub(super)`。`TokioGossiper` の内部実装であり外部 API には露出しない |
 
 備考: `ClusterPubSub` trait は `pub_sub::cluster_pub_sub::ClusterPubSub` のネストパスでのみ公開されており、トップレベル `pub_sub` への re-export はない（実装済み判定は維持、公開面の整理は別件）。`NodeStatus` の Pekko `Down` 相当は `Dead` バリアント（別名実装済み）。
@@ -89,8 +89,8 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 |----|----------------|-----------------|------|
 | core / membership | `Cluster`, `Member`, `MemberStatus`, `CurrentClusterState`, `ClusterEvent`, `Gossip`, `Reachability` | `ClusterExtension`, `ClusterApi`, `NodeRecord`, `NodeStatus`, `CurrentClusterState`, `MembershipCoordinator`, `GossipDisseminationCoordinator`, `ReachabilityMatrix`, `GossipStateModel`, `HeartbeatProtocolState`, `CrossDcHeartbeat` | UniqueAddress、data center、WeaklyUp、reachability matrix、gossip envelope、full gossip merge / tombstone / seen digest、dedicated heartbeat evidence、SeedNodeProcess の core contract はある。Member ordering 公開契約、shutdown 系イベント型、CoordinatedShutdown 連携が不足 |
 | core / downing | `DowningProvider`, `NoDowning`, `SplitBrainResolverProvider` | `DowningProvider`, `DowningDecisionContext`, `DowningStrategyDecision`, `DowningDecisionTrace`, `NoopDowningProvider`, `SplitBrainResolver`, `LeaseMajorityPort`, `SplitBrainResolverProviderHook` | decision model / settings / provider binding は完了。SBR runtime actor（reachability 変化監視 → 責任ノード選択 → 自動 down 発行ループ）と concrete lease backend が未実装 |
-| core / typed | typed `Cluster`, command, subscription, singleton, sharding typed API | `Cluster` / `ClusterCommand` / `ClusterStateSubscription` / `ClusterEventSubscription` / `SelfUp` / `SelfRemoved` / `ClusterSetup` | typed Cluster facade（subscribe / unsubscribe / current_state 含む）はほぼ完備。`PrepareForFullClusterShutdown` command と singleton / sharding typed API が未実装 |
-| core / virtual actor | `ClusterSharding`, `EntityRef`, `EntityTypeKey`, `ShardRegion`, coordinator | `GrainRef`, `GrainKey`, `GrainTypeKey`, typed `GrainRef`, `ShardingEnvelope`, `ShardingMessageExtractor`, `ShardingRouter`, `VirtualActorRegistry`, `PlacementCoordinatorCore`, `PartitionIdentityLookup`, `RendezvousHasher`, `PidCache` | protoactor-go style の同等機能は強いが、Pekko public API 形態（typed Entity / `ClusterSharding.init` / `EntityRef` / `askWithStatus`）、Pekko `HashCodeMessageExtractor` と同じ shard 配置互換、rebalance / remembered entities / query protocol / health check が不足 |
+| core / typed | typed `Cluster`, command, subscription, singleton, sharding typed API | `Cluster` / `ClusterCommand` / `ClusterStateSubscription` / `ClusterEventSubscription` / `SelfUp` / `SelfRemoved` / `ClusterSetup` | typed Cluster facade（subscribe / unsubscribe / current_state / `PrepareForFullClusterShutdown` command 含む）は完備。singleton / sharding typed API が未実装 |
+| core / virtual actor | `ClusterSharding`, `EntityRef`, `EntityTypeKey`, `ShardRegion`, coordinator | `GrainRef`, `GrainKey`, `GrainTypeKey`, typed `GrainRef`, `ShardingEnvelope`, `ShardingMessageExtractor`, `ShardingRouter`, `VirtualActorRegistry`, `PlacementCoordinatorCore`, `PartitionIdentityLookup`, `RendezvousHasher`, `PidCache` | protoactor-go style の同等機能は強いが、Pekko public API 形態（typed Entity / `ClusterSharding.init` / `EntityRef` / `askWithStatus`）、rebalance / remembered entities / query protocol / health check が不足 |
 | core / distributed state | `DistributedData`, `Replicator`, CRDT 型群 | `ReplicatedData`, `DeltaReplicatedData`, `RemovedNodePruning`, `Key`, `SelfUniqueAddress`, `Flag`, `GCounter`, `PNCounter`, `PNCounterMap`（increment / decrement / get のみ）, read/write consistency 語彙 | CRDT 基底 SPI と scalar counter 型は実装済み。`PNCounterMap` は key removal / entries surface が不足。DistributedData / Replicator runtime、protocol、durable store、map/set/register 系 CRDT が不足 |
 | std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `TokioGossiper`, `LocalClusterProvider`, `StaticClusterProvider`, `AwsEcsClusterProvider`, `GenericDiscoveryAdapter`, `ProviderLifecycleBridge`, `ClusterWireCodec`, `ConfiguredPhiAccrualDetectorFactory` | Rust adapter、logical envelope handoff、seed/discovery provider boundary、cluster message serializer contract、failure detector factory はある。sharding/singleton 系 setup と sharding join compat key が不足 |
 
@@ -98,16 +98,15 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 
 各カテゴリのヘッダーに **実装済み数 / 対象公開契約グループ数 (カバレッジ%)** を明記する。ギャップ（未対応・部分実装）のみテーブルに列挙し、実装済みは件数カウントに含めてテーブル行には追加しない。件数はこの台帳の公開契約グループ単位で数え、raw 型名やメソッド名の個数を個別加算しない。
 
-### 1. Cluster membership / lifecycle　✅ 実装済み 18/22 (82%)
+### 1. Cluster membership / lifecycle　✅ 実装済み 19/22 (86%)
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
-| `prepareForFullClusterShutdown` | `Cluster.scala:336` | 部分実装 | core + std | medium | `NodeStatus::PreparingForShutdown` / `ReadyForShutdown` と状態遷移・進行イベントは実装済みだが、`ClusterApi` / `ClusterCommand` から起動する full shutdown command path がない |
 | `CoordinatedShutdownLeave` | `CoordinatedShutdownLeave.scala:30` | 未対応 | core/extension + std | medium | coordinated shutdown phase から cluster leave を駆動する hook がない（actor-core 側に CoordinatedShutdown はある） |
 | `ClusterScope` deploy scope | `ClusterActorRefProvider.scala:148` | 未対応 | core/extension | medium | cluster-aware deployment scope 概念がない。router config はあるが deploy scope としての統合はない |
 | `ClusterSettings.CrossDcFailureDetectorSettings` / `MultiDataCenter` | `ClusterSettings.scala:65`, `ClusterSettings.scala:76` | 未対応 | core/config | easy | `CrossDcHeartbeat` evidence と `FailureDetectorConfig` はあるが、Multi-DC 専用の failure detector 設定 namespace がない |
 
-実装済みとして扱うもの: cluster extension、join/leave/down（`ClusterApi` フルセット）、event stream subscription、current state snapshot、member/up/removed callback、roles/app_version 設定、leader/role leader 算出、startup/shutdown event、`UniqueAddress` semantics（`NodeRecord::unique_address` / `try_join_with_identity`）、data center membership、`WeaklyUp`、`remotePathOf`、`MemberStatus` 全 variant（`Down` ≈ `Dead` 別名実装済み）、`PreparingForShutdown` / `ReadyForShutdown` status、`ClusterSettings` 契約（`ClusterExtensionConfig` + `FailureDetectorConfig` + `ConfigValidation`）、`JoinConfigCompatChecker` + `ConfigValidation`、Member ordering 公開契約（`member_age_order` / `age_ordered` / `oldest_member`、2026-06-11 cluster-membership-event-surface）、`ClusterLogMarker` 相当の構造化 tracing field 契約（`cluster_lifecycle_trace_field` + std `ClusterLifecycleLogSubscriber`、同上）。
+実装済みとして扱うもの: cluster extension、join/leave/down（`ClusterApi` フルセット）、event stream subscription、current state snapshot、member/up/removed callback、roles/app_version 設定、leader/role leader 算出、startup/shutdown event、`prepare_for_full_cluster_shutdown` command path（`MemberStatusChanged` → `MemberPreparingForShutdown` 発火）、`UniqueAddress` semantics（`NodeRecord::unique_address` / `try_join_with_identity`）、data center membership、`WeaklyUp`、`remotePathOf`、`MemberStatus` 全 variant（`Down` ≈ `Dead` 別名実装済み）、`PreparingForShutdown` / `ReadyForShutdown` status、`ClusterSettings` 契約（`ClusterExtensionConfig` + `FailureDetectorConfig` + `ConfigValidation`）、`JoinConfigCompatChecker` + `ConfigValidation`、Member ordering 公開契約（`member_age_order` / `age_ordered` / `oldest_member`、2026-06-11 cluster-membership-event-surface）、`ClusterLogMarker` 相当の構造化 tracing field 契約（`cluster_lifecycle_trace_field` + std `ClusterLifecycleLogSubscriber`、同上）。
 
 ### 2. Gossip / reachability / failure detection　✅ 実装済み 18/18 (100%)
 
@@ -124,21 +123,17 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 
 実装済みとして扱うもの: `DowningProvider` SPI、`NoDowning`（`NoopDowningProvider`）、SBR settings 契約（`SplitBrainResolverConfig` / `SplitBrainResolverStrategy`: KeepMajority / StaticQuorum / KeepOldest / DownAll / LeaseMajority の 5 戦略）。`DowningDecisionContext` / `DowningStrategyDecision` / `DowningDecisionTrace` / `FailureObservation` / `IndirectConnectionEvidence` / `SplitBrainResolverProviderHook` / `StdSplitBrainResolverProvider` / downing provider・SBR settings の join compatibility は上記概念の evidence。
 
-### 4. Cluster router pool / group　✅ 実装済み 5/6 (83%)
+### 4. Cluster router pool / group　✅ 実装済み 6/6 (100%)
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| membership-driven routee add/remove | `ClusterRouterConfig.scala:586` | 部分実装 | std | easy | core policy（`ClusterRouterPool::update_from_members` / group `local_routee_paths`）は実装済み。ClusterEvent 購読 → routee 更新の std 配線が未実装（判定変更: 旧「実装済み」） |
+このカテゴリの未対応ギャップは解消済み。
 
-実装済みとして扱うもの: `ClusterRouterPool`、`ClusterRouterGroup`、pool/group settings の分離、`use_roles` / `satisfies_roles`、`max_instances_per_node`、`ClusterRouterPool::from_candidates` の least-loaded 配置。
+実装済みとして扱うもの: `ClusterRouterPool`、`ClusterRouterGroup`、pool/group settings の分離、`use_roles` / `satisfies_roles`、`max_instances_per_node`、`ClusterRouterPool::from_candidates` の least-loaded 配置、std `ClusterRouterPoolRouteeSubscriber` による `ClusterEvent` 購読 → routee 更新。
 
-### 5. Cluster Typed API　✅ 実装済み 13/14 (93%)
+### 5. Cluster Typed API　✅ 実装済み 14/14 (100%)
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| `PrepareForFullClusterShutdown` command | `cluster-typed/Cluster.scala:175` | 未対応 | core/typed + std | medium | typed `ClusterCommand` に variant がなく、kernel 側 command path（カテゴリ1）も未実装。coordinated shutdown 接続が必要 |
+このカテゴリの未対応ギャップは解消済み。
 
-実装済みとして扱うもの: typed `Cluster` facade、`ClusterStateSubscription` 契約、Subscribe（`Cluster::subscribe` / `subscribe_self_up` / `subscribe_self_removed`）、Unsubscribe（`Cluster::unsubscribe`）、GetCurrentState（`Cluster::current_state`）、`ClusterCommand` sealed 契約と Join / JoinSeedNodes / Leave / Down、`SelfUp`、`SelfRemoved`、typed Cluster extension（`Cluster::get`）、`ClusterSetup`。
+実装済みとして扱うもの: typed `Cluster` facade、`ClusterStateSubscription` 契約、Subscribe（`Cluster::subscribe` / `subscribe_self_up` / `subscribe_self_removed`）、Unsubscribe（`Cluster::unsubscribe`）、GetCurrentState（`Cluster::current_state`）、`ClusterCommand` sealed 契約と Join / JoinSeedNodes / Leave / Down / PrepareForFullClusterShutdown、`SelfUp`、`SelfRemoved`、typed Cluster extension（`Cluster::get`）、`ClusterSetup`。
 
 ### 6. Cluster singleton　✅ 実装済み 3/10 (30%)
 
@@ -156,15 +151,13 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 
 n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSettings` / `ClusterReceptionistSettings`（Pekko 本体で全面 `@deprecated`、gRPC 移行推奨）。typed `ClusterReceptionist` は `@InternalApi`（receptionist の公開契約は actor-typed 側スコープ）。
 
-### 7. Distributed PubSub　✅ 実装済み 10/11 (91%)
+### 7. Distributed PubSub　✅ 実装済み 11/11 (100%)
 
-| Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
-|------------------|------------|-----------------|----------|--------|------|
-| mediator 全体 `Count` query | `DistributedPubSubMediator.scala:253` | 部分実装 | core/pub_sub | trivial | `MediatorQuery::SubscriberCount`（topic 単位）はあるが、トピック横断の subscriber 総数 query がない |
+このカテゴリの未対応ギャップは解消済み。
 
-実装済みとして扱うもの: `DistributedPubSubMediator` protocol（`MediatorCommand` / `MediatorAcknowledgement` / `DistributedPubSubMediatorState`）、`DistributedPubSubConfig`、topic registry gossip / delta collection（`TopicRegistryStatus` / `TopicRegistryDelta` / `TopicRegistryDeltaCollector` / `PubSubGossipHandoff`）、`Send` / `SendToAll` path semantics（`MediatorPathKey` / `PubSubPathSemantics`）、`DistributedPubSub` extension 相当（`ClusterPubSub` trait / `ClusterPubSubImpl` / `ClusterPubSubShared`）、Subscribe / Unsubscribe / Publish メッセージ、`GetTopics` / `CurrentTopics`（`MediatorQuery::CurrentTopics`）、`CountSubscribers`（`MediatorQuery::SubscriberCount`）、`DistributedPubSubMessage` marker 相当（`ClusterMessagePayloadKind` / `PubSubEnvelope`）、broker / delivery（`PubSubBroker` + std `PubSubDeliveryActor` / `PubSubDeliveryIntentExecutor`）。
+実装済みとして扱うもの: `DistributedPubSubMediator` protocol（`MediatorCommand` / `MediatorAcknowledgement` / `DistributedPubSubMediatorState`）、`DistributedPubSubConfig`、topic registry gossip / delta collection（`TopicRegistryStatus` / `TopicRegistryDelta` / `TopicRegistryDeltaCollector` / `PubSubGossipHandoff`）、`Send` / `SendToAll` path semantics（`MediatorPathKey` / `PubSubPathSemantics`）、`DistributedPubSub` extension 相当（`ClusterPubSub` trait / `ClusterPubSubImpl` / `ClusterPubSubShared`）、Subscribe / Unsubscribe / Publish メッセージ、`GetTopics` / `CurrentTopics`（`MediatorQuery::CurrentTopics`）、`CountSubscribers`（`MediatorQuery::SubscriberCount`）、mediator 全体 `Count`（`MediatorQuery::Count`）、`DistributedPubSubMessage` marker 相当（`ClusterMessagePayloadKind` / `PubSubEnvelope`）、broker / delivery（`PubSubBroker` + std `PubSubDeliveryActor` / `PubSubDeliveryIntentExecutor`）。
 
-### 8. Sharding / Grain / Placement / Identity　✅ 実装済み 12/27 (44%)
+### 8. Sharding / Grain / Placement / Identity　✅ 実装済み 13/27 (48%)
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
@@ -172,7 +165,6 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 | typed `ClusterSharding` extension | `typed/scaladsl/ClusterSharding.scala:40` | 部分実装 | core/typed | medium | grain API はあるが typed extension 形態の `init(Entity)` API ではない |
 | `Entity[M, E]` / `EntityContext` | `typed/scaladsl/ClusterSharding.scala:238`, `typed/scaladsl/ClusterSharding.scala:363` | 部分実装 | core/typed + grain | medium | `ActivatedKind` / `GrainContext` は対応するが typed behavior factory ではない |
 | `EntityTypeKey[M]` / typed `EntityRef[M]`（ask / askWithStatus 含む） | `typed/scaladsl/ClusterSharding.scala:407`, `typed/scaladsl/ClusterSharding.scala:429` | 部分実装 | core/typed + grain | easy | `GrainTypeKey<M>` / typed `GrainRef<M>` と typed request / future はあるが、Pekko 形態の `EntityRef` API と `askWithStatus` 統合はない |
-| `HashCodeMessageExtractor` / `HashCodeNoEnvelopeMessageExtractor` の Pekko shard 配置互換 | `ShardRegion.scala:163`, `typed/ShardingMessageExtractor.scala:84` | 部分実装 | core/grain | easy | extractor 型と決定的 shard id はあるが、fraktor-rs は FNV-1a で計算するため JVM `String.hashCode` を使う Pekko `HashCodeMessageExtractor` と既存配置互換にならない。Kafka 互換 `Murmur2MessageExtractor` は実装済み |
 | shard allocation / rebalance strategy | `ShardCoordinator.scala:110`, `ShardCoordinator.scala:295` | 部分実装 | core/placement | hard | rendezvous hashing による placement はあるが、`ShardAllocationStrategy` SPI、`LeastShardAllocationStrategy` 相当の rebalance、coordinator handoff protocol がない |
 | `ClusterShardingSettings`（classic + typed） | `ClusterShardingSettings.scala:32`, `typed/ClusterShardingSettings.scala:33` | 部分実装 | core/config | medium | `GrainCallOptions` / `PartitionIdentityLookupConfig` 等の個別設定はあるが、包括的な sharding settings 契約がない |
 | sharding query protocol（`GetShardRegionState` / `GetShardRegionStats` / `GetClusterShardingStats` / `GetCurrentRegions` + 応答型、classic + typed） | `ShardRegion.scala:237-386`, `ClusterShardingQuery.scala:39` | 未対応 | core/grain + core/typed | medium | shard / region / entity 数の observability query がない（`GrainMetrics` は別系統の metrics） |
@@ -184,7 +176,7 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 | replicated sharding（`ReplicatedShardingExtension` / `ReplicatedSharding` / `ReplicatedEntityProvider` / `ReplicatedEntity`） | `ReplicatedShardingExtension.scala:31`, `ReplicatedEntityProvider.scala:32` | 未対応 | core/typed + placement | hard | data center / replica id model がない |
 | sharding delivery controllers（`ShardingProducerController` / `ShardingConsumerController`） | `ShardingProducerController.scala:104`, `ShardingConsumerController.scala:50` | 未対応 | core/typed + actor-core/delivery | hard | reliable delivery と sharding の接続がない |
 
-実装済みとして扱うもの: `GrainRef`、`GrainKey`、typed `GrainTypeKey<M>`、typed `GrainRef<M>`、`GrainCodec`、`ShardingEnvelope`、`ShardingMessageExtractor` SPI、Kafka 互換 `Murmur2MessageExtractor`、`ShardingRouter`、`VirtualActorRegistry`、`PlacementCoordinatorCore`、`PartitionIdentityLookup`、`RendezvousHasher`、`PidCache`、remote/local placement decision、passivation（基本機構）、RPC router（`GrainRpcRouter`）。FNV-1a 固定の `HashCodeMessageExtractor` / `HashCodeNoEnvelopeMessageExtractor` は fraktor-rs 内で決定的だが、Pekko の hash-code extractor 互換ではないため部分実装として追跡する。
+実装済みとして扱うもの: `GrainRef`、`GrainKey`、typed `GrainTypeKey<M>`、typed `GrainRef<M>`、`GrainCodec`、`ShardingEnvelope`、`ShardingMessageExtractor` SPI、Pekko 互換 `HashCodeMessageExtractor` / `HashCodeNoEnvelopeMessageExtractor`、Kafka 互換 `Murmur2MessageExtractor`、`ShardingRouter`、`VirtualActorRegistry`、`PlacementCoordinatorCore`、`PartitionIdentityLookup`、`RendezvousHasher`、`PidCache`、remote/local placement decision、passivation（基本機構）、RPC router（`GrainRpcRouter`）。
 
 ### 9. Distributed Data / CRDT　✅ 実装済み 6/27 (22%)
 
@@ -241,7 +233,7 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 
 ## 内部モジュール構造ギャップ
 
-今回は API / 実動作ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 64% で、判定基準（カバレッジ 80% 以上、または hard/medium 未実装 5 件以下）を満たさない。
+今回は API / 実動作ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 68% で、判定基準（カバレッジ 80% 以上、または hard/medium 未実装 5 件以下）を満たさない。
 
 次版で構造分析へ進む場合の観点:
 
@@ -268,13 +260,14 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 ### Phase 1: 結線・実動作を閉じる小粒変更（単独 PR 可）
 
 2026-06-11: cluster-membership-event-surface スペックで `Member.ordering` 公開契約、`ClusterLogMarker`（構造化 tracing field 契約）、`MemberPreparingForShutdown` / `MemberReadyForShutdown` event variant、`DataCenterReachabilityEvent` の 4 項目が実装完了し、本リストから除去した。
+2026-06-14: Phase 1 の routee 更新 std 配線、mediator 全体 `Count`、Pekko 互換 hash-code extractor、`prepareForFullClusterShutdown` command path は実装完了。
 
 | 項目 | 実装先層 | 根拠カテゴリ | 完了条件 |
 |------|----------|--------------|----------|
-| membership-driven routee add/remove の std 配線 | std | カテゴリ4 | `ClusterEvent` 購読から routee 更新までを統合テストで確認する |
-| mediator 全体 `Count` query | core/pub_sub | カテゴリ7 | `MediatorQuery` variant、集計ロジック、テストを同じ change で閉じる |
-| `HashCodeMessageExtractor` / `HashCodeNoEnvelopeMessageExtractor` の Pekko shard 配置互換 | core/grain | カテゴリ8 | shard id 計算の互換テストまで含め、配置基盤は増やさない |
-| `prepareForFullClusterShutdown` command path（kernel + typed） | core + core/typed + std | カテゴリ1 / 5 | 既存の shutdown status / event に command path を結線し、kernel と typed command を同じ change で閉じる |
+| membership-driven routee add/remove の std 配線 | std | カテゴリ4 | 実装済み（`ClusterRouterPoolRouteeSubscriber` + event stream テスト） |
+| mediator 全体 `Count` query | core/pub_sub | カテゴリ7 | 実装済み（`MediatorQuery::Count` + 集計ロジック + テスト） |
+| `HashCodeMessageExtractor` / `HashCodeNoEnvelopeMessageExtractor` の Pekko shard 配置互換 | core/grain | カテゴリ8 | 実装済み（JVM `String.hashCode` 互換ベクタテスト） |
+| `prepareForFullClusterShutdown` command path（kernel + typed） | core + core/typed + std | カテゴリ1 / 5 | 実装済み（kernel API + typed command + event 発火テスト） |
 
 注: Phase 1 は「単独で見ても未結線を増やさない」ことを条件にする。設定だけ、wrapper だけ、setup だけの変更はここに置かない。
 
@@ -333,9 +326,9 @@ ClusterClient 系（deprecated）、`@InternalApi` 型、JMX / HOCON / JFR / Jav
 
 ## まとめ
 
-cluster は membership / gossip / heartbeat / reachability / downing decision model / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 4, 5, 7, 10 は 82〜100% のカバレッジに達している。全体カバレッジは 97/151 (64%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（22%）、Pekko sharding public API 形態（44%）の 3 領域に集中している。
+cluster は membership / gossip / heartbeat / reachability / downing decision model / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 4, 5, 7, 10 は 86〜100% のカバレッジに達している。全体カバレッジは 102/151 (68%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（22%）、Pekko sharding public API 形態（48%）の 3 領域に集中している。
 
-最初に単独 PR として進める価値が高いのは、routee 更新の std 配線、mediator 全体 `Count`、Pekko 互換 hash-code extractor、`prepareForFullClusterShutdown` command path のように、既存の runtime / state に結線して挙動を閉じられる項目である。`CrossDcFailureDetectorSettings`、typed singleton settings wrapper、setup integration、`JoinConfigCompatCheckSharding` のような config / wrapper / setup / compatibility key は、対象本体を触る change に同梱する。
+Phase 1 は完了済み。次に進めるなら、`CrossDcFailureDetectorSettings`、typed singleton settings wrapper、setup integration、`JoinConfigCompatCheckSharding` のような config / wrapper / setup / compatibility key は単独で切らず、対象本体を触る change に同梱する。
 
 parity 上の主要ギャップは Phase 3 に集約される: SBR runtime down execution loop（decision model は完成済みで、実行ループだけが欠けている）、Cluster Singleton（manager / proxy / typed extension）、sharding の rebalance / remembered entities / delivery controllers、そして Distributed Data の Replicator 基盤である。特に SBR runtime loop は、既存の `SplitBrainResolver` / `ReachabilityMatrix` / `MembershipCoordinator` が揃っているため、Phase 3 の中では最も着手可能性が高い。
 

--- a/modules/cluster-adaptor-std/src/membership.rs
+++ b/modules/cluster-adaptor-std/src/membership.rs
@@ -1,6 +1,7 @@
 //! Tokio-backed membership and gossip adaptors.
 
 mod cluster_lifecycle_log_subscriber;
+mod cluster_router_pool_routee_subscriber;
 mod configured_phi_accrual_detector_factory;
 mod gossip_wire_delta_v1;
 mod gossip_wire_node_record;
@@ -11,6 +12,7 @@ mod tokio_gossiper;
 mod tokio_gossiper_config;
 
 pub use cluster_lifecycle_log_subscriber::ClusterLifecycleLogSubscriber;
+pub use cluster_router_pool_routee_subscriber::ClusterRouterPoolRouteeSubscriber;
 pub use configured_phi_accrual_detector_factory::ConfiguredPhiAccrualDetectorFactory;
 pub use tokio_gossip_transport::TokioGossipTransport;
 pub use tokio_gossip_transport_config::TokioGossipTransportConfig;

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
@@ -23,7 +23,14 @@ pub struct ClusterRouterPoolRouteeSubscriber {
   router:           SharedLock<ClusterRouterPool>,
   self_authority:   String,
   members:          Vec<NodeRecord>,
-  status_overrides: Vec<(String, NodeStatus)>,
+  status_overrides: Vec<StatusOverride>,
+}
+
+#[derive(Clone)]
+struct StatusOverride {
+  node_id:   String,
+  authority: String,
+  status:    NodeStatus,
 }
 
 impl ClusterRouterPoolRouteeSubscriber {
@@ -52,12 +59,19 @@ impl ClusterRouterPoolRouteeSubscriber {
   }
 
   fn replace_member_authorities(&mut self, authorities: &[String], version: MembershipVersion) {
+    let existing_members = self.members.clone();
     self.members = authorities
       .iter()
       .cloned()
       .map(|authority| {
-        let node_id = authority.clone();
-        NodeRecord::new(node_id, authority, NodeStatus::Up, version, String::new(), Vec::new())
+        if let Some(existing) = existing_members.iter().find(|member| member.authority == authority) {
+          let mut member = existing.clone();
+          member.version = version;
+          member
+        } else {
+          let node_id = authority.clone();
+          NodeRecord::new(node_id, authority, NodeStatus::Up, version, String::new(), Vec::new())
+        }
       })
       .collect();
     self.retain_status_overrides_for_current_members();
@@ -66,8 +80,10 @@ impl ClusterRouterPoolRouteeSubscriber {
   }
 
   fn apply_member_status(&mut self, node_id: &str, authority: &str, to: NodeStatus) {
-    self.record_status_override(authority, to);
-    if let Some(member) = self.members.iter_mut().find(|member| member.authority == authority) {
+    self.record_status_override(node_id, authority, to);
+    if let Some(member) =
+      self.members.iter_mut().find(|member| member.node_id == node_id && member.authority == authority)
+    {
       member.status = to;
     } else {
       self.members.push(NodeRecord::new(
@@ -84,29 +100,43 @@ impl ClusterRouterPoolRouteeSubscriber {
 
   fn apply_status_overrides(&mut self) {
     for member in &mut self.members {
-      if let Some((_, status)) = self.status_overrides.iter().find(|(authority, _)| authority == &member.authority) {
-        member.status = *status;
+      if let Some(override_status) = self.status_overrides.iter().find(|override_status| {
+        override_status.node_id == member.node_id && override_status.authority == member.authority
+      }) {
+        member.status = override_status.status;
       }
     }
   }
 
   fn retain_status_overrides_for_current_members(&mut self) {
     let members = &self.members;
-    self.status_overrides.retain(|(authority, _)| members.iter().any(|member| &member.authority == authority));
+    self.status_overrides.retain(|override_status| {
+      members
+        .iter()
+        .any(|member| member.node_id == override_status.node_id && member.authority == override_status.authority)
+    });
   }
 
-  fn record_status_override(&mut self, authority: &str, status: NodeStatus) {
+  fn record_status_override(&mut self, node_id: &str, authority: &str, status: NodeStatus) {
     if status == NodeStatus::Up {
-      self.status_overrides.retain(|(recorded_authority, _)| recorded_authority != authority);
+      self
+        .status_overrides
+        .retain(|override_status| override_status.node_id != node_id || override_status.authority != authority);
       return;
     }
-    if let Some((_, recorded_status)) =
-      self.status_overrides.iter_mut().find(|(recorded_authority, _)| recorded_authority == authority)
+    if let Some(override_status) = self
+      .status_overrides
+      .iter_mut()
+      .find(|override_status| override_status.node_id == node_id && override_status.authority == authority)
     {
-      *recorded_status = status;
+      override_status.status = status;
       return;
     }
-    self.status_overrides.push((String::from(authority), status));
+    self.status_overrides.push(StatusOverride {
+      node_id: String::from(node_id),
+      authority: String::from(authority),
+      status,
+    });
   }
 
   fn update_router(&self) {

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
@@ -46,6 +46,7 @@ impl ClusterRouterPoolRouteeSubscriber {
 
   fn replace_members(&mut self, members: &[NodeRecord]) {
     self.members = members.to_vec();
+    self.retain_status_overrides_for_current_members();
     self.apply_status_overrides();
     self.update_router();
   }
@@ -59,6 +60,7 @@ impl ClusterRouterPoolRouteeSubscriber {
         NodeRecord::new(node_id, authority, NodeStatus::Up, version, String::new(), Vec::new())
       })
       .collect();
+    self.retain_status_overrides_for_current_members();
     self.apply_status_overrides();
     self.update_router();
   }
@@ -86,6 +88,11 @@ impl ClusterRouterPoolRouteeSubscriber {
         member.status = *status;
       }
     }
+  }
+
+  fn retain_status_overrides_for_current_members(&mut self) {
+    let members = &self.members;
+    self.status_overrides.retain(|(authority, _)| members.iter().any(|member| &member.authority == authority));
   }
 
   fn record_status_override(&mut self, authority: &str, status: NodeStatus) {

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
@@ -60,6 +60,8 @@ impl ClusterRouterPoolRouteeSubscriber {
 
   fn replace_member_authorities(&mut self, authorities: &[String], version: MembershipVersion) {
     let existing_members = self.members.clone();
+    let default_status =
+      if is_full_shutdown_preparing(&existing_members) { NodeStatus::PreparingForShutdown } else { NodeStatus::Up };
     self.members = authorities
       .iter()
       .cloned()
@@ -70,7 +72,7 @@ impl ClusterRouterPoolRouteeSubscriber {
           member
         } else {
           let node_id = authority.clone();
-          NodeRecord::new(node_id, authority, NodeStatus::Up, version, String::new(), Vec::new())
+          NodeRecord::new(node_id, authority, default_status, version, String::new(), Vec::new())
         }
       })
       .collect();
@@ -142,6 +144,13 @@ impl ClusterRouterPoolRouteeSubscriber {
   fn update_router(&self) {
     self.router.with_lock(|router| router.update_from_members(&self.members, &self.self_authority));
   }
+}
+
+fn is_full_shutdown_preparing(members: &[NodeRecord]) -> bool {
+  !members.is_empty()
+    && members
+      .iter()
+      .all(|member| matches!(member.status, NodeStatus::PreparingForShutdown | NodeStatus::ReadyForShutdown))
 }
 
 impl EventStreamSubscriber for ClusterRouterPoolRouteeSubscriber {

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber.rs
@@ -1,0 +1,132 @@
+//! Cluster router pool routee updates driven by cluster events.
+
+#[cfg(test)]
+#[path = "cluster_router_pool_routee_subscriber_test.rs"]
+mod tests;
+
+use alloc::{string::String, vec::Vec};
+
+use fraktor_actor_core_kernel_rs::event::stream::{
+  EventStreamEvent, EventStreamSubscriber, EventStreamSubscription, subscriber_handle,
+};
+use fraktor_cluster_core_kernel_rs::{
+  extension::{ClusterApi, ClusterRouterPool, ClusterSubscriptionInitialStateMode},
+  membership::{MembershipVersion, NodeRecord, NodeStatus},
+  topology::{ClusterEvent, ClusterEventType},
+};
+use fraktor_utils_core_rs::sync::SharedLock;
+
+const CLUSTER_EXTENSION_NAME: &str = "cluster";
+
+/// Event stream subscriber that keeps a cluster router pool in sync with membership.
+pub struct ClusterRouterPoolRouteeSubscriber {
+  router:           SharedLock<ClusterRouterPool>,
+  self_authority:   String,
+  members:          Vec<NodeRecord>,
+  status_overrides: Vec<(String, NodeStatus)>,
+}
+
+impl ClusterRouterPoolRouteeSubscriber {
+  /// Creates a subscriber for the provided router and local authority.
+  #[must_use]
+  pub const fn new(router: SharedLock<ClusterRouterPool>, self_authority: String) -> Self {
+    Self { router, self_authority, members: Vec::new(), status_overrides: Vec::new() }
+  }
+
+  /// Subscribes the router pool to cluster state and member-status events.
+  #[must_use]
+  pub fn subscribe(cluster: &ClusterApi, router: SharedLock<ClusterRouterPool>) -> EventStreamSubscription {
+    let subscriber = subscriber_handle(Self::new(router, cluster.self_authority()));
+    cluster.subscribe(&subscriber, ClusterSubscriptionInitialStateMode::AsSnapshot, &[
+      ClusterEventType::CurrentClusterState,
+      ClusterEventType::TopologyUpdated,
+      ClusterEventType::MemberStatusChanged,
+    ])
+  }
+
+  fn replace_members(&mut self, members: &[NodeRecord]) {
+    self.members = members.to_vec();
+    self.apply_status_overrides();
+    self.update_router();
+  }
+
+  fn replace_member_authorities(&mut self, authorities: &[String], version: MembershipVersion) {
+    self.members = authorities
+      .iter()
+      .cloned()
+      .map(|authority| {
+        let node_id = authority.clone();
+        NodeRecord::new(node_id, authority, NodeStatus::Up, version, String::new(), Vec::new())
+      })
+      .collect();
+    self.apply_status_overrides();
+    self.update_router();
+  }
+
+  fn apply_member_status(&mut self, node_id: &str, authority: &str, to: NodeStatus) {
+    self.record_status_override(authority, to);
+    if let Some(member) = self.members.iter_mut().find(|member| member.authority == authority) {
+      member.status = to;
+    } else {
+      self.members.push(NodeRecord::new(
+        String::from(node_id),
+        String::from(authority),
+        to,
+        MembershipVersion::new(0),
+        String::new(),
+        Vec::new(),
+      ));
+    }
+    self.update_router();
+  }
+
+  fn apply_status_overrides(&mut self) {
+    for member in &mut self.members {
+      if let Some((_, status)) = self.status_overrides.iter().find(|(authority, _)| authority == &member.authority) {
+        member.status = *status;
+      }
+    }
+  }
+
+  fn record_status_override(&mut self, authority: &str, status: NodeStatus) {
+    if status == NodeStatus::Up {
+      self.status_overrides.retain(|(recorded_authority, _)| recorded_authority != authority);
+      return;
+    }
+    if let Some((_, recorded_status)) =
+      self.status_overrides.iter_mut().find(|(recorded_authority, _)| recorded_authority == authority)
+    {
+      *recorded_status = status;
+      return;
+    }
+    self.status_overrides.push((String::from(authority), status));
+  }
+
+  fn update_router(&self) {
+    self.router.with_lock(|router| router.update_from_members(&self.members, &self.self_authority));
+  }
+}
+
+impl EventStreamSubscriber for ClusterRouterPoolRouteeSubscriber {
+  fn on_event(&mut self, stream_event: &EventStreamEvent) {
+    let EventStreamEvent::Extension { name, payload } = stream_event else {
+      return;
+    };
+    if name != CLUSTER_EXTENSION_NAME {
+      return;
+    }
+    let Some(cluster_event) = payload.downcast_ref::<ClusterEvent>() else {
+      return;
+    };
+    match cluster_event {
+      | ClusterEvent::CurrentClusterState { state, .. } => self.replace_members(&state.members),
+      | ClusterEvent::TopologyUpdated { update } => {
+        self.replace_member_authorities(&update.members, MembershipVersion::new(update.topology.hash()));
+      },
+      | ClusterEvent::MemberStatusChanged { node_id, authority, to, .. } => {
+        self.apply_member_status(node_id, authority, *to);
+      },
+      | _ => {},
+    }
+  }
+}

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
@@ -1,0 +1,173 @@
+use alloc::{
+  collections::BTreeMap,
+  string::{String, ToString},
+  vec,
+  vec::Vec,
+};
+use core::time::Duration;
+
+use fraktor_actor_core_kernel_rs::{
+  actor::messaging::AnyMessage,
+  event::stream::{EventStreamEvent, EventStreamShared, subscriber_handle},
+};
+use fraktor_cluster_core_kernel_rs::{
+  extension::{ClusterRouterPool, ClusterRouterPoolConfig},
+  membership::{CurrentClusterState, MembershipVersion, NodeRecord, NodeStatus},
+  topology::{ClusterEvent, ClusterTopology, TopologyUpdate},
+};
+use fraktor_utils_core_rs::{
+  sync::{DefaultMutex, SharedLock},
+  time::TimerInstant,
+};
+
+use super::ClusterRouterPoolRouteeSubscriber;
+
+fn node(authority: &str, status: NodeStatus) -> NodeRecord {
+  NodeRecord::new(
+    authority.to_string(),
+    authority.to_string(),
+    status,
+    MembershipVersion::new(1),
+    String::new(),
+    Vec::new(),
+  )
+}
+
+fn observed_at() -> TimerInstant {
+  TimerInstant::zero(Duration::from_secs(1))
+}
+
+fn cluster_extension_event(event: ClusterEvent) -> EventStreamEvent {
+  EventStreamEvent::Extension { name: String::from("cluster"), payload: AnyMessage::new(event) }
+}
+
+fn topology_update(hash: u64, members: Vec<String>) -> TopologyUpdate {
+  TopologyUpdate::new(
+    ClusterTopology::new(hash, Vec::new(), Vec::new(), Vec::new()),
+    members,
+    Vec::new(),
+    Vec::new(),
+    Vec::new(),
+    Vec::new(),
+    TimerInstant::from_ticks(hash, Duration::from_secs(1)),
+  )
+}
+
+fn routees(router: &SharedLock<ClusterRouterPool>) -> Vec<String> {
+  router.with_lock(|router| router.routees().to_vec())
+}
+
+#[test]
+fn subscribed_pool_updates_routees_from_cluster_events() {
+  let config = ClusterRouterPoolConfig::new(10).with_max_instances_per_node(1).with_allow_local_routees(false);
+  let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));
+  let event_stream = EventStreamShared::default();
+  let subscriber = subscriber_handle(ClusterRouterPoolRouteeSubscriber::new(router.clone(), String::from("self:2551")));
+  let _subscription = event_stream.subscribe_no_replay(&subscriber);
+
+  let state = CurrentClusterState::new(
+    vec![
+      node("self:2551", NodeStatus::Up),
+      node("remote-a:2552", NodeStatus::Up),
+      node("remote-b:2553", NodeStatus::Joining),
+    ],
+    Vec::new(),
+    Vec::new(),
+    None,
+    BTreeMap::new(),
+  );
+  event_stream
+    .publish(&cluster_extension_event(ClusterEvent::CurrentClusterState { state, observed_at: observed_at() }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::MemberStatusChanged {
+    node_id:     String::from("remote-b:2553"),
+    authority:   String::from("remote-b:2553"),
+    from:        NodeStatus::Joining,
+    to:          NodeStatus::Up,
+    observed_at: observed_at(),
+  }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552"), String::from("remote-b:2553")]);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::MemberStatusChanged {
+    node_id:     String::from("remote-a:2552"),
+    authority:   String::from("remote-a:2552"),
+    from:        NodeStatus::Up,
+    to:          NodeStatus::Removed,
+    observed_at: observed_at(),
+  }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-b:2553")]);
+}
+
+#[test]
+fn status_event_keeps_stale_snapshot_from_restoring_routee() {
+  let config = ClusterRouterPoolConfig::new(10).with_max_instances_per_node(1).with_allow_local_routees(false);
+  let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));
+  let event_stream = EventStreamShared::default();
+  let subscriber = subscriber_handle(ClusterRouterPoolRouteeSubscriber::new(router.clone(), String::from("self:2551")));
+  let _subscription = event_stream.subscribe_no_replay(&subscriber);
+
+  let state = CurrentClusterState::new(
+    vec![node("self:2551", NodeStatus::Up), node("remote-a:2552", NodeStatus::Up)],
+    Vec::new(),
+    Vec::new(),
+    None,
+    BTreeMap::new(),
+  );
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       state.clone(),
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::MemberStatusChanged {
+    node_id:     String::from("remote-a:2552"),
+    authority:   String::from("remote-a:2552"),
+    from:        NodeStatus::Up,
+    to:          NodeStatus::PreparingForShutdown,
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), Vec::<String>::new());
+
+  event_stream
+    .publish(&cluster_extension_event(ClusterEvent::CurrentClusterState { state, observed_at: observed_at() }));
+  assert_eq!(routees(&router), Vec::<String>::new());
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::TopologyUpdated {
+    update: topology_update(2, vec![String::from("self:2551"), String::from("remote-a:2552")]),
+  }));
+  assert_eq!(routees(&router), Vec::<String>::new());
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::MemberStatusChanged {
+    node_id:     String::from("remote-a:2552"),
+    authority:   String::from("remote-a:2552"),
+    from:        NodeStatus::PreparingForShutdown,
+    to:          NodeStatus::Up,
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+}
+
+#[test]
+fn topology_updated_refreshes_routees_without_status_events() {
+  let config = ClusterRouterPoolConfig::new(10).with_max_instances_per_node(1).with_allow_local_routees(false);
+  let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));
+  let event_stream = EventStreamShared::default();
+  let subscriber = subscriber_handle(ClusterRouterPoolRouteeSubscriber::new(router.clone(), String::from("self:2551")));
+  let _subscription = event_stream.subscribe_no_replay(&subscriber);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::TopologyUpdated {
+    update: topology_update(1, vec![String::from("self:2551"), String::from("remote-a:2552")]),
+  }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::TopologyUpdated {
+    update: topology_update(2, vec![String::from("self:2551"), String::from("remote-b:2553")]),
+  }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-b:2553")]);
+}

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
@@ -257,6 +257,40 @@ fn status_override_does_not_apply_to_rejoined_member_with_new_node_id() {
 }
 
 #[test]
+fn topology_updated_during_shutdown_does_not_add_new_routees() {
+  let config = ClusterRouterPoolConfig::new(10).with_max_instances_per_node(1).with_allow_local_routees(false);
+  let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));
+  let event_stream = EventStreamShared::default();
+  let subscriber = subscriber_handle(ClusterRouterPoolRouteeSubscriber::new(router.clone(), String::from("self:2551")));
+  let _subscription = event_stream.subscribe_no_replay(&subscriber);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       CurrentClusterState::new(
+      vec![
+        node("self:2551", NodeStatus::PreparingForShutdown),
+        node("remote-a:2552", NodeStatus::PreparingForShutdown),
+      ],
+      Vec::new(),
+      Vec::new(),
+      None,
+      BTreeMap::new(),
+    ),
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), Vec::<String>::new());
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::TopologyUpdated {
+    update: topology_update(2, vec![
+      String::from("self:2551"),
+      String::from("remote-a:2552"),
+      String::from("remote-b:2553"),
+    ]),
+  }));
+
+  assert_eq!(routees(&router), Vec::<String>::new());
+}
+
+#[test]
 fn snapshot_removal_clears_status_override_for_rejoined_member() {
   let config = ClusterRouterPoolConfig::new(10).with_max_instances_per_node(1).with_allow_local_routees(false);
   let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
@@ -23,14 +23,22 @@ use fraktor_utils_core_rs::{
 use super::ClusterRouterPoolRouteeSubscriber;
 
 fn node(authority: &str, status: NodeStatus) -> NodeRecord {
+  node_with_roles(authority, status, Vec::new())
+}
+
+fn node_with_id(node_id: &str, authority: &str, status: NodeStatus) -> NodeRecord {
   NodeRecord::new(
-    authority.to_string(),
+    node_id.to_string(),
     authority.to_string(),
     status,
     MembershipVersion::new(1),
     String::new(),
     Vec::new(),
   )
+}
+
+fn node_with_roles(authority: &str, status: NodeStatus, roles: Vec<String>) -> NodeRecord {
+  NodeRecord::new(authority.to_string(), authority.to_string(), status, MembershipVersion::new(1), String::new(), roles)
 }
 
 fn observed_at() -> TimerInstant {
@@ -170,6 +178,82 @@ fn topology_updated_refreshes_routees_without_status_events() {
   }));
 
   assert_eq!(routees(&router), vec![String::from("remote-b:2553")]);
+}
+
+#[test]
+fn topology_updated_preserves_existing_member_roles() {
+  let config = ClusterRouterPoolConfig::new(10)
+    .with_max_instances_per_node(1)
+    .with_allow_local_routees(false)
+    .with_use_roles(vec![String::from("worker")]);
+  let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));
+  let event_stream = EventStreamShared::default();
+  let subscriber = subscriber_handle(ClusterRouterPoolRouteeSubscriber::new(router.clone(), String::from("self:2551")));
+  let _subscription = event_stream.subscribe_no_replay(&subscriber);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       CurrentClusterState::new(
+      vec![
+        node("self:2551", NodeStatus::Up),
+        node_with_roles("remote-a:2552", NodeStatus::Up, vec![String::from("worker")]),
+      ],
+      Vec::new(),
+      Vec::new(),
+      None,
+      BTreeMap::new(),
+    ),
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::TopologyUpdated {
+    update: topology_update(2, vec![String::from("self:2551"), String::from("remote-a:2552")]),
+  }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+}
+
+#[test]
+fn status_override_does_not_apply_to_rejoined_member_with_new_node_id() {
+  let config = ClusterRouterPoolConfig::new(10).with_max_instances_per_node(1).with_allow_local_routees(false);
+  let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));
+  let event_stream = EventStreamShared::default();
+  let subscriber = subscriber_handle(ClusterRouterPoolRouteeSubscriber::new(router.clone(), String::from("self:2551")));
+  let _subscription = event_stream.subscribe_no_replay(&subscriber);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       CurrentClusterState::new(
+      vec![node("self:2551", NodeStatus::Up), node_with_id("remote-a-old", "remote-a:2552", NodeStatus::Up)],
+      Vec::new(),
+      Vec::new(),
+      None,
+      BTreeMap::new(),
+    ),
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::MemberStatusChanged {
+    node_id:     String::from("remote-a-old"),
+    authority:   String::from("remote-a:2552"),
+    from:        NodeStatus::Up,
+    to:          NodeStatus::PreparingForShutdown,
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), Vec::<String>::new());
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       CurrentClusterState::new(
+      vec![node("self:2551", NodeStatus::Up), node_with_id("remote-a-new", "remote-a:2552", NodeStatus::Up)],
+      Vec::new(),
+      Vec::new(),
+      None,
+      BTreeMap::new(),
+    ),
+    observed_at: observed_at(),
+  }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
 }
 
 #[test]

--- a/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/cluster_router_pool_routee_subscriber_test.rs
@@ -171,3 +171,58 @@ fn topology_updated_refreshes_routees_without_status_events() {
 
   assert_eq!(routees(&router), vec![String::from("remote-b:2553")]);
 }
+
+#[test]
+fn snapshot_removal_clears_status_override_for_rejoined_member() {
+  let config = ClusterRouterPoolConfig::new(10).with_max_instances_per_node(1).with_allow_local_routees(false);
+  let router = SharedLock::new_with_driver::<DefaultMutex<_>>(ClusterRouterPool::new(config, Vec::new()));
+  let event_stream = EventStreamShared::default();
+  let subscriber = subscriber_handle(ClusterRouterPoolRouteeSubscriber::new(router.clone(), String::from("self:2551")));
+  let _subscription = event_stream.subscribe_no_replay(&subscriber);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       CurrentClusterState::new(
+      vec![node("self:2551", NodeStatus::Up), node("remote-a:2552", NodeStatus::Up)],
+      Vec::new(),
+      Vec::new(),
+      None,
+      BTreeMap::new(),
+    ),
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::MemberStatusChanged {
+    node_id:     String::from("remote-a:2552"),
+    authority:   String::from("remote-a:2552"),
+    from:        NodeStatus::Up,
+    to:          NodeStatus::PreparingForShutdown,
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), Vec::<String>::new());
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       CurrentClusterState::new(
+      vec![node("self:2551", NodeStatus::Up)],
+      Vec::new(),
+      Vec::new(),
+      None,
+      BTreeMap::new(),
+    ),
+    observed_at: observed_at(),
+  }));
+  assert_eq!(routees(&router), Vec::<String>::new());
+
+  event_stream.publish(&cluster_extension_event(ClusterEvent::CurrentClusterState {
+    state:       CurrentClusterState::new(
+      vec![node("self:2551", NodeStatus::Up), node("remote-a:2552", NodeStatus::Up)],
+      Vec::new(),
+      Vec::new(),
+      None,
+      BTreeMap::new(),
+    ),
+    observed_at: observed_at(),
+  }));
+
+  assert_eq!(routees(&router), vec![String::from("remote-a:2552")]);
+}

--- a/modules/cluster-core-kernel/src/extension/cluster_api.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_api.rs
@@ -171,6 +171,15 @@ impl ClusterApi {
     self.extension.leave(authority)
   }
 
+  /// Starts full-cluster shutdown preparation.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error when the cluster is not started.
+  pub fn prepare_for_full_cluster_shutdown(&self) -> Result<(), ClusterError> {
+    self.extension.prepare_for_full_cluster_shutdown()
+  }
+
   /// Returns the remote canonical path for an actor reference.
   ///
   /// # Errors

--- a/modules/cluster-core-kernel/src/extension/cluster_api_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_api_test.rs
@@ -467,9 +467,15 @@ fn prepare_for_full_cluster_shutdown_publishes_preparing_events_once() {
   api.prepare_for_full_cluster_shutdown().expect("prepare shutdown");
 
   let events = recorder.events();
-  assert_eq!(events.len(), 4);
+  assert_eq!(events.len(), 5);
   assert!(matches!(
     &events[0],
+    ClusterEvent::CurrentClusterState { state, observed_at }
+      if observed_at.ticks() == 11
+        && state.members.iter().all(|member| member.status == NodeStatus::PreparingForShutdown)
+  ));
+  assert!(matches!(
+    &events[1],
     ClusterEvent::MemberStatusChanged {
       authority,
       from: NodeStatus::Up,
@@ -479,12 +485,12 @@ fn prepare_for_full_cluster_shutdown_publishes_preparing_events_once() {
     } if authority == "node1:8080" && observed_at.ticks() == 11
   ));
   assert!(matches!(
-    &events[1],
+    &events[2],
     ClusterEvent::MemberPreparingForShutdown { authority, observed_at, .. }
       if authority == "node1:8080" && observed_at.ticks() == 11
   ));
   assert!(matches!(
-    &events[2],
+    &events[3],
     ClusterEvent::MemberStatusChanged {
       authority,
       from: NodeStatus::Up,
@@ -494,7 +500,7 @@ fn prepare_for_full_cluster_shutdown_publishes_preparing_events_once() {
     } if authority == "node2:8080" && observed_at.ticks() == 11
   ));
   assert!(matches!(
-    &events[3],
+    &events[4],
     ClusterEvent::MemberPreparingForShutdown { authority, observed_at, .. }
       if authority == "node2:8080" && observed_at.ticks() == 11
   ));
@@ -505,6 +511,81 @@ fn prepare_for_full_cluster_shutdown_publishes_preparing_events_once() {
   api.prepare_for_full_cluster_shutdown().expect("prepare shutdown is idempotent");
 
   assert!(recorder.events().is_empty());
+}
+
+#[test]
+fn prepare_for_full_cluster_shutdown_notifies_current_state_subscribers() {
+  let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  extension.start_member().expect("start member");
+  extension.on_topology(&build_topology_update(11, vec![String::from("node2:8080")], Vec::new()));
+
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+  let recorder = RecordingClusterEvents::new();
+  let subscriber = test_subscriber_handle(recorder.clone());
+  let _subscription = api.subscribe_no_replay(&subscriber, &[ClusterEventType::CurrentClusterState]);
+
+  api.prepare_for_full_cluster_shutdown().expect("prepare shutdown");
+
+  let events = recorder.events();
+  assert_eq!(events.len(), 1);
+  assert!(matches!(
+    &events[0],
+    ClusterEvent::CurrentClusterState { state, observed_at }
+      if observed_at.ticks() == 11
+        && state.members.iter().all(|member| member.status == NodeStatus::PreparingForShutdown)
+  ));
+}
+
+#[test]
+fn prepare_for_full_cluster_shutdown_notifies_new_members_on_rerun() {
+  let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  extension.start_member().expect("start member");
+  extension.on_topology(&build_topology_update(11, vec![String::from("node2:8080")], Vec::new()));
+
+  let recorder = RecordingClusterEvents::new();
+  let subscriber = test_subscriber_handle(recorder.clone());
+  let _subscription = system.event_stream().subscribe_no_replay(&subscriber);
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+
+  api.prepare_for_full_cluster_shutdown().expect("prepare shutdown");
+  recorder.clear();
+  let update = TopologyUpdate::new(
+    ClusterTopology::new(12, vec![String::from("node3:8080")], Vec::new(), Vec::new()),
+    vec![String::from("node1:8080"), String::from("node2:8080"), String::from("node3:8080")],
+    vec![String::from("node3:8080")],
+    Vec::new(),
+    Vec::new(),
+    Vec::new(),
+    TimerInstant::from_ticks(12, Duration::from_secs(1)),
+  );
+  extension.on_topology(&update);
+  recorder.clear();
+
+  api.prepare_for_full_cluster_shutdown().expect("prepare shutdown again");
+
+  let events = recorder.events();
+  assert_eq!(events.len(), 3);
+  assert!(matches!(
+    &events[0],
+    ClusterEvent::CurrentClusterState { state, observed_at }
+      if observed_at.ticks() == 12
+        && state.members.iter().all(|member| member.status == NodeStatus::PreparingForShutdown)
+  ));
+  assert!(matches!(
+    &events[1],
+    ClusterEvent::MemberStatusChanged {
+      authority,
+      from: NodeStatus::Up,
+      to: NodeStatus::PreparingForShutdown,
+      observed_at,
+      ..
+    } if authority == "node3:8080" && observed_at.ticks() == 12
+  ));
+  assert!(matches!(
+    &events[2],
+    ClusterEvent::MemberPreparingForShutdown { authority, observed_at, .. }
+      if authority == "node3:8080" && observed_at.ticks() == 12
+  ));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/extension/cluster_api_test.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_api_test.rs
@@ -27,7 +27,7 @@ use fraktor_utils_core_rs::{
 };
 
 use crate::{
-  ClusterApi, ClusterApiError, ClusterEvent, ClusterEventType, ClusterExtension, ClusterExtensionConfig,
+  ClusterApi, ClusterApiError, ClusterError, ClusterEvent, ClusterEventType, ClusterExtension, ClusterExtensionConfig,
   ClusterProviderError, ClusterRequestError, ClusterResolveError, ClusterSubscriptionInitialStateMode, ClusterTopology,
   MetricsError, TopologyUpdate,
   activation::{
@@ -454,6 +454,93 @@ fn current_state_returns_current_cluster_state_snapshot() {
 }
 
 #[test]
+fn prepare_for_full_cluster_shutdown_publishes_preparing_events_once() {
+  let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  extension.start_member().expect("start member");
+  extension.on_topology(&build_topology_update(11, vec![String::from("node2:8080")], Vec::new()));
+
+  let recorder = RecordingClusterEvents::new();
+  let subscriber = test_subscriber_handle(recorder.clone());
+  let _subscription = system.event_stream().subscribe_no_replay(&subscriber);
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+
+  api.prepare_for_full_cluster_shutdown().expect("prepare shutdown");
+
+  let events = recorder.events();
+  assert_eq!(events.len(), 4);
+  assert!(matches!(
+    &events[0],
+    ClusterEvent::MemberStatusChanged {
+      authority,
+      from: NodeStatus::Up,
+      to: NodeStatus::PreparingForShutdown,
+      observed_at,
+      ..
+    } if authority == "node1:8080" && observed_at.ticks() == 11
+  ));
+  assert!(matches!(
+    &events[1],
+    ClusterEvent::MemberPreparingForShutdown { authority, observed_at, .. }
+      if authority == "node1:8080" && observed_at.ticks() == 11
+  ));
+  assert!(matches!(
+    &events[2],
+    ClusterEvent::MemberStatusChanged {
+      authority,
+      from: NodeStatus::Up,
+      to: NodeStatus::PreparingForShutdown,
+      observed_at,
+      ..
+    } if authority == "node2:8080" && observed_at.ticks() == 11
+  ));
+  assert!(matches!(
+    &events[3],
+    ClusterEvent::MemberPreparingForShutdown { authority, observed_at, .. }
+      if authority == "node2:8080" && observed_at.ticks() == 11
+  ));
+  let state = api.current_state();
+  assert!(state.members.iter().all(|member| member.status == NodeStatus::PreparingForShutdown));
+
+  recorder.clear();
+  api.prepare_for_full_cluster_shutdown().expect("prepare shutdown is idempotent");
+
+  assert!(recorder.events().is_empty());
+}
+
+#[test]
+fn prepare_for_full_cluster_shutdown_allows_subscribers_to_read_current_state() {
+  let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  extension.start_member().expect("start member");
+  extension.on_topology(&build_topology_update(11, vec![String::from("node2:8080")], Vec::new()));
+
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+  let state_reader = CurrentStateDuringShutdownSubscriber::new(api.clone());
+  let subscriber = test_subscriber_handle(state_reader.clone());
+  let _subscription = system.event_stream().subscribe_no_replay(&subscriber);
+
+  api.prepare_for_full_cluster_shutdown().expect("prepare shutdown");
+
+  let statuses = state_reader.statuses();
+  assert_eq!(statuses.len(), 2);
+  assert!(statuses.iter().all(|snapshot| snapshot.iter().all(|status| *status == NodeStatus::PreparingForShutdown)));
+}
+
+#[test]
+fn prepare_for_full_cluster_shutdown_rejects_client_mode() {
+  let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
+  extension.start_client().expect("start client");
+
+  let api = ClusterApi::try_from_system(&system).expect("cluster api");
+  let err = api.prepare_for_full_cluster_shutdown().expect_err("client mode rejected");
+
+  assert!(matches!(
+    err,
+    ClusterError::Provider(ClusterProviderError::ShutdownFailed(reason))
+      if reason == "full-cluster shutdown preparation requires member mode"
+  ));
+}
+
+#[test]
 fn subscribe_no_replay_skips_buffered_cluster_events() {
   let (system, extension) = build_system_with_extension(|| Box::new(StaticIdentityLookup::new("node1:8080")));
   extension.start_member().expect("start member");
@@ -708,6 +795,34 @@ impl EventStreamSubscriber for RecordingClusterEvents {
       && let Some(cluster_event) = payload.payload().downcast_ref::<ClusterEvent>()
     {
       self.events.lock().push(cluster_event.clone());
+    }
+  }
+}
+
+#[derive(Clone)]
+struct CurrentStateDuringShutdownSubscriber {
+  api:      ClusterApi,
+  statuses: ArcShared<SpinSyncMutex<Vec<Vec<NodeStatus>>>>,
+}
+
+impl CurrentStateDuringShutdownSubscriber {
+  fn new(api: ClusterApi) -> Self {
+    Self { api, statuses: ArcShared::new(SpinSyncMutex::new(Vec::new())) }
+  }
+
+  fn statuses(&self) -> Vec<Vec<NodeStatus>> {
+    self.statuses.lock().clone()
+  }
+}
+
+impl EventStreamSubscriber for CurrentStateDuringShutdownSubscriber {
+  fn on_event(&mut self, event: &EventStreamEvent) {
+    if let EventStreamEvent::Extension { name, payload } = event
+      && name == "cluster"
+      && let Some(ClusterEvent::MemberPreparingForShutdown { .. }) = payload.payload().downcast_ref::<ClusterEvent>()
+    {
+      let statuses = self.api.current_state().members.into_iter().map(|member| member.status).collect();
+      self.statuses.lock().push(statuses);
     }
   }
 }

--- a/modules/cluster-core-kernel/src/extension/cluster_core.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_core.rs
@@ -37,27 +37,28 @@ use crate::{
 
 /// Aggregates configuration and shared dependencies for cluster runtime flows.
 pub struct ClusterCore {
-  provider:                ClusterProviderShared,
-  block_list_provider:     ArcShared<dyn BlockListProvider>,
-  event_stream:            EventStreamShared,
-  downing_provider:        SharedLock<Box<dyn DowningProvider>>,
-  gossiper:                GossiperShared,
-  pub_sub:                 ClusterPubSubShared,
+  provider: ClusterProviderShared,
+  block_list_provider: ArcShared<dyn BlockListProvider>,
+  event_stream: EventStreamShared,
+  downing_provider: SharedLock<Box<dyn DowningProvider>>,
+  gossiper: GossiperShared,
+  pub_sub: ClusterPubSubShared,
   failure_detector_config: FailureDetectorConfig,
-  startup_state:           ClusterStartupState,
-  metrics_enabled:         bool,
-  kind_registry:           KindRegistry,
-  identity_lookup:         IdentityLookupShared,
-  virtual_actor_count:     i64,
-  mode:                    Option<StartupMode>,
-  metrics:                 Option<ClusterMetrics>,
-  blocked_members:         Vec<String>,
-  member_count:            usize,
-  pid_cache:               Option<PidCache>,
-  last_topology_hash:      Option<u64>,
-  current_members:         Vec<String>,
-  observed_at:             TimerInstant,
-  preparing_for_shutdown:  bool,
+  startup_state: ClusterStartupState,
+  metrics_enabled: bool,
+  kind_registry: KindRegistry,
+  identity_lookup: IdentityLookupShared,
+  virtual_actor_count: i64,
+  mode: Option<StartupMode>,
+  metrics: Option<ClusterMetrics>,
+  blocked_members: Vec<String>,
+  member_count: usize,
+  pid_cache: Option<PidCache>,
+  last_topology_hash: Option<u64>,
+  current_members: Vec<String>,
+  observed_at: TimerInstant,
+  preparing_for_shutdown: bool,
+  shutdown_prepared_members: BTreeSet<String>,
 }
 
 impl ClusterCore {
@@ -102,6 +103,7 @@ impl ClusterCore {
       current_members: Vec::new(),
       observed_at: TimerInstant::zero(Duration::from_secs(1)),
       preparing_for_shutdown: false,
+      shutdown_prepared_members: BTreeSet::new(),
     }
   }
 
@@ -302,6 +304,7 @@ impl ClusterCore {
         self.current_members = Vec::from([address.clone()]);
         self.observed_at = TimerInstant::zero(Duration::from_secs(1));
         self.preparing_for_shutdown = false;
+        self.shutdown_prepared_members.clear();
         self.update_metrics(self.member_count, self.virtual_actor_count);
         self.publish_cluster_event(ClusterEvent::Startup { address, mode: StartupMode::Member });
         Ok(())
@@ -360,6 +363,7 @@ impl ClusterCore {
         self.current_members = Vec::from([address.clone()]);
         self.observed_at = TimerInstant::zero(Duration::from_secs(1));
         self.preparing_for_shutdown = false;
+        self.shutdown_prepared_members.clear();
         self.update_metrics(self.member_count, self.virtual_actor_count);
         self.publish_cluster_event(ClusterEvent::Startup { address, mode: StartupMode::Client });
         Ok(())
@@ -407,6 +411,7 @@ impl ClusterCore {
         self.observed_at = TimerInstant::zero(Duration::from_secs(1));
         self.last_topology_hash = None;
         self.preparing_for_shutdown = false;
+        self.shutdown_prepared_members.clear();
         self.mode = None;
         self.publish_cluster_event(ClusterEvent::Shutdown { address, mode });
         Ok(())
@@ -480,25 +485,31 @@ impl ClusterCore {
         "full-cluster shutdown preparation requires member mode",
       )));
     }
-    if self.preparing_for_shutdown {
+    self.preparing_for_shutdown = true;
+    let observed_at = self.observed_at;
+    let members_to_prepare = self
+      .current_members
+      .iter()
+      .filter(|authority| !self.shutdown_prepared_members.contains(*authority))
+      .cloned()
+      .collect::<Vec<_>>();
+    if members_to_prepare.is_empty() {
       return Ok(Vec::new());
     }
-    let (state, observed_at) = self.current_cluster_state_snapshot();
-    self.preparing_for_shutdown = true;
+
     let mut events = Vec::new();
-    for member in state.members.iter().filter(|member| member.status == NodeStatus::Up) {
+    let (prepared_state, _) = self.current_cluster_state_snapshot();
+    events.push(ClusterEvent::CurrentClusterState { state: prepared_state, observed_at });
+    for authority in members_to_prepare {
+      self.shutdown_prepared_members.insert(authority.clone());
       events.push(ClusterEvent::MemberStatusChanged {
-        node_id: member.node_id.clone(),
-        authority: member.authority.clone(),
+        node_id: authority.clone(),
+        authority: authority.clone(),
         from: NodeStatus::Up,
         to: NodeStatus::PreparingForShutdown,
         observed_at,
       });
-      events.push(ClusterEvent::MemberPreparingForShutdown {
-        node_id: member.node_id.clone(),
-        authority: member.authority.clone(),
-        observed_at,
-      });
+      events.push(ClusterEvent::MemberPreparingForShutdown { node_id: authority.clone(), authority, observed_at });
     }
     Ok(events)
   }
@@ -572,6 +583,10 @@ impl ClusterCore {
     self.update_metrics(self.member_count, self.virtual_actor_count);
     self.current_members = update.members.clone();
     self.observed_at = update.observed_at;
+    if self.preparing_for_shutdown {
+      let members = &self.current_members;
+      self.shutdown_prepared_members.retain(|authority| members.contains(authority));
+    }
 
     if let Some(cache) = self.pid_cache.as_mut() {
       for authority in update.left.iter().chain(update.dead.iter()) {

--- a/modules/cluster-core-kernel/src/extension/cluster_core.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_core.rs
@@ -57,6 +57,7 @@ pub struct ClusterCore {
   last_topology_hash:      Option<u64>,
   current_members:         Vec<String>,
   observed_at:             TimerInstant,
+  preparing_for_shutdown:  bool,
 }
 
 impl ClusterCore {
@@ -100,6 +101,7 @@ impl ClusterCore {
       last_topology_hash: None,
       current_members: Vec::new(),
       observed_at: TimerInstant::zero(Duration::from_secs(1)),
+      preparing_for_shutdown: false,
     }
   }
 
@@ -197,13 +199,14 @@ impl ClusterCore {
   #[must_use]
   pub fn current_cluster_state_snapshot(&self) -> (CurrentClusterState, TimerInstant) {
     let version = MembershipVersion::new(self.last_topology_hash.unwrap_or(0));
+    let status = if self.preparing_for_shutdown { NodeStatus::PreparingForShutdown } else { NodeStatus::Up };
     let members = self
       .current_members
       .iter()
       .cloned()
       .map(|authority| {
         let node_id = authority.clone();
-        NodeRecord::new(node_id, authority, NodeStatus::Up, version, String::new(), Vec::new())
+        NodeRecord::new(node_id, authority, status, version, String::new(), Vec::new())
       })
       .collect::<Vec<_>>();
     let leader = members.iter().map(|record| record.authority.clone()).min();
@@ -298,6 +301,7 @@ impl ClusterCore {
         self.member_count = 1;
         self.current_members = Vec::from([address.clone()]);
         self.observed_at = TimerInstant::zero(Duration::from_secs(1));
+        self.preparing_for_shutdown = false;
         self.update_metrics(self.member_count, self.virtual_actor_count);
         self.publish_cluster_event(ClusterEvent::Startup { address, mode: StartupMode::Member });
         Ok(())
@@ -355,6 +359,7 @@ impl ClusterCore {
         self.member_count = 1;
         self.current_members = Vec::from([address.clone()]);
         self.observed_at = TimerInstant::zero(Duration::from_secs(1));
+        self.preparing_for_shutdown = false;
         self.update_metrics(self.member_count, self.virtual_actor_count);
         self.publish_cluster_event(ClusterEvent::Startup { address, mode: StartupMode::Client });
         Ok(())
@@ -401,6 +406,7 @@ impl ClusterCore {
         self.current_members.clear();
         self.observed_at = TimerInstant::zero(Duration::from_secs(1));
         self.last_topology_hash = None;
+        self.preparing_for_shutdown = false;
         self.mode = None;
         self.publish_cluster_event(ClusterEvent::Shutdown { address, mode });
         Ok(())
@@ -461,6 +467,40 @@ impl ClusterCore {
       return Err(ClusterError::from(ClusterProviderError::leave("cluster is not started")));
     }
     self.provider.with_write(|provider| provider.leave(authority)).map_err(ClusterError::from)
+  }
+
+  /// Starts full-cluster shutdown preparation.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the cluster has not been started.
+  pub fn prepare_for_full_cluster_shutdown(&mut self) -> Result<Vec<ClusterEvent>, ClusterError> {
+    if self.mode != Some(StartupMode::Member) {
+      return Err(ClusterError::from(ClusterProviderError::shutdown(
+        "full-cluster shutdown preparation requires member mode",
+      )));
+    }
+    if self.preparing_for_shutdown {
+      return Ok(Vec::new());
+    }
+    let (state, observed_at) = self.current_cluster_state_snapshot();
+    self.preparing_for_shutdown = true;
+    let mut events = Vec::new();
+    for member in state.members.iter().filter(|member| member.status == NodeStatus::Up) {
+      events.push(ClusterEvent::MemberStatusChanged {
+        node_id: member.node_id.clone(),
+        authority: member.authority.clone(),
+        from: NodeStatus::Up,
+        to: NodeStatus::PreparingForShutdown,
+        observed_at,
+      });
+      events.push(ClusterEvent::MemberPreparingForShutdown {
+        node_id: member.node_id.clone(),
+        authority: member.authority.clone(),
+        observed_at,
+      });
+    }
+    Ok(events)
   }
 
   fn publish_cluster_event(&self, event: ClusterEvent) {

--- a/modules/cluster-core-kernel/src/extension/cluster_extension.rs
+++ b/modules/cluster-core-kernel/src/extension/cluster_extension.rs
@@ -730,6 +730,19 @@ impl ClusterExtension {
     self.core.with_lock(|core| core.leave(authority))
   }
 
+  /// Starts full-cluster shutdown preparation.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error when the cluster is not started.
+  pub fn prepare_for_full_cluster_shutdown(&self) -> Result<(), ClusterError> {
+    let events = self.core.with_lock(|core| core.prepare_for_full_cluster_shutdown())?;
+    for event in events {
+      self.publish_cluster_event(event);
+    }
+    Ok(())
+  }
+
   /// Registers kinds for member mode.
   ///
   /// # Errors
@@ -783,6 +796,12 @@ impl ClusterExtension {
         self.event_stream.publish(&extension_event);
       },
     }
+  }
+
+  fn publish_cluster_event(&self, event: ClusterEvent) {
+    let payload = AnyMessage::new(event);
+    let extension_event = EventStreamEvent::Extension { name: String::from(CLUSTER_EVENT_STREAM_NAME), payload };
+    self.event_stream.publish(&extension_event);
   }
 
   /// Registers a callback invoked when a member reaches `Up` status.

--- a/modules/cluster-core-kernel/src/grain/hash_code_message_extractor.rs
+++ b/modules/cluster-core-kernel/src/grain/hash_code_message_extractor.rs
@@ -9,26 +9,31 @@ use super::{ShardingEnvelope, ShardingExtractorConfigError, ShardingMessageExtra
 #[path = "hash_code_message_extractor_test.rs"]
 mod tests;
 
-/// FNV-1a 32bit hash shared by the hash-code standard extractors.
+/// JVM `String.hashCode` compatible hash shared by the hash-code standard extractors.
 ///
-/// Fixed specification: offset basis `0x811C9DC5`, prime `0x01000193`,
-/// applied to the UTF-8 bytes of the input.
-pub(super) fn fnv1a_32(value: &str) -> u32 {
-  let mut hash: u32 = 0x811C_9DC5;
-  for byte in value.as_bytes() {
-    hash ^= u32::from(*byte);
-    hash = hash.wrapping_mul(0x0100_0193);
+/// The hash is computed over UTF-16 code units with wrapping 32bit signed
+/// arithmetic, matching Java and Scala `String.hashCode`.
+pub(super) fn pekko_hash_code(value: &str) -> i32 {
+  let mut hash = 0_i32;
+  for code_unit in value.encode_utf16() {
+    hash = hash.wrapping_mul(31).wrapping_add(i32::from(code_unit));
   }
   hash
 }
 
+/// Pekko-compatible shard id for the given entity id and shard count.
+pub(super) fn pekko_hash_code_shard_id(entity_id: &str, number_of_shards: u32) -> String {
+  let hash = pekko_hash_code(entity_id);
+  let positive_hash = if hash == i32::MIN { i32::MIN } else { hash.abs() };
+  let shard = i64::from(positive_hash) % i64::from(number_of_shards);
+  shard.to_string()
+}
+
 /// Standard extractor deriving the shard id from the envelope entity id.
 ///
-/// Mirrors Pekko's `HashCodeMessageExtractor[M]`. The hash function is fixed
-/// to FNV-1a 32bit (offset basis `0x811C9DC5`, prime `0x01000193`) over the
-/// UTF-8 bytes of the entity id, and the shard id is
-/// `(hash % number_of_shards)` rendered as a decimal string. The derivation
-/// is pure and identical across hosts and node topologies.
+/// Mirrors Pekko's `HashCodeMessageExtractor[M]`. The shard id is derived by
+/// `math.abs(entityId.hashCode) % numberOfShards`, rendered as a decimal
+/// string, including the JVM `Int.MinValue` edge case.
 #[derive(Debug, Clone)]
 pub struct HashCodeMessageExtractor<M> {
   number_of_shards: u32,
@@ -56,7 +61,7 @@ impl<M> ShardingMessageExtractor<ShardingEnvelope<M>, M> for HashCodeMessageExtr
   }
 
   fn shard_id(&self, entity_id: &str) -> String {
-    (fnv1a_32(entity_id) % self.number_of_shards).to_string()
+    pekko_hash_code_shard_id(entity_id, self.number_of_shards)
   }
 
   fn unwrap_message(&self, message: ShardingEnvelope<M>) -> M {

--- a/modules/cluster-core-kernel/src/grain/hash_code_message_extractor_test.rs
+++ b/modules/cluster-core-kernel/src/grain/hash_code_message_extractor_test.rs
@@ -34,19 +34,20 @@ fn shard_id_is_deterministic_for_same_input() {
 }
 
 #[test]
-fn shard_id_matches_known_fnv1a_vectors() {
-  // FNV-1a 32bit の既知ベクタでハッシュ仕様を固定する。
-  // 期待値の根拠: offset basis 0x811C9DC5 / prime 0x01000193 による手計算
-  // （fnv1a32("counter-1") = 0xA5D60CE1 = 2782268641, fnv1a32("device-42") = 0xE9174B68 = 3910617960,
-  //   fnv1a32("") = 0x811C9DC5 = 2166136261 = offset basis）。
-  // shard 数に u32::MAX を使うとハッシュ値がそのまま shard id
-  // になるため、ハッシュ仕様自体を固定できる。
+fn shard_id_matches_known_pekko_hash_code_vectors() {
+  // Pekko は Scala/JVM の String.hashCode を使うため、UTF-16 code unit
+  // による 31 倍加算と math.abs(hash) % numberOfShards の結果を固定する。
   let identity_shards = HashCodeMessageExtractor::<u32>::new(u32::MAX).expect("extractor");
-  assert_eq!(identity_shards.shard_id("counter-1"), "2782268641");
-  assert_eq!(identity_shards.shard_id("device-42"), "3910617960");
-  assert_eq!(identity_shards.shard_id(""), "2166136261");
+  assert_eq!(identity_shards.shard_id("counter-1"), "1352256672");
+  assert_eq!(identity_shards.shard_id("device-42"), "25160021");
+  assert_eq!(identity_shards.shard_id("acct-1"), "1423448841");
+  assert_eq!(identity_shards.shard_id(""), "0");
 
   let ten_shards = HashCodeMessageExtractor::<u32>::new(10).expect("extractor");
-  assert_eq!(ten_shards.shard_id("counter-1"), "1");
-  assert_eq!(ten_shards.shard_id("device-42"), "0");
+  assert_eq!(ten_shards.shard_id("counter-1"), "2");
+  assert_eq!(ten_shards.shard_id("device-42"), "1");
+  assert_eq!(ten_shards.shard_id("acct-1"), "1");
+  assert_eq!(ten_shards.shard_id("Aa"), "2");
+  assert_eq!(ten_shards.shard_id("BB"), "2");
+  assert_eq!(ten_shards.shard_id("polygenelubricants"), "-8");
 }

--- a/modules/cluster-core-kernel/src/grain/hash_code_no_envelope_message_extractor.rs
+++ b/modules/cluster-core-kernel/src/grain/hash_code_no_envelope_message_extractor.rs
@@ -1,12 +1,11 @@
 //! Hash-based standard extractor for messages without an envelope.
 
-use alloc::{
-  boxed::Box,
-  string::{String, ToString},
-};
+use alloc::{boxed::Box, string::String};
 use core::fmt::{self, Formatter, Result as FmtResult};
 
-use super::{ShardingExtractorConfigError, ShardingMessageExtractor, hash_code_message_extractor::fnv1a_32};
+use super::{
+  ShardingExtractorConfigError, ShardingMessageExtractor, hash_code_message_extractor::pekko_hash_code_shard_id,
+};
 
 #[cfg(test)]
 #[path = "hash_code_no_envelope_message_extractor_test.rs"]
@@ -19,11 +18,9 @@ type ExtractEntityIdFn<M> = Box<dyn Fn(&M) -> Option<String> + Send + Sync>;
 ///
 /// Mirrors Pekko's `HashCodeNoEnvelopeMessageExtractor[M]`. The entity id is
 /// derived by the function given at construction (returning `None` when it
-/// cannot be derived), and the shard id uses the same fixed FNV-1a 32bit rule
-/// as [`HashCodeMessageExtractor`](super::HashCodeMessageExtractor), so the
-/// same entity id always maps to the same shard id across both extractors.
-/// `unwrap_message` is the identity. The derivation is pure and identical
-/// across hosts and node topologies.
+/// cannot be derived), and the shard id uses the same Pekko-compatible
+/// `String.hashCode` rule as [`HashCodeMessageExtractor`](super::HashCodeMessageExtractor).
+/// `unwrap_message` is the identity.
 pub struct HashCodeNoEnvelopeMessageExtractor<M> {
   number_of_shards:  u32,
   extract_entity_id: ExtractEntityIdFn<M>,
@@ -62,7 +59,7 @@ impl<M> ShardingMessageExtractor<M, M> for HashCodeNoEnvelopeMessageExtractor<M>
   }
 
   fn shard_id(&self, entity_id: &str) -> String {
-    (fnv1a_32(entity_id) % self.number_of_shards).to_string()
+    pekko_hash_code_shard_id(entity_id, self.number_of_shards)
   }
 
   fn unwrap_message(&self, message: M) -> M {

--- a/modules/cluster-core-kernel/src/grain/hash_code_no_envelope_message_extractor_test.rs
+++ b/modules/cluster-core-kernel/src/grain/hash_code_no_envelope_message_extractor_test.rs
@@ -51,15 +51,15 @@ fn unwrap_message_is_identity() {
 
 #[test]
 fn shard_id_matches_hash_code_extractor_for_same_entity_id() {
-  // HashCode 標準実装（共有 FNV-1a）と同一の shard 規則であることを実装間比較で検証する。
+  // HashCode 標準実装（共有 Pekko hashCode）と同一の shard 規則であることを実装間比較で検証する。
   let no_envelope = account_extractor(10);
   let with_envelope = HashCodeMessageExtractor::<u32>::new(10).expect("extractor");
 
   for entity_id in ["counter-1", "device-42", "acct-1"] {
     assert_eq!(no_envelope.shard_id(entity_id), with_envelope.shard_id(entity_id), "entity_id={entity_id}");
   }
-  // 既知ベクタによる固定（fnv1a32("counter-1") = 2782268641, % 10 = 1）
-  assert_eq!(no_envelope.shard_id("counter-1"), "1");
+  // 既知ベクタによる固定（"counter-1".hashCode = 1352256672, % 10 = 2）
+  assert_eq!(no_envelope.shard_id("counter-1"), "2");
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/pub_sub/distributed_pub_sub_mediator_state.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/distributed_pub_sub_mediator_state.rs
@@ -17,7 +17,7 @@ use super::{
   MediatorDeliveryMode, MediatorQuery, MediatorQueryResult, PubSubEnvelope, PubSubError, PubSubNoSubscriberBehavior,
   PubSubPathSemantics, PubSubRoutingMode, PubSubSubscriber, PubSubTopic, SendPathInput, SendToAllPathInput,
   TopicRegistryApplyOutcome, TopicRegistryBucket, TopicRegistryBucketView, TopicRegistryDelta,
-  TopicRegistryDeltaCollector, TopicRegistryEntryKind, TopicRegistryStatus,
+  TopicRegistryDeltaCollector, TopicRegistryEntryKey, TopicRegistryEntryKind, TopicRegistryStatus,
 };
 
 /// Registry-backed mediator state for pub-sub commands.
@@ -249,6 +249,7 @@ impl DistributedPubSubMediatorState {
 
   fn query_result(&self, query: MediatorQuery, active_owners: &[UniqueAddress]) -> MediatorQueryResult {
     match query {
+      | MediatorQuery::Count => MediatorQueryResult::Count { count: self.active_registration_count(active_owners) },
       | MediatorQuery::CurrentTopics => {
         MediatorQueryResult::CurrentTopics { topics: self.current_topics(active_owners) }
       },
@@ -269,6 +270,28 @@ impl DistributedPubSubMediatorState {
       }
     }
     topics.into_iter().collect()
+  }
+
+  fn active_registration_count(&self, active_owners: &[UniqueAddress]) -> usize {
+    let mut registrations = BTreeSet::new();
+    for view in self.delivery_views(active_owners) {
+      for entry in view.entries() {
+        match entry.kind() {
+          | TopicRegistryEntryKind::Path { path, target } => {
+            registrations.insert(TopicRegistryEntryKey::Path { path: path.clone(), target: target.clone() });
+          },
+          | TopicRegistryEntryKind::TopicSubscription { topic, group, subscriber } => {
+            registrations.insert(TopicRegistryEntryKey::TopicSubscription {
+              topic:      topic.clone(),
+              group:      group.clone(),
+              subscriber: subscriber.clone(),
+            });
+          },
+          | TopicRegistryEntryKind::Removed { .. } => {},
+        }
+      }
+    }
+    registrations.len()
   }
 
   fn topic_subscribers(&self, topic: &PubSubTopic, active_owners: &[UniqueAddress]) -> Vec<PubSubSubscriber> {

--- a/modules/cluster-core-kernel/src/pub_sub/distributed_pub_sub_mediator_state_test.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/distributed_pub_sub_mediator_state_test.rs
@@ -387,6 +387,77 @@ fn subscriber_count_deduplicates_same_subscriber_across_buckets() {
 }
 
 #[test]
+fn count_returns_total_active_subscriber_registrations() {
+  let local = owner("node-a", 1);
+  let remote = owner("node-b", 2);
+  let inactive = owner("node-c", 3);
+  let news = PubSubTopic::new("news");
+  let metrics = PubSubTopic::new("metrics");
+  let local_subscriber = subscriber("same-target");
+  let remote_subscriber = subscriber("remote-target");
+  let active = vec![local.clone(), remote.clone()];
+  let mut state = DistributedPubSubMediatorState::new(config(PubSubNoSubscriberBehavior::Drop), local.clone());
+
+  state
+    .apply_command(
+      MediatorCommand::try_subscribe(news.clone(), None, local_subscriber.clone()).expect("subscribe"),
+      10,
+      &active,
+    )
+    .expect("news subscribed");
+  state
+    .apply_command(
+      MediatorCommand::try_subscribe(metrics.clone(), None, local_subscriber.clone()).expect("subscribe"),
+      11,
+      &active,
+    )
+    .expect("metrics subscribed");
+
+  let mut remote_bucket = TopicRegistryBucket::new(remote);
+  remote_bucket.put_subscription(news, None, local_subscriber);
+  remote_bucket.put_subscription(metrics, Some(String::from("blue")), remote_subscriber);
+  state.upsert_remote_bucket(remote_bucket);
+
+  let mut inactive_bucket = TopicRegistryBucket::new(inactive);
+  inactive_bucket.put_subscription(PubSubTopic::new("ignored"), None, subscriber("inactive"));
+  state.upsert_remote_bucket(inactive_bucket);
+
+  let count = state.apply_command(MediatorCommand::count(), 12, &active).expect("count");
+
+  assert_eq!(count, MediatorCommandOutcome::Query(MediatorQueryResult::Count { count: 3 }));
+}
+
+#[test]
+fn count_includes_active_path_registrations() {
+  let local = owner("node-a", 1);
+  let remote = owner("node-b", 2);
+  let inactive = owner("node-c", 3);
+  let path = MediatorPathKey::parse("fraktor://sys/user/service").expect("path");
+  let mut state = DistributedPubSubMediatorState::new(config(PubSubNoSubscriberBehavior::Drop), local.clone());
+  let active = vec![local.clone(), remote.clone()];
+
+  state
+    .apply_command(
+      MediatorCommand::try_put("fraktor://sys/user/service", subscriber("local-path-target")).expect("put"),
+      10,
+      &active,
+    )
+    .expect("put");
+
+  let mut remote_bucket = TopicRegistryBucket::new(remote);
+  remote_bucket.put_path(path.clone(), subscriber("remote-path-target"));
+  state.upsert_remote_bucket(remote_bucket);
+
+  let mut inactive_bucket = TopicRegistryBucket::new(inactive);
+  inactive_bucket.put_path(path, subscriber("inactive-path-target"));
+  state.upsert_remote_bucket(inactive_bucket);
+
+  let count = state.apply_command(MediatorCommand::count(), 11, &active).expect("count");
+
+  assert_eq!(count, MediatorCommandOutcome::Query(MediatorQueryResult::Count { count: 2 }));
+}
+
+#[test]
 fn publish_and_send_use_separate_registry_namespaces() {
   let local = owner("node-a", 1);
   let mut state = DistributedPubSubMediatorState::new(config(PubSubNoSubscriberBehavior::Drop), local.clone());

--- a/modules/cluster-core-kernel/src/pub_sub/mediator_command.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/mediator_command.rs
@@ -157,6 +157,12 @@ impl MediatorCommand {
     Self::Query(MediatorQuery::CurrentTopics)
   }
 
+  /// Creates a total subscriber-count query command.
+  #[must_use]
+  pub const fn count() -> Self {
+    Self::Query(MediatorQuery::Count)
+  }
+
   /// Creates a validated subscriber-count query command.
   ///
   /// # Errors

--- a/modules/cluster-core-kernel/src/pub_sub/mediator_command_test.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/mediator_command_test.rs
@@ -130,6 +130,9 @@ fn command_constructors_keep_protocol_fields() {
 
 #[test]
 fn query_commands_keep_requested_shape() {
+  let total = MediatorCommand::count();
+  assert!(matches!(total, MediatorCommand::Query(MediatorQuery::Count)));
+
   let command = MediatorCommand::subscriber_count(PubSubTopic::new("news")).expect("query");
 
   match command {
@@ -151,6 +154,9 @@ fn acknowledgement_preserves_subscription_operation_fields() {
 
 #[test]
 fn query_result_preserves_snapshot_fields() {
+  let total = MediatorQueryResult::Count { count: 2 };
+  assert!(matches!(total, MediatorQueryResult::Count { count: 2 }));
+
   let result = MediatorQueryResult::CurrentTopics { topics: vec![PubSubTopic::new("news")] };
 
   assert!(matches!(result, MediatorQueryResult::CurrentTopics { .. }));

--- a/modules/cluster-core-kernel/src/pub_sub/mediator_query.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/mediator_query.rs
@@ -5,6 +5,8 @@ use super::PubSubTopic;
 /// Query command for mediator registry snapshots.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MediatorQuery {
+  /// Returns total subscriber registrations across all current topics.
+  Count,
   /// Returns all current topics.
   CurrentTopics,
   /// Returns subscriber count for a topic.

--- a/modules/cluster-core-kernel/src/pub_sub/mediator_query_result.rs
+++ b/modules/cluster-core-kernel/src/pub_sub/mediator_query_result.rs
@@ -7,6 +7,11 @@ use super::PubSubTopic;
 /// Completed query result for mediator registry snapshots.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MediatorQueryResult {
+  /// Total subscriber registrations across all current topics.
+  Count {
+    /// Number of subscriber registrations currently observed by the mediator.
+    count: usize,
+  },
   /// Current topic names.
   CurrentTopics {
     /// Topics observed in the registry snapshot.

--- a/modules/cluster-core-typed/src/cluster.rs
+++ b/modules/cluster-core-typed/src/cluster.rs
@@ -380,6 +380,10 @@ impl Cluster {
     self.inner.down(authority)
   }
 
+  pub(crate) fn prepare_for_full_cluster_shutdown(&self) -> Result<(), ClusterError> {
+    self.inner.prepare_for_full_cluster_shutdown()
+  }
+
   /// Builds a typed grain reference for the given typed identity.
   ///
   /// This is the fraktor equivalent of Pekko's `ClusterSharding#entityRefFor`.

--- a/modules/cluster-core-typed/src/cluster_command.rs
+++ b/modules/cluster-core-typed/src/cluster_command.rs
@@ -29,6 +29,8 @@ pub enum ClusterCommand {
     /// Member authority.
     address: String,
   },
+  /// Initiate full-cluster shutdown preparation.
+  PrepareForFullClusterShutdown,
 }
 
 impl ClusterCommand {
@@ -48,6 +50,7 @@ impl ClusterCommand {
       },
       | Self::Leave { address } => cluster.leave(address),
       | Self::Down { address } => cluster.down(address),
+      | Self::PrepareForFullClusterShutdown => cluster.prepare_for_full_cluster_shutdown(),
     }
   }
 }

--- a/modules/cluster-core-typed/tests/cluster.rs
+++ b/modules/cluster-core-typed/tests/cluster.rs
@@ -64,6 +64,13 @@ fn cluster_command_delegates_membership_operations_to_kernel_cluster_api() {
     .expect("join seed nodes");
   ClusterCommand::Leave { address: String::from("node2:8080") }.apply_to(&cluster).expect("leave");
   ClusterCommand::Down { address: String::from("node5:8080") }.apply_to(&cluster).expect("down");
+  let shutdown_events = ArcShared::new(SpinSyncMutex::new(Vec::<ClusterEvent>::new()));
+  let _subscription = cluster.subscribe(
+    &typed_cluster_event_ref(shutdown_events.clone()),
+    ClusterSubscriptionInitialStateMode::AsEvents,
+    &[ClusterEventType::MemberPreparingForShutdown],
+  );
+  ClusterCommand::PrepareForFullClusterShutdown.apply_to(&cluster).expect("prepare shutdown");
 
   assert_eq!(joined.lock().clone(), vec![
     String::from("node2:8080"),
@@ -72,6 +79,12 @@ fn cluster_command_delegates_membership_operations_to_kernel_cluster_api() {
   ]);
   assert_eq!(left.lock().clone(), vec![String::from("node2:8080")]);
   assert_eq!(downed.lock().clone(), vec![String::from("node5:8080")]);
+  let captured_shutdown_events = shutdown_events.lock().clone();
+  assert_eq!(captured_shutdown_events.len(), 1);
+  assert!(matches!(
+    captured_shutdown_events.first(),
+    Some(ClusterEvent::MemberPreparingForShutdown { authority, .. }) if authority == "node1:8080"
+  ));
 }
 
 #[test]


### PR DESCRIPTION
## 概要
- Phase 1 の routee 更新 std 配線、mediator Count query、Pekko 互換 HashCode extractor、prepareForFullClusterShutdown command path を実装
- gap analysis の該当カテゴリと Phase 1 状態を更新
- kernel / std adaptor / typed cluster のテストを追加

## 検証
- `cargo fmt --all`
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p fraktor-cluster-core-kernel-rs count_returns_total_active_subscriber_registrations`
- `cargo test -p fraktor-cluster-core-kernel-rs shard_id_matches_known_pekko_hash_code_vectors`
- `cargo test -p fraktor-cluster-adaptor-std-rs subscribed_pool_updates_routees_from_cluster_events`
- `cargo test -p fraktor-cluster-core-kernel-rs prepare_for_full_cluster_shutdown_publishes_preparing_events_once`
- `cargo test -p fraktor-cluster-core-typed-rs cluster_command_delegates_membership_operations_to_kernel_cluster_api`
- `./scripts/ci-check.sh ai fmt dylint clippy`
- `cargo test -p fraktor-cluster-core-kernel-rs -p fraktor-cluster-adaptor-std-rs -p fraktor-cluster-core-typed-rs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster membership events, router routees, pub-sub query semantics, and shard id assignment—behavioral parity fixes that can affect routing and placement in mixed or migrated clusters.
> 
> **Overview**
> Implements the four **cluster gap-analysis Phase 1** items and refreshes `docs/gap-analysis/cluster-gap-analysis.md` (coverage **64% → 68%**, Phase 1 marked complete).
> 
> **Cluster router pools:** Adds std `ClusterRouterPoolRouteeSubscriber` to subscribe to `CurrentClusterState`, `TopologyUpdated`, and `MemberStatusChanged`, then drive `ClusterRouterPool::update_from_members`. Status overrides handle stale snapshots, shutdown, and rejoin with a new node id.
> 
> **Distributed pub-sub:** Adds `MediatorQuery::Count` and `MediatorCommand::count()`; the mediator returns the deduplicated count of active topic subscriptions and path registrations across active owners.
> 
> **Sharding:** Replaces FNV-1a with JVM `String.hashCode` (UTF-16) for `HashCodeMessageExtractor` / `HashCodeNoEnvelopeMessageExtractor` so shard ids align with Pekko.
> 
> **Full-cluster shutdown:** Exposes `prepare_for_full_cluster_shutdown` on `ClusterApi` / `ClusterExtension` / `ClusterCore` (member mode only), emits `CurrentClusterState`, `MemberStatusChanged`, and `MemberPreparingForShutdown`, and wires typed `ClusterCommand::PrepareForFullClusterShutdown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d044c97fd54f959a75e16a686e1c59adb43523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster member state tracking with automatic synchronization
  * Implemented full cluster shutdown preparation with status notifications
  * Added subscriber count query functionality for pub/sub system
  * Improved hash code computation for Pekko compatibility

* **Tests**
  * Added comprehensive test coverage for member state updates
  * Added shutdown preparation event verification tests
  * Added subscriber count query tests
  * Added hash code compatibility validation tests

* **Documentation**
  * Updated implementation coverage metrics (64% → 68%)
  * Updated phase completion status and roadmap

<!-- end of auto-generated comment: release notes by coderabbit.ai -->