### PR TITLE
SBR runtime down execution loop を実装

### DIFF
--- a/docs/gap-analysis/cluster-gap-analysis.md
+++ b/docs/gap-analysis/cluster-gap-analysis.md
@@ -1,6 +1,6 @@
 # cluster モジュール ギャップ分析
 
-更新日: 2026-06-14 (parity 分母再構成 + 全カテゴリ再検証 + 完了証跡同期)
+更新日: 2026-06-15 (SBR runtime down execution loop 完了証跡同期)
 
 ## 位置づけ
 
@@ -58,18 +58,18 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 | 指標 | 値 |
 |------|-----|
 | Pekko 固定スコープ対象公開契約グループ | 151 |
-| fraktor-rs 固定スコープ対応公開契約グループ（実装済み） | 103 |
-| 固定スコープカバレッジ | 103/151 (68%) |
-| 部分実装 | 10 |
+| fraktor-rs 固定スコープ対応公開契約グループ（実装済み） | 104 |
+| 固定スコープカバレッジ | 104/151 (69%) |
+| 部分実装 | 9 |
 | 未対応 | 38（ギャップ表上は31行。カテゴリ9の13行が20未対応公開契約グループを集約） |
 | raw public type declarations | 297 (core-kernel: 265, core-typed: 9, std: 23) |
 | raw public method declarations | 843 (core-kernel: 730, core-typed: 32, std: 81) |
-| hard / medium / easy / trivial gap | 11 / 29 / 8 / 0 |
+| hard / medium / easy / trivial gap | 10 / 29 / 8 / 0 |
 | panic 系スタブ | 0 件 |
 | 機能 placeholder / TODO | 0 件 |
 
 注: `raw public` は `pub(crate)` など内部到達可能な `pub` を含む参考値であり、crate 外から到達可能な外部公開 API 数ではない。
-注: `実装済み` / `部分実装` / `未対応` / 難易度内訳は、この台帳で定義した公開契約グループ単位で数える。ギャップ表は41行（部分実装10行、未対応31行）だが、カテゴリ9の protocol / CRDT 行は複数の公開契約グループを1行に集約している。raw 型名やメソッド名の個数を個別加算するものではない。
+注: `実装済み` / `部分実装` / `未対応` / 難易度内訳は、この台帳で定義した公開契約グループ単位で数える。ギャップ表は40行（部分実装9行、未対応31行）だが、カテゴリ9の protocol / CRDT 行は複数の公開契約グループを1行に集約している。raw 型名やメソッド名の個数を個別加算するものではない。
 
 ### 前回 (2026-06-05) からの判定変更
 
@@ -80,6 +80,7 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 | `SubscriptionInitialStateMode` | 分母外 | 実装済み | `ClusterSubscriptionInitialStateMode` が extension モジュールに存在 |
 | pub-sub query | mediator protocol に包含 | 実装済み | `MediatorQuery::CurrentTopics` / `SubscriberCount` / `Count` を実装済み。`Count` は active owner の delivery view からトピック横断 subscriber 登録総数を返す |
 | `MembershipCoordinatorDriver` | 実装済み概念として列挙 | 公開型ではない | `pub(super)`。`TokioGossiper` の内部実装であり外部 API には露出しない |
+| SBR runtime down execution loop | 部分実装 | 実装済み | `SplitBrainResolverProviderHook::decide_strategy_context` / `StdSplitBrainResolverProvider::decide_strategy_context` が target-aware decision を保持し、std `SplitBrainResolverDowningDriver` + `TokioGossiper::with_split_brain_resolver_downing` が reachability snapshot から downing target を `MembershipCoordinator::handle_down` と `ClusterProvider::down` へ自動発行 |
 
 備考: `ClusterPubSub` trait は `pub_sub::cluster_pub_sub::ClusterPubSub` のネストパスでのみ公開されており、トップレベル `pub_sub` への re-export はない（実装済み判定は維持、公開面の整理は別件）。`NodeStatus` の Pekko `Down` 相当は `Dead` バリアント（別名実装済み）。
 
@@ -88,11 +89,11 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 | 層 | Pekko 対応範囲 | fraktor-rs 現状 | 評価 |
 |----|----------------|-----------------|------|
 | core / membership | `Cluster`, `Member`, `MemberStatus`, `CurrentClusterState`, `ClusterEvent`, `Gossip`, `Reachability` | `ClusterExtension`, `ClusterApi`, `NodeRecord`, `NodeStatus`, `CurrentClusterState`, `MembershipCoordinator`, `GossipDisseminationCoordinator`, `ReachabilityMatrix`, `GossipStateModel`, `HeartbeatProtocolState`, `CrossDcHeartbeat` | UniqueAddress、data center、WeaklyUp、reachability matrix、gossip envelope、full gossip merge / tombstone / seen digest、dedicated heartbeat evidence、SeedNodeProcess の core contract はある。Member ordering 公開契約、shutdown 系イベント型、CoordinatedShutdown 連携が不足 |
-| core / downing | `DowningProvider`, `NoDowning`, `SplitBrainResolverProvider` | `DowningProvider`, `DowningDecisionContext`, `DowningStrategyDecision`, `DowningDecisionTrace`, `NoopDowningProvider`, `SplitBrainResolver`, `LeaseMajorityPort`, `SplitBrainResolverProviderHook` | decision model / settings / provider binding は完了。SBR runtime actor（reachability 変化監視 → 責任ノード選択 → 自動 down 発行ループ）と concrete lease backend が未実装 |
+| core / downing | `DowningProvider`, `NoDowning`, `SplitBrainResolverProvider` | `DowningProvider`, `DowningDecisionContext`, `DowningStrategyDecision`, `DowningDecisionTrace`, `NoopDowningProvider`, `SplitBrainResolver`, `LeaseMajorityPort`, `SplitBrainResolverProviderHook` | decision model / settings / provider binding / target-aware runtime decision は完了。std 側の自動 down 発行ループも `TokioGossiper` opt-in で接続済み。concrete lease backend が未実装 |
 | core / typed | typed `Cluster`, command, subscription, singleton, sharding typed API | `Cluster` / `ClusterCommand` / `ClusterStateSubscription` / `ClusterEventSubscription` / `SelfUp` / `SelfRemoved` / `ClusterSetup` | typed Cluster facade（subscribe / unsubscribe / current_state / `PrepareForFullClusterShutdown` command 含む）は完備。singleton / sharding typed API が未実装 |
 | core / virtual actor | `ClusterSharding`, `EntityRef`, `EntityTypeKey`, `ShardRegion`, coordinator | `GrainRef`, `GrainKey`, `GrainTypeKey`, typed `GrainRef`, `ShardingEnvelope`, `ShardingMessageExtractor`, `ShardingRouter`, `VirtualActorRegistry`, `PlacementCoordinatorCore`, `PartitionIdentityLookup`, `RendezvousHasher`, `PidCache` | protoactor-go style の同等機能は強いが、Pekko public API 形態（typed Entity / `ClusterSharding.init` / `EntityRef` / `askWithStatus`）、rebalance / remembered entities / query protocol / health check が不足 |
 | core / distributed state | `DistributedData`, `Replicator`, CRDT 型群 | `ReplicatedData`, `DeltaReplicatedData`, `RemovedNodePruning`, `Key`, `SelfUniqueAddress`, `Flag`, `GCounter`, `PNCounter`, `PNCounterMap`（increment / decrement / get / entries / remove）, read/write consistency 語彙 | CRDT 基底 SPI と scalar counter 型、`PNCounterMap` の entries surface / observed-remove key deletion は実装済み。DistributedData / Replicator runtime、protocol、durable store、map/set/register 系 CRDT が不足 |
-| std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `TokioGossiper`, `LocalClusterProvider`, `StaticClusterProvider`, `AwsEcsClusterProvider`, `GenericDiscoveryAdapter`, `ProviderLifecycleBridge`, `ClusterWireCodec`, `ConfiguredPhiAccrualDetectorFactory` | Rust adapter、logical envelope handoff、seed/discovery provider boundary、cluster message serializer contract、failure detector factory はある。sharding/singleton 系 setup と sharding join compat key が不足 |
+| std / adapter | gossip transport, provider, discovery adapter | `TokioGossipTransport`, `TokioGossiper`, `LocalClusterProvider`, `StaticClusterProvider`, `AwsEcsClusterProvider`, `GenericDiscoveryAdapter`, `ProviderLifecycleBridge`, `ClusterWireCodec`, `ConfiguredPhiAccrualDetectorFactory` | Rust adapter、logical envelope handoff、seed/discovery provider boundary、cluster message serializer contract、failure detector factory、SBR down execution loop はある。sharding/singleton 系 setup と sharding join compat key が不足 |
 
 ## カテゴリ別ギャップ
 
@@ -114,14 +115,13 @@ fraktor-rs 側はスキル指定の `pub` 系抽出で、型 297 件 (core-kerne
 
 実装済みとして扱うもの: `Reachability` matrix（`ReachabilityMatrix` / `ReachabilityRecord` / `ReachabilitySnapshot`）、full `Gossip` merge / tombstone / seen digest（`GossipStateModel` / `GossipStateSnapshot`）、`GossipEnvelope` + logical handoff、dedicated heartbeat protocol（`HeartbeatProtocolState`）、`CrossDcClusterHeartbeat` evidence（`CrossDcHeartbeat`）、`SeedNodeProcess`、config compatibility full key set（`ClusterCompatibilityKeyCatalog` / `JoinCompatibilityComposition`）、Failure Detector Configuration（`FailureDetectorConfig` + `ConfiguredPhiAccrualDetectorFactory`）、`SubscriptionInitialStateMode`（`ClusterSubscriptionInitialStateMode`）、`MembershipTable` / `MembershipDelta` / `MembershipVersion` / `VectorClock`、`DefaultFailureDetectorRegistry`、`MembershipCoordinator::poll` による suspect/dead 遷移、indirect connection evidence、`TokioGossipTransport`。
 
-### 3. Downing / Split Brain Resolver　✅ 実装済み 3/5 (60%)
+### 3. Downing / Split Brain Resolver　✅ 実装済み 4/5 (80%)
 
 | Pekko API / 契約 | Pekko 参照 | fraktor-rs 対応 | 実装先層 | 難易度 | 備考 |
 |------------------|------------|-----------------|----------|--------|------|
-| SBR runtime down execution loop | `SplitBrainResolver.scala:160`（@InternalApi actor だが機能として公開契約） | 部分実装 | core + std | hard | `SplitBrainResolver` の decision model / trace / provider hook は実装済み。reachability 変化の購読、stable-after タイマー駆動、責任ノード選択、`ClusterCore::down` への自動発行ループが未実装。現状 down は明示呼び出しのみ |
 | concrete lease coordination backend | `DowningStrategy.scala:602` | 部分実装 | std | hard | `LeaseMajorityPort` / `LeaseAcquisitionOutcome` / `StdLeaseMajorityBackend` trait は実装済み。実際の分散 lease backend（coordination service 連携、retry、network I/O）が未実装 |
 
-実装済みとして扱うもの: `DowningProvider` SPI、`NoDowning`（`NoopDowningProvider`）、SBR settings 契約（`SplitBrainResolverConfig` / `SplitBrainResolverStrategy`: KeepMajority / StaticQuorum / KeepOldest / DownAll / LeaseMajority の 5 戦略）。`DowningDecisionContext` / `DowningStrategyDecision` / `DowningDecisionTrace` / `FailureObservation` / `IndirectConnectionEvidence` / `SplitBrainResolverProviderHook` / `StdSplitBrainResolverProvider` / downing provider・SBR settings の join compatibility は上記概念の evidence。
+実装済みとして扱うもの: `DowningProvider` SPI、`NoDowning`（`NoopDowningProvider`）、SBR settings 契約（`SplitBrainResolverConfig` / `SplitBrainResolverStrategy`: KeepMajority / StaticQuorum / KeepOldest / DownAll / LeaseMajority の 5 戦略）、SBR runtime down execution loop（`SplitBrainResolverProviderHook::decide_strategy_context` / `StdSplitBrainResolverProvider::decide_strategy_context` / std `SplitBrainResolverDowningDriver` / `TokioGossiper::with_split_brain_resolver_downing` / `MembershipCoordinator::handle_down`）。`DowningDecisionContext` / `DowningStrategyDecision` / `DowningDecisionTrace` / `FailureObservation` / `IndirectConnectionEvidence` / downing provider・SBR settings の join compatibility は上記概念の evidence。
 
 ### 4. Cluster router pool / group　✅ 実装済み 6/6 (100%)
 
@@ -232,13 +232,13 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 
 ## 内部モジュール構造ギャップ
 
-今回は API / 実動作ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 68% で、判定基準（カバレッジ 80% 以上、または hard/medium 未実装 5 件以下）を満たさない。
+今回は API / 実動作ギャップが支配的なため、内部モジュール構造ギャップの詳細分析は省略する。固定スコープ概念カバレッジは 69% で、判定基準（カバレッジ 80% 以上、または hard/medium 未実装 5 件以下）を満たさない。
 
 次版で構造分析へ進む場合の観点:
 
 | 構造観点 | 現状 | 次に見るべき点 |
 |----------|------|----------------|
-| membership と provider の境界 | pure coordinator と provider/event-stream adapter が分かれている | SBR runtime loop / CoordinatedShutdownLeave がどちらに入るべきか |
+| membership と provider の境界 | pure coordinator と provider/event-stream adapter が分かれている | SBR runtime loop は std `TokioGossiper` の opt-in driver として接続済み。次は CoordinatedShutdownLeave をどちらに入れるか |
 | gossip と wire の境界 | core gossip / heartbeat contract + std logical handoff + postcard delta UDP + actor-core serialization bridge | Pekko/protobuf 完全バイナリ互換を将来採用するか |
 | grain と typed sharding の境界 | protoactor-go style の Grain API が中心 | Pekko typed sharding wrapper（Entity / EntityRef / Extractor）を薄く載せられるか |
 | pubsub と distributed-data の境界 | PubSub は独自 broker、CRDT 基本型はあるが Replicator は未実装 | PubSub registry gossip を ddata Replicator 相当に寄せるか |
@@ -302,7 +302,6 @@ n/a へ移動: `ClusterClient` / `ClusterClientReceptionist` / `ClusterClientSet
 
 | 項目 | 実装先層 | 根拠カテゴリ |
 |------|----------|--------------|
-| SBR runtime down execution loop（reachability 監視 → 責任ノード選択 → 自動 down 発行） | core + std | カテゴリ3 |
 | concrete lease coordination backend | std | カテゴリ3 |
 | classic `ClusterSingletonManager`（oldest election / handover） | std + core | カテゴリ6 |
 | `ClusterSingletonProxy` | std + core | カテゴリ6 |
@@ -325,10 +324,10 @@ ClusterClient 系（deprecated）、`@InternalApi` 型、JMX / HOCON / JFR / Jav
 
 ## まとめ
 
-cluster は membership / gossip / heartbeat / reachability / downing decision model / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 4, 5, 7, 10 は 82〜100% のカバレッジに達している。全体カバレッジは 103/151 (68%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（26%）、Pekko sharding public API 形態（48%）の 3 領域に集中している。
+cluster は membership / gossip / heartbeat / reachability / downing decision model / SBR runtime down execution loop / typed Cluster facade / Grain runtime / PubSub / discovery provider / message serializer contract という基礎契約は強く、カテゴリ 1, 2, 3, 4, 5, 7, 10 は 80〜100% のカバレッジに達している。全体カバレッジは 104/151 (69%) で、未実装の大半は Cluster Singleton（30%）、Distributed Data / CRDT（26%）、Pekko sharding public API 形態（48%）の 3 領域に集中している。
 
 Phase 1 は完了済み。次に進めるなら、`CrossDcFailureDetectorSettings`、typed singleton settings wrapper、setup integration、`JoinConfigCompatCheckSharding` のような config / wrapper / setup / compatibility key は単独で切らず、対象本体を触る change に同梱する。
 
-parity 上の主要ギャップは Phase 3 に集約される: SBR runtime down execution loop（decision model は完成済みで、実行ループだけが欠けている）、Cluster Singleton（manager / proxy / typed extension）、sharding の rebalance / remembered entities / delivery controllers、そして Distributed Data の Replicator 基盤である。特に SBR runtime loop は、既存の `SplitBrainResolver` / `ReachabilityMatrix` / `MembershipCoordinator` が揃っているため、Phase 3 の中では最も着手可能性が高い。
+parity 上の主要ギャップは Phase 3 に集約される: concrete lease coordination backend、Cluster Singleton（manager / proxy / typed extension）、sharding の rebalance / remembered entities / delivery controllers、そして Distributed Data の Replicator 基盤である。
 
 API ギャップが支配的であり、内部モジュール構造の比較は、singleton / ddata / sharding public API の scope を採用する OpenSpec change が立った後に進めるのが妥当である。

--- a/modules/cluster-adaptor-std/src/cluster_provider/split_brain_resolver_provider.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/split_brain_resolver_provider.rs
@@ -10,7 +10,8 @@ use core::time::Duration;
 use fraktor_cluster_core_kernel_rs::{
   downing_provider::{
     DowningDecision, DowningDecisionContext, DowningInput, DowningProvider, DowningProviderCompatibility,
-    LeaseAcquisitionOutcome, LeaseMajorityPort, SplitBrainResolverConfig, SplitBrainResolverProviderHook,
+    DowningStrategyDecision, LeaseAcquisitionOutcome, LeaseMajorityPort, SplitBrainResolverConfig,
+    SplitBrainResolverProviderHook,
   },
   extension::ClusterProviderError,
 };
@@ -101,6 +102,28 @@ impl StdSplitBrainResolverProvider {
       return hook.decide_context_with_lease(context, &mut lease_port);
     }
     hook.decide_context(context)
+  }
+
+  /// Decides from a prebuilt context while preserving strategy target details.
+  ///
+  /// The provider starts lazily when it has not been explicitly started yet. A stopped provider
+  /// still rejects the decision.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError::DownFailed`] when the provider is stopped or the core hook
+  /// reports a decision failure.
+  pub fn decide_strategy_context(
+    &mut self,
+    context: &DowningDecisionContext,
+  ) -> Result<DowningStrategyDecision, ClusterProviderError> {
+    self.ensure_started_for_downing_provider()?;
+    let hook = self.hook.as_mut().ok_or_else(|| ClusterProviderError::down(NOT_STARTED))?;
+    if let Some(lease_backend) = self.lease_backend.as_mut() {
+      let mut lease_port = StdLeaseMajorityPort { backend: lease_backend.as_mut() };
+      return hook.decide_strategy_context_with_lease(context, &mut lease_port);
+    }
+    hook.decide_strategy_context(context)
   }
 
   fn close_active(&mut self) {

--- a/modules/cluster-adaptor-std/src/cluster_provider/split_brain_resolver_provider_test.rs
+++ b/modules/cluster-adaptor-std/src/cluster_provider/split_brain_resolver_provider_test.rs
@@ -215,6 +215,30 @@ fn downing_provider_decide_context_routes_trait_path_to_lease_backend() {
 }
 
 #[test]
+fn strategy_context_starts_factory_provider_lazily_and_preserves_targets() {
+  let calls = counter();
+  let closed = counter();
+  let calls_for_factory = calls.clone();
+  let closed_for_factory = closed.clone();
+  let mut provider =
+    StdSplitBrainResolverProvider::new(lease_majority_config()).with_lease_backend_factory(move || {
+      Box::new(RecordingLeaseBackend::new(
+        LeaseAcquisitionOutcome::Acquired,
+        calls_for_factory.clone(),
+        closed_for_factory.clone(),
+      ))
+    });
+  let node_c = unique("node-c", 3);
+
+  let decision = provider.decide_strategy_context(&majority_context()).expect("strategy decision");
+
+  assert!(provider.is_started());
+  assert_eq!(decision.simple_decision(), DowningDecision::Keep);
+  assert_eq!(decision.downing_targets(), &[node_c]);
+  assert_eq!(calls.with_read(|calls| *calls), 1);
+}
+
+#[test]
 fn downing_provider_trait_path_starts_factory_provider_lazily() {
   let calls = counter();
   let closed = counter();

--- a/modules/cluster-adaptor-std/src/membership.rs
+++ b/modules/cluster-adaptor-std/src/membership.rs
@@ -6,6 +6,7 @@ mod configured_phi_accrual_detector_factory;
 mod gossip_wire_delta_v1;
 mod gossip_wire_node_record;
 mod membership_coordinator_driver;
+mod split_brain_resolver_downing_driver;
 mod tokio_gossip_transport;
 mod tokio_gossip_transport_config;
 mod tokio_gossiper;

--- a/modules/cluster-adaptor-std/src/membership/membership_coordinator_driver.rs
+++ b/modules/cluster-adaptor-std/src/membership/membership_coordinator_driver.rs
@@ -7,6 +7,7 @@ use fraktor_actor_core_kernel_rs::{
   event::stream::{EventStreamEvent, EventStreamShared},
 };
 use fraktor_cluster_core_kernel_rs::{
+  extension::ClusterProviderShared,
   membership::{
     GossipTransport, MembershipCoordinatorError, MembershipCoordinatorOutcome, MembershipCoordinatorShared,
   },
@@ -14,15 +15,21 @@ use fraktor_cluster_core_kernel_rs::{
 };
 use fraktor_utils_core_rs::{sync::SharedAccess, time::TimerInstant};
 
+use crate::{
+  cluster_provider::StdSplitBrainResolverProvider,
+  membership::split_brain_resolver_downing_driver::SplitBrainResolverDowningDriver,
+};
+
 #[cfg(test)]
 #[path = "membership_coordinator_driver_test.rs"]
 mod tests;
 
 /// Driver that applies coordinator outcomes to EventStream and gossip transport.
 pub(super) struct MembershipCoordinatorDriver<TTransport: GossipTransport> {
-  coordinator:  MembershipCoordinatorShared,
-  transport:    TTransport,
-  event_stream: EventStreamShared,
+  coordinator:                 MembershipCoordinatorShared,
+  transport:                   TTransport,
+  event_stream:                EventStreamShared,
+  split_brain_resolver_driver: Option<SplitBrainResolverDowningDriver>,
 }
 
 impl<TTransport: GossipTransport> MembershipCoordinatorDriver<TTransport> {
@@ -33,7 +40,20 @@ impl<TTransport: GossipTransport> MembershipCoordinatorDriver<TTransport> {
     transport: TTransport,
     event_stream: EventStreamShared,
   ) -> Self {
-    Self { coordinator, transport, event_stream }
+    Self { coordinator, transport, event_stream, split_brain_resolver_driver: None }
+  }
+
+  /// Returns a driver that executes Split Brain Resolver downing targets during polling.
+  #[must_use]
+  pub(super) fn with_split_brain_resolver_downing(
+    mut self,
+    provider: StdSplitBrainResolverProvider,
+    local_authority: impl Into<String>,
+    cluster_provider: ClusterProviderShared,
+  ) -> Self {
+    self.split_brain_resolver_driver =
+      Some(SplitBrainResolverDowningDriver::new(provider, local_authority.into(), cluster_provider));
+    self
   }
 
   /// Polls incoming gossip deltas and applies them.
@@ -49,7 +69,9 @@ impl<TTransport: GossipTransport> MembershipCoordinatorDriver<TTransport> {
   /// Polls coordinator timers to emit topology updates.
   pub(super) fn poll(&mut self, now: TimerInstant) -> Result<(), MembershipCoordinatorError> {
     let outcome = self.coordinator.with_write(|coordinator| coordinator.poll(now))?;
-    self.apply_outcome(outcome)
+    self.apply_outcome(outcome)?;
+    self.apply_split_brain_resolver_downing(now)?;
+    Ok(())
   }
 
   fn apply_outcome(&mut self, outcome: MembershipCoordinatorOutcome) -> Result<(), MembershipCoordinatorError> {
@@ -69,5 +91,34 @@ impl<TTransport: GossipTransport> MembershipCoordinatorDriver<TTransport> {
     let payload = AnyMessage::new(event);
     let extension_event = EventStreamEvent::Extension { name: String::from("cluster"), payload };
     self.event_stream.publish(&extension_event);
+  }
+
+  fn apply_split_brain_resolver_downing(&mut self, now: TimerInstant) -> Result<(), MembershipCoordinatorError> {
+    let Some(driver) = self.split_brain_resolver_driver.as_mut() else {
+      return Ok(());
+    };
+    let snapshot = self.coordinator.with_read(|coordinator| coordinator.snapshot());
+    let authorities = driver.poll_downing_authorities(&snapshot, now);
+    let mut provider_error = None;
+    for authority in authorities {
+      if let Some(driver) = self.split_brain_resolver_driver.as_ref() {
+        match driver.down_cluster_provider(authority.as_str()) {
+          | Ok(()) => {},
+          | Err(_) if driver.is_local_authority(authority.as_str()) => {},
+          | Err(error) => {
+            if provider_error.is_none() {
+              provider_error = Some(error);
+            }
+            continue;
+          },
+        }
+      }
+      let outcome = self.coordinator.with_write(|coordinator| coordinator.handle_down(authority.as_str(), now))?;
+      self.apply_outcome(outcome)?;
+    }
+    if let Some(error) = provider_error {
+      return Err(MembershipCoordinatorError::ClusterProvider(error));
+    }
+    Ok(())
   }
 }

--- a/modules/cluster-adaptor-std/src/membership/membership_coordinator_driver_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/membership_coordinator_driver_test.rs
@@ -6,18 +6,21 @@ use std::{
 
 use fraktor_actor_core_kernel_rs::event::stream::EventStreamShared;
 use fraktor_cluster_core_kernel_rs::{
-  extension::ClusterExtensionConfig,
+  cluster_provider::ClusterProvider,
+  downing_provider::{SplitBrainResolverConfig, SplitBrainResolverStrategy},
+  extension::{ClusterExtensionConfig, ClusterProviderError, ClusterProviderShared},
   failure_detector::{DefaultFailureDetectorRegistry, FailureDetectorConfig},
   membership::{
     GossipOutbound, GossipTransport, GossipTransportError, MembershipCoordinator, MembershipCoordinatorConfig,
-    MembershipCoordinatorShared, MembershipDelta, MembershipSnapshot, MembershipTable, NodeStatus,
+    MembershipCoordinatorError, MembershipCoordinatorShared, MembershipDelta, MembershipSnapshot, MembershipTable,
+    NodeStatus,
   },
 };
 use fraktor_remote_core_rs::address::Address;
 use fraktor_utils_core_rs::{sync::SharedAccess, time::TimerInstant};
 
 use super::MembershipCoordinatorDriver;
-use crate::membership::ConfiguredPhiAccrualDetectorFactory;
+use crate::{cluster_provider::StdSplitBrainResolverProvider, membership::ConfiguredPhiAccrualDetectorFactory};
 
 impl<TTransport: GossipTransport> MembershipCoordinatorDriver<TTransport> {
   const fn coordinator(&self) -> &MembershipCoordinatorShared {
@@ -137,6 +140,20 @@ impl DemoNode {
     Self { driver, phi_threshold }
   }
 
+  fn with_split_brain_resolver_downing(
+    mut self,
+    local_authority: impl Into<String>,
+    cluster_provider: ClusterProviderShared,
+  ) -> Self {
+    let provider = StdSplitBrainResolverProvider::new(SplitBrainResolverConfig::new(
+      Duration::ZERO,
+      SplitBrainResolverStrategy::KeepMajority,
+      Duration::from_secs(30),
+    ));
+    self.driver = self.driver.with_split_brain_resolver_downing(provider, local_authority, cluster_provider);
+    self
+  }
+
   fn handle_join(&mut self, node_id: &str, authority: &str, now: TimerInstant) {
     let joining_config = ClusterExtensionConfig::new()
       .with_advertised_address(authority)
@@ -187,6 +204,173 @@ fn config_with_suspect_timeout(timeout: Duration) -> MembershipCoordinatorConfig
   let mut config = config();
   config.suspect_timeout = timeout;
   config
+}
+
+#[derive(Clone, Default)]
+struct RecordingProviderState {
+  members: Arc<Mutex<BTreeSet<String>>>,
+}
+
+impl RecordingProviderState {
+  fn with_members(authorities: &[&str]) -> Self {
+    let state = Self::default();
+    {
+      let mut members = state.members.lock().expect("members lock");
+      members.extend(authorities.iter().map(|authority| (*authority).to_string()));
+    }
+    state
+  }
+
+  fn member_count(&self) -> usize {
+    self.members.lock().expect("members lock").len()
+  }
+}
+
+struct RecordingClusterProvider {
+  state: RecordingProviderState,
+}
+
+impl RecordingClusterProvider {
+  fn shared(authorities: &[&str]) -> (ClusterProviderShared, RecordingProviderState) {
+    let state = RecordingProviderState::with_members(authorities);
+    let provider = Self { state: state.clone() };
+    (ClusterProviderShared::new(Box::new(provider)), state)
+  }
+}
+
+impl ClusterProvider for RecordingClusterProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.state.members.lock().expect("members lock").remove(authority);
+    Ok(())
+  }
+
+  fn join(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.state.members.lock().expect("members lock").insert(authority.to_string());
+    Ok(())
+  }
+
+  fn leave(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.state.members.lock().expect("members lock").remove(authority);
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct FailingDownClusterProvider;
+
+impl ClusterProvider for FailingDownClusterProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Err(ClusterProviderError::down("down failed"))
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct FailingSelfDownClusterProvider {
+  local_authority: String,
+}
+
+impl FailingSelfDownClusterProvider {
+  fn new(local_authority: impl Into<String>) -> Self {
+    Self { local_authority: local_authority.into() }
+  }
+}
+
+impl ClusterProvider for FailingSelfDownClusterProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    if authority == self.local_authority {
+      return Err(ClusterProviderError::down("cannot down self authority"));
+    }
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+struct FailingAuthorityDownClusterProvider {
+  failing_authority: String,
+}
+
+impl FailingAuthorityDownClusterProvider {
+  fn new(failing_authority: impl Into<String>) -> Self {
+    Self { failing_authority: failing_authority.into() }
+  }
+}
+
+impl ClusterProvider for FailingAuthorityDownClusterProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, authority: &str) -> Result<(), ClusterProviderError> {
+    if authority == self.failing_authority {
+      return Err(ClusterProviderError::down(format!("down failed for {authority}")));
+    }
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
 }
 
 fn now(ticks: u64) -> TimerInstant {
@@ -283,6 +467,180 @@ fn failure_detection_keeps_suspect_until_downing_decision() {
   }
   assert_status(&node_a, "node-c", NodeStatus::Suspect);
   assert_status(&node_b, "node-c", NodeStatus::Suspect);
+}
+
+#[test]
+fn split_brain_resolver_downing_downs_unreachable_target_when_attached() {
+  let bus = Arc::new(Mutex::new(InMemoryBus::new()));
+  let event_stream = EventStreamShared::default();
+  let (provider, provider_state) = RecordingClusterProvider::shared(&["node-a", "node-b", "node-c"]);
+  let mut node_a =
+    DemoNode::new("node-a", config(), bus, event_stream).with_split_brain_resolver_downing("node-a", provider);
+
+  let t1 = now(1);
+  node_a.handle_join("node-a", "node-a", t1);
+  node_a.handle_join("node-b", "node-b", t1);
+  node_a.handle_join("node-c", "node-c", t1);
+
+  let t2 = now(2);
+  node_a.handle_heartbeat("node-a", t2);
+  node_a.handle_heartbeat("node-b", t2);
+  node_a.handle_heartbeat("node-c", t2);
+
+  let t3 = now(3);
+  node_a.handle_heartbeat("node-a", t3);
+  node_a.handle_heartbeat("node-b", t3);
+  node_a.handle_heartbeat("node-c", t3);
+
+  let t4 = now(4);
+  node_a.handle_heartbeat("node-a", t4);
+  node_a.handle_heartbeat("node-b", t4);
+
+  let t5 = now(5);
+  node_a.handle_heartbeat("node-a", t5);
+  node_a.handle_heartbeat("node-b", t5);
+
+  assert_eq!(provider_state.member_count(), 3);
+  let mut down_tick = 5_u64;
+  assert_status_eventually("node-c", NodeStatus::Dead, 3, || {
+    node_a.poll(now(down_tick));
+    down_tick += 1;
+    node_a.status_of("node-c")
+  });
+
+  assert_eq!(provider_state.member_count(), 2);
+}
+
+#[test]
+fn split_brain_resolver_downing_keeps_membership_when_provider_down_fails() {
+  let bus = Arc::new(Mutex::new(InMemoryBus::new()));
+  let event_stream = EventStreamShared::default();
+  let provider = ClusterProviderShared::new(Box::new(FailingDownClusterProvider));
+  let mut node_a =
+    DemoNode::new("node-a", config(), bus, event_stream).with_split_brain_resolver_downing("node-a", provider);
+
+  let t1 = now(1);
+  node_a.handle_join("node-a", "node-a", t1);
+  node_a.handle_join("node-b", "node-b", t1);
+  node_a.handle_join("node-c", "node-c", t1);
+
+  let t2 = now(2);
+  node_a.handle_heartbeat("node-a", t2);
+  node_a.handle_heartbeat("node-b", t2);
+  node_a.handle_heartbeat("node-c", t2);
+
+  let t3 = now(3);
+  node_a.handle_heartbeat("node-a", t3);
+  node_a.handle_heartbeat("node-b", t3);
+  node_a.handle_heartbeat("node-c", t3);
+
+  let t4 = now(4);
+  node_a.handle_heartbeat("node-a", t4);
+  node_a.handle_heartbeat("node-b", t4);
+
+  let t5 = now(5);
+  node_a.handle_heartbeat("node-a", t5);
+  node_a.handle_heartbeat("node-b", t5);
+
+  let err = node_a.driver.poll(now(6)).expect_err("provider down failure");
+  assert!(matches!(
+    err,
+    MembershipCoordinatorError::ClusterProvider(ClusterProviderError::DownFailed(reason))
+      if reason == "down failed"
+  ));
+  assert_status(&node_a, "node-c", NodeStatus::Suspect);
+}
+
+#[test]
+fn split_brain_resolver_downing_applies_membership_per_successful_provider_target() {
+  let bus = Arc::new(Mutex::new(InMemoryBus::new()));
+  let event_stream = EventStreamShared::default();
+  let cluster_provider = ClusterProviderShared::new(Box::new(FailingAuthorityDownClusterProvider::new("node-c")));
+  let provider = StdSplitBrainResolverProvider::new(SplitBrainResolverConfig::new(
+    Duration::ZERO,
+    SplitBrainResolverStrategy::DownAll,
+    Duration::ZERO,
+  ));
+  let mut node_a = DemoNode::new("node-a", config(), bus, event_stream);
+  node_a.driver = node_a.driver.with_split_brain_resolver_downing(provider, "node-a", cluster_provider);
+
+  let t1 = now(1);
+  node_a.handle_join("node-a", "node-a", t1);
+  node_a.handle_join("node-b", "node-b", t1);
+  node_a.handle_join("node-c", "node-c", t1);
+
+  let t2 = now(2);
+  node_a.handle_heartbeat("node-a", t2);
+  node_a.handle_heartbeat("node-b", t2);
+  node_a.handle_heartbeat("node-c", t2);
+
+  let t3 = now(3);
+  node_a.handle_heartbeat("node-a", t3);
+  node_a.handle_heartbeat("node-b", t3);
+  node_a.handle_heartbeat("node-c", t3);
+
+  let t4 = now(4);
+  node_a.handle_heartbeat("node-a", t4);
+
+  let t5 = now(5);
+  node_a.handle_heartbeat("node-a", t5);
+
+  let mut observed_error = None;
+  for tick in 6..=8 {
+    match node_a.driver.poll(now(tick)) {
+      | Ok(()) => {},
+      | Err(error) => {
+        observed_error = Some(error);
+        break;
+      },
+    }
+  }
+  let err = observed_error.expect("provider down failure");
+  assert!(matches!(
+    err,
+    MembershipCoordinatorError::ClusterProvider(ClusterProviderError::DownFailed(reason))
+      if reason == "down failed for node-c"
+  ));
+  assert_status(&node_a, "node-a", NodeStatus::Dead);
+  assert_status(&node_a, "node-b", NodeStatus::Dead);
+  assert_status(&node_a, "node-c", NodeStatus::Suspect);
+}
+
+#[test]
+fn split_brain_resolver_downing_marks_self_dead_when_provider_rejects_self_down() {
+  let bus = Arc::new(Mutex::new(InMemoryBus::new()));
+  let event_stream = EventStreamShared::default();
+  let provider = ClusterProviderShared::new(Box::new(FailingSelfDownClusterProvider::new("node-a")));
+  let mut node_a =
+    DemoNode::new("node-a", config(), bus, event_stream).with_split_brain_resolver_downing("node-a", provider);
+
+  let t1 = now(1);
+  node_a.handle_join("node-a", "node-a", t1);
+  node_a.handle_join("node-b", "node-b", t1);
+  node_a.handle_join("node-c", "node-c", t1);
+
+  let t2 = now(2);
+  node_a.handle_heartbeat("node-a", t2);
+  node_a.handle_heartbeat("node-b", t2);
+  node_a.handle_heartbeat("node-c", t2);
+
+  let t3 = now(3);
+  node_a.handle_heartbeat("node-a", t3);
+  node_a.handle_heartbeat("node-b", t3);
+  node_a.handle_heartbeat("node-c", t3);
+
+  let t4 = now(4);
+  node_a.handle_heartbeat("node-a", t4);
+
+  let t5 = now(5);
+  node_a.handle_heartbeat("node-a", t5);
+
+  let mut down_tick = 5_u64;
+  assert_status_eventually("node-a", NodeStatus::Dead, 3, || {
+    node_a.poll(now(down_tick));
+    down_tick += 1;
+    node_a.status_of("node-a")
+  });
 }
 
 #[test]

--- a/modules/cluster-adaptor-std/src/membership/split_brain_resolver_downing_driver.rs
+++ b/modules/cluster-adaptor-std/src/membership/split_brain_resolver_downing_driver.rs
@@ -1,0 +1,144 @@
+//! std runtime bridge that executes Split Brain Resolver downing targets.
+
+#[cfg(test)]
+#[path = "split_brain_resolver_downing_driver_test.rs"]
+mod tests;
+
+use alloc::{collections::BTreeSet, string::String, vec::Vec};
+
+use fraktor_cluster_core_kernel_rs::{
+  downing_provider::DowningDecisionContext,
+  extension::{ClusterProviderError, ClusterProviderShared},
+  membership::{MembershipSnapshot, MembershipVersion, NodeRecord, ReachabilityStatus},
+};
+use fraktor_remote_core_rs::address::UniqueAddress;
+use fraktor_utils_core_rs::{sync::SharedAccess, time::TimerInstant};
+
+use crate::cluster_provider::StdSplitBrainResolverProvider;
+
+pub(super) struct SplitBrainResolverDowningDriver {
+  provider:             StdSplitBrainResolverProvider,
+  local_authority:      String,
+  cluster_provider:     ClusterProviderShared,
+  unstable_observation: Option<UnstableObservation>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct UnstableObservation {
+  active_members:      BTreeSet<ActiveMemberObservation>,
+  unreachable_members: BTreeSet<UniqueAddress>,
+  since:               TimerInstant,
+}
+
+type ActiveMemberObservation = (UniqueAddress, MembershipVersion);
+
+impl SplitBrainResolverDowningDriver {
+  pub(super) fn new(
+    provider: StdSplitBrainResolverProvider,
+    local_authority: String,
+    cluster_provider: ClusterProviderShared,
+  ) -> Self {
+    Self { provider, local_authority, cluster_provider, unstable_observation: None }
+  }
+
+  pub(super) fn poll_downing_authorities(&mut self, snapshot: &MembershipSnapshot, now: TimerInstant) -> Vec<String> {
+    let Some(local_record) = self.local_record(snapshot) else {
+      self.unstable_observation = None;
+      return Vec::new();
+    };
+    let unreachable_members = local_unreachable_members(snapshot, &local_record.unique_address);
+    if unreachable_members.is_empty() {
+      self.unstable_observation = None;
+      return Vec::new();
+    }
+
+    let active_members = active_members(snapshot);
+    let unstable_since = self.unstable_since(active_members, unreachable_members, now);
+    let context = DowningDecisionContext::from_membership_snapshot(snapshot.clone(), now)
+      .with_reachability_observer(local_record.unique_address.clone())
+      .with_unstable_since(unstable_since);
+
+    let decision = match self.provider.decide_strategy_context(&context) {
+      | Ok(decision) => decision,
+      | Err(error) => {
+        tracing::warn!(reason = %error.reason(), "split-brain-resolver downing decision failed");
+        return Vec::new();
+      },
+    };
+    downing_authorities(snapshot, decision.downing_targets())
+  }
+
+  fn local_record(&self, snapshot: &MembershipSnapshot) -> Option<NodeRecord> {
+    snapshot
+      .entries
+      .iter()
+      .find(|record| record.authority == self.local_authority && record.status.is_active())
+      .cloned()
+  }
+
+  fn unstable_since(
+    &mut self,
+    active_members: BTreeSet<ActiveMemberObservation>,
+    unreachable_members: BTreeSet<UniqueAddress>,
+    now: TimerInstant,
+  ) -> TimerInstant {
+    if let Some(observation) = self.unstable_observation.as_ref()
+      && observation.active_members == active_members
+      && observation.unreachable_members == unreachable_members
+    {
+      return observation.since;
+    }
+    self.unstable_observation = Some(UnstableObservation { active_members, unreachable_members, since: now });
+    now
+  }
+
+  pub(super) fn down_cluster_provider(&self, authority: &str) -> Result<(), ClusterProviderError> {
+    self.cluster_provider.with_write(|provider| provider.down(authority)).inspect_err(|error| {
+      tracing::warn!(
+        target = %authority,
+        reason = %error.reason(),
+        "split-brain-resolver cluster provider downing target execution failed"
+      );
+    })
+  }
+
+  pub(super) fn is_local_authority(&self, authority: &str) -> bool {
+    self.local_authority == authority
+  }
+}
+
+fn active_members(snapshot: &MembershipSnapshot) -> BTreeSet<ActiveMemberObservation> {
+  snapshot
+    .entries
+    .iter()
+    .filter(|record| record.status.is_active())
+    .map(|record| (record.unique_address.clone(), record.join_version))
+    .collect()
+}
+
+fn local_unreachable_members(snapshot: &MembershipSnapshot, observer: &UniqueAddress) -> BTreeSet<UniqueAddress> {
+  if !snapshot.reachability.has_observer(observer) {
+    return BTreeSet::new();
+  }
+  snapshot
+    .entries
+    .iter()
+    .filter(|record| record.status.is_active() && &record.unique_address != observer)
+    .filter(|record| {
+      matches!(
+        snapshot.reachability.observed_status(observer, &record.unique_address),
+        Some(ReachabilityStatus::Unreachable | ReachabilityStatus::Terminated)
+      )
+    })
+    .map(|record| record.unique_address.clone())
+    .collect()
+}
+
+fn downing_authorities(snapshot: &MembershipSnapshot, targets: &[UniqueAddress]) -> Vec<String> {
+  snapshot
+    .entries
+    .iter()
+    .filter(|record| targets.iter().any(|target| target == &record.unique_address))
+    .map(|record| record.authority.clone())
+    .collect()
+}

--- a/modules/cluster-adaptor-std/src/membership/split_brain_resolver_downing_driver_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/split_brain_resolver_downing_driver_test.rs
@@ -1,0 +1,119 @@
+use core::time::Duration;
+
+use fraktor_cluster_core_kernel_rs::{
+  cluster_provider::ClusterProvider,
+  downing_provider::{SplitBrainResolverConfig, SplitBrainResolverStrategy},
+  extension::{ClusterProviderError, ClusterProviderShared},
+  membership::{MembershipSnapshot, MembershipVersion, NodeRecord, NodeStatus, ReachabilityMatrix},
+};
+use fraktor_utils_core_rs::time::TimerInstant;
+
+use super::SplitBrainResolverDowningDriver;
+use crate::cluster_provider::StdSplitBrainResolverProvider;
+
+#[test]
+fn poll_downing_authorities_resets_stable_after_when_unreachable_set_changes() {
+  let mut driver = SplitBrainResolverDowningDriver::new(
+    StdSplitBrainResolverProvider::new(SplitBrainResolverConfig::new(
+      Duration::from_secs(3),
+      SplitBrainResolverStrategy::KeepMajority,
+      Duration::from_secs(30),
+    )),
+    "node-a:2552".to_string(),
+    ClusterProviderShared::new(Box::new(NoopClusterProvider)),
+  );
+
+  let c_unreachable = snapshot(&["node-c:2552"]);
+  assert!(driver.poll_downing_authorities(&c_unreachable, now(1)).is_empty());
+  assert_eq!(driver.poll_downing_authorities(&c_unreachable, now(4)), vec!["node-c:2552".to_string()]);
+
+  let b_and_c_unreachable = snapshot(&["node-b:2552", "node-c:2552"]);
+  assert!(driver.poll_downing_authorities(&b_and_c_unreachable, now(5)).is_empty());
+  assert_eq!(driver.poll_downing_authorities(&b_and_c_unreachable, now(8)), vec!["node-a:2552".to_string()]);
+}
+
+#[test]
+fn poll_downing_authorities_resets_stable_after_when_active_membership_changes() {
+  let mut driver = SplitBrainResolverDowningDriver::new(
+    StdSplitBrainResolverProvider::new(SplitBrainResolverConfig::new(
+      Duration::from_secs(3),
+      SplitBrainResolverStrategy::KeepMajority,
+      Duration::from_secs(30),
+    )),
+    "node-a:2552".to_string(),
+    ClusterProviderShared::new(Box::new(NoopClusterProvider)),
+  );
+
+  let c_unreachable = snapshot(&["node-c:2552"]);
+  assert!(driver.poll_downing_authorities(&c_unreachable, now(1)).is_empty());
+  assert_eq!(driver.poll_downing_authorities(&c_unreachable, now(4)), vec!["node-c:2552".to_string()]);
+
+  let c_unreachable_with_d =
+    snapshot_with_authorities(&["node-a:2552", "node-b:2552", "node-c:2552", "node-d:2552"], &["node-c:2552"]);
+  assert!(driver.poll_downing_authorities(&c_unreachable_with_d, now(5)).is_empty());
+  assert_eq!(driver.poll_downing_authorities(&c_unreachable_with_d, now(8)), vec!["node-c:2552".to_string()]);
+}
+
+struct NoopClusterProvider;
+
+impl ClusterProvider for NoopClusterProvider {
+  fn start_member(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn start_client(&mut self) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn down(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn join(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn leave(&mut self, _authority: &str) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+
+  fn shutdown(&mut self, _graceful: bool) -> Result<(), ClusterProviderError> {
+    Ok(())
+  }
+}
+
+fn snapshot(unreachable_authorities: &[&str]) -> MembershipSnapshot {
+  snapshot_with_authorities(&["node-a:2552", "node-b:2552", "node-c:2552"], unreachable_authorities)
+}
+
+fn snapshot_with_authorities(authorities: &[&str], unreachable_authorities: &[&str]) -> MembershipSnapshot {
+  let records = authorities.iter().map(|authority| record_from_authority(authority)).collect::<Vec<_>>();
+  let local = records[0].unique_address.clone();
+  let mut reachability = ReachabilityMatrix::new();
+  for authority in unreachable_authorities {
+    let subject =
+      records.iter().find(|record| record.authority == *authority).expect("subject record").unique_address.clone();
+    reachability.unreachable(local.clone(), subject);
+  }
+  MembershipSnapshot::new_with_reachability(MembershipVersion::new(1), records, reachability.snapshot())
+}
+
+fn record_from_authority(authority: &str) -> NodeRecord {
+  let node_id = authority.split(':').next().unwrap_or(authority);
+  record(node_id, authority)
+}
+
+fn record(node_id: &str, authority: &str) -> NodeRecord {
+  NodeRecord::new(
+    node_id.to_string(),
+    authority.to_string(),
+    NodeStatus::Up,
+    MembershipVersion::new(1),
+    "1.0.0".to_string(),
+    Vec::new(),
+  )
+}
+
+const fn now(ticks: u64) -> TimerInstant {
+  TimerInstant::from_ticks(ticks, Duration::from_secs(1))
+}

--- a/modules/cluster-adaptor-std/src/membership/tokio_gossiper.rs
+++ b/modules/cluster-adaptor-std/src/membership/tokio_gossiper.rs
@@ -3,7 +3,10 @@
 use core::time::Duration;
 
 use fraktor_actor_core_kernel_rs::event::stream::EventStreamShared;
-use fraktor_cluster_core_kernel_rs::membership::{Gossiper, MembershipCoordinatorShared};
+use fraktor_cluster_core_kernel_rs::{
+  extension::ClusterProviderShared,
+  membership::{Gossiper, MembershipCoordinatorError, MembershipCoordinatorShared},
+};
 use fraktor_utils_core_rs::time::TimerInstant;
 use tokio::{
   runtime::Handle,
@@ -15,6 +18,7 @@ use super::{
   membership_coordinator_driver::MembershipCoordinatorDriver, tokio_gossip_transport::TokioGossipTransport,
   tokio_gossiper_config::TokioGossiperConfig,
 };
+use crate::cluster_provider::StdSplitBrainResolverProvider;
 
 #[cfg(test)]
 #[path = "tokio_gossiper_test.rs"]
@@ -29,6 +33,7 @@ pub struct TokioGossiper {
   tokio_handle: Handle,
   shutdown:     Option<Sender<()>>,
   task:         Option<JoinHandle<()>>,
+  sbr_downing:  Option<(StdSplitBrainResolverProvider, String, ClusterProviderShared)>,
 }
 
 impl TokioGossiper {
@@ -41,7 +46,28 @@ impl TokioGossiper {
     event_stream: EventStreamShared,
     tokio_handle: Handle,
   ) -> Self {
-    Self { config, coordinator, transport: Some(transport), event_stream, tokio_handle, shutdown: None, task: None }
+    Self {
+      config,
+      coordinator,
+      transport: Some(transport),
+      event_stream,
+      tokio_handle,
+      shutdown: None,
+      task: None,
+      sbr_downing: None,
+    }
+  }
+
+  /// Enables automatic Split Brain Resolver down execution during membership polling.
+  #[must_use]
+  pub fn with_split_brain_resolver_downing(
+    mut self,
+    provider: StdSplitBrainResolverProvider,
+    local_authority: impl Into<String>,
+    cluster_provider: ClusterProviderShared,
+  ) -> Self {
+    self.sbr_downing = Some((provider, local_authority.into(), cluster_provider));
+    self
   }
 
   /// Returns the shared coordinator handle.
@@ -66,6 +92,9 @@ impl Gossiper for TokioGossiper {
     let tick_interval = self.config.tick_interval;
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
     let mut driver = MembershipCoordinatorDriver::new(coordinator, transport, event_stream);
+    if let Some((provider, local_authority, cluster_provider)) = self.sbr_downing.take() {
+      driver = driver.with_split_brain_resolver_downing(provider, local_authority, cluster_provider);
+    }
 
     let task = self.tokio_handle.spawn(async move {
       let mut interval = tokio::time::interval(tick_interval);
@@ -81,7 +110,12 @@ impl Gossiper for TokioGossiper {
             if driver.handle_gossip_deltas(now).is_err() {
               break;
             }
-            if driver.poll(now).is_err() {
+            if let Err(error) = driver.poll(now) {
+              if should_continue_after_poll_error(&error) {
+                tracing::warn!(?error, "membership coordinator poll error did not stop gossip");
+                continue;
+              }
+              tracing::warn!(?error, "membership coordinator poll failed");
               break;
             }
           }
@@ -108,4 +142,8 @@ impl Gossiper for TokioGossiper {
     }
     Ok(())
   }
+}
+
+fn should_continue_after_poll_error(error: &MembershipCoordinatorError) -> bool {
+  matches!(error, MembershipCoordinatorError::ClusterProvider(_))
 }

--- a/modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs
+++ b/modules/cluster-adaptor-std/src/membership/tokio_gossiper_test.rs
@@ -2,15 +2,17 @@ use core::time::Duration;
 
 use fraktor_actor_core_kernel_rs::event::stream::EventStreamShared;
 use fraktor_cluster_core_kernel_rs::{
-  extension::ClusterExtensionConfig,
+  extension::{ClusterExtensionConfig, ClusterProviderError},
   failure_detector::{DefaultFailureDetectorRegistry, FailureDetectorConfig},
   membership::{
-    Gossiper, MembershipCoordinator, MembershipCoordinatorConfig, MembershipCoordinatorShared, MembershipTable,
+    Gossiper, MembershipCoordinator, MembershipCoordinatorConfig, MembershipCoordinatorError,
+    MembershipCoordinatorShared, MembershipTable,
   },
 };
 use fraktor_remote_core_rs::address::Address;
 use tokio::runtime::Handle;
 
+use super::should_continue_after_poll_error;
 use crate::membership::{
   ConfiguredPhiAccrualDetectorFactory, TokioGossipTransport, TokioGossipTransportConfig, TokioGossiper,
   TokioGossiperConfig,
@@ -40,6 +42,13 @@ fn build_coordinator() -> MembershipCoordinatorShared {
 
 fn detector_address() -> Address {
   Address::new("cluster-test", "127.0.0.1", 0)
+}
+
+#[test]
+fn poll_error_policy_keeps_cluster_provider_failure_non_fatal() {
+  let provider_error = MembershipCoordinatorError::ClusterProvider(ClusterProviderError::down("down failed"));
+  assert!(should_continue_after_poll_error(&provider_error));
+  assert!(!should_continue_after_poll_error(&MembershipCoordinatorError::NotStarted));
 }
 
 #[tokio::test]

--- a/modules/cluster-core-kernel/src/downing_provider/downing_strategy_decision.rs
+++ b/modules/cluster-core-kernel/src/downing_provider/downing_strategy_decision.rs
@@ -73,6 +73,12 @@ impl DowningStrategyDecision {
     self.simple_decision
   }
 
+  #[must_use]
+  pub(crate) const fn with_simple_decision(mut self, simple_decision: DowningDecision) -> Self {
+    self.simple_decision = simple_decision;
+    self
+  }
+
   /// Returns the trace explaining this decision.
   #[must_use]
   pub const fn trace(&self) -> &DowningDecisionTrace {

--- a/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_provider_hook.rs
+++ b/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_provider_hook.rs
@@ -66,9 +66,23 @@ impl SplitBrainResolverProviderHook {
     if context.explicit_down_authority().is_some() {
       return Ok(DowningDecision::Down);
     }
+    let strategy_decision = self.decide_strategy_context(context)?;
+    Ok(Self::provider_decision(context, &strategy_decision))
+  }
+
+  /// Decides from a prebuilt context and preserves strategy target details.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError::DownFailed`] when the evaluator trace reports a provider
+  /// failure.
+  pub fn decide_strategy_context(
+    &mut self,
+    context: &DowningDecisionContext,
+  ) -> Result<DowningStrategyDecision, ClusterProviderError> {
     let strategy_decision = self.resolver.decide(context);
     Self::map_trace(strategy_decision.trace())?;
-    Ok(Self::provider_decision(context, &strategy_decision))
+    Ok(Self::apply_provider_decision(context, strategy_decision))
   }
 
   /// Decides from a prebuilt context with a lease backend port.
@@ -85,9 +99,24 @@ impl SplitBrainResolverProviderHook {
     if context.explicit_down_authority().is_some() {
       return Ok(DowningDecision::Down);
     }
+    let strategy_decision = self.decide_strategy_context_with_lease(context, lease_port)?;
+    Ok(Self::provider_decision(context, &strategy_decision))
+  }
+
+  /// Decides from a prebuilt context with a lease backend and preserves strategy target details.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`ClusterProviderError::DownFailed`] when the evaluator trace reports a provider
+  /// failure.
+  pub fn decide_strategy_context_with_lease(
+    &mut self,
+    context: &DowningDecisionContext,
+    lease_port: &mut dyn LeaseMajorityPort,
+  ) -> Result<DowningStrategyDecision, ClusterProviderError> {
     let strategy_decision = self.resolver.decide_with_lease(context, lease_port);
     Self::map_trace(strategy_decision.trace())?;
-    Ok(Self::provider_decision(context, &strategy_decision))
+    Ok(Self::apply_provider_decision(context, strategy_decision))
   }
 
   fn expected_compatibility(config: SplitBrainResolverConfig) -> DowningProviderCompatibility {
@@ -122,6 +151,14 @@ impl SplitBrainResolverProviderHook {
       return DowningDecision::Down;
     }
     strategy_decision.simple_decision()
+  }
+
+  fn apply_provider_decision(
+    context: &DowningDecisionContext,
+    strategy_decision: DowningStrategyDecision,
+  ) -> DowningStrategyDecision {
+    let provider_decision = Self::provider_decision(context, &strategy_decision);
+    strategy_decision.with_simple_decision(provider_decision)
   }
 }
 

--- a/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_provider_hook_test.rs
+++ b/modules/cluster-core-kernel/src/downing_provider/split_brain_resolver_provider_hook_test.rs
@@ -142,6 +142,19 @@ fn provider_hook_downing_provider_decide_context_uses_membership_context() {
 }
 
 #[test]
+fn provider_hook_strategy_decision_preserves_downing_targets() {
+  let config =
+    SplitBrainResolverConfig::new(Duration::ZERO, SplitBrainResolverStrategy::KeepMajority, Duration::from_secs(30));
+  let mut hook = SplitBrainResolverProviderHook::new(config);
+  let node_c = unique("node-c", 3);
+
+  let decision = hook.decide_strategy_context(&majority_context()).expect("strategy decision");
+
+  assert_eq!(decision.simple_decision(), DowningDecision::Keep);
+  assert_eq!(decision.downing_targets(), &[node_c]);
+}
+
+#[test]
 fn provider_hook_returns_down_when_local_observer_is_downing_target() {
   let config =
     SplitBrainResolverConfig::new(Duration::ZERO, SplitBrainResolverStrategy::KeepMajority, Duration::from_secs(30));
@@ -150,6 +163,19 @@ fn provider_hook_returns_down_when_local_observer_is_downing_target() {
   let decision = hook.decide_context(&minority_observer_context());
 
   assert_eq!(decision, Ok(DowningDecision::Down));
+}
+
+#[test]
+fn provider_hook_strategy_decision_returns_down_when_local_observer_is_downing_target() {
+  let config =
+    SplitBrainResolverConfig::new(Duration::ZERO, SplitBrainResolverStrategy::KeepMajority, Duration::from_secs(30));
+  let mut hook = SplitBrainResolverProviderHook::new(config);
+  let node_a = unique("node-a", 1);
+
+  let decision = hook.decide_strategy_context(&minority_observer_context()).expect("strategy decision");
+
+  assert_eq!(decision.simple_decision(), DowningDecision::Down);
+  assert_eq!(decision.downing_targets(), &[node_a]);
 }
 
 #[test]
@@ -198,5 +224,21 @@ fn provider_hook_with_lease_returns_down_when_local_observer_is_downing_target()
   let decision = hook.decide_context_with_lease(&minority_observer_context(), &mut lease_port);
 
   assert_eq!(decision, Ok(DowningDecision::Down));
+  assert_eq!(lease_port.calls, 0);
+}
+
+#[test]
+fn provider_hook_strategy_decision_with_lease_returns_down_when_local_observer_is_downing_target() {
+  let config =
+    SplitBrainResolverConfig::new(Duration::ZERO, SplitBrainResolverStrategy::LeaseMajority, Duration::from_secs(30));
+  let mut hook = SplitBrainResolverProviderHook::new(config);
+  let mut lease_port = RecordingLeasePort { outcome: LeaseAcquisitionOutcome::Acquired, calls: 0 };
+  let node_a = unique("node-a", 1);
+
+  let decision =
+    hook.decide_strategy_context_with_lease(&minority_observer_context(), &mut lease_port).expect("strategy decision");
+
+  assert_eq!(decision.simple_decision(), DowningDecision::Down);
+  assert_eq!(decision.downing_targets(), &[node_a]);
   assert_eq!(lease_port.calls, 0);
 }

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator.rs
@@ -176,8 +176,11 @@ impl MembershipCoordinator {
     let mut outcome = MembershipCoordinatorOutcome { membership_events, ..Default::default() };
 
     if changed {
+      if let Some(record) = self.gossip.table().record(&authority).cloned() {
+        self.clear_rejoining_reachability(&record, before);
+      }
       self.update_suspect_tracking(&authority, NodeStatus::Joining, now);
-      self.topology_accumulator.joined.insert(authority.clone());
+      self.topology_accumulator.mark_joined(authority.clone());
       self.refresh_peers();
       if self.config.gossip_enabled {
         outcome.gossip_outbound = self.gossip.disseminate(&delta);
@@ -225,7 +228,7 @@ impl MembershipCoordinator {
     let membership_events = self.gossip.table_mut().drain_events();
     let mut outcome = MembershipCoordinatorOutcome { membership_events, ..Default::default() };
     if self.gossip.table().record(authority).map(|record| record.status) == Some(NodeStatus::Removed) {
-      self.topology_accumulator.left.insert(authority.to_string());
+      self.topology_accumulator.mark_left(authority.to_string());
     }
     if let Some(status) = self.gossip.table().record(authority).map(|record| record.status) {
       self.update_suspect_tracking(authority, status, now);
@@ -265,6 +268,53 @@ impl MembershipCoordinator {
       });
     }
 
+    self.collect_gossip_and_state_events(now, &mut outcome);
+    Ok(outcome)
+  }
+
+  /// Handles a downing decision for a member selected by a downing provider.
+  ///
+  /// # Errors
+  ///
+  /// Returns [`MembershipCoordinatorError::NotStarted`] when stopped,
+  /// [`MembershipCoordinatorError::InvalidState`] in client mode, or a membership
+  /// error when the target cannot transition to `Dead`.
+  pub fn handle_down(
+    &mut self,
+    authority: &str,
+    now: TimerInstant,
+  ) -> Result<MembershipCoordinatorOutcome, MembershipCoordinatorError> {
+    self.ensure_member()?;
+
+    let before = self.gossip.table().record(authority).map(|record| record.status);
+    let Some(delta) = self.gossip.table_mut().mark_dead(authority).map_err(MembershipCoordinatorError::Membership)?
+    else {
+      return Ok(MembershipCoordinatorOutcome::default());
+    };
+
+    let mut outcome = MembershipCoordinatorOutcome::default();
+    self.refresh_peers();
+    if self.config.gossip_enabled {
+      outcome.gossip_outbound.extend(self.gossip.disseminate(&delta));
+    }
+    if let Some(record) = self.gossip.table().record(authority).cloned() {
+      self.update_suspect_tracking(authority, record.status, now);
+      self.topology_accumulator.mark_dead(authority.to_string());
+      self.record_terminated(&record);
+      if let Some(from) = before {
+        self.emit_status_change(authority, from, record.status, now, &mut outcome);
+      }
+      let reason = "downing-decision".to_string();
+      let event = self.quarantine.quarantine(authority.to_string(), reason.clone(), now, self.config.quarantine_ttl);
+      outcome.quarantine_events.push(event);
+      outcome.member_events.push(ClusterEvent::MemberQuarantined {
+        authority: authority.to_string(),
+        reason,
+        observed_at: now,
+      });
+    }
+
+    outcome.membership_events = self.gossip.table_mut().drain_events();
     self.collect_gossip_and_state_events(now, &mut outcome);
     Ok(outcome)
   }
@@ -529,14 +579,15 @@ impl MembershipCoordinator {
     match status {
       | NodeStatus::Joining | NodeStatus::WeaklyUp | NodeStatus::Up | NodeStatus::Suspect => {
         if before.is_none() || matches!(before, Some(NodeStatus::Removed | NodeStatus::Dead)) {
-          self.topology_accumulator.joined.insert(record.authority.clone());
+          self.clear_rejoining_reachability(record, before);
+          self.topology_accumulator.mark_joined(record.authority.clone());
         }
       },
       | NodeStatus::Removed => {
-        self.topology_accumulator.left.insert(record.authority.clone());
+        self.topology_accumulator.mark_left(record.authority.clone());
       },
       | NodeStatus::Dead => {
-        self.topology_accumulator.dead.insert(record.authority.clone());
+        self.topology_accumulator.mark_dead(record.authority.clone());
         let reason = "gossip-dead".to_string();
         let event =
           self.quarantine.quarantine(record.authority.clone(), reason.clone(), now, self.config.quarantine_ttl);
@@ -601,6 +652,17 @@ impl MembershipCoordinator {
 
   fn record_reachable(&mut self, subject: &NodeRecord) {
     self.reachability.reachable(self.local_unique_address(), subject.unique_address.clone());
+  }
+
+  fn record_terminated(&mut self, subject: &NodeRecord) {
+    self.reachability.terminated(self.local_unique_address(), subject.unique_address.clone());
+  }
+
+  fn clear_rejoining_reachability(&mut self, record: &NodeRecord, before: Option<NodeStatus>) {
+    if matches!(before, Some(NodeStatus::Removed | NodeStatus::Dead)) {
+      self.reachability.clear_subject(&record.unique_address);
+      self.reachability.clear_observer(&record.unique_address);
+    }
   }
 
   fn local_unique_address(&self) -> UniqueAddress {
@@ -770,6 +832,24 @@ impl TopologyAccumulator {
     self.joined.clear();
     self.left.clear();
     self.dead.clear();
+  }
+
+  fn mark_joined(&mut self, authority: String) {
+    self.left.remove(&authority);
+    self.dead.remove(&authority);
+    self.joined.insert(authority);
+  }
+
+  fn mark_left(&mut self, authority: String) {
+    self.joined.remove(&authority);
+    self.dead.remove(&authority);
+    self.left.insert(authority);
+  }
+
+  fn mark_dead(&mut self, authority: String) {
+    self.joined.remove(&authority);
+    self.left.remove(&authority);
+    self.dead.insert(authority);
   }
 
   fn joined_sorted(&self) -> Vec<String> {

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator_error.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator_error.rs
@@ -1,7 +1,7 @@
 //! Membership coordinator error types.
 
 use super::{GossipTransportError, MembershipCoordinatorState, MembershipError};
-use crate::failure_detector::FailureDetectorConfigError;
+use crate::{extension::ClusterProviderError, failure_detector::FailureDetectorConfigError};
 
 /// Errors returned by the membership coordinator.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,4 +19,6 @@ pub enum MembershipCoordinatorError {
   Configuration(FailureDetectorConfigError),
   /// Gossip transport error.
   Transport(GossipTransportError),
+  /// Cluster provider error.
+  ClusterProvider(ClusterProviderError),
 }

--- a/modules/cluster-core-kernel/src/membership/membership_coordinator_test.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_coordinator_test.rs
@@ -85,6 +85,7 @@ fn stopped_rejects_inputs() {
   let now = now(1);
 
   assert_eq!(coordinator.handle_heartbeat("node-a", now).unwrap_err(), MembershipCoordinatorError::NotStarted);
+  assert_eq!(coordinator.handle_down("node-a", now).unwrap_err(), MembershipCoordinatorError::NotStarted);
   assert_eq!(coordinator.poll(now).unwrap_err(), MembershipCoordinatorError::NotStarted);
 
   let delta = MembershipDelta::new(MembershipVersion::zero(), MembershipVersion::zero(), Vec::new());
@@ -103,6 +104,9 @@ fn client_rejects_join_and_leave() {
   assert_eq!(err, MembershipCoordinatorError::InvalidState { state: MembershipCoordinatorState::Client });
 
   let err = coordinator.handle_leave("node-a", now(1)).unwrap_err();
+  assert_eq!(err, MembershipCoordinatorError::InvalidState { state: MembershipCoordinatorState::Client });
+
+  let err = coordinator.handle_down("node-a", now(1)).unwrap_err();
   assert_eq!(err, MembershipCoordinatorError::InvalidState { state: MembershipCoordinatorState::Client });
 }
 
@@ -233,6 +237,166 @@ fn leave_emits_exiting_then_removed() {
       .iter()
       .any(|event| matches!(event, MembershipEvent::Left { authority, .. } if authority == "node-a"))
   );
+}
+
+#[test]
+fn down_marks_suspect_dead_and_terminates_reachability() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config_with_address(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let _ = coordinator
+    .handle_join("node-1".to_string(), "node-a:2552".to_string(), &joining_cluster_config(), now(1))
+    .unwrap();
+  let _ = coordinator.handle_heartbeat("node-a:2552", now(2)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a:2552", now(3)).unwrap();
+  let _ = coordinator.poll(now(5)).unwrap();
+
+  let suspect_record =
+    coordinator.snapshot().entries.into_iter().find(|record| record.authority == "node-a:2552").expect("node-a record");
+  assert_eq!(suspect_record.status, NodeStatus::Suspect);
+
+  let outcome = coordinator.handle_down("node-a:2552", now(6)).unwrap();
+  assert!(
+    outcome
+      .member_events
+      .iter()
+      .any(|event| matches!(event, ClusterEvent::MemberStatusChanged { to: NodeStatus::Dead, .. }))
+  );
+  assert!(
+    outcome
+      .member_events
+      .iter()
+      .any(|event| matches!(event, ClusterEvent::MemberQuarantined { authority, .. } if authority == "node-a:2552"))
+  );
+
+  let snapshot = coordinator.snapshot();
+  assert!(snapshot.entries.iter().any(|record| record.authority == "node-a:2552" && record.status == NodeStatus::Dead));
+  assert_eq!(snapshot.reachability.aggregate_status(&suspect_record.unique_address), ReachabilityStatus::Terminated);
+}
+
+#[test]
+fn down_marks_up_dead_for_self_downing_target() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config_with_address(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let _ = coordinator
+    .handle_join("node-1".to_string(), "node-a:2552".to_string(), &joining_cluster_config(), now(1))
+    .unwrap();
+  let _ = coordinator.handle_heartbeat("node-a:2552", now(2)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a:2552", now(3)).unwrap();
+
+  let up_record =
+    coordinator.snapshot().entries.into_iter().find(|record| record.authority == "node-a:2552").expect("node-a record");
+  assert_eq!(up_record.status, NodeStatus::Up);
+
+  let outcome = coordinator.handle_down("node-a:2552", now(4)).unwrap();
+
+  assert!(outcome.member_events.iter().any(|event| matches!(event, ClusterEvent::MemberStatusChanged {
+    from: NodeStatus::Up,
+    to: NodeStatus::Dead,
+    ..
+  })));
+  let snapshot = coordinator.snapshot();
+  assert!(snapshot.entries.iter().any(|record| record.authority == "node-a:2552" && record.status == NodeStatus::Dead));
+}
+
+#[test]
+fn rejoin_after_down_clears_terminated_reachability() {
+  let table = MembershipTable::new(3);
+  let config = base_config();
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config_with_address(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let _ = coordinator
+    .handle_join("node-1".to_string(), "node-a:2552".to_string(), &joining_cluster_config(), now(1))
+    .unwrap();
+  let _ = coordinator.handle_heartbeat("node-a:2552", now(2)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-a:2552", now(3)).unwrap();
+  let _ = coordinator.handle_down("node-a:2552", now(4)).unwrap();
+
+  let down_record =
+    coordinator.snapshot().entries.into_iter().find(|record| record.authority == "node-a:2552").expect("down record");
+  assert_eq!(
+    coordinator.snapshot().reachability.aggregate_status(&down_record.unique_address),
+    ReachabilityStatus::Terminated
+  );
+
+  let _ = coordinator.poll(now(6)).unwrap();
+  let _ = coordinator
+    .handle_join("node-1".to_string(), "node-a:2552".to_string(), &joining_cluster_config(), now(7))
+    .unwrap();
+
+  let snapshot = coordinator.snapshot();
+  let rejoined_record =
+    snapshot.entries.iter().find(|record| record.authority == "node-a:2552").expect("rejoined record");
+  assert_eq!(rejoined_record.status, NodeStatus::Joining);
+  assert_eq!(snapshot.reachability.aggregate_status(&rejoined_record.unique_address), ReachabilityStatus::Reachable);
+}
+
+#[test]
+fn rejoin_after_down_clears_observer_reachability_rows() {
+  let table = MembershipTable::new(3);
+  let mut config = base_config();
+  config.suspect_timeout = Duration::from_secs(30);
+  config.dead_timeout = Duration::from_secs(30);
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config_with_address(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let _ = coordinator
+    .handle_join("local-node".to_string(), "local:2552".to_string(), &local_cluster_config(), now(1))
+    .unwrap();
+  let _ = coordinator
+    .handle_join("node-b".to_string(), "node-b:2552".to_string(), &joining_cluster_config(), now(1))
+    .unwrap();
+  let _ = coordinator.handle_heartbeat("node-b:2552", now(2)).unwrap();
+  let _ = coordinator.handle_heartbeat("node-b:2552", now(3)).unwrap();
+  let _ = coordinator.poll(now(5)).unwrap();
+
+  let node_b_record =
+    coordinator.snapshot().entries.into_iter().find(|record| record.authority == "node-b:2552").expect("node-b record");
+  assert_eq!(
+    coordinator.snapshot().reachability.aggregate_status(&node_b_record.unique_address),
+    ReachabilityStatus::Unreachable
+  );
+
+  let _ = coordinator.handle_down("local:2552", now(6)).unwrap();
+  let _ = coordinator.poll(now(8)).unwrap();
+  let _ = coordinator
+    .handle_join("local-node".to_string(), "local:2552".to_string(), &local_cluster_config(), now(9))
+    .unwrap();
+
+  assert_eq!(
+    coordinator.snapshot().reachability.aggregate_status(&node_b_record.unique_address),
+    ReachabilityStatus::Reachable
+  );
+}
+
+#[test]
+fn down_cancels_pending_joined_topology_delta() {
+  let table = MembershipTable::new(3);
+  let mut config = base_config();
+  config.topology_emit_interval = Duration::from_secs(2);
+  let mut coordinator = MembershipCoordinator::new(config, local_cluster_config(), table, registry(1.0));
+  coordinator.start_member().unwrap();
+
+  let _ =
+    coordinator.handle_join("node-1".to_string(), "node-a".to_string(), &joining_cluster_config(), now(1)).unwrap();
+  assert!(coordinator.poll(now(1)).unwrap().topology_event.is_none());
+  let _ = coordinator.handle_down("node-a", now(2)).unwrap();
+
+  let outcome = coordinator.poll(now(3)).unwrap();
+  let update = outcome
+    .topology_event
+    .and_then(|event| if let ClusterEvent::TopologyUpdated { update } = event { Some(update) } else { None })
+    .expect("topology update");
+
+  assert!(update.joined.is_empty());
+  assert!(update.left.is_empty());
+  assert_eq!(update.dead, vec![String::from("node-a")]);
 }
 
 #[test]

--- a/modules/cluster-core-kernel/src/membership/membership_table.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_table.rs
@@ -351,7 +351,7 @@ impl MembershipTable {
 
     match record.status {
       | NodeStatus::Dead => return Ok(None),
-      | NodeStatus::Suspect | NodeStatus::WeaklyUp => {},
+      | status if status.is_active() => {},
       | _ => {
         return Err(MembershipError::InvalidTransition {
           authority: authority.to_string(),

--- a/modules/cluster-core-kernel/src/membership/membership_table_test.rs
+++ b/modules/cluster-core-kernel/src/membership/membership_table_test.rs
@@ -322,6 +322,39 @@ fn weakly_up_can_leave_or_be_marked_dead() {
 }
 
 #[test]
+fn active_member_can_be_marked_dead() {
+  for (status, authority, node_id) in [
+    (NodeStatus::Joining, "n1:4050", "node-joining"),
+    (NodeStatus::WeaklyUp, "n2:4050", "node-weakly-up"),
+    (NodeStatus::Up, "n3:4050", "node-up"),
+    (NodeStatus::Suspect, "n4:4050", "node-suspect"),
+  ] {
+    let mut table = MembershipTable::new(3);
+    table
+      .try_join(node_id.to_string(), authority.to_string(), "1.0.0".to_string(), vec!["backend".to_string()])
+      .expect("join succeeds");
+    match status {
+      | NodeStatus::Joining => {},
+      | NodeStatus::WeaklyUp => {
+        table.mark_weakly_up(authority).expect("weakly up succeeds");
+      },
+      | NodeStatus::Up => {
+        table.mark_weakly_up(authority).expect("weakly up succeeds");
+        table.mark_up(authority).expect("up succeeds");
+      },
+      | NodeStatus::Suspect => {
+        table.mark_suspect(authority).expect("suspect succeeds");
+      },
+      | _ => unreachable!("test covers active statuses only"),
+    }
+
+    let dead_delta = table.mark_dead(authority).expect("active member can be downed").expect("delta");
+
+    assert_eq!(dead_delta.entries[0].status, NodeStatus::Dead);
+  }
+}
+
+#[test]
 fn heartbeat_miss_is_ignored_for_exiting_member() {
   let mut table = MembershipTable::new(1);
   table

--- a/modules/cluster-core-kernel/src/membership/reachability_matrix.rs
+++ b/modules/cluster-core-kernel/src/membership/reachability_matrix.rs
@@ -39,6 +39,37 @@ impl ReachabilityMatrix {
     self.update(observer, subject, ReachabilityStatus::Terminated);
   }
 
+  /// Clears all reachability records for a subject.
+  pub fn clear_subject(&mut self, subject: &UniqueAddress) {
+    let observers = self
+      .records
+      .keys()
+      .filter(|(_, record_subject)| record_subject == subject)
+      .map(|(observer, _)| observer.clone())
+      .collect::<Vec<_>>();
+    for observer in observers {
+      self.records.remove(&(observer.clone(), subject.clone()));
+      self.bump_observer_version(observer);
+    }
+  }
+
+  /// Clears all reachability records reported by an observer.
+  pub fn clear_observer(&mut self, observer: &UniqueAddress) {
+    let subjects = self
+      .records
+      .keys()
+      .filter(|(record_observer, _)| record_observer == observer)
+      .map(|(_, subject)| subject.clone())
+      .collect::<Vec<_>>();
+    if subjects.is_empty() {
+      return;
+    }
+    for subject in subjects {
+      self.records.remove(&(observer.clone(), subject));
+    }
+    self.bump_observer_version(observer.clone());
+  }
+
   /// Returns the aggregate status for a subject across all observers.
   #[must_use]
   pub fn aggregate_status(&self, subject: &UniqueAddress) -> ReachabilityStatus {

--- a/modules/cluster-core-kernel/src/membership/reachability_matrix_test.rs
+++ b/modules/cluster-core-kernel/src/membership/reachability_matrix_test.rs
@@ -73,6 +73,51 @@ fn terminated_has_aggregate_precedence_and_is_not_overwritten_by_reachable() {
 }
 
 #[test]
+fn clear_subject_removes_terminated_records_and_bumps_observer_version() {
+  let observer_a = unique("observer-a", 1);
+  let observer_b = unique("observer-b", 2);
+  let subject = unique("subject-a", 3);
+  let other_subject = unique("subject-b", 4);
+  let mut matrix = ReachabilityMatrix::new();
+
+  matrix.terminated(observer_a.clone(), subject.clone());
+  matrix.unreachable(observer_b.clone(), subject.clone());
+  matrix.unreachable(observer_b.clone(), other_subject.clone());
+
+  matrix.clear_subject(&subject);
+
+  let snapshot = matrix.snapshot();
+  assert!(snapshot.records.iter().all(|record| record.subject != subject));
+  assert!(snapshot.records.iter().any(|record| record.subject == other_subject));
+  assert_eq!(snapshot.observer_versions.get(&observer_a), Some(&2));
+  assert_eq!(snapshot.observer_versions.get(&observer_b), Some(&3));
+  assert_eq!(matrix.aggregate_status(&subject), ReachabilityStatus::Reachable);
+}
+
+#[test]
+fn clear_observer_removes_row_and_bumps_observer_version_once() {
+  let observer = unique("observer-a", 1);
+  let subject_a = unique("subject-a", 2);
+  let subject_b = unique("subject-b", 3);
+  let other_observer = unique("observer-b", 4);
+  let mut matrix = ReachabilityMatrix::new();
+
+  matrix.unreachable(observer.clone(), subject_a.clone());
+  matrix.terminated(observer.clone(), subject_b.clone());
+  matrix.unreachable(other_observer.clone(), subject_b.clone());
+
+  matrix.clear_observer(&observer);
+
+  let snapshot = matrix.snapshot();
+  assert!(snapshot.records.iter().all(|record| record.observer != observer));
+  assert!(snapshot.records.iter().any(|record| record.observer == other_observer));
+  assert_eq!(snapshot.observer_versions.get(&observer), Some(&3));
+  assert_eq!(snapshot.observer_versions.get(&other_observer), Some(&1));
+  assert_eq!(matrix.aggregate_status(&subject_a), ReachabilityStatus::Reachable);
+  assert_eq!(matrix.aggregate_status(&subject_b), ReachabilityStatus::Unreachable);
+}
+
+#[test]
 fn repeated_same_status_does_not_advance_observer_version() {
   let observer = unique("observer-a", 1);
   let subject = unique("subject-a", 2);


### PR DESCRIPTION
## 概要

- SBR provider hook に target-aware な strategy decision API を追加しました。
- std adaptor の `StdSplitBrainResolverProvider` / `TokioGossiper` / `MembershipCoordinatorDriver` に downing 実行ループを接続しました。
- `docs/gap-analysis/cluster-gap-analysis.md` の Phase 3 進捗と集計を更新しました。

## 検証

- `cargo test -p fraktor-cluster-core-kernel-rs provider_hook_strategy_decision_preserves_downing_targets`
- `cargo test -p fraktor-cluster-adaptor-std-rs strategy_context_starts_factory_provider_lazily_and_preserves_targets`
- `cargo test -p fraktor-cluster-adaptor-std-rs split_brain_resolver_downing_downs_unreachable_target_when_attached`
- `cargo test -p fraktor-cluster-adaptor-std-rs failure_detection_keeps_suspect_until_downing_decision`
- `cargo test -p fraktor-cluster-core-kernel-rs -p fraktor-cluster-adaptor-std-rs`
- `./scripts/ci-check.sh ai fmt dylint clippy`
- `./scripts/ci-check.sh ai all`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes cluster membership transitions, reachability, and automatic downing in production gossip paths; incorrect targeting or partial-failure handling could wrongly remove nodes or leave split views.
> 
> **Overview**
> Adds an **opt-in Split Brain Resolver runtime loop** that turns reachability-based strategy decisions into automatic down actions during membership polling, instead of requiring manual `down` calls.
> 
> Core downing APIs now expose **`decide_strategy_context`** (with lease variants) so callers keep full **downing target lists** while still applying provider-facing `Keep`/`Down` semantics when the local observer is in the target set. The std stack adds **`SplitBrainResolverDowningDriver`**, wires it through **`MembershipCoordinatorDriver::poll`** and **`TokioGossiper::with_split_brain_resolver_downing`**, and for each target calls **`ClusterProvider::down`** then **`MembershipCoordinator::handle_down`**.
> 
> **`handle_down`** is new: it marks any active member `Dead`, emits status/quarantine/topology events, gossips the delta, and records reachability as terminated. Related fixes broaden **`mark_dead`** to all active statuses, reset reachability rows on rejoin after down, and keep topology join/left/dead sets consistent when downing cancels a pending join.
> 
> **`TokioGossiper`** treats **`MembershipCoordinatorError::ClusterProvider`** as non-fatal so gossip keeps running after partial provider down failures. Tests cover stable-after resets, provider failure paths, and self-down. **`cluster-gap-analysis.md`** marks the SBR execution loop implemented (69% parity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42f12f1052ed730f7781f8d3c58061a6b42af83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Split Brain Resolver のダウニングをクラスタランタイムに統合し、自動で適用できるようにしました。
* **Behavior Changes / Bug Fixes**
  * ダウニング時のメンバー状態遷移と到達性更新を整理し、アクティブ状態の Dead 反映や不要な到達性情報の除去を改善しました。
* **Tests**
  * ダウニング判断、遅延起動、状態遷移、安定期間リセットのテストを追加しました。
* **Documentation**
  * ギャップ分析ドキュメントを更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->