### PR TITLE
PNCounterMap の key removal / entries surface を実装

### DIFF
--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -325,7 +325,7 @@ ClusterClient 系（deprecated）、`@InternalApi` 型、JMX / HOCON / JFR / Jav
 
 ## まとめ
 
-cluster は membership / gossip / heartbeat / reachability / downing decision model / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 4, 5, 7, 10 は 86〜100% のカバレッジに達している。全体カバレッジは 103/151 (68%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（26%）、Pekko sharding public API 形態（48%）の 3 領域に集中している。
+cluster は membership / gossip / heartbeat / reachability / downing decision model / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 4, 5, 7, 10 は 82〜100% のカバレッジに達している。全体カバレッジは 103/151 (68%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（26%）、Pekko sharding public API 形態（48%）の 3 領域に集中している。
 
 Phase 1 は完了済み。次に進めるなら、`CrossDcFailureDetectorSettings`、typed singleton settings wrapper、setup integration、`JoinConfigCompatCheckSharding` のような config / wrapper / setup / compatibility key は単独で切らず、対象本体を触る change に同梱する。
 

--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -58,18 +58,18 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象公開契約グループ | 151 |
-| fraktor-rs 固定スコープ対応公開契約グループ（実装済み） | 102 |
-| 固定スコープカバレッジ | 102/151 (68%) |
-| 部分実装 | 11 |
+| fraktor-rs 固定スコープ対応公開契約グループ（実装済み） | 103 |
+| 固定スコープカバレッジ | 103/151 (68%) |
+| 部分実装 | 10 |
 | 未対応 | 38（ギャップ表上は31行。カテゴリ9の13行が20未対応公開契約グループを集約） |
 | raw public type declarations | 297 (core-kernel: 265, core-typed: 9, std: 23) |
 | raw public method declarations | 843 (core-kernel: 730, core-typed: 32, std: 81) |
-| hard / medium / easy / trivial gap | 11 / 30 / 8 / 0 |
+| hard / medium / easy / trivial gap | 11 / 29 / 8 / 0 |
 | panic 系スタブ | 0 件 |
 | 機能 placeholder / TODO | 0 件 |
 
 注: `raw public` は `pub(crate)` など内部到達可能な `pub` を含む参考値であり、crate 外から到達可能な外部公開 API 数ではない。
-注: `実装済み` / `部分実装` / `未対応` / 難易度内訳は、この台帳で定義した公開契約グループ単位で数える。ギャップ表は42行（部分実装11行、未対応31行）だが、カテゴリ9の protocol / CRDT 行は複数の公開契約グループを1行に集約している。raw 型名やメソッド名の個数を個別加算するものではない。
+注: `実装済み` / `部分実装` / `未対応` / 難易度内訳は、この台帳で定義した公開契約グループ単位で数える。ギャップ表は41行（部分実装10行、未対応31行）だが、カテゴリ9の protocol / CRDT 行は複数の公開契約グループを1行に集約している。raw 型名やメソッド名の個数を個別加算するものではない。
 
 ### 前回 (2026-06-05) からの判定変更
 
@@ -91,7 +91,7 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 | core / downing | `DowningProvider`, `NoDowning`, `SplitBrainResolverProvider` | `DowningProvider`, `DowningDecisionContext`, `DowningStrategyDecision`, `DowningDecisionTrace`, `NoopDowningProvider`, `SplitBrainResolver`, `LeaseMajorityPort`, `SplitBrainResolverProviderHook` | decision model / settings / provider binding は完了。SBR runtime actor（reachability 変化監視 → 責任ノード選択 → 自動 down 発行ループ）と concrete lease backend が未実装 |
 | core / typed | typed `Cluster`, command, subscription, singleton, sharding typed API | `Cluster` / `ClusterCommand` / `ClusterStateSubscription` / `ClusterEventSubscription` / `SelfUp` / `SelfRemoved` / `ClusterSetup` | typed Cluster facade（subscribe / unsubscribe / current_state / `PrepareForFullClusterShutdown` command 含む）は完備。singleton / sharding typed API が未実装 |
 | core / virtual actor | `ClusterSharding`, `EntityRef`, `EntityTypeKey`, `ShardRegion`, coordinator | `GrainRef`, `GrainKey`, `GrainTypeKey`, typed `GrainRef`, `ShardingEnvelope`, `ShardingMessageExtractor`, `ShardingRouter`, `VirtualActorRegistry`, `PlacementCoordinatorCore`, `PartitionIdentityLookup`, `RendezvousHasher`, `PidCache` | protoactor-go style の同等機能は強いが、Pekko public API 形態（typed Entity / `ClusterSharding.init` / `EntityRef` / `askWithStatus`）、rebalance / remembered entities / query protocol / health check が不足 |
-| core / distributed state | `DistributedData`, `Replicator`, CRDT 型群 | `ReplicatedData`, `DeltaReplicatedData`, `RemovedNodePruning`, `Key`, `SelfUniqueAddress`, `Flag`, `GCounter`, `PNCounter`, `PNCounterMap`（increment / decrement / get のみ）, read/write consistency 語彙 | CRDT 基底 SPI と scalar counter 型は実装済み。`PNCounterMap` は key removal / entries surface が不足。DistributedData / Replicator runtime、protocol、durable store、map/set/register 系 CRDT が不足 |
+| core / distributed state | `DistributedData`, `Replicator`, CRDT 型群 | `ReplicatedData`, `DeltaReplicatedData`, `RemovedNodePruning`, `Key`, `SelfUniqueAddress`, `Flag`, `GCounter`, `PNCounter`, `PNCounterMap`（increment / decrement / get / entries / remove）, read/write consistency 語彙 | CRDT 基底 SPI と scalar counter 型、`PNCounterMap` の entries surface / observed-remove key deletion は実装済み。DistributedData / Replicator runtime、protocol、durable store、map/set/register 系 CRDT が不足 |
 | std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `TokioGossiper`, `LocalClusterProvider`, `StaticClusterProvider`, `AwsEcsClusterProvider`, `GenericDiscoveryAdapter`, `ProviderLifecycleBridge`, `ClusterWireCodec`, `ConfiguredPhiAccrualDetectorFactory` | Rust adapter、logical envelope handoff、seed/discovery provider boundary、cluster message serializer contract、failure detector factory はある。sharding/singleton 系 setup と sharding join compat key が不足 |
 
 ## カテゴリ別ギャップ
@@ -178,9 +178,9 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 
 実装済みとして扱うもの: `GrainRef`、`GrainKey`、typed `GrainTypeKey<M>`、typed `GrainRef<M>`、`GrainCodec`、`ShardingEnvelope`、`ShardingMessageExtractor` SPI、Pekko 互換 `HashCodeMessageExtractor` / `HashCodeNoEnvelopeMessageExtractor`、Kafka 互換 `Murmur2MessageExtractor`、`ShardingRouter`、`VirtualActorRegistry`、`PlacementCoordinatorCore`、`PartitionIdentityLookup`、`RendezvousHasher`、`PidCache`、remote/local placement decision、passivation（基本機構）、RPC router（`GrainRpcRouter`）。
 
-### 9. Distributed Data / CRDT　✅ 実装済み 6/27 (22%)
+### 9. Distributed Data / CRDT　✅ 実装済み 7/27 (26%)
 
-このカテゴリの `6/27` は raw 型数ではなく、(1) CRDT 基底 SPI、(2) Key 階層、(3) SelfUniqueAddress、(4) scalar state / counter CRDT 群（`Flag` / `GCounter` / `PNCounter`）、(5) read/write consistency 語彙、(6) 補助 protocol 語彙、という公開契約グループ単位で数える。`PNCounterMap` は型自体と increment / decrement / get はあるが、Pekko の key removal / entries surface がないため部分実装として扱う。
+このカテゴリの `7/27` は raw 型数ではなく、(1) CRDT 基底 SPI、(2) Key 階層、(3) SelfUniqueAddress、(4) scalar state / counter CRDT 群（`Flag` / `GCounter` / `PNCounter`）、(5) read/write consistency 語彙、(6) 補助 protocol 語彙、(7) `PNCounterMap` の entries surface / observed-remove key deletion、という公開契約グループ単位で数える。
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
@@ -196,10 +196,9 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 | durable store std adapter（`LmdbDurableStore` 相当） | `DurableStore.scala:112` | 未対応 | std | medium | LMDB 完全互換ではなく、embedded KV による std 実装が対象 |
 | `LWWRegister` / `LWWMap` | `LWWRegister.scala:21`, `LWWMap.scala:21` | 未対応 | core/ddata | medium | timestamp / node ordering と clock 抽象が必要 |
 | `ORSet` / `ORMap` / `ORMultiMap` | `ORSet.scala:43`, `ORMap.scala:24`, `ORMultiMap.scala:21` | 未対応 | core/ddata | medium | dot / tombstone / delta semantics が必要 |
-| `PNCounterMap` key removal / entries surface | `PNCounterMap.scala:63`, `PNCounterMap.scala:142` | 部分実装 | core/ddata | medium | `PNCounterMap` 型、increment / decrement / get、delta / pruning はあるが、Pekko 契約の `entries` surface と observed-remove key deletion がない |
 | `VersionVector` | `VersionVector.scala:28` | 未対応 | core/ddata | medium | membership 用 `VectorClock` はあるが CRDT pruning / dot 管理用ではない |
 
-実装済みとして扱うもの: CRDT merge / delta / pruning 基底 SPI（`ReplicatedData` / `DeltaReplicatedData` / `ReplicatedDelta` / `RequiresCausalDeliveryOfDeltas` / `RemovedNodePruning`）、`Key<T>` と基本 key alias、`SelfUniqueAddress`、`Flag`、`GCounter`、`PNCounter`、read/write consistency 語彙（`ReadConsistency` / `WriteConsistency`）、補助 protocol 語彙（`GetReplicaCount` / `ReplicaCount` / `FlushChanges`）。
+実装済みとして扱うもの: CRDT merge / delta / pruning 基底 SPI（`ReplicatedData` / `DeltaReplicatedData` / `ReplicatedDelta` / `RequiresCausalDeliveryOfDeltas` / `RemovedNodePruning`）、`Key<T>` と基本 key alias、`SelfUniqueAddress`、`Flag`、`GCounter`、`PNCounter`、`PNCounterMap`（increment / decrement / get / entries / remove、delta / pruning）、read/write consistency 語彙（`ReadConsistency` / `WriteConsistency`）、補助 protocol 語彙（`GetReplicaCount` / `ReplicaCount` / `FlushChanges`）。
 
 ### 10. std adapter / discovery / wire integration　✅ 実装済み 9/11 (82%)
 
@@ -296,7 +295,7 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 | durable store std adapter | std | カテゴリ9 | - |
 | `LWWRegister` / `LWWMap` | core/ddata | カテゴリ9 | - |
 | `ORSet` / `ORMap` / `ORMultiMap` | core/ddata | カテゴリ9 | - |
-| `PNCounterMap` key removal / entries surface | core/ddata | カテゴリ9 | - |
+| `PNCounterMap` key removal / entries surface | core/ddata | カテゴリ9 | 実装済み（`PNCounterMap::entries` / `contains_key` / `len` / `is_empty` + observed-remove `remove` + full/delta merge テスト） |
 | `VersionVector` | core/ddata | カテゴリ9 | - |
 
 ### Phase 3: hard（新しい基盤・アーキテクチャ変更を要するもの）
@@ -326,7 +325,7 @@ ClusterClient 系（deprecated）、`@InternalApi` 型、JMX / HOCON / JFR / Jav
 
 ## まとめ
 
-cluster は membership / gossip / heartbeat / reachability / downing decision model / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 4, 5, 7, 10 は 86〜100% のカバレッジに達している。全体カバレッジは 102/151 (68%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（22%）、Pekko sharding public API 形態（48%）の 3 領域に集中している。
+cluster は membership / gossip / heartbeat / reachability / downing decision model / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 4, 5, 7, 10 は 86〜100% のカバレッジに達している。全体カバレッジは 103/151 (68%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（26%）、Pekko sharding public API 形態（48%）の 3 領域に集中している。
 
 Phase 1 は完了済み。次に進めるなら、`CrossDcFailureDetectorSettings`、typed singleton settings wrapper、setup integration、`JoinConfigCompatCheckSharding` のような config / wrapper / setup / compatibility key は単独で切らず、対象本体を触る change に同梱する。
 

--- a/modules/cluster-core-kernel/src/ddata/g_counter.rs
+++ b/modules/cluster-core-kernel/src/ddata/g_counter.rs
@@ -47,6 +47,10 @@ impl GCounter {
     Self { state, delta }
   }
 
+  pub(super) fn state_value(&self, node: &UniqueAddress) -> u128 {
+    self.state.get(node).copied().unwrap_or(0)
+  }
+
   /// Returns a counter with `n` added to the local node slot.
   ///
   /// # Errors

--- a/modules/cluster-core-kernel/src/ddata/g_counter.rs
+++ b/modules/cluster-core-kernel/src/ddata/g_counter.rs
@@ -47,6 +47,25 @@ impl GCounter {
     Self { state, delta }
   }
 
+  pub(super) fn replace_nodes(&self, nodes: &BTreeMap<UniqueAddress, u64>, replacement: &Self) -> Self {
+    let mut state = self.state.clone();
+    let mut delta = self.delta.clone();
+
+    for node in nodes.keys() {
+      match replacement.state.get(node).copied() {
+        | Some(value) if value != 0 => {
+          state.insert(node.clone(), value);
+        },
+        | _ => {
+          state.remove(node);
+        },
+      }
+      delta.remove(node);
+    }
+
+    Self { state, delta }
+  }
+
   pub(super) fn state_value(&self, node: &UniqueAddress) -> u128 {
     self.state.get(node).copied().unwrap_or(0)
   }

--- a/modules/cluster-core-kernel/src/ddata/g_counter.rs
+++ b/modules/cluster-core-kernel/src/ddata/g_counter.rs
@@ -30,6 +30,23 @@ impl GCounter {
     Self { state, delta }
   }
 
+  pub(super) fn retain_nodes(&self, nodes: &BTreeMap<UniqueAddress, u64>) -> Self {
+    let state = self
+      .state
+      .iter()
+      .filter(|(node, _)| nodes.contains_key(*node))
+      .map(|(node, value)| (node.clone(), *value))
+      .collect();
+    let delta = self
+      .delta
+      .iter()
+      .filter(|(node, _)| nodes.contains_key(*node))
+      .map(|(node, value)| (node.clone(), *value))
+      .collect();
+
+    Self { state, delta }
+  }
+
   /// Returns a counter with `n` added to the local node slot.
   ///
   /// # Errors

--- a/modules/cluster-core-kernel/src/ddata/pn_counter.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter.rs
@@ -38,6 +38,66 @@ impl PNCounter {
     Self { increments: self.increments.retain_nodes(nodes), decrements: self.decrements.retain_nodes(nodes) }
   }
 
+  pub(super) fn retain_visible_nodes(
+    &self,
+    dots: &BTreeMap<UniqueAddress, u64>,
+    removed_dots: Option<&BTreeMap<UniqueAddress, u64>>,
+    own_removed_dots: Option<&BTreeMap<UniqueAddress, u64>>,
+    removed_prefix: Option<&Self>,
+  ) -> Option<(Self, BTreeMap<UniqueAddress, u64>)> {
+    let mut increment_state = BTreeMap::new();
+    let mut decrement_state = BTreeMap::new();
+    let mut visible_dots = BTreeMap::new();
+
+    for (node, version) in dots {
+      let removed_version = removed_dots.and_then(|removed_dots| removed_dots.get(node)).copied().unwrap_or(0);
+      let increment = self.increments.state_value(node);
+      let decrement = self.decrements.state_value(node);
+      let removed_increment =
+        removed_prefix.map(|removed_prefix| removed_prefix.increments.state_value(node)).unwrap_or(0);
+      let removed_decrement =
+        removed_prefix.map(|removed_prefix| removed_prefix.decrements.state_value(node)).unwrap_or(0);
+      let owns_covering_remove = own_removed_dots
+        .and_then(|own_removed_dots| own_removed_dots.get(node))
+        .copied()
+        .is_some_and(|own_removed_version| own_removed_version >= removed_version && *version > own_removed_version);
+
+      let (visible_increment, visible_decrement) = if *version <= removed_version {
+        if increment <= removed_increment && decrement <= removed_decrement {
+          continue;
+        }
+        (increment, decrement)
+      } else if owns_covering_remove {
+        (increment, decrement)
+      } else {
+        (subtract_removed_prefix(increment, removed_increment), subtract_removed_prefix(decrement, removed_decrement))
+      };
+
+      if visible_increment == 0 && visible_decrement == 0 {
+        continue;
+      }
+      if visible_increment != 0 {
+        increment_state.insert(node.clone(), visible_increment);
+      }
+      if visible_decrement != 0 {
+        decrement_state.insert(node.clone(), visible_decrement);
+      }
+      visible_dots.insert(node.clone(), *version);
+    }
+
+    if visible_dots.is_empty() {
+      None
+    } else {
+      Some((
+        Self::from_parts(
+          GCounter::from_parts(increment_state, BTreeMap::new()),
+          GCounter::from_parts(decrement_state, BTreeMap::new()),
+        ),
+        visible_dots,
+      ))
+    }
+  }
+
   /// Returns a counter with `n` added to the positive component.
   ///
   /// # Errors
@@ -67,6 +127,10 @@ impl PNCounter {
   pub fn value(&self) -> Result<i128, CounterArithmeticError> {
     signed_difference(self.increments.value()?, self.decrements.value()?)
   }
+}
+
+const fn subtract_removed_prefix(current: u128, removed_prefix: u128) -> u128 {
+  if current > removed_prefix { current - removed_prefix } else { current }
 }
 
 impl ReplicatedData for PNCounter {

--- a/modules/cluster-core-kernel/src/ddata/pn_counter.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter.rs
@@ -4,7 +4,7 @@
 #[path = "pn_counter_test.rs"]
 mod tests;
 
-use alloc::collections::BTreeSet;
+use alloc::collections::{BTreeMap, BTreeSet};
 use core::convert::TryFrom;
 
 use fraktor_remote_core_rs::address::UniqueAddress;
@@ -32,6 +32,10 @@ impl PNCounter {
 
   pub(super) const fn from_parts(increments: GCounter, decrements: GCounter) -> Self {
     Self { increments, decrements }
+  }
+
+  pub(super) fn retain_nodes(&self, nodes: &BTreeMap<UniqueAddress, u64>) -> Self {
+    Self { increments: self.increments.retain_nodes(nodes), decrements: self.decrements.retain_nodes(nodes) }
   }
 
   /// Returns a counter with `n` added to the positive component.

--- a/modules/cluster-core-kernel/src/ddata/pn_counter.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter.rs
@@ -38,6 +38,35 @@ impl PNCounter {
     Self { increments: self.increments.retain_nodes(nodes), decrements: self.decrements.retain_nodes(nodes) }
   }
 
+  pub(super) fn replace_nodes(&self, nodes: &BTreeMap<UniqueAddress, u64>, replacement: &Self) -> Self {
+    Self {
+      increments: self.increments.replace_nodes(nodes, &replacement.increments),
+      decrements: self.decrements.replace_nodes(nodes, &replacement.decrements),
+    }
+  }
+
+  pub(super) fn from_node_components(components: BTreeMap<UniqueAddress, (u128, u128)>) -> Self {
+    let mut increments = BTreeMap::new();
+    let mut decrements = BTreeMap::new();
+    for (node, (increment, decrement)) in components {
+      if increment != 0 {
+        increments.insert(node.clone(), increment);
+      }
+      if decrement != 0 {
+        decrements.insert(node, decrement);
+      }
+    }
+
+    Self::from_parts(
+      GCounter::from_parts(increments, BTreeMap::new()),
+      GCounter::from_parts(decrements, BTreeMap::new()),
+    )
+  }
+
+  pub(super) fn node_components(&self, node: &UniqueAddress) -> (u128, u128) {
+    (self.increments.state_value(node), self.decrements.state_value(node))
+  }
+
   pub(super) fn retain_visible_nodes(
     &self,
     dots: &BTreeMap<UniqueAddress, u64>,
@@ -50,7 +79,7 @@ impl PNCounter {
     let mut visible_dots = BTreeMap::new();
 
     for (node, version) in dots {
-      let removed_version = removed_dots.and_then(|removed_dots| removed_dots.get(node)).copied().unwrap_or(0);
+      let removed_version = removed_dots.and_then(|removed_dots| removed_dots.get(node)).copied();
       let increment = self.increments.state_value(node);
       let decrement = self.decrements.state_value(node);
       let removed_increment =
@@ -60,18 +89,24 @@ impl PNCounter {
       let owns_covering_remove = own_removed_dots
         .and_then(|own_removed_dots| own_removed_dots.get(node))
         .copied()
-        .is_some_and(|own_removed_version| own_removed_version >= removed_version && *version > own_removed_version);
+        .is_some_and(|own_removed_version| {
+          let removed_version = removed_version.unwrap_or(0);
+          own_removed_version >= removed_version && *version > own_removed_version
+        });
 
-      let (visible_increment, visible_decrement) = if *version <= removed_version {
-        if increment <= removed_increment && decrement <= removed_decrement {
-          continue;
-        }
-        (increment, decrement)
-      } else if owns_covering_remove {
-        (increment, decrement)
-      } else {
-        (subtract_removed_prefix(increment, removed_increment), subtract_removed_prefix(decrement, removed_decrement))
-      };
+      let (visible_increment, visible_decrement) =
+        if removed_version.is_some_and(|removed_version| *version <= removed_version) {
+          if increment == removed_increment && decrement == removed_decrement {
+            continue;
+          }
+          (increment, decrement)
+        } else if owns_covering_remove {
+          (increment, decrement)
+        } else if removed_version.is_some() {
+          (subtract_removed_prefix(increment, removed_increment), subtract_removed_prefix(decrement, removed_decrement))
+        } else {
+          (increment, decrement)
+        };
 
       if visible_increment == 0 && visible_decrement == 0 {
         continue;
@@ -130,7 +165,7 @@ impl PNCounter {
 }
 
 const fn subtract_removed_prefix(current: u128, removed_prefix: u128) -> u128 {
-  if current > removed_prefix { current - removed_prefix } else { current }
+  if current >= removed_prefix { current - removed_prefix } else { current }
 }
 
 impl ReplicatedData for PNCounter {

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -20,12 +20,14 @@ use super::{
 #[derive(Debug, Clone)]
 pub struct PNCounterMap<K> {
   // Invariant: every visible entry has a matching dot map; merge derives candidates from dots.
-  entries:            BTreeMap<K, PNCounter>,
-  dots:               BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
-  removed_dots:       BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
-  delta:              BTreeMap<K, PNCounter>,
-  delta_dots:         BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
-  delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  entries:              BTreeMap<K, PNCounter>,
+  dots:                 BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  removed_dots:         BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  removed_values:       BTreeMap<K, PNCounter>,
+  delta:                BTreeMap<K, PNCounter>,
+  delta_dots:           BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  delta_removed_dots:   BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  delta_removed_values: BTreeMap<K, PNCounter>,
 }
 
 impl<K> PNCounterMap<K>
@@ -36,12 +38,14 @@ where
   #[must_use]
   pub const fn new() -> Self {
     Self {
-      entries:            BTreeMap::new(),
-      dots:               BTreeMap::new(),
-      removed_dots:       BTreeMap::new(),
-      delta:              BTreeMap::new(),
-      delta_dots:         BTreeMap::new(),
-      delta_removed_dots: BTreeMap::new(),
+      entries:              BTreeMap::new(),
+      dots:                 BTreeMap::new(),
+      removed_dots:         BTreeMap::new(),
+      removed_values:       BTreeMap::new(),
+      delta:                BTreeMap::new(),
+      delta_dots:           BTreeMap::new(),
+      delta_removed_dots:   BTreeMap::new(),
+      delta_removed_values: BTreeMap::new(),
     }
   }
 
@@ -125,14 +129,25 @@ where
     let mut removed_dots = self.removed_dots.clone();
     merge_dot_map_entry(&mut removed_dots, key.clone(), &observed_dots);
 
+    let observed_value = self.entries.get(key).map(|counter| counter.retain_nodes(&observed_dots).reset_delta());
+    let mut removed_values = self.removed_values.clone();
+    if let Some(observed_value) = &observed_value {
+      merge_counter_map_entry(&mut removed_values, key.clone(), observed_value.clone());
+    }
+
     let mut delta_removed_dots = self.delta_removed_dots.clone();
     merge_dot_map_entry(&mut delta_removed_dots, key.clone(), &observed_dots);
 
+    let mut delta_removed_values = self.delta_removed_values.clone();
+    if let Some(observed_value) = observed_value {
+      merge_counter_map_entry(&mut delta_removed_values, key.clone(), observed_value);
+    }
+
     let mut delta = self.delta.clone();
     let mut delta_dots = self.delta_dots.clone();
-    apply_removed_dots(&mut delta, &mut delta_dots, key, &observed_dots);
+    apply_removed_dots(&mut delta, &mut delta_dots, key, &observed_dots, None, removed_values.get(key));
 
-    Self { entries, dots, removed_dots, delta, delta_dots, delta_removed_dots }
+    Self { entries, dots, removed_dots, removed_values, delta, delta_dots, delta_removed_dots, delta_removed_values }
   }
 
   fn update_key(
@@ -171,9 +186,11 @@ where
       entries,
       dots,
       removed_dots: self.removed_dots.clone(),
+      removed_values: self.removed_values.clone(),
       delta,
       delta_dots,
       delta_removed_dots: self.delta_removed_dots.clone(),
+      delta_removed_values: self.delta_removed_values.clone(),
     })
   }
 }
@@ -184,16 +201,45 @@ where
 {
   fn merge(&self, other: &Self) -> Self {
     let removed_dots = merge_dot_maps(&self.removed_dots, &other.removed_dots);
-    let (entries, dots) =
-      merge_entries(&self.entries, &self.dots, &other.removed_dots, &other.entries, &other.dots, &self.removed_dots);
+    let removed_values = merge_counter_maps(&self.removed_values, &other.removed_values);
+    let (entries, dots) = merge_entries(
+      &MergeEntrySide {
+        entries:                 &self.entries,
+        dots:                    &self.dots,
+        own_removed:             &self.removed_dots,
+        removed_by_other:        &other.removed_dots,
+        removed_values_by_other: &other.removed_values,
+      },
+      &MergeEntrySide {
+        entries:                 &other.entries,
+        dots:                    &other.dots,
+        own_removed:             &other.removed_dots,
+        removed_by_other:        &self.removed_dots,
+        removed_values_by_other: &self.removed_values,
+      },
+    );
+    let mut delta = self.delta.clone();
+    let mut delta_dots = self.delta_dots.clone();
+    for (key, removed_key_dots) in &other.removed_dots {
+      apply_removed_dots(
+        &mut delta,
+        &mut delta_dots,
+        key,
+        removed_key_dots,
+        self.delta_removed_dots.get(key),
+        other.removed_values.get(key),
+      );
+    }
 
     Self {
       entries,
       dots,
       removed_dots,
-      delta: self.delta.clone(),
-      delta_dots: self.delta_dots.clone(),
+      removed_values,
+      delta,
+      delta_dots,
       delta_removed_dots: self.delta_removed_dots.clone(),
+      delta_removed_values: self.delta_removed_values.clone(),
     }
   }
 }
@@ -205,16 +251,18 @@ where
   type Delta = Self;
 
   fn delta(&self) -> Option<Self::Delta> {
-    if self.delta.is_empty() && self.delta_removed_dots.is_empty() {
+    if self.delta.is_empty() && self.delta_removed_dots.is_empty() && self.delta_removed_values.is_empty() {
       None
     } else {
       Some(Self {
-        entries:            self.delta.clone(),
-        dots:               self.delta_dots.clone(),
-        removed_dots:       self.delta_removed_dots.clone(),
-        delta:              BTreeMap::new(),
-        delta_dots:         BTreeMap::new(),
-        delta_removed_dots: BTreeMap::new(),
+        entries:              self.delta.clone(),
+        dots:                 self.delta_dots.clone(),
+        removed_dots:         self.delta_removed_dots.clone(),
+        removed_values:       self.delta_removed_values.clone(),
+        delta:                BTreeMap::new(),
+        delta_dots:           BTreeMap::new(),
+        delta_removed_dots:   BTreeMap::new(),
+        delta_removed_values: BTreeMap::new(),
       })
     }
   }
@@ -223,23 +271,42 @@ where
     let mut entries = self.entries.clone();
     let mut dots = self.dots.clone();
     let mut removed_dots = self.removed_dots.clone();
+    let mut removed_values = self.removed_values.clone();
     let mut local_delta = self.delta.clone();
     let mut local_delta_dots = self.delta_dots.clone();
 
     for (key, removed_key_dots) in &delta.removed_dots {
       merge_dot_map_entry(&mut removed_dots, key.clone(), removed_key_dots);
-      apply_removed_dots(&mut entries, &mut dots, key, removed_key_dots);
-      apply_removed_dots(&mut local_delta, &mut local_delta_dots, key, removed_key_dots);
+      if let Some(removed_value) = delta.removed_values.get(key) {
+        merge_counter_map_entry(&mut removed_values, key.clone(), removed_value.clone());
+      }
+      apply_removed_dots(
+        &mut entries,
+        &mut dots,
+        key,
+        removed_key_dots,
+        self.removed_dots.get(key),
+        removed_values.get(key),
+      );
+      apply_removed_dots(
+        &mut local_delta,
+        &mut local_delta_dots,
+        key,
+        removed_key_dots,
+        self.delta_removed_dots.get(key),
+        removed_values.get(key),
+      );
     }
 
     for (key, counter) in &delta.entries {
       let incoming_dots = delta.dots.get(key).cloned().unwrap_or_default();
-      let visible_dots = filter_visible_dots(&incoming_dots, removed_dots.get(key));
-      if visible_dots.is_empty() {
-        continue;
-      }
-
-      let Some(counter) = visible_counter(counter, &visible_dots) else {
+      let Some((counter, visible_dots)) = visible_counter(
+        counter,
+        &incoming_dots,
+        removed_dots.get(key),
+        delta.removed_dots.get(key),
+        removed_values.get(key),
+      ) else {
         continue;
       };
       let counter = counter.reset_delta();
@@ -256,9 +323,11 @@ where
       entries,
       dots,
       removed_dots,
+      removed_values,
       delta: local_delta,
       delta_dots: local_delta_dots,
       delta_removed_dots: self.delta_removed_dots.clone(),
+      delta_removed_values: self.delta_removed_values.clone(),
     }
   }
 
@@ -269,9 +338,11 @@ where
       entries,
       dots: self.dots.clone(),
       removed_dots: self.removed_dots.clone(),
+      removed_values: self.removed_values.clone(),
       delta: BTreeMap::new(),
       delta_dots: BTreeMap::new(),
       delta_removed_dots: BTreeMap::new(),
+      delta_removed_values: BTreeMap::new(),
     }
   }
 }
@@ -307,6 +378,9 @@ where
     for key_dots in self.removed_dots.values() {
       nodes.extend(key_dots.keys().cloned());
     }
+    for counter in self.removed_values.values() {
+      nodes.extend(counter.modified_by_nodes());
+    }
     nodes
   }
 
@@ -314,26 +388,38 @@ where
     self.entries.values().any(|counter| counter.need_pruning_from(removed_node))
       || self.dots.values().any(|key_dots| key_dots.contains_key(removed_node))
       || self.removed_dots.values().any(|key_dots| key_dots.contains_key(removed_node))
+      || self.removed_values.values().any(|counter| counter.need_pruning_from(removed_node))
   }
 
   fn prune(&self, removed_node: &UniqueAddress, collapse_into: &UniqueAddress) -> Result<Self, Self::PruneError> {
     let mut entries = BTreeMap::new();
     let mut dots = BTreeMap::new();
     let mut removed_dots = BTreeMap::new();
+    let mut removed_values = BTreeMap::new();
     let mut delta = BTreeMap::new();
     let mut delta_dots = BTreeMap::new();
     let delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>> = self
       .delta_removed_dots
       .iter()
       .filter_map(|(key, key_dots)| {
-        let key_dots = pruning_cleanup_dots(key_dots, removed_node);
+        let key_dots = prune_tombstone_dots(key_dots, removed_node, collapse_into);
         if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
       })
       .collect();
+    let mut delta_removed_values = BTreeMap::new();
+    for (key, counter) in &self.delta_removed_values {
+      let counter = counter.prune(removed_node, collapse_into)?;
+      if !counter.modified_by_nodes().is_empty() {
+        delta_removed_values.insert(key.clone(), counter.reset_delta());
+      }
+    }
 
     for (key, counter) in &self.entries {
       let counter = counter.prune(removed_node, collapse_into)?;
-      let pruned_dots = self.dots.get(key).map(|key_dots| prune_dots(key_dots, removed_node, collapse_into));
+      let pruned_dots = self
+        .dots
+        .get(key)
+        .map(|key_dots| prune_entry_dots(key_dots, removed_node, collapse_into, self.removed_dots.get(key)));
       let dots_changed = pruned_dots.as_ref() != self.dots.get(key);
       if counter.delta().is_some() || dots_changed {
         delta.insert(key.clone(), counter.reset_delta());
@@ -345,17 +431,33 @@ where
     }
 
     for (key, key_dots) in &self.dots {
-      dots.insert(key.clone(), prune_dots(key_dots, removed_node, collapse_into));
+      dots.insert(key.clone(), prune_entry_dots(key_dots, removed_node, collapse_into, self.removed_dots.get(key)));
     }
 
     for (key, key_dots) in &self.removed_dots {
-      let pruned_dots = pruning_cleanup_dots(key_dots, removed_node);
+      let pruned_dots = prune_tombstone_dots(key_dots, removed_node, collapse_into);
       if !pruned_dots.is_empty() {
         removed_dots.insert(key.clone(), pruned_dots);
       }
     }
 
-    Ok(Self { entries, dots, removed_dots, delta, delta_dots, delta_removed_dots })
+    for (key, counter) in &self.removed_values {
+      let counter = counter.prune(removed_node, collapse_into)?;
+      if !counter.modified_by_nodes().is_empty() {
+        removed_values.insert(key.clone(), counter.reset_delta());
+      }
+    }
+
+    Ok(Self {
+      entries,
+      dots,
+      removed_dots,
+      removed_values,
+      delta,
+      delta_dots,
+      delta_removed_dots,
+      delta_removed_values,
+    })
   }
 
   fn pruning_cleanup(&self, removed_node: &UniqueAddress) -> Self {
@@ -375,6 +477,14 @@ where
       .filter_map(|(key, key_dots)| {
         let key_dots = pruning_cleanup_dots(key_dots, removed_node);
         if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
+      })
+      .collect();
+    let removed_values = self
+      .removed_values
+      .iter()
+      .filter_map(|(key, counter)| {
+        let counter = counter.pruning_cleanup(removed_node);
+        if counter.modified_by_nodes().is_empty() { None } else { Some((key.clone(), counter)) }
       })
       .collect();
     let delta = self
@@ -401,8 +511,16 @@ where
         if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
       })
       .collect();
+    let delta_removed_values = self
+      .delta_removed_values
+      .iter()
+      .filter_map(|(key, counter)| {
+        let counter = counter.pruning_cleanup(removed_node);
+        if counter.modified_by_nodes().is_empty() { None } else { Some((key.clone(), counter)) }
+      })
+      .collect();
 
-    Self { entries, dots, removed_dots, delta, delta_dots, delta_removed_dots }
+    Self { entries, dots, removed_dots, removed_values, delta, delta_dots, delta_removed_dots, delta_removed_values }
   }
 }
 
@@ -420,44 +538,62 @@ where
   K: Ord,
 {
   fn eq(&self, other: &Self) -> bool {
-    self.entries == other.entries && self.dots == other.dots && self.removed_dots == other.removed_dots
+    self.entries == other.entries
+      && self.dots == other.dots
+      && self.removed_dots == other.removed_dots
+      && self.removed_values == other.removed_values
   }
 }
 
 impl<K> Eq for PNCounterMap<K> where K: Ord {}
 
+struct MergeEntrySide<'a, K> {
+  entries:                 &'a BTreeMap<K, PNCounter>,
+  dots:                    &'a BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  own_removed:             &'a BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  removed_by_other:        &'a BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  removed_values_by_other: &'a BTreeMap<K, PNCounter>,
+}
+
 fn merge_entries<K>(
-  left_entries: &BTreeMap<K, PNCounter>,
-  left_dots: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
-  left_removed_by_right: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
-  right_entries: &BTreeMap<K, PNCounter>,
-  right_dots: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
-  right_removed_by_left: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  left: &MergeEntrySide<'_, K>,
+  right: &MergeEntrySide<'_, K>,
 ) -> (BTreeMap<K, PNCounter>, BTreeMap<K, BTreeMap<UniqueAddress, u64>>)
 where
   K: Ord + Clone, {
-  debug_assert!(left_entries.keys().all(|key| left_dots.contains_key(key)));
-  debug_assert!(right_entries.keys().all(|key| right_dots.contains_key(key)));
+  debug_assert!(left.entries.keys().all(|key| left.dots.contains_key(key)));
+  debug_assert!(right.entries.keys().all(|key| right.dots.contains_key(key)));
 
   let mut keys = BTreeSet::new();
-  keys.extend(left_dots.keys().cloned());
-  keys.extend(right_dots.keys().cloned());
+  keys.extend(left.dots.keys().cloned());
+  keys.extend(right.dots.keys().cloned());
 
   let mut entries = BTreeMap::new();
   let mut dots = BTreeMap::new();
 
   for key in keys {
-    let left_visible_dots = left_dots
-      .get(&key)
-      .map(|key_dots| filter_visible_dots(key_dots, left_removed_by_right.get(&key)))
-      .unwrap_or_default();
-    let right_visible_dots = right_dots
-      .get(&key)
-      .map(|key_dots| filter_visible_dots(key_dots, right_removed_by_left.get(&key)))
-      .unwrap_or_default();
-
-    let left_value = left_entries.get(&key).and_then(|counter| visible_counter(counter, &left_visible_dots));
-    let right_value = right_entries.get(&key).and_then(|counter| visible_counter(counter, &right_visible_dots));
+    let left_visible = left.entries.get(&key).and_then(|counter| {
+      visible_counter(
+        counter,
+        left.dots.get(&key)?,
+        left.removed_by_other.get(&key),
+        left.own_removed.get(&key),
+        left.removed_values_by_other.get(&key),
+      )
+    });
+    let right_visible = right.entries.get(&key).and_then(|counter| {
+      visible_counter(
+        counter,
+        right.dots.get(&key)?,
+        right.removed_by_other.get(&key),
+        right.own_removed.get(&key),
+        right.removed_values_by_other.get(&key),
+      )
+    });
+    let left_visible_dots = left_visible.as_ref().map(|(_, dots)| dots.clone()).unwrap_or_default();
+    let right_visible_dots = right_visible.as_ref().map(|(_, dots)| dots.clone()).unwrap_or_default();
+    let left_value = left_visible.map(|(counter, _)| counter);
+    let right_value = right_visible.map(|(counter, _)| counter);
     let value = match (left_value, right_value) {
       | (Some(left), Some(right)) => Some(left.merge(&right)),
       | (Some(left), None) => Some(left),
@@ -477,13 +613,14 @@ where
   (entries, dots)
 }
 
-fn visible_counter(counter: &PNCounter, visible_dots: &BTreeMap<UniqueAddress, u64>) -> Option<PNCounter> {
-  if visible_dots.is_empty() {
-    return None;
-  }
-
-  let counter = counter.retain_nodes(visible_dots);
-  if counter.modified_by_nodes().is_empty() { None } else { Some(counter) }
+fn visible_counter(
+  counter: &PNCounter,
+  dots: &BTreeMap<UniqueAddress, u64>,
+  removed_dots: Option<&BTreeMap<UniqueAddress, u64>>,
+  own_removed_dots: Option<&BTreeMap<UniqueAddress, u64>>,
+  removed_value: Option<&PNCounter>,
+) -> Option<(PNCounter, BTreeMap<UniqueAddress, u64>)> {
+  counter.retain_visible_nodes(dots, removed_dots, own_removed_dots, removed_value)
 }
 
 fn merge_dot_maps<K>(
@@ -497,6 +634,22 @@ where
     merge_dot_map_entry(&mut merged, key.clone(), dots);
   }
   merged
+}
+
+fn merge_counter_maps<K>(left: &BTreeMap<K, PNCounter>, right: &BTreeMap<K, PNCounter>) -> BTreeMap<K, PNCounter>
+where
+  K: Ord + Clone, {
+  let mut merged = left.clone();
+  for (key, counter) in right {
+    merge_counter_map_entry(&mut merged, key.clone(), counter.clone());
+  }
+  merged
+}
+
+fn merge_counter_map_entry<K>(target: &mut BTreeMap<K, PNCounter>, key: K, incoming: PNCounter)
+where
+  K: Ord, {
+  target.entry(key).and_modify(|current| *current = current.merge(&incoming)).or_insert(incoming);
 }
 
 fn merge_dot_map_entry<K>(
@@ -523,46 +676,25 @@ fn merge_dots_into(target: &mut BTreeMap<UniqueAddress, u64>, incoming: &BTreeMa
   }
 }
 
-fn filter_visible_dots(
-  key_dots: &BTreeMap<UniqueAddress, u64>,
-  removed_key_dots: Option<&BTreeMap<UniqueAddress, u64>>,
-) -> BTreeMap<UniqueAddress, u64> {
-  let Some(removed_key_dots) = removed_key_dots else {
-    return key_dots.clone();
-  };
-
-  key_dots
-    .iter()
-    .filter(|(node, version)| removed_key_dots.get(*node).copied().unwrap_or(0) < **version)
-    .map(|(node, version)| (node.clone(), *version))
-    .collect()
-}
-
-fn remove_covered_dots(key_dots: &mut BTreeMap<UniqueAddress, u64>, removed_key_dots: &BTreeMap<UniqueAddress, u64>) {
-  key_dots.retain(|node, version| removed_key_dots.get(node).copied().unwrap_or(0) < *version);
-}
-
 fn apply_removed_dots<K>(
   entries: &mut BTreeMap<K, PNCounter>,
   dots: &mut BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
   key: &K,
   removed_key_dots: &BTreeMap<UniqueAddress, u64>,
+  own_removed_dots: Option<&BTreeMap<UniqueAddress, u64>>,
+  removed_value: Option<&PNCounter>,
 ) where
   K: Ord + Clone, {
-  let Some(current_dots) = dots.get_mut(key) else {
+  let Some(current_dots) = dots.get(key).cloned() else {
     return;
   };
 
-  remove_covered_dots(current_dots, removed_key_dots);
-  if current_dots.is_empty() {
-    dots.remove(key);
-    entries.remove(key);
-    return;
-  }
-
   if let Some(counter) = entries.get(key).cloned() {
-    if let Some(counter) = visible_counter(&counter, current_dots) {
+    if let Some((counter, visible_dots)) =
+      visible_counter(&counter, &current_dots, Some(removed_key_dots), own_removed_dots, removed_value)
+    {
       entries.insert(key.clone(), counter);
+      dots.insert(key.clone(), visible_dots);
     } else {
       dots.remove(key);
       entries.remove(key);
@@ -570,7 +702,27 @@ fn apply_removed_dots<K>(
   }
 }
 
-fn prune_dots(
+fn prune_entry_dots(
+  key_dots: &BTreeMap<UniqueAddress, u64>,
+  removed_node: &UniqueAddress,
+  collapse_into: &UniqueAddress,
+  removed_key_dots: Option<&BTreeMap<UniqueAddress, u64>>,
+) -> BTreeMap<UniqueAddress, u64> {
+  let mut pruned = key_dots.clone();
+  if pruned.remove(removed_node).is_none() {
+    return pruned;
+  }
+
+  if removed_node != collapse_into {
+    let current = pruned.get(collapse_into).copied().unwrap_or(0);
+    let removed = removed_key_dots.and_then(|key_dots| key_dots.get(collapse_into)).copied().unwrap_or(0);
+    pruned.insert(collapse_into.clone(), current.max(removed).saturating_add(1));
+  }
+
+  pruned
+}
+
+fn prune_tombstone_dots(
   key_dots: &BTreeMap<UniqueAddress, u64>,
   removed_node: &UniqueAddress,
   collapse_into: &UniqueAddress,

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -15,8 +15,8 @@ use super::{
 
 /// CRDT map whose values are positive-negative counters.
 ///
-/// Equality is based on the visible counter entries only; causal dot metadata is internal
-/// convergence state.
+/// Equality ignores local delta buffers but includes causal dot and tombstone metadata because
+/// that state affects future merges.
 #[derive(Debug, Clone)]
 pub struct PNCounterMap<K> {
   entries:            BTreeMap<K, PNCounter>,
@@ -226,33 +226,29 @@ where
     let mut dots = self.dots.clone();
     let mut removed_dots = self.removed_dots.clone();
 
+    for (key, removed_key_dots) in &delta.removed_dots {
+      merge_dot_map_entry(&mut removed_dots, key.clone(), removed_key_dots);
+      apply_removed_dots(&mut entries, &mut dots, key, removed_key_dots);
+    }
+
     for (key, counter) in &delta.entries {
       let incoming_dots = delta.dots.get(key).cloned().unwrap_or_default();
-      let visible_dots = filter_visible_dots(&incoming_dots, self.removed_dots.get(key));
+      let visible_dots = filter_visible_dots(&incoming_dots, removed_dots.get(key));
       if visible_dots.is_empty() {
         continue;
       }
+
+      let Some(counter) = visible_counter(counter, &visible_dots) else {
+        continue;
+      };
+      let counter = counter.reset_delta();
 
       dots
         .entry(key.clone())
         .and_modify(|current| merge_dots_into(current, &visible_dots))
         .or_insert_with(|| visible_dots.clone());
 
-      entries
-        .entry(key.clone())
-        .and_modify(|current| *current = current.merge(counter))
-        .or_insert_with(|| counter.reset_delta());
-    }
-
-    for (key, removed_key_dots) in &delta.removed_dots {
-      merge_dot_map_entry(&mut removed_dots, key.clone(), removed_key_dots);
-      if let Some(current_dots) = dots.get_mut(key) {
-        remove_covered_dots(current_dots, removed_key_dots);
-        if current_dots.is_empty() {
-          dots.remove(key);
-          entries.remove(key);
-        }
-      }
+      entries.entry(key.clone()).and_modify(|current| *current = current.merge(&counter)).or_insert(counter);
     }
 
     Self {
@@ -325,7 +321,14 @@ where
     let mut removed_dots = BTreeMap::new();
     let mut delta = BTreeMap::new();
     let mut delta_dots = BTreeMap::new();
-    let mut delta_removed_dots = BTreeMap::new();
+    let mut delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>> = self
+      .delta_removed_dots
+      .iter()
+      .filter_map(|(key, key_dots)| {
+        let key_dots = prune_dots(key_dots, removed_node, collapse_into);
+        if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
+      })
+      .collect();
 
     for (key, counter) in &self.entries {
       let counter = counter.prune(removed_node, collapse_into)?;
@@ -347,7 +350,7 @@ where
     for (key, key_dots) in &self.removed_dots {
       let pruned_dots = prune_dots(key_dots, removed_node, collapse_into);
       if pruned_dots != *key_dots {
-        delta_removed_dots.insert(key.clone(), pruned_dots.clone());
+        merge_dot_map_entry(&mut delta_removed_dots, key.clone(), &pruned_dots);
       }
       removed_dots.insert(key.clone(), pruned_dots);
     }
@@ -414,7 +417,7 @@ where
   K: Ord,
 {
   fn eq(&self, other: &Self) -> bool {
-    self.entries == other.entries
+    self.entries == other.entries && self.dots == other.dots && self.removed_dots == other.removed_dots
   }
 }
 
@@ -447,11 +450,11 @@ where
       .map(|key_dots| filter_visible_dots(key_dots, right_removed_by_left.get(&key)))
       .unwrap_or_default();
 
-    let left_value = if left_visible_dots.is_empty() { None } else { left_entries.get(&key) };
-    let right_value = if right_visible_dots.is_empty() { None } else { right_entries.get(&key) };
+    let left_value = left_entries.get(&key).and_then(|counter| visible_counter(counter, &left_visible_dots));
+    let right_value = right_entries.get(&key).and_then(|counter| visible_counter(counter, &right_visible_dots));
     let value = match (left_value, right_value) {
-      | (Some(left), Some(right)) => Some(left.merge(right)),
-      | (Some(left), None) => Some(left.clone()),
+      | (Some(left), Some(right)) => Some(left.merge(&right)),
+      | (Some(left), None) => Some(left),
       | (None, Some(right)) => Some(right.reset_delta()),
       | (None, None) => None,
     };
@@ -466,6 +469,15 @@ where
   }
 
   (entries, dots)
+}
+
+fn visible_counter(counter: &PNCounter, visible_dots: &BTreeMap<UniqueAddress, u64>) -> Option<PNCounter> {
+  if visible_dots.is_empty() {
+    return None;
+  }
+
+  let counter = counter.retain_nodes(visible_dots);
+  if counter.modified_by_nodes().is_empty() { None } else { Some(counter) }
 }
 
 fn merge_dot_maps<K>(
@@ -522,6 +534,34 @@ fn filter_visible_dots(
 
 fn remove_covered_dots(key_dots: &mut BTreeMap<UniqueAddress, u64>, removed_key_dots: &BTreeMap<UniqueAddress, u64>) {
   key_dots.retain(|node, version| removed_key_dots.get(node).copied().unwrap_or(0) < *version);
+}
+
+fn apply_removed_dots<K>(
+  entries: &mut BTreeMap<K, PNCounter>,
+  dots: &mut BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  key: &K,
+  removed_key_dots: &BTreeMap<UniqueAddress, u64>,
+) where
+  K: Ord + Clone, {
+  let Some(current_dots) = dots.get_mut(key) else {
+    return;
+  };
+
+  remove_covered_dots(current_dots, removed_key_dots);
+  if current_dots.is_empty() {
+    dots.remove(key);
+    entries.remove(key);
+    return;
+  }
+
+  if let Some(counter) = entries.get(key).cloned() {
+    if let Some(counter) = visible_counter(&counter, current_dots) {
+      entries.insert(key.clone(), counter);
+    } else {
+      dots.remove(key);
+      entries.remove(key);
+    }
+  }
 }
 
 fn prune_dots(

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -128,14 +128,11 @@ where
     let mut delta_removed_dots = self.delta_removed_dots.clone();
     merge_dot_map_entry(&mut delta_removed_dots, key.clone(), &observed_dots);
 
-    Self {
-      entries,
-      dots,
-      removed_dots,
-      delta: self.delta.clone(),
-      delta_dots: self.delta_dots.clone(),
-      delta_removed_dots,
-    }
+    let mut delta = self.delta.clone();
+    let mut delta_dots = self.delta_dots.clone();
+    apply_removed_dots(&mut delta, &mut delta_dots, key, &observed_dots);
+
+    Self { entries, dots, removed_dots, delta, delta_dots, delta_removed_dots }
   }
 
   fn update_key(
@@ -226,10 +223,13 @@ where
     let mut entries = self.entries.clone();
     let mut dots = self.dots.clone();
     let mut removed_dots = self.removed_dots.clone();
+    let mut local_delta = self.delta.clone();
+    let mut local_delta_dots = self.delta_dots.clone();
 
     for (key, removed_key_dots) in &delta.removed_dots {
       merge_dot_map_entry(&mut removed_dots, key.clone(), removed_key_dots);
       apply_removed_dots(&mut entries, &mut dots, key, removed_key_dots);
+      apply_removed_dots(&mut local_delta, &mut local_delta_dots, key, removed_key_dots);
     }
 
     for (key, counter) in &delta.entries {
@@ -256,8 +256,8 @@ where
       entries,
       dots,
       removed_dots,
-      delta: self.delta.clone(),
-      delta_dots: self.delta_dots.clone(),
+      delta: local_delta,
+      delta_dots: local_delta_dots,
       delta_removed_dots: self.delta_removed_dots.clone(),
     }
   }
@@ -322,11 +322,11 @@ where
     let mut removed_dots = BTreeMap::new();
     let mut delta = BTreeMap::new();
     let mut delta_dots = BTreeMap::new();
-    let mut delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>> = self
+    let delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>> = self
       .delta_removed_dots
       .iter()
       .filter_map(|(key, key_dots)| {
-        let key_dots = prune_dots(key_dots, removed_node, collapse_into);
+        let key_dots = pruning_cleanup_dots(key_dots, removed_node);
         if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
       })
       .collect();
@@ -349,11 +349,10 @@ where
     }
 
     for (key, key_dots) in &self.removed_dots {
-      let pruned_dots = prune_dots(key_dots, removed_node, collapse_into);
-      if pruned_dots != *key_dots {
-        merge_dot_map_entry(&mut delta_removed_dots, key.clone(), &pruned_dots);
+      let pruned_dots = pruning_cleanup_dots(key_dots, removed_node);
+      if !pruned_dots.is_empty() {
+        removed_dots.insert(key.clone(), pruned_dots);
       }
-      removed_dots.insert(key.clone(), pruned_dots);
     }
 
     Ok(Self { entries, dots, removed_dots, delta, delta_dots, delta_removed_dots })

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -16,8 +16,12 @@ use super::{
 /// CRDT map whose values are positive-negative counters.
 #[derive(Debug, Clone)]
 pub struct PNCounterMap<K> {
-  entries: BTreeMap<K, PNCounter>,
-  delta:   BTreeMap<K, PNCounter>,
+  entries:            BTreeMap<K, PNCounter>,
+  dots:               BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  removed_dots:       BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  delta:              BTreeMap<K, PNCounter>,
+  delta_dots:         BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
 }
 
 impl<K> PNCounterMap<K>
@@ -27,7 +31,14 @@ where
   /// Creates an empty counter map.
   #[must_use]
   pub const fn new() -> Self {
-    Self { entries: BTreeMap::new(), delta: BTreeMap::new() }
+    Self {
+      entries:            BTreeMap::new(),
+      dots:               BTreeMap::new(),
+      removed_dots:       BTreeMap::new(),
+      delta:              BTreeMap::new(),
+      delta_dots:         BTreeMap::new(),
+      delta_removed_dots: BTreeMap::new(),
+    }
   }
 
   /// Returns a map with `n` added to the counter at `key`.
@@ -60,6 +71,69 @@ where
     self.entries.get(key).map(PNCounter::value).transpose()
   }
 
+  /// Returns the visible entries as signed counter values.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`CounterArithmeticError::Overflow`] when any nested counter value cannot fit in
+  /// `i128`.
+  pub fn entries(&self) -> Result<BTreeMap<K, i128>, CounterArithmeticError> {
+    self.entries.iter().map(|(key, counter)| Ok((key.clone(), counter.value()?))).collect()
+  }
+
+  /// Returns true when `key` has a visible counter entry.
+  #[must_use]
+  pub fn contains_key(&self, key: &K) -> bool {
+    self.entries.contains_key(key)
+  }
+
+  /// Returns true when the map has no visible counter entries.
+  #[must_use]
+  pub fn is_empty(&self) -> bool {
+    self.entries.is_empty()
+  }
+
+  /// Returns the number of visible counter entries.
+  #[must_use]
+  pub fn len(&self) -> usize {
+    self.entries.len()
+  }
+
+  /// Returns a map with the observed entry for `key` removed.
+  ///
+  /// A concurrent update that has not been observed by this replica survives a later merge.
+  #[must_use]
+  pub fn remove(&self, key: &K) -> Self {
+    if !self.entries.contains_key(key) {
+      return self.clone();
+    }
+
+    let Some(observed_dots) = self.dots.get(key).cloned() else {
+      return self.clone();
+    };
+
+    let mut entries = self.entries.clone();
+    entries.remove(key);
+
+    let mut dots = self.dots.clone();
+    dots.remove(key);
+
+    let mut removed_dots = self.removed_dots.clone();
+    merge_dot_map_entry(&mut removed_dots, key.clone(), &observed_dots);
+
+    let mut delta_removed_dots = self.delta_removed_dots.clone();
+    merge_dot_map_entry(&mut delta_removed_dots, key.clone(), &observed_dots);
+
+    Self {
+      entries,
+      dots,
+      removed_dots,
+      delta: self.delta.clone(),
+      delta_dots: self.delta_dots.clone(),
+      delta_removed_dots,
+    }
+  }
+
   fn update_key(
     &self,
     node: &SelfUniqueAddress,
@@ -77,10 +151,29 @@ where
     let mut entries = self.entries.clone();
     entries.insert(key.clone(), next.clone());
 
-    let mut delta = self.delta.clone();
-    delta.insert(key, next.delta().unwrap_or_default());
+    let mut dots = self.dots.clone();
+    let mut key_dots = dots.remove(&key).unwrap_or_default();
+    let node_dot = node.unique_address().clone();
+    let current_dot = key_dots.get(&node_dot).copied().unwrap_or(0);
+    let removed_dot =
+      self.removed_dots.get(&key).and_then(|removed_key_dots| removed_key_dots.get(&node_dot)).copied().unwrap_or(0);
+    key_dots.insert(node_dot, current_dot.max(removed_dot).saturating_add(1));
+    dots.insert(key.clone(), key_dots.clone());
 
-    Ok(Self { entries, delta })
+    let mut delta = self.delta.clone();
+    delta.insert(key.clone(), next.reset_delta());
+
+    let mut delta_dots = self.delta_dots.clone();
+    delta_dots.insert(key, key_dots);
+
+    Ok(Self {
+      entries,
+      dots,
+      removed_dots: self.removed_dots.clone(),
+      delta,
+      delta_dots,
+      delta_removed_dots: self.delta_removed_dots.clone(),
+    })
   }
 }
 
@@ -89,16 +182,18 @@ where
   K: Ord + Clone,
 {
   fn merge(&self, other: &Self) -> Self {
-    let mut entries = self.entries.clone();
+    let removed_dots = merge_dot_maps(&self.removed_dots, &other.removed_dots);
+    let (entries, dots) =
+      merge_entries(&self.entries, &self.dots, &other.removed_dots, &other.entries, &other.dots, &self.removed_dots);
 
-    for (key, counter) in &other.entries {
-      entries
-        .entry(key.clone())
-        .and_modify(|current| *current = current.merge(counter))
-        .or_insert_with(|| counter.reset_delta());
+    Self {
+      entries,
+      dots,
+      removed_dots,
+      delta: self.delta.clone(),
+      delta_dots: self.delta_dots.clone(),
+      delta_removed_dots: self.delta_removed_dots.clone(),
     }
-
-    Self { entries, delta: self.delta.clone() }
   }
 }
 
@@ -109,26 +204,75 @@ where
   type Delta = Self;
 
   fn delta(&self) -> Option<Self::Delta> {
-    if self.delta.is_empty() { None } else { Some(Self { entries: self.delta.clone(), delta: BTreeMap::new() }) }
+    if self.delta.is_empty() && self.delta_removed_dots.is_empty() {
+      None
+    } else {
+      Some(Self {
+        entries:            self.delta.clone(),
+        dots:               self.delta_dots.clone(),
+        removed_dots:       self.delta_removed_dots.clone(),
+        delta:              BTreeMap::new(),
+        delta_dots:         BTreeMap::new(),
+        delta_removed_dots: BTreeMap::new(),
+      })
+    }
   }
 
   fn merge_delta(&self, delta: &Self::Delta) -> Self {
     let mut entries = self.entries.clone();
+    let mut dots = self.dots.clone();
+    let mut removed_dots = self.removed_dots.clone();
 
     for (key, counter) in &delta.entries {
+      let incoming_dots = delta.dots.get(key).cloned().unwrap_or_default();
+      let visible_dots = filter_visible_dots(&incoming_dots, self.removed_dots.get(key));
+      if visible_dots.is_empty() {
+        continue;
+      }
+
+      dots
+        .entry(key.clone())
+        .and_modify(|current| merge_dots_into(current, &visible_dots))
+        .or_insert_with(|| visible_dots.clone());
+
       entries
         .entry(key.clone())
-        .and_modify(|current| *current = current.merge_delta(counter))
+        .and_modify(|current| *current = current.merge(counter))
         .or_insert_with(|| counter.reset_delta());
     }
 
-    Self { entries, delta: self.delta.clone() }
+    for (key, removed_key_dots) in &delta.removed_dots {
+      merge_dot_map_entry(&mut removed_dots, key.clone(), removed_key_dots);
+      if let Some(current_dots) = dots.get_mut(key) {
+        remove_covered_dots(current_dots, removed_key_dots);
+        if current_dots.is_empty() {
+          dots.remove(key);
+          entries.remove(key);
+        }
+      }
+    }
+
+    Self {
+      entries,
+      dots,
+      removed_dots,
+      delta: self.delta.clone(),
+      delta_dots: self.delta_dots.clone(),
+      delta_removed_dots: self.delta_removed_dots.clone(),
+    }
   }
 
   fn reset_delta(&self) -> Self {
     let entries = self.entries.iter().map(|(key, counter)| (key.clone(), counter.reset_delta())).collect();
 
-    Self { entries, delta: BTreeMap::new() }
+    Self {
+      entries,
+      dots: self.dots.clone(),
+      removed_dots: self.removed_dots.clone(),
+      delta: BTreeMap::new(),
+      delta_dots: BTreeMap::new(),
+      delta_removed_dots: BTreeMap::new(),
+    }
   }
 }
 
@@ -157,31 +301,73 @@ where
     for counter in self.entries.values() {
       nodes.extend(counter.modified_by_nodes());
     }
+    for key_dots in self.dots.values() {
+      nodes.extend(key_dots.keys().cloned());
+    }
+    for key_dots in self.removed_dots.values() {
+      nodes.extend(key_dots.keys().cloned());
+    }
     nodes
   }
 
   fn need_pruning_from(&self, removed_node: &UniqueAddress) -> bool {
     self.entries.values().any(|counter| counter.need_pruning_from(removed_node))
+      || self.dots.values().any(|key_dots| key_dots.contains_key(removed_node))
+      || self.removed_dots.values().any(|key_dots| key_dots.contains_key(removed_node))
   }
 
   fn prune(&self, removed_node: &UniqueAddress, collapse_into: &UniqueAddress) -> Result<Self, Self::PruneError> {
     let mut entries = BTreeMap::new();
+    let mut dots = BTreeMap::new();
+    let mut removed_dots = BTreeMap::new();
     let mut delta = BTreeMap::new();
+    let mut delta_dots = BTreeMap::new();
+    let mut delta_removed_dots = BTreeMap::new();
 
     for (key, counter) in &self.entries {
       let counter = counter.prune(removed_node, collapse_into)?;
-      if let Some(counter_delta) = counter.delta() {
-        delta.insert(key.clone(), counter_delta);
+      let pruned_dots = self.dots.get(key).map(|key_dots| prune_dots(key_dots, removed_node, collapse_into));
+      let dots_changed = pruned_dots.as_ref() != self.dots.get(key);
+      if counter.delta().is_some() || dots_changed {
+        delta.insert(key.clone(), counter.reset_delta());
+        if let Some(pruned_dots) = &pruned_dots {
+          delta_dots.insert(key.clone(), pruned_dots.clone());
+        }
       }
       entries.insert(key.clone(), counter);
     }
 
-    Ok(Self { entries, delta })
+    for (key, key_dots) in &self.dots {
+      dots.insert(key.clone(), prune_dots(key_dots, removed_node, collapse_into));
+    }
+
+    for (key, key_dots) in &self.removed_dots {
+      let pruned_dots = prune_dots(key_dots, removed_node, collapse_into);
+      if pruned_dots != *key_dots {
+        delta_removed_dots.insert(key.clone(), pruned_dots.clone());
+      }
+      removed_dots.insert(key.clone(), pruned_dots);
+    }
+
+    Ok(Self { entries, dots, removed_dots, delta, delta_dots, delta_removed_dots })
   }
 
   fn pruning_cleanup(&self, removed_node: &UniqueAddress) -> Self {
-    let entries =
-      self.entries.iter().map(|(key, counter)| (key.clone(), counter.pruning_cleanup(removed_node))).collect();
+    let mut entries = BTreeMap::new();
+    let mut dots = BTreeMap::new();
+    for (key, counter) in &self.entries {
+      let key_dots = self.dots.get(key).map(|dots| pruning_cleanup_dots(dots, removed_node)).unwrap_or_default();
+      if !key_dots.is_empty() {
+        entries.insert(key.clone(), counter.pruning_cleanup(removed_node));
+        dots.insert(key.clone(), key_dots);
+      }
+    }
+
+    let removed_dots = self
+      .removed_dots
+      .iter()
+      .map(|(key, key_dots)| (key.clone(), pruning_cleanup_dots(key_dots, removed_node)))
+      .collect();
     let delta = self
       .delta
       .iter()
@@ -190,8 +376,24 @@ where
         if counter.modified_by_nodes().is_empty() { None } else { Some((key.clone(), counter)) }
       })
       .collect();
+    let delta_dots = self
+      .delta_dots
+      .iter()
+      .filter_map(|(key, key_dots)| {
+        let key_dots = pruning_cleanup_dots(key_dots, removed_node);
+        if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
+      })
+      .collect();
+    let delta_removed_dots = self
+      .delta_removed_dots
+      .iter()
+      .filter_map(|(key, key_dots)| {
+        let key_dots = pruning_cleanup_dots(key_dots, removed_node);
+        if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
+      })
+      .collect();
 
-    Self { entries, delta }
+    Self { entries, dots, removed_dots, delta, delta_dots, delta_removed_dots }
   }
 }
 
@@ -214,3 +416,136 @@ where
 }
 
 impl<K> Eq for PNCounterMap<K> where K: Ord {}
+
+fn merge_entries<K>(
+  left_entries: &BTreeMap<K, PNCounter>,
+  left_dots: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  left_removed_by_right: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  right_entries: &BTreeMap<K, PNCounter>,
+  right_dots: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  right_removed_by_left: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+) -> (BTreeMap<K, PNCounter>, BTreeMap<K, BTreeMap<UniqueAddress, u64>>)
+where
+  K: Ord + Clone, {
+  let mut keys = BTreeSet::new();
+  keys.extend(left_dots.keys().cloned());
+  keys.extend(right_dots.keys().cloned());
+
+  let mut entries = BTreeMap::new();
+  let mut dots = BTreeMap::new();
+
+  for key in keys {
+    let left_visible_dots = left_dots
+      .get(&key)
+      .map(|key_dots| filter_visible_dots(key_dots, left_removed_by_right.get(&key)))
+      .unwrap_or_default();
+    let right_visible_dots = right_dots
+      .get(&key)
+      .map(|key_dots| filter_visible_dots(key_dots, right_removed_by_left.get(&key)))
+      .unwrap_or_default();
+
+    let left_value = if left_visible_dots.is_empty() { None } else { left_entries.get(&key) };
+    let right_value = if right_visible_dots.is_empty() { None } else { right_entries.get(&key) };
+    let value = match (left_value, right_value) {
+      | (Some(left), Some(right)) => Some(left.merge(right)),
+      | (Some(left), None) => Some(left.clone()),
+      | (None, Some(right)) => Some(right.reset_delta()),
+      | (None, None) => None,
+    };
+
+    if let Some(value) = value {
+      let merged_dots = merge_dots(&left_visible_dots, &right_visible_dots);
+      if !merged_dots.is_empty() {
+        dots.insert(key.clone(), merged_dots);
+        entries.insert(key, value);
+      }
+    }
+  }
+
+  (entries, dots)
+}
+
+fn merge_dot_maps<K>(
+  left: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  right: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+) -> BTreeMap<K, BTreeMap<UniqueAddress, u64>>
+where
+  K: Ord + Clone, {
+  let mut merged = left.clone();
+  for (key, dots) in right {
+    merge_dot_map_entry(&mut merged, key.clone(), dots);
+  }
+  merged
+}
+
+fn merge_dot_map_entry<K>(
+  target: &mut BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  key: K,
+  incoming: &BTreeMap<UniqueAddress, u64>,
+) where
+  K: Ord, {
+  target.entry(key).and_modify(|current| merge_dots_into(current, incoming)).or_insert_with(|| incoming.clone());
+}
+
+fn merge_dots(
+  left: &BTreeMap<UniqueAddress, u64>,
+  right: &BTreeMap<UniqueAddress, u64>,
+) -> BTreeMap<UniqueAddress, u64> {
+  let mut merged = left.clone();
+  merge_dots_into(&mut merged, right);
+  merged
+}
+
+fn merge_dots_into(target: &mut BTreeMap<UniqueAddress, u64>, incoming: &BTreeMap<UniqueAddress, u64>) {
+  for (node, version) in incoming {
+    target.entry(node.clone()).and_modify(|current| *current = (*current).max(*version)).or_insert(*version);
+  }
+}
+
+fn filter_visible_dots(
+  key_dots: &BTreeMap<UniqueAddress, u64>,
+  removed_key_dots: Option<&BTreeMap<UniqueAddress, u64>>,
+) -> BTreeMap<UniqueAddress, u64> {
+  let Some(removed_key_dots) = removed_key_dots else {
+    return key_dots.clone();
+  };
+
+  key_dots
+    .iter()
+    .filter(|(node, version)| removed_key_dots.get(*node).copied().unwrap_or(0) < **version)
+    .map(|(node, version)| (node.clone(), *version))
+    .collect()
+}
+
+fn remove_covered_dots(key_dots: &mut BTreeMap<UniqueAddress, u64>, removed_key_dots: &BTreeMap<UniqueAddress, u64>) {
+  key_dots.retain(|node, version| removed_key_dots.get(node).copied().unwrap_or(0) < *version);
+}
+
+fn prune_dots(
+  key_dots: &BTreeMap<UniqueAddress, u64>,
+  removed_node: &UniqueAddress,
+  collapse_into: &UniqueAddress,
+) -> BTreeMap<UniqueAddress, u64> {
+  let mut pruned = key_dots.clone();
+  let Some(removed_version) = pruned.remove(removed_node) else {
+    return pruned;
+  };
+
+  if removed_node != collapse_into {
+    pruned
+      .entry(collapse_into.clone())
+      .and_modify(|current| *current = (*current).max(removed_version))
+      .or_insert(removed_version);
+  }
+
+  pruned
+}
+
+fn pruning_cleanup_dots(
+  key_dots: &BTreeMap<UniqueAddress, u64>,
+  removed_node: &UniqueAddress,
+) -> BTreeMap<UniqueAddress, u64> {
+  let mut cleaned = key_dots.clone();
+  cleaned.remove(removed_node);
+  cleaned
+}

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -227,7 +227,7 @@ where
         key,
         removed_key_dots,
         self.delta_removed_dots.get(key),
-        other.removed_values.get(key),
+        removed_values.get(key),
       );
     }
 

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -5,6 +5,7 @@
 mod tests;
 
 use alloc::collections::{BTreeMap, BTreeSet};
+use core::cmp::Ordering;
 
 use fraktor_remote_core_rs::address::UniqueAddress;
 
@@ -132,7 +133,7 @@ where
     let observed_value = self.entries.get(key).map(|counter| counter.retain_nodes(&observed_dots).reset_delta());
     let mut removed_values = self.removed_values.clone();
     if let Some(observed_value) = &observed_value {
-      merge_counter_map_entry(&mut removed_values, key.clone(), observed_value.clone());
+      replace_counter_map_entry(&mut removed_values, key.clone(), &observed_dots, observed_value);
     }
 
     let mut delta_removed_dots = self.delta_removed_dots.clone();
@@ -140,7 +141,7 @@ where
 
     let mut delta_removed_values = self.delta_removed_values.clone();
     if let Some(observed_value) = observed_value {
-      merge_counter_map_entry(&mut delta_removed_values, key.clone(), observed_value);
+      replace_counter_map_entry(&mut delta_removed_values, key.clone(), &observed_dots, &observed_value);
     }
 
     let mut delta = self.delta.clone();
@@ -200,8 +201,8 @@ where
   K: Ord + Clone,
 {
   fn merge(&self, other: &Self) -> Self {
-    let removed_dots = merge_dot_maps(&self.removed_dots, &other.removed_dots);
-    let removed_values = merge_counter_maps(&self.removed_values, &other.removed_values);
+    let (removed_dots, removed_values) =
+      merge_removed_metadata(&self.removed_dots, &self.removed_values, &other.removed_dots, &other.removed_values);
     let (entries, dots) = merge_entries(
       &MergeEntrySide {
         entries:                 &self.entries,
@@ -270,16 +271,12 @@ where
   fn merge_delta(&self, delta: &Self::Delta) -> Self {
     let mut entries = self.entries.clone();
     let mut dots = self.dots.clone();
-    let mut removed_dots = self.removed_dots.clone();
-    let mut removed_values = self.removed_values.clone();
+    let (removed_dots, removed_values) =
+      merge_removed_metadata(&self.removed_dots, &self.removed_values, &delta.removed_dots, &delta.removed_values);
     let mut local_delta = self.delta.clone();
     let mut local_delta_dots = self.delta_dots.clone();
 
     for (key, removed_key_dots) in &delta.removed_dots {
-      merge_dot_map_entry(&mut removed_dots, key.clone(), removed_key_dots);
-      if let Some(removed_value) = delta.removed_values.get(key) {
-        merge_counter_map_entry(&mut removed_values, key.clone(), removed_value.clone());
-      }
       apply_removed_dots(
         &mut entries,
         &mut dots,
@@ -398,7 +395,7 @@ where
     let mut removed_values = BTreeMap::new();
     let mut delta = BTreeMap::new();
     let mut delta_dots = BTreeMap::new();
-    let delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>> = self
+    let mut delta_removed_dots: BTreeMap<K, BTreeMap<UniqueAddress, u64>> = self
       .delta_removed_dots
       .iter()
       .filter_map(|(key, key_dots)| {
@@ -421,30 +418,36 @@ where
         .get(key)
         .map(|key_dots| prune_entry_dots(key_dots, removed_node, collapse_into, self.removed_dots.get(key)));
       let dots_changed = pruned_dots.as_ref() != self.dots.get(key);
-      if counter.delta().is_some() || dots_changed {
-        delta.insert(key.clone(), counter.reset_delta());
-        if let Some(pruned_dots) = &pruned_dots {
+      if let Some(pruned_dots) = pruned_dots.filter(|key_dots| !key_dots.is_empty()) {
+        if counter.delta().is_some() || dots_changed {
+          delta.insert(key.clone(), counter.reset_delta());
           delta_dots.insert(key.clone(), pruned_dots.clone());
         }
+        dots.insert(key.clone(), pruned_dots);
+        entries.insert(key.clone(), counter);
       }
-      entries.insert(key.clone(), counter);
-    }
-
-    for (key, key_dots) in &self.dots {
-      dots.insert(key.clone(), prune_entry_dots(key_dots, removed_node, collapse_into, self.removed_dots.get(key)));
     }
 
     for (key, key_dots) in &self.removed_dots {
       let pruned_dots = prune_tombstone_dots(key_dots, removed_node, collapse_into);
+      let dots_changed = pruned_dots != *key_dots;
       if !pruned_dots.is_empty() {
+        if dots_changed {
+          merge_dot_map_entry(&mut delta_removed_dots, key.clone(), &pruned_dots);
+        }
         removed_dots.insert(key.clone(), pruned_dots);
       }
     }
 
     for (key, counter) in &self.removed_values {
       let counter = counter.prune(removed_node, collapse_into)?;
+      let counter_changed = counter.delta().is_some();
       if !counter.modified_by_nodes().is_empty() {
-        removed_values.insert(key.clone(), counter.reset_delta());
+        let counter = counter.reset_delta();
+        if counter_changed && let Some(key_dots) = removed_dots.get(key) {
+          replace_counter_map_entry(&mut delta_removed_values, key.clone(), key_dots, &counter);
+        }
+        removed_values.insert(key.clone(), counter);
       }
     }
 
@@ -636,20 +639,58 @@ where
   merged
 }
 
-fn merge_counter_maps<K>(left: &BTreeMap<K, PNCounter>, right: &BTreeMap<K, PNCounter>) -> BTreeMap<K, PNCounter>
+fn merge_removed_metadata<K>(
+  left_dots: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  left_values: &BTreeMap<K, PNCounter>,
+  right_dots: &BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
+  right_values: &BTreeMap<K, PNCounter>,
+) -> (BTreeMap<K, BTreeMap<UniqueAddress, u64>>, BTreeMap<K, PNCounter>)
 where
   K: Ord + Clone, {
-  let mut merged = left.clone();
-  for (key, counter) in right {
-    merge_counter_map_entry(&mut merged, key.clone(), counter.clone());
+  let removed_dots = merge_dot_maps(left_dots, right_dots);
+  let mut removed_values = BTreeMap::new();
+
+  for (key, key_dots) in &removed_dots {
+    let mut components = BTreeMap::new();
+    for node in key_dots.keys() {
+      let left_version = left_dots.get(key).and_then(|dots| dots.get(node)).copied().unwrap_or(0);
+      let right_version = right_dots.get(key).and_then(|dots| dots.get(node)).copied().unwrap_or(0);
+      let left_components = left_values.get(key).map(|counter| counter.node_components(node)).unwrap_or((0, 0));
+      let right_components = right_values.get(key).map(|counter| counter.node_components(node)).unwrap_or((0, 0));
+      let (increment, decrement) = match left_version.cmp(&right_version) {
+        | Ordering::Greater if right_version == 0 && right_components != (0, 0) => {
+          (left_components.0.max(right_components.0), left_components.1.max(right_components.1))
+        },
+        | Ordering::Greater => left_components,
+        | Ordering::Less if left_version == 0 && left_components != (0, 0) => {
+          (left_components.0.max(right_components.0), left_components.1.max(right_components.1))
+        },
+        | Ordering::Less => right_components,
+        | Ordering::Equal => (left_components.0.max(right_components.0), left_components.1.max(right_components.1)),
+      };
+      if increment != 0 || decrement != 0 {
+        components.insert(node.clone(), (increment, decrement));
+      }
+    }
+    if !components.is_empty() {
+      removed_values.insert(key.clone(), PNCounter::from_node_components(components));
+    }
   }
-  merged
+
+  (removed_dots, removed_values)
 }
 
-fn merge_counter_map_entry<K>(target: &mut BTreeMap<K, PNCounter>, key: K, incoming: PNCounter)
-where
+fn replace_counter_map_entry<K>(
+  target: &mut BTreeMap<K, PNCounter>,
+  key: K,
+  nodes: &BTreeMap<UniqueAddress, u64>,
+  incoming: &PNCounter,
+) where
   K: Ord, {
-  target.entry(key).and_modify(|current| *current = current.merge(&incoming)).or_insert(incoming);
+  target
+    .entry(key)
+    .and_modify(|current| *current = current.replace_nodes(nodes, incoming).reset_delta())
+    .or_insert_with(|| incoming.clone());
 }
 
 fn merge_dot_map_entry<K>(

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -226,7 +226,7 @@ where
         &mut delta_dots,
         key,
         removed_key_dots,
-        self.delta_removed_dots.get(key),
+        self.removed_dots.get(key),
         removed_values.get(key),
       );
     }
@@ -293,7 +293,7 @@ where
         &mut local_delta_dots,
         key,
         removed_key_dots,
-        self.delta_removed_dots.get(key),
+        self.removed_dots.get(key),
         removed_values.get(key),
       );
     }

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -19,6 +19,7 @@ use super::{
 /// that state affects future merges.
 #[derive(Debug, Clone)]
 pub struct PNCounterMap<K> {
+  // Invariant: every visible entry has a matching dot map; merge derives candidates from dots.
   entries:            BTreeMap<K, PNCounter>,
   dots:               BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
   removed_dots:       BTreeMap<K, BTreeMap<UniqueAddress, u64>>,
@@ -372,7 +373,10 @@ where
     let removed_dots = self
       .removed_dots
       .iter()
-      .map(|(key, key_dots)| (key.clone(), pruning_cleanup_dots(key_dots, removed_node)))
+      .filter_map(|(key, key_dots)| {
+        let key_dots = pruning_cleanup_dots(key_dots, removed_node);
+        if key_dots.is_empty() { None } else { Some((key.clone(), key_dots)) }
+      })
       .collect();
     let delta = self
       .delta
@@ -433,6 +437,9 @@ fn merge_entries<K>(
 ) -> (BTreeMap<K, PNCounter>, BTreeMap<K, BTreeMap<UniqueAddress, u64>>)
 where
   K: Ord + Clone, {
+  debug_assert!(left_entries.keys().all(|key| left_dots.contains_key(key)));
+  debug_assert!(right_entries.keys().all(|key| right_dots.contains_key(key)));
+
   let mut keys = BTreeSet::new();
   keys.extend(left_dots.keys().cloned());
   keys.extend(right_dots.keys().cloned());

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map.rs
@@ -14,6 +14,9 @@ use super::{
 };
 
 /// CRDT map whose values are positive-negative counters.
+///
+/// Equality is based on the visible counter entries only; causal dot metadata is internal
+/// convergence state.
 #[derive(Debug, Clone)]
 pub struct PNCounterMap<K> {
   entries:            BTreeMap<K, PNCounter>,

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -25,18 +25,42 @@ fn self_address(index: usize) -> SelfUniqueAddress {
   SelfUniqueAddress::new(unique_address(index))
 }
 
-fn map_from_ops(ops: &[(usize, u8, bool, u64)]) -> PNCounterMap<u8> {
+#[derive(Debug, Clone)]
+enum MapOp {
+  Increment { index: usize, key: u8, amount: u64 },
+  Decrement { index: usize, key: u8, amount: u64 },
+  Remove { key: u8 },
+}
+
+fn map_from_ops(ops: &[MapOp]) -> PNCounterMap<u8> {
   let mut map = PNCounterMap::new();
-  for (index, key, increment, amount) in ops {
-    let node = self_address(*index);
-    map = if *increment { map.increment(&node, *key, *amount) } else { map.decrement(&node, *key, *amount) }
-      .expect("small generated increments must fit");
+  for op in ops {
+    map = match op {
+      | MapOp::Increment { index, key, amount } => {
+        map.increment(&self_address(*index), *key, *amount).expect("small generated increments must fit")
+      },
+      | MapOp::Decrement { index, key, amount } => {
+        map.decrement(&self_address(*index), *key, *amount).expect("small generated decrements must fit")
+      },
+      | MapOp::Remove { key } => map.remove(key),
+    };
   }
   map
 }
 
-fn op_strategy() -> impl Strategy<Value = Vec<(usize, u8, bool, u64)>> {
-  prop::collection::vec((0_usize..4, 0_u8..4, any::<bool>(), 0_u64..20), 0..24)
+fn op_strategy_for_nodes(nodes: impl Strategy<Value = usize> + Clone + 'static) -> impl Strategy<Value = Vec<MapOp>> {
+  prop::collection::vec(
+    prop_oneof![
+      (nodes.clone(), 0_u8..4, 0_u64..20).prop_map(|(index, key, amount)| MapOp::Increment { index, key, amount }),
+      (nodes, 0_u8..4, 0_u64..20).prop_map(|(index, key, amount)| MapOp::Decrement { index, key, amount }),
+      (0_u8..4).prop_map(|key| MapOp::Remove { key }),
+    ],
+    0..24,
+  )
+}
+
+fn op_strategy() -> impl Strategy<Value = Vec<MapOp>> {
+  op_strategy_for_nodes(0_usize..4)
 }
 
 fn g_counter_with_slot(index: usize, value: u128) -> GCounter {
@@ -300,6 +324,17 @@ fn pruning_cleanup_drops_emptied_delta_entries() {
 }
 
 #[test]
+fn pruning_cleanup_drops_emptied_removed_dots_entries() {
+  let removed = self_address(0);
+  let map = PNCounterMap::new().increment(&removed, 1, 7).expect("increment must fit").remove(&1);
+
+  let cleaned = map.pruning_cleanup(removed.unique_address());
+
+  assert!(cleaned.removed_dots.is_empty());
+  assert_eq!(cleaned, PNCounterMap::new());
+}
+
+#[test]
 fn pruning_delegates_to_entries() {
   let removed = self_address(0);
   let collapse_into = self_address(1);
@@ -382,7 +417,10 @@ fn get_propagates_nested_counter_overflow() {
 
 proptest! {
   #[test]
-  fn merge_delta_matches_full_state_merge(base_ops in op_strategy(), delta_ops in op_strategy()) {
+  fn merge_delta_matches_full_state_merge(
+    base_ops in op_strategy_for_nodes(0_usize..2),
+    delta_ops in op_strategy_for_nodes(2_usize..4),
+  ) {
     let base = map_from_ops(&base_ops);
     let full_with_delta = map_from_ops(&delta_ops);
     let delta = full_with_delta.delta().unwrap_or_else(PNCounterMap::new);
@@ -391,7 +429,7 @@ proptest! {
   }
 
   #[test]
-  fn merge_is_commutative(left_ops in op_strategy(), right_ops in op_strategy()) {
+  fn merge_is_commutative(left_ops in op_strategy_for_nodes(0_usize..2), right_ops in op_strategy_for_nodes(2_usize..4)) {
     let left = map_from_ops(&left_ops);
     let right = map_from_ops(&right_ops);
 
@@ -399,7 +437,11 @@ proptest! {
   }
 
   #[test]
-  fn merge_is_associative(left_ops in op_strategy(), middle_ops in op_strategy(), right_ops in op_strategy()) {
+  fn merge_is_associative(
+    left_ops in op_strategy_for_nodes(0_usize..1),
+    middle_ops in op_strategy_for_nodes(1_usize..2),
+    right_ops in op_strategy_for_nodes(2_usize..3),
+  ) {
     let left = map_from_ops(&left_ops);
     let middle = map_from_ops(&middle_ops);
     let right = map_from_ops(&right_ops);

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -297,10 +297,6 @@ fn full_state_merge_prunes_local_delta_with_merged_removed_value_prefix() {
   let removed_prefix_5 = PNCounter::new().increment(&self_address(0), 5).expect("increment must fit").reset_delta();
   let pending_value_8 = PNCounter::new().increment(&self_address(0), 8).expect("increment must fit").reset_delta();
 
-  let mut local_removed_key_dots = BTreeMap::new();
-  local_removed_key_dots.insert(node.clone(), 1);
-  let mut local_removed_dots = BTreeMap::new();
-  local_removed_dots.insert(1, local_removed_key_dots);
   let mut local_removed_values = BTreeMap::new();
   local_removed_values.insert(1, removed_prefix_5);
   let mut local_delta = BTreeMap::new();
@@ -312,7 +308,7 @@ fn full_state_merge_prunes_local_delta_with_merged_removed_value_prefix() {
   let local = PNCounterMap {
     entries:              BTreeMap::new(),
     dots:                 BTreeMap::new(),
-    removed_dots:         local_removed_dots,
+    removed_dots:         BTreeMap::new(),
     removed_values:       local_removed_values,
     delta:                local_delta,
     delta_dots:           local_delta_dots,
@@ -340,6 +336,32 @@ fn full_state_merge_prunes_local_delta_with_merged_removed_value_prefix() {
   let merged_delta = local.merge(&remote).delta().expect("remaining delta must be visible");
 
   assert_eq!(merged_delta.get(&1), Ok(Some(3)));
+}
+
+#[test]
+fn full_state_merge_keeps_recreated_local_delta_after_reset_delta() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let recreated = original.remove(&1).reset_delta().increment(&self_address(0), 1, 8).expect("increment must fit");
+  let remote_remove = original.reset_delta().remove(&1);
+
+  let merged = recreated.merge(&remote_remove);
+  let remaining_delta = merged.delta().expect("recreated local value must remain in delta");
+
+  assert_eq!(merged.get(&1), Ok(Some(8)));
+  assert_eq!(remaining_delta.get(&1), Ok(Some(8)));
+}
+
+#[test]
+fn merge_delta_keeps_recreated_local_delta_after_reset_delta() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let recreated = original.remove(&1).reset_delta().increment(&self_address(0), 1, 8).expect("increment must fit");
+  let remove_delta = original.reset_delta().remove(&1).delta().expect("remove must create delta");
+
+  let merged = recreated.merge_delta(&remove_delta);
+  let remaining_delta = merged.delta().expect("recreated local value must remain in delta");
+
+  assert_eq!(merged.get(&1), Ok(Some(8)));
+  assert_eq!(remaining_delta.get(&1), Ok(Some(8)));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -63,6 +63,26 @@ fn increment_decrement_and_get_are_key_scoped() {
 }
 
 #[test]
+fn entries_surface_reports_visible_counter_values() {
+  let map = PNCounterMap::new()
+    .increment(&self_address(0), 1, 7)
+    .expect("increment must fit")
+    .decrement(&self_address(1), 1, 2)
+    .expect("decrement must fit")
+    .increment(&self_address(2), 2, 11)
+    .expect("increment must fit");
+
+  let mut expected = BTreeMap::new();
+  expected.insert(1, 5);
+  expected.insert(2, 11);
+
+  assert_eq!(map.entries(), Ok(expected));
+  assert!(map.contains_key(&1));
+  assert_eq!(map.len(), 2);
+  assert!(!map.is_empty());
+}
+
+#[test]
 fn merge_unions_keys_and_merges_shared_counters() {
   let left = PNCounterMap::new()
     .increment(&self_address(0), 1, 7)
@@ -80,6 +100,56 @@ fn merge_unions_keys_and_merges_shared_counters() {
   assert_eq!(merged.get(&1), Ok(Some(5)));
   assert_eq!(merged.get(&2), Ok(Some(3)));
   assert_eq!(merged.get(&3), Ok(Some(4)));
+}
+
+#[test]
+fn remove_drops_observed_key_after_full_state_merge() {
+  let left = PNCounterMap::new()
+    .increment(&self_address(0), 1, 1)
+    .expect("increment must fit")
+    .increment(&self_address(0), 2, 3)
+    .expect("increment must fit")
+    .increment(&self_address(0), 3, 2)
+    .expect("increment must fit");
+  let right = PNCounterMap::new().increment(&self_address(1), 3, 5).expect("increment must fit");
+  let merged = left.merge(&right);
+
+  let removed = merged.remove(&2);
+  let merged_after_remove = merged.merge(&removed);
+
+  let mut expected = BTreeMap::new();
+  expected.insert(1, 1);
+  expected.insert(3, 7);
+
+  assert_eq!(merged_after_remove.entries(), Ok(expected));
+  assert_eq!(merged_after_remove.get(&2), Ok(None));
+}
+
+#[test]
+fn remove_keeps_concurrent_full_state_update() {
+  let left = PNCounterMap::new()
+    .increment(&self_address(0), 1, 1)
+    .expect("increment must fit")
+    .increment(&self_address(0), 2, 3)
+    .expect("increment must fit")
+    .increment(&self_address(0), 3, 2)
+    .expect("increment must fit");
+  let right = PNCounterMap::new().increment(&self_address(1), 3, 5).expect("increment must fit");
+  let merged = left.merge(&right);
+
+  let removed = merged.remove(&2);
+  let concurrent = merged.increment(&self_address(1), 2, 10).expect("increment must fit");
+
+  assert_eq!(removed.merge(&concurrent).get(&2), Ok(Some(13)));
+}
+
+#[test]
+fn remove_then_recreate_ignores_stale_observed_value() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let recreated = original.remove(&1).increment(&self_address(0), 1, 1).expect("increment must fit");
+
+  assert_eq!(recreated.get(&1), Ok(Some(1)));
+  assert_eq!(recreated.merge(&original).get(&1), Ok(Some(1)));
 }
 
 #[test]
@@ -110,6 +180,43 @@ fn merge_delta_preserves_local_delta() {
   assert_eq!(merged.get(&2), Ok(Some(-2)));
   assert_eq!(remaining_delta.get(&1), Ok(Some(7)));
   assert_eq!(remaining_delta.get(&2), Ok(None));
+}
+
+#[test]
+fn remove_delta_drops_observed_key() {
+  let left = PNCounterMap::new()
+    .increment(&self_address(0), 1, 1)
+    .expect("increment must fit")
+    .increment(&self_address(0), 2, 3)
+    .expect("increment must fit")
+    .increment(&self_address(0), 3, 2)
+    .expect("increment must fit");
+  let right = PNCounterMap::new().increment(&self_address(1), 3, 5).expect("increment must fit");
+  let merged = left.merge(&right);
+
+  let removed = merged.reset_delta().remove(&2);
+  let remove_delta = removed.delta().expect("remove must create delta");
+
+  assert_eq!(merged.merge_delta(&remove_delta).get(&2), Ok(None));
+}
+
+#[test]
+fn remove_delta_keeps_concurrent_update_delta() {
+  let left = PNCounterMap::new()
+    .increment(&self_address(0), 1, 1)
+    .expect("increment must fit")
+    .increment(&self_address(0), 2, 3)
+    .expect("increment must fit")
+    .increment(&self_address(0), 3, 2)
+    .expect("increment must fit");
+  let right = PNCounterMap::new().increment(&self_address(1), 3, 5).expect("increment must fit");
+  let merged = left.merge(&right);
+
+  let removed = merged.reset_delta().remove(&2);
+  let concurrent = merged.reset_delta().increment(&self_address(1), 2, 10).expect("increment must fit");
+  let concurrent_delta = concurrent.delta().expect("concurrent update must create delta");
+
+  assert_eq!(removed.merge_delta(&concurrent_delta).get(&2), Ok(Some(13)));
 }
 
 #[test]
@@ -208,9 +315,17 @@ fn get_propagates_nested_counter_overflow() {
   let counter = PNCounter::from_parts(g_counter_with_slot(0, u128::MAX), GCounter::new());
   let mut entries = BTreeMap::new();
   entries.insert(1, counter);
-  let map = PNCounterMap { entries, delta: BTreeMap::new() };
+  let map = PNCounterMap {
+    entries,
+    dots: BTreeMap::new(),
+    removed_dots: BTreeMap::new(),
+    delta: BTreeMap::new(),
+    delta_dots: BTreeMap::new(),
+    delta_removed_dots: BTreeMap::new(),
+  };
 
   assert_eq!(map.get(&1), Err(CounterArithmeticError::Overflow));
+  assert_eq!(map.entries(), Err(CounterArithmeticError::Overflow));
 }
 
 proptest! {

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -280,6 +280,17 @@ fn remote_remove_drops_covered_local_delta() {
 }
 
 #[test]
+fn full_state_remove_drops_covered_local_delta() {
+  let local = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let remote_remove = local.reset_delta().remove(&1);
+
+  let merged = local.merge(&remote_remove);
+
+  assert_eq!(merged.get(&1), Ok(None));
+  assert_eq!(merged.delta(), None);
+}
+
+#[test]
 fn remove_tombstone_participates_in_equality() {
   let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
   let removed = original.remove(&1);
@@ -301,6 +312,15 @@ fn merge_excludes_tombstoned_counter_slots() {
   assert_eq!(left_associated.get(&1), Ok(Some(2)));
   assert_eq!(right_associated.get(&1), Ok(Some(2)));
   assert_eq!(left_associated, right_associated);
+}
+
+#[test]
+fn merge_subtracts_removed_same_node_prefix_from_later_dot() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let removed = original.remove(&1);
+  let stale_later_dot = original.increment(&self_address(0), 1, 3).expect("increment must fit");
+
+  assert_eq!(removed.merge(&stale_later_dot).get(&1), Ok(Some(3)));
 }
 
 #[test]
@@ -434,6 +454,35 @@ fn prune_does_not_retarget_removed_dot_tombstones() {
 }
 
 #[test]
+fn prune_avoids_collapse_dot_collision_with_target_tombstone() {
+  let removed = self_address(0);
+  let collapse_into = self_address(2);
+  let target_removed = PNCounterMap::new().increment(&collapse_into, 1, 7).expect("increment must fit").remove(&1);
+  let visible_removed_node_entry = PNCounterMap::new().increment(&removed, 1, 5).expect("increment must fit");
+  let map = target_removed.merge(&visible_removed_node_entry);
+
+  let pruned = map.prune(removed.unique_address(), collapse_into.unique_address()).expect("pruning must fit");
+
+  assert_eq!(pruned.get(&1), Ok(Some(5)));
+  assert_eq!(pruned.merge(&pruned).get(&1), Ok(Some(5)));
+}
+
+#[test]
+fn pruned_tombstone_suppresses_pruned_removed_node_entry() {
+  let removed = self_address(0);
+  let collapse_into = self_address(2);
+  let original = PNCounterMap::new().increment(&removed, 1, 5).expect("increment must fit");
+  let pruned_tombstone = original
+    .remove(&1)
+    .prune(removed.unique_address(), collapse_into.unique_address())
+    .expect("pruning tombstone must fit");
+  let pruned_entry =
+    original.prune(removed.unique_address(), collapse_into.unique_address()).expect("pruning entry must fit");
+
+  assert_eq!(pruned_tombstone.merge(&pruned_entry).get(&1), Ok(None));
+}
+
+#[test]
 fn get_propagates_nested_counter_overflow() {
   let counter = PNCounter::from_parts(g_counter_with_slot(0, u128::MAX), GCounter::new());
   let mut entries = BTreeMap::new();
@@ -442,9 +491,11 @@ fn get_propagates_nested_counter_overflow() {
     entries,
     dots: BTreeMap::new(),
     removed_dots: BTreeMap::new(),
+    removed_values: BTreeMap::new(),
     delta: BTreeMap::new(),
     delta_dots: BTreeMap::new(),
     delta_removed_dots: BTreeMap::new(),
+    delta_removed_values: BTreeMap::new(),
   };
 
   assert_eq!(map.get(&1), Err(CounterArithmeticError::Overflow));

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -239,6 +239,17 @@ fn remove_delta_drops_observed_key() {
 }
 
 #[test]
+fn remove_drops_covered_pending_add_delta() {
+  let added = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let removed = added.remove(&1);
+  let remove_delta = removed.delta().expect("remove must create delta");
+
+  assert_eq!(remove_delta.get(&1), Ok(None));
+  assert_eq!(PNCounterMap::new().merge(&remove_delta).get(&1), Ok(None));
+  assert_eq!(added.merge_delta(&remove_delta).get(&1), Ok(None));
+}
+
+#[test]
 fn remove_delta_keeps_concurrent_update_delta() {
   let left = PNCounterMap::new()
     .increment(&self_address(0), 1, 1)
@@ -255,6 +266,17 @@ fn remove_delta_keeps_concurrent_update_delta() {
   let concurrent_delta = concurrent.delta().expect("concurrent update must create delta");
 
   assert_eq!(removed.merge_delta(&concurrent_delta).get(&2), Ok(Some(10)));
+}
+
+#[test]
+fn remote_remove_drops_covered_local_delta() {
+  let local = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let remove_delta = local.reset_delta().remove(&1).delta().expect("remove must create delta");
+
+  let merged = local.merge_delta(&remove_delta);
+
+  assert_eq!(merged.get(&1), Ok(None));
+  assert_eq!(merged.delta(), None);
 }
 
 #[test]
@@ -395,6 +417,20 @@ fn prune_preserves_pending_remove_delta() {
   let delta = pruned.delta().expect("pending remove must remain in delta");
 
   assert_eq!(original.merge_delta(&delta).get(&1), Ok(None));
+}
+
+#[test]
+fn prune_does_not_retarget_removed_dot_tombstones() {
+  let removed = self_address(0);
+  let collapse_into = self_address(2);
+  let removed_entry = PNCounterMap::new().increment(&removed, 1, 5).expect("increment must fit");
+  let tombstone = removed_entry.remove(&1);
+
+  let pruned = tombstone.prune(removed.unique_address(), collapse_into.unique_address()).expect("pruning must fit");
+  let concurrent = PNCounterMap::new().increment(&collapse_into, 1, 7).expect("increment must fit");
+
+  assert!(!pruned.need_pruning_from(removed.unique_address()));
+  assert_eq!(pruned.merge(&concurrent).get(&1), Ok(Some(7)));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -398,6 +398,25 @@ fn merge_subtracts_removed_same_node_prefix_from_later_dot() {
 }
 
 #[test]
+fn merge_subtracts_equal_removed_prefix_from_later_dot() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let removed = original.remove(&1);
+  let stale_later_dot = original.decrement(&self_address(0), 1, 2).expect("decrement must fit");
+
+  assert_eq!(removed.merge(&stale_later_dot).get(&1), Ok(Some(-2)));
+}
+
+#[test]
+fn repeated_remove_replaces_same_node_removed_prefix() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let recreated = original.remove(&1).increment(&self_address(0), 1, 3).expect("increment must fit");
+  let removed_again = recreated.remove(&1);
+  let concurrent = recreated.increment(&self_address(0), 1, 2).expect("increment must fit");
+
+  assert_eq!(removed_again.merge(&concurrent).get(&1), Ok(Some(2)));
+}
+
+#[test]
 fn merge_preserves_local_delta() {
   let local = PNCounterMap::new().increment(&self_address(0), 1, 7).expect("increment must fit");
   let remote = PNCounterMap::new().decrement(&self_address(1), 2, 2).expect("decrement must fit");
@@ -500,6 +519,19 @@ fn prune_records_entry_collapse_contribution_in_delta() {
 }
 
 #[test]
+fn prune_drops_entry_when_pruned_dots_become_empty() {
+  let removed = self_address(0);
+  let map = PNCounterMap::new().increment(&removed, 1, 5).expect("increment must fit").reset_delta();
+
+  let pruned = map.prune(removed.unique_address(), removed.unique_address()).expect("pruning must fit");
+
+  assert_eq!(pruned.get(&1), Ok(None));
+  assert!(!pruned.contains_key(&1));
+  assert_eq!(pruned.len(), 0);
+  assert!(pruned.is_empty());
+}
+
+#[test]
 fn prune_preserves_pending_remove_delta() {
   let removed = self_address(2);
   let collapse_into = self_address(3);
@@ -514,6 +546,22 @@ fn prune_preserves_pending_remove_delta() {
 }
 
 #[test]
+fn prune_emits_stable_tombstone_delta() {
+  let removed = self_address(0);
+  let collapse_into = self_address(2);
+  let original = PNCounterMap::new().increment(&removed, 1, 5).expect("increment must fit");
+  let stable_tombstone = original.remove(&1).reset_delta();
+
+  let pruned_tombstone =
+    stable_tombstone.prune(removed.unique_address(), collapse_into.unique_address()).expect("pruning must fit");
+  let tombstone_delta = pruned_tombstone.delta().expect("pruned tombstone must be replicated");
+  let pruned_entry =
+    original.prune(removed.unique_address(), collapse_into.unique_address()).expect("pruning must fit");
+
+  assert_eq!(pruned_entry.merge_delta(&tombstone_delta).get(&1), Ok(None));
+}
+
+#[test]
 fn prune_does_not_retarget_removed_dot_tombstones() {
   let removed = self_address(0);
   let collapse_into = self_address(2);
@@ -521,10 +569,10 @@ fn prune_does_not_retarget_removed_dot_tombstones() {
   let tombstone = removed_entry.remove(&1);
 
   let pruned = tombstone.prune(removed.unique_address(), collapse_into.unique_address()).expect("pruning must fit");
-  let concurrent = PNCounterMap::new().increment(&collapse_into, 1, 7).expect("increment must fit");
+  let concurrent = PNCounterMap::new().increment(&collapse_into, 1, 4).expect("increment must fit");
 
   assert!(!pruned.need_pruning_from(removed.unique_address()));
-  assert_eq!(pruned.merge(&concurrent).get(&1), Ok(Some(7)));
+  assert_eq!(pruned.merge(&concurrent).get(&1), Ok(Some(4)));
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -291,6 +291,58 @@ fn full_state_remove_drops_covered_local_delta() {
 }
 
 #[test]
+fn full_state_merge_prunes_local_delta_with_merged_removed_value_prefix() {
+  let node = unique_address(0);
+  let removed_prefix_3 = PNCounter::new().increment(&self_address(0), 3).expect("increment must fit").reset_delta();
+  let removed_prefix_5 = PNCounter::new().increment(&self_address(0), 5).expect("increment must fit").reset_delta();
+  let pending_value_8 = PNCounter::new().increment(&self_address(0), 8).expect("increment must fit").reset_delta();
+
+  let mut local_removed_key_dots = BTreeMap::new();
+  local_removed_key_dots.insert(node.clone(), 1);
+  let mut local_removed_dots = BTreeMap::new();
+  local_removed_dots.insert(1, local_removed_key_dots);
+  let mut local_removed_values = BTreeMap::new();
+  local_removed_values.insert(1, removed_prefix_5);
+  let mut local_delta = BTreeMap::new();
+  local_delta.insert(1, pending_value_8);
+  let mut local_delta_key_dots = BTreeMap::new();
+  local_delta_key_dots.insert(node.clone(), 2);
+  let mut local_delta_dots = BTreeMap::new();
+  local_delta_dots.insert(1, local_delta_key_dots);
+  let local = PNCounterMap {
+    entries:              BTreeMap::new(),
+    dots:                 BTreeMap::new(),
+    removed_dots:         local_removed_dots,
+    removed_values:       local_removed_values,
+    delta:                local_delta,
+    delta_dots:           local_delta_dots,
+    delta_removed_dots:   BTreeMap::new(),
+    delta_removed_values: BTreeMap::new(),
+  };
+
+  let mut remote_removed_key_dots = BTreeMap::new();
+  remote_removed_key_dots.insert(node, 1);
+  let mut remote_removed_dots = BTreeMap::new();
+  remote_removed_dots.insert(1, remote_removed_key_dots);
+  let mut remote_removed_values = BTreeMap::new();
+  remote_removed_values.insert(1, removed_prefix_3);
+  let remote = PNCounterMap {
+    entries:              BTreeMap::new(),
+    dots:                 BTreeMap::new(),
+    removed_dots:         remote_removed_dots,
+    removed_values:       remote_removed_values,
+    delta:                BTreeMap::new(),
+    delta_dots:           BTreeMap::new(),
+    delta_removed_dots:   BTreeMap::new(),
+    delta_removed_values: BTreeMap::new(),
+  };
+
+  let merged_delta = local.merge(&remote).delta().expect("remaining delta must be visible");
+
+  assert_eq!(merged_delta.get(&1), Ok(Some(3)));
+}
+
+#[test]
 fn remove_tombstone_participates_in_equality() {
   let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
   let removed = original.remove(&1);

--- a/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
+++ b/modules/cluster-core-kernel/src/ddata/pn_counter_map_test.rs
@@ -140,7 +140,7 @@ fn remove_keeps_concurrent_full_state_update() {
   let removed = merged.remove(&2);
   let concurrent = merged.increment(&self_address(1), 2, 10).expect("increment must fit");
 
-  assert_eq!(removed.merge(&concurrent).get(&2), Ok(Some(13)));
+  assert_eq!(removed.merge(&concurrent).get(&2), Ok(Some(10)));
 }
 
 #[test]
@@ -150,6 +150,20 @@ fn remove_then_recreate_ignores_stale_observed_value() {
 
   assert_eq!(recreated.get(&1), Ok(Some(1)));
   assert_eq!(recreated.merge(&original).get(&1), Ok(Some(1)));
+}
+
+#[test]
+fn remove_then_recreate_delta_ignores_stale_observed_value() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let recreated_delta = original
+    .reset_delta()
+    .remove(&1)
+    .increment(&self_address(0), 1, 1)
+    .expect("increment must fit")
+    .delta()
+    .expect("remove and recreate must create delta");
+
+  assert_eq!(original.merge_delta(&recreated_delta).get(&1), Ok(Some(1)));
 }
 
 #[test]
@@ -216,7 +230,31 @@ fn remove_delta_keeps_concurrent_update_delta() {
   let concurrent = merged.reset_delta().increment(&self_address(1), 2, 10).expect("increment must fit");
   let concurrent_delta = concurrent.delta().expect("concurrent update must create delta");
 
-  assert_eq!(removed.merge_delta(&concurrent_delta).get(&2), Ok(Some(13)));
+  assert_eq!(removed.merge_delta(&concurrent_delta).get(&2), Ok(Some(10)));
+}
+
+#[test]
+fn remove_tombstone_participates_in_equality() {
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let removed = original.remove(&1);
+
+  assert_ne!(removed, PNCounterMap::new());
+  assert_eq!(removed.merge(&original).get(&1), Ok(None));
+  assert_eq!(PNCounterMap::new().merge(&original).get(&1), Ok(Some(5)));
+}
+
+#[test]
+fn merge_excludes_tombstoned_counter_slots() {
+  let node_0_entry = PNCounterMap::new().increment(&self_address(0), 1, 1).expect("increment must fit");
+  let node_1_entry = PNCounterMap::new().increment(&self_address(1), 1, 2).expect("increment must fit");
+  let node_0_removed = node_0_entry.remove(&1);
+
+  let left_associated = node_0_entry.merge(&node_1_entry.merge(&node_0_removed));
+  let right_associated = node_0_entry.merge(&node_1_entry).merge(&node_0_removed);
+
+  assert_eq!(left_associated.get(&1), Ok(Some(2)));
+  assert_eq!(right_associated.get(&1), Ok(Some(2)));
+  assert_eq!(left_associated, right_associated);
 }
 
 #[test]
@@ -308,6 +346,20 @@ fn prune_records_entry_collapse_contribution_in_delta() {
   let delta = pruned.delta().expect("collapse contribution must be replicated");
 
   assert_eq!(PNCounterMap::new().merge_delta(&delta).get(&1), Ok(Some(5)));
+}
+
+#[test]
+fn prune_preserves_pending_remove_delta() {
+  let removed = self_address(2);
+  let collapse_into = self_address(3);
+  let original = PNCounterMap::new().increment(&self_address(0), 1, 5).expect("increment must fit");
+  let pending_remove = original.reset_delta().remove(&1);
+
+  let pruned =
+    pending_remove.prune(removed.unique_address(), collapse_into.unique_address()).expect("pruning must fit");
+  let delta = pruned.delta().expect("pending remove must remain in delta");
+
+  assert_eq!(original.merge_delta(&delta).get(&1), Ok(None));
 }
 
 #[test]


### PR DESCRIPTION
## 概要

- `PNCounterMap` に `entries` / `contains_key` / `is_empty` / `len` / `remove` を追加
- key ごとの observed-remove dot metadata を保持し、full state / delta merge で削除済み key と同時更新を収束
- `docs/gap-analysis/cluster-gap-analysis.md` のカテゴリ9と Phase 2 の状態を更新

## 検証

- `cargo test -p fraktor-cluster-core-kernel-rs pn_counter_map -- --nocapture`
- `cargo test -p fraktor-cluster-core-kernel-rs`
- `./scripts/ci-check.sh ai fmt dylint clippy`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large change to distributed CRDT merge, delta, and pruning behavior; correctness risk is mitigated by extensive unit and property tests but mistakes would affect replicated cluster state semantics.
> 
> **Overview**
> Closes a Pekko parity gap for **`PNCounterMap`** by adding **`entries`**, **`contains_key`**, **`len`**, **`is_empty`**, and observed-remove **`remove`**, and by tracking per-key causal dots plus removal tombstones so full-state and delta merges converge correctly when keys are deleted concurrently.
> 
> **`GCounter`** and **`PNCounter`** gain internal helpers (`retain_nodes`, `replace_nodes`, `retain_visible_nodes`, etc.) to support visibility filtering and removed-prefix subtraction during map merge and pruning. **`RemovedNodePruning`** for the map now accounts for dot and tombstone metadata, and equality includes that metadata.
> 
> **`docs/gap-analysis/cluster-gap-analysis.md`** is updated so category 9 treats this contract group as implemented (103/151 overall coverage unchanged at 68%).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d28410f1e61324d553ed4e3fbddcd811b298af57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート
* **新機能**
  * PNCounterMapに可視エントリの取得（entries）、存在確認（contains_key）、空判定（is_empty）、サイズ（len）、およびキー削除（remove）を追加しました。
* **改善**
  * 削除の可視性、差分反映、プルーニング挙動を更新し、結果の整合性を向上しました。
* **テスト**
  * 可視性・削除・差分・プルーニングのエッジケース検証を拡充しました。
* **ドキュメント**
  * パリティギャップ分析ドキュメントの集計値・注記・カテゴリ定義を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->