### PR TITLE
docs(agents): add `kiro-to-grill` and `grill-to-kiro` skill documenta…

### DIFF
--- a/.agents/skills/grill-to-kiro/SKILL.md
+++ b/.agents/skills/grill-to-kiro/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: grill-to-kiro
+description: >
+  Kiro / SDD の新規 spec 作成、kiro-discovery、kiro-spec-init、要件化、
+  仕様化、feature brief 作成に進む前に使う入口スキル。ユーザーの要求を
+  そのまま kiro-* 系スキルへ渡さず、先に grill-with-docs で用語・境界・
+  不可逆な設計判断を詰め、必要に応じて CONTEXT.md と docs/adr/* に残してから
+  kiro-discovery または kiro-spec-init へつなぐ。新しい作業の相談、曖昧な
+  feature idea、Kiro spec の起票、requirements 化の依頼では、ユーザーが
+  明示的に grilling を省略すると言わない限りこのスキルを使うこと。既存
+  spec の status 確認、requirements/design/tasks/impl の継続、単純な実装、
+  既に十分な brief.md がある作業では使わなくてよい。
+---
+
+# Grill to Kiro
+
+`grill-with-docs` でドメイン用語と設計判断を固めてから、Kiro の discovery / spec init に渡すための入口スキル。
+
+## 目的
+
+Kiro は requirements / design / tasks を強く進めるため、入力が曖昧なまま渡ると spec 側に曖昧さが固定される。このスキルでは、Kiro に渡す前に次を明確にする。
+
+- domain terminology: `CONTEXT.md` に残すべき正規用語、避ける語、不変条件
+- accepted decisions: `docs/adr/*` に残すべき不可逆・非自明・trade-off を伴う判断
+- spec boundary: Kiro spec が所有する範囲、所有しない範囲、隣接 spec / subsystem
+- handoff input: `kiro-discovery` または `kiro-spec-init` に渡す、会話だけに依存しない要約
+
+## 入口判断
+
+このスキルを使うのは、要求が Kiro / SDD の入口に近いとき。
+
+- 新しい機能、仕組み、改善案を spec 化したい
+- `kiro-discovery` または `kiro-spec-init` に進みたい
+- requirements / design / tasks に入る前に要求を固めたい
+- `CONTEXT.md` や ADR に残すべき用語・判断がありそう
+- ユーザーが「煮詰めてから Kiro」「grill してから spec」のように言っている
+
+使わないケース:
+
+- 既存 spec の status 確認だけをしたい
+- 既に承認済みの requirements / design / tasks / implementation を継続するだけ
+- 明らかに spec 不要の小さな修正、設定変更、単純なリファクタリング
+- ユーザーが明示的に grilling を省略し、直接 Kiro に進めるよう指示している
+
+## 手順
+
+### 1. 既存 context を軽く確認する
+
+`AGENTS.md` / `CLAUDE.md` の `Project Context Sources` に従い、存在するものだけ確認する。存在しないファイルを理由に止まらない。
+
+- `CONTEXT.md`, `CONTEXT-MAP.md`
+- `docs/adr/`
+- `docs/agents/`
+- `.kiro/steering/`
+- `.kiro/specs/**`
+- `openspec/**`
+
+この段階では、Kiro の成果物を新規作成しない。既存の語彙、ADR、spec boundary を把握するだけに留める。
+
+### 2. grill-with-docs を先に通す
+
+`grill-with-docs` を使い、ユーザーの要求を Kiro に渡せる粒度まで煮詰める。
+
+質問は一度に並べず、境界判断に効く順で一つずつ聞く。コードや既存 docs を読めば答えられることは、ユーザーに聞かずに確認する。
+
+最低限、次を明確にする。
+
+- 誰のどんな問題か
+- 現状は何で、何が不足しているか
+- 完了後に何が真であればよいか
+- Kiro spec が所有する範囲
+- Kiro spec が所有しない範囲
+- 既存 spec / subsystem / public contract との関係
+- 新しく確定した domain term / avoid term / invariant
+- ADR 化すべき不可逆・非自明・trade-off を伴う判断の有無
+
+用語が確定したら `CONTEXT.md` に残す。ADR は `domain-modeling` の基準に従い、必要な場合だけ `docs/adr/*` に残す。`CONTEXT.md` は spec や作業計画ではなく glossary として扱う。
+
+### 3. Kiro handoff を作る
+
+Kiro に渡す前に、会話の生ログではなく次の handoff を作る。
+
+```md
+## Kiro Handoff
+
+### Problem
+[誰が、何に困っているか]
+
+### Current State
+[現状と不足]
+
+### Desired Outcome
+[完了後に真であるべきこと]
+
+### Scope
+- In: [...]
+- Out: [...]
+
+### Boundary Candidates
+- [...]
+
+### Upstream / Downstream
+- Upstream: [...]
+- Downstream: [...]
+
+### Domain Context Updates
+- CONTEXT.md: [追加・更新した用語。なければ none]
+- ADR: [作成・検討した ADR。なければ none]
+
+### Kiro Route
+[kiro-discovery | kiro-spec-init | no-spec]
+```
+
+この handoff を Kiro の入力にする。ユーザーの最初の要求文をそのまま Kiro に渡さない。
+
+### 4. Kiro へ接続する
+
+handoff に基づいて次のいずれかを選ぶ。
+
+- 境界がまだ探索対象、または multi-scope / mixed decomposition の可能性がある: `$kiro-discovery "<handoff summary>"`
+- 単一 spec の境界と feature 名が十分に明確: `$kiro-spec-init "<handoff summary>"`
+- spec 不要: Kiro に進まず、直接実装または別 workflow を提案する
+
+`kiro-discovery` が `.kiro/specs/<feature>/brief.md` や `.kiro/steering/roadmap.md` を作る場合は、作成後に読み返して、grill-with-docs で確定した用語・境界・ADR 判断が落ちていないか確認する。
+
+`kiro-spec-init` に進む場合は、既存 `brief.md` があればそれを優先し、なければ handoff を project description として使う。
+
+## 禁止事項
+
+- 曖昧な初期要求をそのまま `kiro-discovery` / `kiro-spec-init` に渡さない。
+- `CONTEXT.md` に implementation detail、タスク、spec 本文を混ぜない。
+- ADR を spec の台帳として作らない。
+- `kiro-*` 配布スキル本体をこの workflow のために書き換えない。
+- requirements / design / tasks / implementation まで勝手に進めない。ユーザーが明示的に続行を依頼した場合だけ downstream phase に進む。
+
+## 完了条件
+
+このスキルの完了は、次のいずれか。
+
+- `grill-with-docs` の結果を反映した `CONTEXT.md` / `docs/adr/*` と Kiro handoff が揃い、`kiro-discovery` または `kiro-spec-init` へ接続した
+- spec 不要と判断し、その理由と次の実装方針を提示した
+- 未解決の境界・用語・判断が残り、Kiro に進む前にユーザー判断が必要だと明示した

--- a/.agents/skills/kiro-to-grill/SKILL.md
+++ b/.agents/skills/kiro-to-grill/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: kiro-to-grill
+description: >
+  Kiro / SDD の spec から未登録のユビキタス言語、canonical term、
+  avoid term、不変条件、境界名、契約名、ADR 候補となる仕様変更を検出し、
+  domain-modeling / grill-with-docs で確定してから CONTEXT.md と docs/adr/*
+  に反映するスキル。ユーザーが「.kiro/specs を見て未定義語を拾って」、
+  「Kiro spec から CONTEXT.md を更新して」、「spec の仕様変更を ADR に反映」、
+  「glossary gap を埋めて」、「ユビキタス言語を逆引きして」などを依頼した
+  場合に使う。単なる spec status 確認、requirements/design/tasks の生成、
+  実装、または Kiro に渡す前の要求整理には使わない。
+---
+
+# Kiro to Grill
+
+Kiro spec に固定された言葉や設計判断を、domain docs へ戻すための reconciliation skill。
+
+## 目的
+
+Kiro spec は feature-level の requirements / design / tasks を持つが、ユビキタス言語や不可逆な設計判断の正本ではない。このスキルでは、Kiro spec から domain docs に戻すべき差分を見つけ、`CONTEXT.md` と `docs/adr/*` に反映する。
+
+- `CONTEXT.md`: domain terminology、canonical term、avoid term、invariant だけを残す
+- `docs/adr/*`: 不可逆・非自明・trade-off を伴う設計判断だけを残す
+- `.kiro/specs/**`: 反映元として読む。ユーザーが明示しない限り、このスキルでは編集しない
+
+## 入口判断
+
+このスキルを使うのは、Kiro spec が先にあり、その内容を domain docs に戻したいとき。
+
+- `.kiro/specs/**` から未登録のユビキタス言語を探したい
+- spec 内の境界名、契約名、不変条件を `CONTEXT.md` と照合したい
+- requirements / design / tasks の変更から ADR 候補を見つけたい
+- spec と `CONTEXT.md` / `docs/adr/*` の矛盾を洗い出したい
+- Kiro spec 由来の glossary gap を `domain-modeling` / `grill-with-docs` 経由で解消したい
+
+使わないケース:
+
+- 新しい要求を Kiro に渡す前に煮詰めたい場合。代わりに `grill-to-kiro` を使う
+- requirements / design / tasks を生成・更新したいだけの場合
+- 実装タスクを進めたいだけの場合
+- spec status を確認したいだけの場合
+
+## 手順
+
+### 1. 対象 spec と context docs を特定する
+
+対象 spec は、次の順で決める。
+
+1. ユーザーが feature 名や path を指定していれば、それだけを対象にする。
+2. git diff に `.kiro/specs/**` の変更があれば、変更された spec を優先する。
+3. ユーザーが「全部」「全体」と言っていれば `.kiro/specs/**` 全体を見る。
+4. それ以外は、対象を広げる前に確認する。
+
+`AGENTS.md` / `CLAUDE.md` の `Project Context Sources` に従い、存在するものだけ確認する。
+
+- `CONTEXT.md`, `CONTEXT-MAP.md`
+- `docs/adr/`
+- `.kiro/steering/`
+- `.kiro/specs/<feature>/{brief.md,requirements.md,research.md,design.md,tasks.md,spec.json}`
+- `openspec/**` は public contract の照合が必要な場合だけ読む
+
+存在しない context docs は未作成として扱う。未作成を理由に止まらない。
+
+### 2. Kiro spec から候補を抽出する
+
+spec ごとに、domain docs に戻す候補を分類する。
+
+**Domain terminology 候補**
+- ドメイン概念、役割、状態、イベント、境界名
+- feature をまたいで使われる契約名、public contract 名
+- requirements / design で不変条件として扱われている制約
+- spec の `Out of Boundary` や `Boundary Commitments` を理解するために必要な語
+
+**Avoid term 候補**
+- spec 内で曖昧に使われている語
+- 既存 `CONTEXT.md` の avoid terms と衝突する語
+- 同じ概念を複数表記している語
+
+**ADR 候補**
+- 後から変更するコストが高い設計判断
+- 未来の読者が理由を知りたくなる非自明な判断
+- 代替案があり、trade-off を伴う判断
+- data ownership、dependency direction、public contract、storage model、consistency model、boundary split の変更
+
+**除外するもの**
+- ファイル名、関数名、型名だけの implementation detail
+- 一時的な task label、作業メモ、チェックリスト項目
+- 一般的な技術語
+- spec 内だけで閉じる局所的な表現
+
+### 3. 既存 docs と照合する
+
+候補ごとに次を判断する。
+
+- `registered`: 既に `CONTEXT.md` / ADR にある
+- `missing`: domain docs に戻すべきだが未登録
+- `conflict`: spec と domain docs の定義・表記・判断が矛盾している
+- `needs_grill`: 意味が曖昧で、反映前に `domain-modeling` / `grill-with-docs` が必要
+- `ignore`: domain docs に戻すべきではない
+
+`CONTEXT.md` が未作成の場合でも、すべてを自動登録しない。domain boundary を表す語だけを候補にする。
+
+### 4. Kiro to Grill Report を出す
+
+編集前に、短い report を作る。
+
+```md
+## Kiro to Grill Report
+
+### Sources
+- Specs: [...]
+- Domain docs: [...]
+
+### CONTEXT.md candidates
+| Term | Source | Classification | Action |
+|------|--------|----------------|--------|
+
+### ADR candidates
+| Decision | Source | Why ADR | Action |
+|----------|--------|---------|--------|
+
+### Conflicts
+- [...]
+
+### Ignored
+- [...]
+```
+
+`needs_grill` や `conflict` がある場合は、`domain-modeling` / `grill-with-docs` の質問を一つずつ行い、意味を確定してから編集する。
+
+### 5. CONTEXT.md と ADR に反映する
+
+反映時は `domain-modeling` の責務に従う。
+
+`CONTEXT.md`:
+- 既存ファイルがあれば、その見出し・書式・用語表の粒度に合わせる。
+- 未作成なら、最初に確定した domain terminology がある時点で作る。
+- glossary として書く。spec、作業計画、実装詳細を混ぜない。
+- canonical term / avoid term / invariant を明確に分ける。
+
+`docs/adr/*`:
+- 既存 ADR の採番・書式に合わせる。
+- 未作成なら、最初の ADR が必要になった時点で `docs/adr/` を作る。
+- ADR は、不可逆・非自明・trade-off の3条件を満たす場合だけ作る。
+- spec の全変更履歴や task の台帳として ADR を作らない。
+
+矛盾がある場合は、黙って `CONTEXT.md` や ADR を上書きしない。ユーザーに確認し、どちらを正本にするか決めてから反映する。
+
+### 6. 反映後に検証する
+
+反映後、次を確認する。
+
+- `CONTEXT.md` に implementation detail が混ざっていない
+- ADR が spec 台帳になっていない
+- spec 内の用語と `CONTEXT.md` の canonical term が矛盾していない
+- 追加した ADR が既存 ADR と矛盾していない
+- `git diff --check` が通る
+
+## 出力
+
+最後に次を短く報告する。
+
+- 読んだ Kiro spec
+- 追加・更新した `CONTEXT.md` の用語
+- 作成・更新した ADR
+- 残した未解決の確認事項
+- 実行した検証
+
+## 禁止事項
+
+- spec 内の語を機械的に全部 `CONTEXT.md` へ追加しない。
+- `CONTEXT.md` に spec 本文、task、implementation detail を入れない。
+- ADR を spec 差分の履歴台帳として作らない。
+- 矛盾する既存 ADR を黙って上書きしない。
+- ユーザーが明示しない限り `.kiro/specs/**` を編集しない。


### PR DESCRIPTION
…tion
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/j5ik2o/fraktor-rs/pull/2037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only agent skill definitions; no runtime, auth, or application code changes.
> 
> **Overview**
> Adds two complementary **agent skills** under `.agents/skills/` that wire **domain grilling** (`grill-with-docs`, `CONTEXT.md`, `docs/adr/*`) to the **Kiro / SDD** workflow.
> 
> **`grill-to-kiro`** is the upstream gate: before `kiro-discovery` or `kiro-spec-init`, agents must clarify scope, terminology, and ADR-worthy decisions, optionally update domain docs, then produce a structured **Kiro Handoff** (not raw user chat) and route to discovery, spec init, or no-spec.
> 
> **`kiro-to-grill`** is the downstream reconciliation: read `.kiro/specs/**`, classify glossary and ADR candidates against existing domain docs, emit a **Kiro to Grill Report**, resolve conflicts via grilling, and update `CONTEXT.md` / ADRs without editing specs by default.
> 
> Together they encode when to use each path, forbidden behaviors (e.g. ADR as spec changelog), and completion criteria—documentation-only, aligned with existing context rules that already point at `grill-with-docs` for glossary gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23f11f2804bbacc8db4b482c265a14024b6c5f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * スキルの手順書を追加：アーキテクチャ要件の準備フロー、判断基準、成果物フォーマット、実施制約を定義
  * スキル手順書を追加：仕様からドメイン用語と設計判断をシステム文書へ統合するワークフロー、検証ルール、禁止事項を明文化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->