### PR TITLE
[codex] Set up Matt Pocock engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 - すべて日本語でやりとりすること
 
+## Agent skills
+
+Matt Pocock の engineering skills は `CLAUDE.md` と `docs/agents/` に設定する。
+
+- Issue tracker: GitHub Issues を使う。詳細は `docs/agents/issue-tracker.md` を見る。
+- Triage labels: mattpocock/skills の default labels を使う。詳細は `docs/agents/triage-labels.md` を見る。
+- Domain docs: single-context repo として root `CONTEXT.md` と `docs/adr/` を使う。詳細は `docs/agents/domain.md` を見る。
+
 ## Review exclusion settings
 
 - 人間の明示的な許可なしに `.coderabbit.yml` / `.coderabbit.yaml` を変更しないこと。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # CLAUDE.md
 
+## Agent skills
+
+### Issue tracker
+
+このリポジトリの issue と PRD は GitHub Issues で管理する。詳細は `docs/agents/issue-tracker.md` を見る。
+
+### Triage labels
+
+mattpocock/skills の default triage labels を使う。詳細は `docs/agents/triage-labels.md` を見る。
+
+### Domain docs
+
+このリポジトリは single-context repo として、root `CONTEXT.md` と `docs/adr/` を使う。詳細は `docs/agents/domain.md` を見る。
+
 ## Review exclusion settings
 
 - 人間の明示的な許可なしに `.coderabbit.yml` / `.coderabbit.yaml` を変更しないこと。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+Engineering skills がこのリポジトリのドメイン文書を読むときのルール。
+
+## Before exploring, read these
+
+- root の `CONTEXT.md`
+- `docs/adr/` のうち、作業対象に関係する ADR
+
+このリポジトリは single-context repo として扱う。root に `CONTEXT-MAP.md` が追加された場合は、multi-context repo として、関連する context ごとの `CONTEXT.md` も読む。
+
+対象ファイルが存在しない場合は静かに続行する。欠落を理由に upfront で新規作成を提案しない。`/domain-modeling` skill は、用語や判断が実際に解決された時点で必要な文書を遅延作成する。
+
+## File structure
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   └── 0001-failure-detector-configuration-contract.md
+└── modules/
+```
+
+## Use the glossary's vocabulary
+
+issue title、refactor proposal、hypothesis、test name などでドメイン概念を名付ける場合は、`CONTEXT.md` に定義された用語を使う。`CONTEXT.md` の `_Avoid_` にある言い換えへ drift させない。
+
+必要な概念が glossary に無い場合は、既存語彙で表現できるかを先に確認する。新しい重要概念として確定する場合は、実装や spec へ進む前に `CONTEXT.md` への反映を検討する。
+
+## Flag ADR conflicts
+
+出力が既存 ADR と矛盾する場合は、黙って上書きせず明示する。
+
+例:
+
+> ADR-0001 と矛盾する可能性がある。Failure Detector Configuration (故障検出器設定) を Failure Detector Algorithm Selection (故障検出器アルゴリズム選択) として扱わない前提を再確認する。

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+このリポジトリの issue と PRD は GitHub Issues で管理する。操作には `gh` CLI を使う。
+
+## Conventions
+
+- issue を作る: `gh issue create --title "..." --body "..."`。複数行本文は heredoc を使う。
+- issue を読む: `gh issue view <number> --comments`。必要に応じて `jq` でコメントとラベルを絞り込む。
+- issue を一覧する: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` に、必要な `--label` / `--state` フィルタを加える。
+- コメントする: `gh issue comment <number> --body "..."`
+- ラベルを付け外しする: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- close する: `gh issue close <number> --comment "..."`
+
+repo は `git remote -v` から推定する。通常、clone 内で `gh` を実行すれば自動で対象 repo が選ばれる。
+
+## When a skill says "publish to the issue tracker"
+
+GitHub issue を作成する。
+
+## When a skill says "fetch the relevant ticket"
+
+`gh issue view <number> --comments` を実行する。

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+Matt Pocock の engineering skills が使う5つの canonical triage role を、このリポジトリの issue tracker 上のラベル文字列へ対応付ける。
+
+| Label in mattpocock/skills | Label in our tracker | Meaning |
+| -------------------------- | -------------------- | ------- |
+| `needs-triage` | `needs-triage` | maintainer が評価する必要がある |
+| `needs-info` | `needs-info` | reporter からの追加情報待ち |
+| `ready-for-agent` | `ready-for-agent` | AFK agent が人間の追加文脈なしで着手できる |
+| `ready-for-human` | `ready-for-human` | 人間による実装が必要 |
+| `wontfix` | `wontfix` | 対応しない |
+
+skill が triage role に言及した場合は、この表の `Label in our tracker` にあるラベル文字列を使う。
+
+既存運用に合わせてラベル名を変える場合は、右列だけを変更する。


### PR DESCRIPTION
## Summary

- Add Matt Pocock engineering skills routing to `CLAUDE.md`.
- Add a Codex-facing pointer in `AGENTS.md` so agents can find the same setup.
- Document GitHub Issues, default triage labels, and single-context domain docs under `docs/agents/`.

## Impact

This lets Matt Pocock engineering skills use the repository's GitHub issue tracker, triage label vocabulary, and domain documentation consistently.

## Validation

- `git diff --staged --check`
- GitHub labels verified and missing default labels created: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`; `wontfix` already existed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent instructions; no runtime, auth, or data-path impact.
> 
> **Overview**
> **Agent-facing docs** now route Matt Pocock engineering skills through `CLAUDE.md` and a matching **Agent skills** block in `AGENTS.md`, both pointing at `docs/agents/`.
> 
> Three new guides define how skills should behave in this repo: **GitHub Issues + `gh` CLI** (`issue-tracker.md`), **canonical triage label names** aligned with mattpocock/skills (`triage-labels.md`), and **single-context domain reading** via root `CONTEXT.md` and `docs/adr/` with glossary/ADR conflict rules (`domain.md`).
> 
> No application or infrastructure code changes—only agent instructions and documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be59a26e9956acd3cdb8b7c4252b8f67a5e3f71a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->