### PR TITLE
[codex] Plan actor gap discovery specs

### DIFF
--- a/.kiro/specs/actor-blocking-bounded-mailbox-compat/brief.md
+++ b/.kiro/specs/actor-blocking-bounded-mailbox-compat/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-blocking-bounded-mailbox-compat
+
+## Problem
+
+Pekko の bounded mailbox family は `pushTimeOut` を持つが、fraktor-rs の bounded queue は reject / evict / dead letter observation に寄せている。async-first actor adapters 方針では低優先度だが、Pekko parity としては明確な medium gap であり、互換 option として設計境界を決める必要がある。
+
+## Current State
+
+bounded / priority / stable-priority / deque / control-aware queue family は存在する。満杯時は overflow strategy に従い、損失は dead letters で観測される。enqueue 側が空きを待つ contract、timeout まで待って失敗する contract、std adaptor での blocking / async wait integration はない。
+
+## Desired Outcome
+
+`pushTimeOut` 付き bounded mailbox の互換 contract が core と std adaptor の境界で定義される。core は policy / result / capability を所有し、std adaptor は必要な wait mechanism を提供する。default は既存 async-first overflow behavior を維持する。
+
+## Approach
+
+blocking wait を core に直接持ち込まず、core には timeout-capable enqueue contract と observability を置く。std adaptor で timeout wait を実現する場合の executor / blocker / scheduler の責務を明確にし、Embassy には強制しない。
+
+## Scope
+
+- **In**: pushTimeOut semantics の contract、timeout-capable bounded mailbox policy、std adaptor compatibility option、dead letter / rejection observability、tests
+- **Out**: 既存 bounded mailbox default behavior の変更、Embassy adaptor への blocking wait 強制、Pekko HOCON config の完全移植
+
+## Boundary Candidates
+
+- core mailbox policy と std wait implementation
+- overflow strategy と timeout wait strategy
+- control-aware bounded semantics と normal bounded semantics
+
+## Out of Boundary
+
+- queue type / lookupByQueueType resolution
+- BalancingDispatcher compatibility contract
+- mailbox run loop の全面 rewrite
+
+## Upstream / Downstream
+
+- **Upstream**: actor-mailbox-resolution-contract
+- **Downstream**: std adaptor mailbox compatibility showcase、将来の config-driven mailbox compatibility option
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: actor-mailbox-resolution-contract、actor-adaptor-std dispatch implementation
+
+## Constraints
+
+async-first 方針を壊さず、互換 option と default behavior を分ける。`actor-core-kernel` は std blocking primitive に依存しない。timeout behavior は deterministic test 可能な clock / scheduler abstraction に接続する。

--- a/.kiro/specs/actor-cell-facet-structure/brief.md
+++ b/.kiro/specs/actor-cell-facet-structure/brief.md
@@ -1,0 +1,49 @@
+# Brief: actor-cell-facet-structure
+
+## Problem
+
+`docs/gap-analysis/actor-gap-analysis.md` は `ActorCell` が dispatch / fault handling / DeathWatch / children / receive timeout / stash / timers / pipe を 1 ファイルに抱え、後続の actor parity work の変更面を大きくしていると指摘している。Phase 1 API gap の多くは `ActorCell` 周辺に触れるため、先に責務を分けないと小さな parity 追加でも巨大 diff になりやすい。
+
+## Current State
+
+`modules/actor-core-kernel/src/actor/actor_cell.rs` は複数責務をまとめた orchestrator になっている。receive timeout は `receive_timeout_state.rs` / `receive_timeout_state_shared.rs` / `actor_cell.rs` / `actor_context.rs` に分散している。既存 public behavior は高く実装済みなので、目的はふるまい追加ではなく構造整理である。
+
+## Desired Outcome
+
+`ActorCell` の同一型に対する `impl` を dispatch、fault handling、DeathWatch、children、receive timeout などの facet 単位へ分割し、`ActorCell` 本体は orchestration と公開境界に寄せる。receive timeout の状態遷移と cell 連携は専用 facet に集約され、既存テストは同じふるまいを保ったまま通る。
+
+## Approach
+
+公開 API を増やさず、同一クレート内の module / impl split と sibling test の再配置で進める。Pekko の `actor/dungeon/*` は責務分離の参照に使うが、Rust では継承 trait ではなく module と private helper の分離で表現する。
+
+## Scope
+
+- **In**: `ActorCell` の facet 分割、receive timeout 責務の集約、既存テストの移動または分割、後続 API work のための private helper 境界整理
+- **Out**: 新しい actor public API、mailbox selection の仕様変更、EventBus の汎用化、supervision policy の意味変更
+
+## Boundary Candidates
+
+- dispatch facet と mailbox / dispatcher 側 contract
+- fault handling facet と supervision / lifecycle contract
+- DeathWatch / children facet と actor tree management
+- receive timeout facet と context API
+
+## Out of Boundary
+
+- `SystemState` の registry split
+- typed actor facade の分離
+- 既存 public re-export の visibility audit
+
+## Upstream / Downstream
+
+- **Upstream**: 既存 `actor-core-kernel` の ActorCell / ActorContext / lifecycle / receive timeout 実装
+- **Downstream**: actor-kernel-message-observability、actor-coordinated-shutdown-task-variants、将来の lifecycle / supervision parity work
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: actor-kernel-message-observability、actor-kernel-public-surface-audit
+
+## Constraints
+
+`actor-core-kernel` の `no_std` + alloc 境界を維持する。構造変更は挙動を変えず、既存 public API の追加・削除は行わない。1 公開型 1 ファイル、sibling `_test.rs`、FQCN import rule に従う。

--- a/.kiro/specs/actor-coordinated-shutdown-task-variants/brief.md
+++ b/.kiro/specs/actor-coordinated-shutdown-task-variants/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-coordinated-shutdown-task-variants
+
+## Problem
+
+`CoordinatedShutdown` は基本 task registration と run contract を持つが、Pekko `addCancellableTask` / `addActorTerminationTask` 相当がない。shutdown 中に登録解除可能な task や actor termination を待つ task を表現できず、lifecycle parity に小さな穴が残っている。
+
+## Current State
+
+`actor-core-kernel/src/system/coordinated_shutdown.rs` は phase と task を持ち、`add_task` / `run` の基本機能を提供する。actor termination future や cancellable handle との統合は専用 API として露出していない。
+
+## Desired Outcome
+
+CoordinatedShutdown に cancellable task registration と actor termination task registration が追加される。actor termination task は既存 ActorRef / termination future / watch path と整合し、shutdown phase の順序と失敗処理を保つ。
+
+## Approach
+
+既存 task model を拡張し、cancellable registration は handle で task を解除できる contract にする。actor termination task は actor stop request と termination wait を合成する thin helper として実装し、shutdown engine 自体を大きく書き換えない。
+
+## Scope
+
+- **In**: cancellable task API、actor termination task API、phase ordering と cancellation semantics の tests、failure / timeout behavior の明文化
+- **Out**: OS signal integration、cluster full shutdown command、new shutdown phase taxonomy、process exit handling
+
+## Boundary Candidates
+
+- task registration registry と run loop
+- ActorRef termination waiting と shutdown phase
+- cancellation handle と idempotency
+
+## Out of Boundary
+
+- SystemState registry split の構造変更そのもの
+- remote / cluster coordinated shutdown integration
+- metrics / tracing field contract
+
+## Upstream / Downstream
+
+- **Upstream**: actor-system-state-registry-split、既存 CoordinatedShutdown 実装
+- **Downstream**: cluster lifecycle shutdown integration、showcase の coordinated shutdown example
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: cluster-membership-event-surface（shutdown progress event とは別責務）
+
+## Constraints
+
+`actor-core-kernel` の `no_std` 境界を維持する。actor termination task は std blocking wait を持たず、既存 future / scheduler / actor system contract を使う。既存 `add_task` の後方挙動を変えない。

--- a/.kiro/specs/actor-eventbus-classification-contract/brief.md
+++ b/.kiro/specs/actor-eventbus-classification-contract/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-eventbus-classification-contract
+
+## Problem
+
+fraktor-rs の EventStream は実用的だが、Pekko の汎用 EventBus trait 族（Lookup / Subchannel / Scanning / ManagedActor classification）に相当する拡張契約がない。ユーザー定義の event bus や classification strategy を構築できず、event / logging カテゴリの主要 medium gap として残っている。
+
+## Current State
+
+`actor-core-kernel/src/event/stream.rs` は fixed classifier と subscriber model を持つ。dead letter / unhandled message / logging event は流せるが、classification trait を外部実装して独自 EventBus を組み立てる surface はない。
+
+## Desired Outcome
+
+EventBus、ActorEventBus、LookupClassification、SubchannelClassification、ScanningClassification、ManagedActorClassification 相当の trait / helper が kernel に定義される。既存 EventStream は互換性を保ちつつ、どの分類 strategy を採用しているかが明確になる。
+
+## Approach
+
+Pekko の trait 階層を Rust の trait + associated type / generic helper に変換する。既存 EventStream を一気に置き換えず、まず汎用 classification contract と既存 EventStream への bridge を定義する。
+
+## Scope
+
+- **In**: EventBus trait 族、classification strategy trait、actor subscriber 管理 contract、既存 EventStream との bridge / tests
+- **Out**: logging backend の置換、cluster pubsub mediator、typed eventstream の再設計、すべての event publication path の一括 rewrite
+
+## Boundary Candidates
+
+- generic EventBus contract と concrete EventStream
+- classifier strategy と subscriber registry
+- actor subscriber lifecycle と dead letter / unhandled message publication
+
+## Out of Boundary
+
+- DeadLetterSuppression marker の導入そのもの
+- mailbox selection / dispatcher contract
+- std tracing subscriber
+
+## Upstream / Downstream
+
+- **Upstream**: actor-system-state-registry-split、actor-kernel-message-observability
+- **Downstream**: actor-kernel-public-surface-audit、将来の custom event bus / logging extension
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: actor-kernel-message-observability、cluster-pubsub-mediator-protocol
+
+## Constraints
+
+`actor-core-kernel` の `no_std` + alloc で実装可能な trait にする。Pekko の継承構造をそのまま移植せず、Rust の trait composition に寄せる。既存 EventStream の public behavior を壊さない。

--- a/.kiro/specs/actor-kernel-message-observability/brief.md
+++ b/.kiro/specs/actor-kernel-message-observability/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-kernel-message-observability
+
+## Problem
+
+actor gap Phase 1 には、FSM transition subscription、dead letter suppression、`PossiblyHarmful`、`WrappedMessage` という message observability 系の未対応が残っている。これらは remote / event stream / debugging の将来利用点になるが、kernel 側に marker と protocol がないため、外部から観測可能な契約として扱えない。
+
+## Current State
+
+FSM は `on_transition` closure による内部観測を持つが、外部 actor が transition を購読する message protocol はない。`DeadLetterReason` には suppressed 相当の variant があるが、ユーザーメッセージが抑制を宣言する marker と `SuppressedDeadLetter` 生成経路は未配線である。`PossiblyHarmful` と `WrappedMessage` 相当の marker / wrapper trait も存在しない。
+
+## Desired Outcome
+
+FSM transition subscription protocol が kernel に追加され、外部 actor が current state と transition を購読 / 解除できる。DeadLetterSuppression marker と SuppressedDeadLetter 生成経路が event stream に接続される。`PossiblyHarmful` と `WrappedMessage` は remote / event stream が将来参照できる最小 marker contract として定義される。
+
+## Approach
+
+Pekko の message names を参考にしつつ、Rust では enum / trait / marker 型として最小 surface を置く。ActorCell facet split 後の message dispatch / dead letter path に接続し、remote untrusted enforcement は本 spec では実装しない。
+
+## Scope
+
+- **In**: FSM CurrentState / SubscribeTransitionCallBack / UnsubscribeTransitionCallBack 相当、DeadLetterSuppression marker、SuppressedDeadLetter 生成経路、PossiblyHarmful marker、WrappedMessage trait、event stream tests
+- **Out**: remote untrusted mode の遮断実装、cluster event integration、typed-only DSL sugar、testkit helpers
+
+## Boundary Candidates
+
+- FSM protocol と FSM runtime state
+- dead letter generation と event stream publication
+- marker traits と remote / serialization の将来利用点
+
+## Out of Boundary
+
+- 汎用 EventBus trait 族
+- ActorSelection ask
+- mailbox selection contract
+
+## Upstream / Downstream
+
+- **Upstream**: actor-cell-facet-structure
+- **Downstream**: actor-eventbus-classification-contract、actor-kernel-public-surface-audit、remote untrusted message filtering の将来 spec
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: remote gap work（PossiblyHarmful の利用先）、actor-eventbus-classification-contract
+
+## Constraints
+
+`actor-core-kernel` の `no_std` 境界で完結させる。marker は過剰な trait 階層にせず、実際に event stream / remote boundary から参照できる最小契約にする。既存 dead letter semantics を壊さない。

--- a/.kiro/specs/actor-kernel-public-surface-audit/brief.md
+++ b/.kiro/specs/actor-kernel-public-surface-audit/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-kernel-public-surface-audit
+
+## Problem
+
+actor gap analysis は API gap が縮んだ後のボトルネックとして、kernel public surface の広さと層配置の曖昧さを挙げている。`ActorCell` / `ActorShared` / `ChildRef` などの低レベル型が public re-export され、`SystemMessage` の配置も dispatch 責務とずれているため、外部契約と internal surface の境界が読み取りにくい。
+
+## Current State
+
+`actor-core-kernel` は runtime 実装に必要な低レベル型を広めに公開している。`SystemMessage` は actor messaging 配下にあり、dispatch / mailbox 側が actor domain から取得する形になっている。typed facade / behavior 実装の混在も一部残る。
+
+## Desired Outcome
+
+actor kernel の public re-export が「利用者向け contract」と「crate internal implementation」に整理される。`SystemMessage` の責務配置が dispatch 層へ寄せられるか、少なくとも現在配置の理由が明文化される。typed receptionist setup 後に残る facade / behavior 混在も棚卸しされる。
+
+## Approach
+
+後続 API specs が入ったあとに public surface を棚卸しし、実際に外部から必要な型だけを公開する。pre-release 前提なので破壊的 visibility 変更は許容するが、各削除 / 移動は compile error と tests で影響範囲を確認してから行う。
+
+## Scope
+
+- **In**: public re-export audit、低レベル型の `pub(crate)` 化候補整理、`SystemMessage` の dispatch 層配置検討と移動、typed facade 残存混在の棚卸し、gap analysis 更新
+- **Out**: 新しい actor behavior、mailbox resolution の仕様追加、EventBus trait の新設、cluster / remote API の整理
+
+## Boundary Candidates
+
+- external actor runtime API と internal cell / system implementation
+- actor messaging と dispatch system message
+- typed facade API と behavior implementation
+
+## Out of Boundary
+
+- ActorCell facet split の実作業
+- SystemState registry split の実作業
+- ReceptionistSetup の導入
+
+## Upstream / Downstream
+
+- **Upstream**: actor-kernel-message-observability、actor-eventbus-classification-contract、actor-mailbox-resolution-contract、actor-typed-receptionist-setup
+- **Downstream**: README / docs public API cleanup、future actor parity specs
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: actor-cell-facet-structure、actor-system-state-registry-split、actor-typed-receptionist-setup
+
+## Constraints
+
+人間の明示判断なしに `.coderabbit.yml` / `.coderabbit.yaml` は変更しない。public surface の削減は compile / tests / docs update と一体で確認する。単なる好みの rename は扱わず、gap analysis に根拠がある境界整理に限定する。

--- a/.kiro/specs/actor-mailbox-resolution-contract/brief.md
+++ b/.kiro/specs/actor-mailbox-resolution-contract/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-mailbox-resolution-contract
+
+## Problem
+
+mailbox runtime core は強いが、Pekko parity としては queue type / requirement ベースの mailbox selection contract が薄い。`RequiresMessageQueue[T]` / `ProducesMessageQueue[T]` 相当、`lookupByQueueType`、deploy / dispatcher / actor requirement / default の多段 precedence、BalancingDispatcher mailbox compatibility が未整理である。
+
+## Current State
+
+`MailboxRequirement` による capability 検証と `Props::with_mailbox_id` / `MailboxConfig` による単純な selection は存在する。主要 queue family も揃っている。一方で actor 宣言ベースの queue type 解決、mailbox id alias mapping、dispatcher 側 requirement との調停はない。
+
+## Desired Outcome
+
+queue semantics marker、RequiresMessageQueue / ProducesMessageQueue 相当、queue type から mailbox type を引く lookup contract、多段 mailbox selection precedence が kernel に定義される。BalancingDispatcher は multiple-consumer compatible mailbox の要求と検証を外部から見える mailbox contract として持つ。
+
+## Approach
+
+既存 `MailboxRequirement` と registry を捨てず、queue type resolution layer を追加する。selection precedence は HOCON 依存ではなく Rust の deploy / dispatcher / props / default source の順序として明文化する。
+
+## Scope
+
+- **In**: queue semantics marker、actor / mailbox type declaration、lookupByQueueType 相当、selection precedence、BalancingDispatcher compatibility contract、mailbox resolution tests
+- **Out**: pushTimeOut 付き blocking bounded mailbox、JVM HOCON loading、Pekko alias chain の完全互換、testkit mailbox
+
+## Boundary Candidates
+
+- actor-declared requirement と mailbox-provided capability
+- dispatcher config / deploy / props / default の selection source
+- BalancingDispatcher shared queue と mailbox type compatibility
+
+## Out of Boundary
+
+- bounded mailbox blocking semantics
+- mailbox run loop / scheduling gate の変更
+- actor system registry split の構造変更そのもの
+
+## Upstream / Downstream
+
+- **Upstream**: actor-system-state-registry-split、既存 dispatch / mailbox implementation
+- **Downstream**: actor-blocking-bounded-mailbox-compat、actor-kernel-public-surface-audit
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: actor-mailbox-gap-analysis、actor-system-state-registry-split
+
+## Constraints
+
+`actor-core-kernel` の `no_std` 境界を維持する。async-first 方針を保ち、blocking semantics をこの spec に混ぜない。既存 mailbox id / config API は可能な限り bridge し、selection precedence の追加で利用者が意図しない queue へ silently fallback しないよう診断を明確にする。

--- a/.kiro/specs/actor-pattern-utility-parity/brief.md
+++ b/.kiro/specs/actor-pattern-utility-parity/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-pattern-utility-parity
+
+## Problem
+
+actor gap Phase 1 には pattern utility の小さな欠けが残っている。`FutureTimeoutSupport.after` 相当の delayed future helper、ActorSelection に対する ask 合成、CircuitBreaker の状態遷移 listener と exponential backoff / random factor が未対応であり、Pekko pattern parity の利用体験が一段薄い。
+
+## Current State
+
+classic ask は `ActorRef` に対して timeout 付きで提供されている。`ActorSelection` の resolve path はあるが ask helper とは合成されていない。CircuitBreaker は Closed / Open / HalfOpen の状態を持つが、transition listener と reset timeout の指数バックオフ / jitter contract はない。
+
+## Desired Outcome
+
+kernel pattern module に scheduler-backed `after` helper、ActorSelection ask helper、CircuitBreaker transition listener と backoff / jitter 設定が追加される。既存 ask / retry / graceful_stop / circuit breaker API と整合し、std runtime へ直接依存しない。
+
+## Approach
+
+既存 `Scheduler` / `Clock` / `CircuitBreakerShared` を使い、delayed future と timeout behavior を core contract として表現する。ActorSelection ask は resolve + ActorRef ask の合成に留め、selection resolution 自体の仕様は変えない。
+
+## Scope
+
+- **In**: `after` helper、ActorSelection ask、CircuitBreaker on_open / on_close / on_half_open listener、exponential backoff / random factor 設定、deterministic tests
+- **Out**: typed ask surface の再設計、scheduler runtime 実装の変更、retry policy の全面刷新
+
+## Boundary Candidates
+
+- scheduler-backed future helper と ask timeout
+- ActorSelection resolution と ask composition
+- CircuitBreaker state machine と listener notification
+
+## Out of Boundary
+
+- mailbox blocking semantics
+- EventBus classification
+- remote actor selection transport
+
+## Upstream / Downstream
+
+- **Upstream**: 既存 pattern / scheduler / actor selection 実装
+- **Downstream**: typed facade utility の将来追加、showcase の pattern parity example
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: actor-kernel-message-observability、actor-coordinated-shutdown-task-variants
+
+## Constraints
+
+`actor-core-kernel` に std sleep / Tokio time を持ち込まない。jitter は deterministic test が可能な injectable source か、既存 project pattern に合う設定型で扱う。listener callback は must-use / ignored return value lint に反しない形にする。

--- a/.kiro/specs/actor-system-state-registry-split/brief.md
+++ b/.kiro/specs/actor-system-state-registry-split/brief.md
@@ -1,0 +1,50 @@
+# Brief: actor-system-state-registry-split
+
+## Problem
+
+`SystemState` / `SystemStateShared` は dispatcher registry、cell table、guardian、serialization、remote hook、scheduler などをまとめて保持しており、EventBus や mailbox workstream の変更が無関係な system state に波及しやすい。actor gap closure の Phase 2 は mailbox / EventBus / shutdown に触れるため、registry 境界を先に分ける必要がある。
+
+## Current State
+
+`modules/actor-core-kernel/src/system/state.rs` と周辺 shared 型は複数 subsystem の状態と accessor を同居させている。既存の `system/registries.rs` などの分離単位はあるが、system state 自体は束ね役を超えて具象責務を持つ。
+
+## Desired Outcome
+
+SystemState は subsystem registry の束ね役に縮小される。dispatcher / mailbox / event / guardian / serialization / remote / scheduler などは責務ごとの private struct または module に分離され、後続の EventBus / mailbox / CoordinatedShutdown 変更が局所化される。
+
+## Approach
+
+外部 API を変えずに internal registry を抽出し、既存 accessor は段階的に新 registry へ委譲する。shared wrapper は project-defined `Shared*` / `ArcShared` パターンに合わせ、直接の `Arc` / `Mutex` 追加を避ける。
+
+## Scope
+
+- **In**: SystemState / SystemStateShared の subsystem registry 分離、既存 accessor の委譲化、対象 unit / integration test の維持
+- **Out**: mailbox resolution の新仕様、EventBus trait 族の導入、CoordinatedShutdown task variant の導入、remote / serialization の public behavior 変更
+
+## Boundary Candidates
+
+- mailbox / dispatcher registry
+- event stream / logging registry
+- guardian / cell table registry
+- serialization / remote hook registry
+- scheduler / shutdown coordination state
+
+## Out of Boundary
+
+- ActorCell facet 分割
+- typed system の facade 分離
+- public re-export audit
+
+## Upstream / Downstream
+
+- **Upstream**: 既存 `actor-core-kernel` system state と shared wrapper
+- **Downstream**: actor-eventbus-classification-contract、actor-mailbox-resolution-contract、actor-coordinated-shutdown-task-variants
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: actor-cell-facet-structure、actor-kernel-public-surface-audit
+
+## Constraints
+
+`actor-core-kernel` の `no_std` 境界を維持する。shared state の操作は closure-based API を優先し、read-then-act を増やさない。構造整理 spec なので observable behavior を変えない。

--- a/.kiro/specs/actor-typed-receptionist-setup/brief.md
+++ b/.kiro/specs/actor-typed-receptionist-setup/brief.md
@@ -1,0 +1,48 @@
+# Brief: actor-typed-receptionist-setup
+
+## Problem
+
+typed layer は receptionist API とローカル behavior 実装を持つが、Pekko `ReceptionistSetup` 相当の差し替え契約がない。clustered receptionist などの将来実装を入れる場合、現在の固定インストール経路では typed system 生成時に receptionist 実装を差し替えられない。
+
+## Current State
+
+`actor-core-typed` には `Receptionist` extension、`ServiceKey`、`Register` / `Deregister` / `Subscribe` / `Find`、`Listing` などの surface が存在する。`system.rs` の install path はローカル receptionist を固定的に組み立てる。`receptionist/extension.rs` は extension API と behavior 実装が同居している。
+
+## Desired Outcome
+
+typed system setup に `ReceptionistSetup` 相当の差し替え契約が追加され、ローカル receptionist を default として維持しつつ、利用者または後続 cluster work が代替 receptionist factory を渡せる。extension API、behavior 実装、内部 sender はファイル境界で分離される。
+
+## Approach
+
+Pekko の `ReceptionistSetup` を参照し、Rust では typed system setup に差し込む小さな factory / installer contract として表現する。clustered receptionist 実装は作らず、local receptionist の current behavior を default setup として保持する。
+
+## Scope
+
+- **In**: `ReceptionistSetup` 相当の setup 型、typed system install path の default / custom 分岐、receptionist extension API と behavior 実装の分離、setup tests
+- **Out**: clustered receptionist runtime、cluster membership 連携、receptionist wire protocol、typed public API の大規模再設計
+
+## Boundary Candidates
+
+- setup contract と receptionist behavior 実装
+- local receptionist default と custom receptionist factory
+- typed facade と internal sender / adapter implementation
+
+## Out of Boundary
+
+- ActorCell / SystemState の構造整理
+- EventBus generic classification
+- cluster receptionist 実装
+
+## Upstream / Downstream
+
+- **Upstream**: 既存 `actor-core-typed` receptionist / typed system setup
+- **Downstream**: actor-kernel-public-surface-audit、将来の cluster receptionist spec
+
+## Existing Spec Touchpoints
+
+- **Extends**: なし
+- **Adjacent**: cluster-grain-typed-entity-facade（typed facade との語彙整合）、actor-kernel-public-surface-audit
+
+## Constraints
+
+`actor-core-typed` の facade は `actor-core-kernel` 上に構築する。default local receptionist の既存 behavior を壊さない。差し替え contract は最小にし、cluster runtime の詳細を typed core に持ち込まない。

--- a/.kiro/steering/roadmap.md
+++ b/.kiro/steering/roadmap.md
@@ -8,6 +8,8 @@
 
 **Phase 2 (2026-06-11)**: gap analysis の再検証（parity 分母 151 概念への再構成）で確定した「実装優先度 Phase 1（trivial / easy、24 項目）」を、責務境界で 6 つの新規 spec + 既存 spec 更新 1 件 + 直接実装 2 件に分解した。前提 SPI が必要な項目（extractor 実装群、基本 CRDT 型群）は、依存する medium 項目（extractor SPI、ReplicatedData 基底 SPI）を同じ spec に前倒しで束ね、配線されない型を作らない。
 
+**Phase 3 (2026-06-19)**: `docs/gap-analysis/actor-gap-analysis.md` の actor gap closure を、API parity と内部構造ギャップの両方として扱う。Phase 1（trivial / easy）と Phase 2（medium）に加え、同 document の内部モジュール構造ギャップ（ActorCell dungeon facet、SystemState registry split、typed receptionist facade 分離、public surface audit）を、後続の API 実装を安全に進める前提 workstream として spec 化する。
+
 ## Approach Decision
 
 - **Chosen**: active follow-up を7つの spec に分け、依存順に仕様化する。
@@ -16,18 +18,22 @@
 
 **Phase 2 の判断**: gap analysis Phase 1（trivial/easy 24 項目）も同じ責務分割方針を踏襲し、6 spec に分ける。難易度・層別の粗い 3 spec 案は Phase 1 と同じ理由で却下。1 項目 1 spec の 24 分割案は review/PR の固定費が過大なため却下。極小項目（routee std 配線、mediator 全体 Count）は spec を立てず直接実装とし、既存完了 spec の自然な拡張（Multi-DC failure detector 設定）は既存 spec の更新として扱う。
 
+**Phase 3 の判断**: actor gap closure は、(1) Phase 1 API gap をすべて単一 spec に入れる案、(2) 内部構造 refactor を後回しにして API だけ先に埋める案、(3) 高変更頻度の構造ギャップを先行 spec に切り出し、その上に API parity spec を重ねる案を比較した。採用するのは (3) である。`actor_cell.rs` / `SystemState` / typed receptionist 周辺は actor gap document 上でも変更速度のボトルネックとして示されており、ここを spec 化せず API を追加すると、後続 PR がさらに巨大化するため。
+
 ## Scope
 
 - **In**:
   - (Phase 1) `Active comparison follow-up: trivial / easy`、`medium`、`hard` にある項目のうち、現在の cluster roadmap と矛盾しない comparison-driven runtime contract。
   - (Phase 2) gap analysis「実装優先度 Phase 1（trivial/easy、24 項目）」: membership イベント表層、singleton 設定契約、typed entity facade、extractor 契約 + 実装群、sharding health / join compat、基本 CRDT 型群。runtime 基盤（singleton manager、Replicator）の前提となる「契約・型・検証」までを In とする。
-- **Out**: Cluster Client（Pekko 本体で全面 deprecated）、Receptionist 実装、Cluster Singleton の runtime（manager / proxy / handover election）、Distributed Data の Replicator runtime と OR/LWW 系 CRDT、sharding の rebalance / remembered entities / delivery controllers、JVM 固有機能、完全な Akka/Pekko 互換 migration layer。これらは gap analysis の Phase 2-3（medium / hard）として別フェーズで扱う。
+  - (Phase 3) actor gap analysis の Phase 1 / Phase 2 項目（FSM transition subscription、dead letter suppression、CircuitBreaker listener/backoff、CoordinatedShutdown task variants、ReceptionistSetup、FutureTimeoutSupport.after、selection ask、marker traits、EventBus classification、mailbox queue type resolution、blocking bounded compatibility）と、同 document の内部構造ギャップのうち actor parity 実装に直接関係する構造整理。
+- **Out**: Cluster Client（Pekko 本体で全面 deprecated）、Receptionist 実装、Cluster Singleton の runtime（manager / proxy / handover election）、Distributed Data の Replicator runtime と OR/LWW 系 CRDT、sharding の rebalance / remembered entities / delivery controllers、JVM 固有機能、完全な Akka/Pekko 互換 migration layer。actor gap closure では Java DSL / Java interop、Scala 構文糖、JVM reflection / classloader / HOCON loading、Java serialization / JFR、deprecated classic remoting / ActorDSL / TypedActor、Pekko IO / TCP / UDP / DNS、testkit / TCK / tests は対象外にする。
 
 ## Constraints
 
 - `*-core` は `no_std` 境界を維持し、Tokio・network I/O・host lifecycle は `*-adaptor-std` に置く。
 - 既存の Grain runtime 方向性を優先し、Pekko public API parity を現在の cluster roadmap として扱わない。
 - `docs/gap-analysis/cluster-gap-analysis.md` は comparison evidence として更新し、実装契約は spec / tests / showcases で証明する。
+- `docs/gap-analysis/actor-gap-analysis.md` は actor parity の comparison evidence として扱い、Pekko の公開契約を Rust の `no_std` core / std adaptor 境界へ写像する。JVM 固有、Java DSL、Scala 構文糖、testkit は引き続き out of scope とする。
 - 参照実装に寄せる場合も、Rust の型境界、crate boundary、port-and-adapter 方針を優先する。
 
 ## Boundary Strategy
@@ -35,6 +41,7 @@
 - **Why this split**: 各 spec を module boundary と review scope に近い単位へ分けることで、membership の基礎 contract、transport/wire、downing decision、pubsub protocol を独立して進められる。
 - **Shared seams to watch**: `membership` と `downing_provider`、`membership` と `pub_sub`、`cluster-adaptor-std` と `remote-adaptor-std`、actor-core serialization boundary、provider lifecycle と topology input。
 - **Phase 2 で追加の seam**: `extension`（config validation / join compatibility）と singleton / sharding 設定契約、`grain` と `cluster-core-typed`（typed facade）、新設 `ddata` モジュールと membership 用 `VectorClock`（混同しないこと — CRDT 用 `VersionVector` は別物として Phase 3 で扱う）。
+- **Phase 3 で追加の seam**: `actor-core-kernel` の ActorCell facet と dispatch/mailbox/event/system registries、`actor-core-typed` の receptionist extension API と behavior 実装、`actor-adaptor-std` の blocking compatibility option、Pekko parity 用 marker/protocol と remote/cluster 側の将来利用点を分けて扱う。
 
 ## Specs (dependency order)
 
@@ -51,6 +58,16 @@
 - [x] cluster-sharding-extractor-contract -- ShardingEnvelope / ShardingMessageExtractor SPI と HashCode / Murmur2 標準実装群を定義する。Dependencies: cluster-grain-typed-entity-facade（2026-06-13 完了、PR #1990）
 - [x] cluster-sharding-health-and-join-compat -- grain/placement の readiness check（core 完結の純粋判定 + 公開アクセサ）と sharding join compatibility の除外キー整備（required key の追加は config 所有化とともに後続スペックへ委譲）を定義する。Dependencies: cluster-active-compatibility-baseline（2026-06-13 完了、PR #1993）
 - [x] cluster-ddata-core-types -- ReplicatedData 基底 SPI、Key、SelfUniqueAddress、基本 CRDT（Flag / GCounter / PNCounter / PNCounterMap）、consistency levels、補助 protocol 型を新設 ddata モジュールに定義する。Dependencies: none
+- [ ] actor-cell-facet-structure -- ActorCell の dispatch / fault handling / death watch / children / receive timeout facet 分離と receive timeout 集約を行い、後続 API 追加の変更面を小さくする。Dependencies: none
+- [ ] actor-system-state-registry-split -- SystemState / SystemStateShared の dispatcher / mailbox / event / guardian / serialization / remote / scheduler registry 分離を行い、mailbox と EventBus workstream の変更点を独立させる。Dependencies: none
+- [ ] actor-typed-receptionist-setup -- typed receptionist の extension API と behavior 実装を分離し、ReceptionistSetup 相当の差し替え契約を定義する。Dependencies: none
+- [ ] actor-kernel-message-observability -- FSM transition subscription、DeadLetterSuppression / SuppressedDeadLetter 生成経路、PossiblyHarmful、WrappedMessage を kernel の message observability contract として定義する。Dependencies: actor-cell-facet-structure
+- [ ] actor-pattern-utility-parity -- FutureTimeoutSupport.after、ActorSelection ask、CircuitBreaker state listeners と exponential backoff / jitter を pattern utility parity として定義する。Dependencies: none
+- [ ] actor-coordinated-shutdown-task-variants -- CoordinatedShutdown の cancellable task と actor termination task 変種を kernel lifecycle contract として定義する。Dependencies: actor-system-state-registry-split
+- [ ] actor-eventbus-classification-contract -- Lookup / Subchannel / Scanning / ManagedActor classification を含む汎用 EventBus trait 族を定義し、既存 EventStream との関係を明確にする。Dependencies: actor-system-state-registry-split, actor-kernel-message-observability
+- [ ] actor-mailbox-resolution-contract -- RequiresMessageQueue / ProducesMessageQueue 相当、lookupByQueueType、多段 mailbox selection precedence、BalancingDispatcher mailbox compatibility を mailbox 設定契約として定義する。Dependencies: actor-system-state-registry-split
+- [ ] actor-blocking-bounded-mailbox-compat -- pushTimeOut 付き bounded mailbox の互換契約を core + std の境界で定義し、async-first 方針との調停を明文化する。Dependencies: actor-mailbox-resolution-contract
+- [ ] actor-kernel-public-surface-audit -- actor kernel の低レベル public re-export、SystemMessage の層配置、typed facade の残存混在を棚卸しし、外部契約と internal surface を分ける。Dependencies: actor-kernel-message-observability, actor-eventbus-classification-contract, actor-mailbox-resolution-contract, actor-typed-receptionist-setup
 
 ## Existing Spec Updates
 


### PR DESCRIPTION
## Summary

- `docs/gap-analysis/actor-gap-analysis.md` の gap closure を Kiro roadmap の Phase 3 として追記
- actor gap を 10 個の spec boundary に分解し、それぞれの `brief.md` を追加
- ActorCell / SystemState / typed receptionist の構造整理を先行させ、その後に API parity work を重ねる dependency order を定義

## Scope

この PR は discovery artifact のみです。実装、requirements/design/tasks 生成、既存 Rust code の変更は含めていません。

## Validation

- `git diff --check --cached`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and planning only; no executable or public API changes.
> 
> **Overview**
> Introduces **Phase 3** on the Kiro roadmap for `docs/gap-analysis/actor-gap-analysis.md`, treating actor gap closure as both API parity and internal-structure work. The roadmap adopts **structural refactors first, then API specs** so later parity PRs stay smaller.
> 
> Adds **10 new spec briefs** under `.kiro/specs/`, each defining problem, scope, boundaries, and dependencies: `actor-cell-facet-structure`, `actor-system-state-registry-split`, `actor-typed-receptionist-setup`, `actor-kernel-message-observability`, `actor-pattern-utility-parity`, `actor-coordinated-shutdown-task-variants`, `actor-eventbus-classification-contract`, `actor-mailbox-resolution-contract`, `actor-blocking-bounded-mailbox-compat`, and `actor-kernel-public-surface-audit`. **`roadmap.md`** is extended with Phase 3 scope/constraints, boundary seams, and an unchecked dependency-ordered spec checklist.
> 
> **No Rust or runtime changes**—discovery artifacts only (no requirements/design/tasks or code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a172b73854898c9436f5ed11e6a619af909d9929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->