### PR TITLE
[codex] Use default Codex home in corporate runner

### DIFF
--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-export CODEX_HOME="${HOME}/.codex-corporate"
+export CODEX_HOME="${HOME}/.codex"
 mkdir -p "${CODEX_HOME}"
 exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"


### PR DESCRIPTION
## Summary

- Update `scripts/run-codex-corporate.sh` to use the default `~/.codex` home directory.

## Impact

This keeps the corporate Codex launcher aligned with the intended default Codex configuration directory while preserving the existing `mise exec -- codex` invocation.

## Validation

- `git diff --check -- scripts/run-codex-corporate.sh`
- `bash -n scripts/run-codex-corporate.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line environment variable change in a launcher script; no auth, data, or application logic affected.
> 
> **Overview**
> The corporate Codex launcher (`scripts/run-codex-corporate.sh`) now sets **`CODEX_HOME`** to **`${HOME}/.codex`** instead of **`${HOME}/.codex-corporate`**, so it uses the same default Codex config directory as a normal install.
> 
> Behavior is otherwise unchanged: it still creates the home directory if needed and runs **`mise exec -- codex --dangerously-bypass-approvals-and-sandbox`** with the passed-through arguments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcfb1d6287315da77b2919d56de45f32ca098f27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->