### PR TITLE
[codex] Mark completed actor roadmap specs

### DIFF
--- a/.kiro/steering/roadmap.md
+++ b/.kiro/steering/roadmap.md
@@ -58,8 +58,8 @@
 - [x] cluster-sharding-extractor-contract -- ShardingEnvelope / ShardingMessageExtractor SPI と HashCode / Murmur2 標準実装群を定義する。Dependencies: cluster-grain-typed-entity-facade（2026-06-13 完了、PR #1990）
 - [x] cluster-sharding-health-and-join-compat -- grain/placement の readiness check（core 完結の純粋判定 + 公開アクセサ）と sharding join compatibility の除外キー整備（required key の追加は config 所有化とともに後続スペックへ委譲）を定義する。Dependencies: cluster-active-compatibility-baseline（2026-06-13 完了、PR #1993）
 - [x] cluster-ddata-core-types -- ReplicatedData 基底 SPI、Key、SelfUniqueAddress、基本 CRDT（Flag / GCounter / PNCounter / PNCounterMap）、consistency levels、補助 protocol 型を新設 ddata モジュールに定義する。Dependencies: none
-- [ ] actor-cell-facet-structure -- ActorCell の dispatch / fault handling / death watch / children / receive timeout facet 分離と receive timeout 集約を行い、後続 API 追加の変更面を小さくする。Dependencies: none
-- [ ] actor-system-state-registry-split -- SystemState / SystemStateShared の dispatcher / mailbox / event / guardian / serialization / remote / scheduler registry 分離を行い、mailbox と EventBus workstream の変更点を独立させる。Dependencies: none
+- [x] actor-cell-facet-structure -- ActorCell の dispatch / fault handling / death watch / children / receive timeout facet 分離と receive timeout 集約を行い、後続 API 追加の変更面を小さくする。Dependencies: none
+- [x] actor-system-state-registry-split -- SystemState / SystemStateShared の dispatcher / mailbox / event / guardian / serialization / remote / scheduler registry 分離を行い、mailbox と EventBus workstream の変更点を独立させる。Dependencies: none
 - [ ] actor-typed-receptionist-setup -- typed receptionist の extension API と behavior 実装を分離し、ReceptionistSetup 相当の差し替え契約を定義する。Dependencies: none
 - [ ] actor-kernel-message-observability -- FSM transition subscription、DeadLetterSuppression / SuppressedDeadLetter 生成経路、PossiblyHarmful、WrappedMessage を kernel の message observability contract として定義する。Dependencies: actor-cell-facet-structure
 - [ ] actor-pattern-utility-parity -- FutureTimeoutSupport.after、ActorSelection ask、CircuitBreaker state listeners と exponential backoff / jitter を pattern utility parity として定義する。Dependencies: none


### PR DESCRIPTION
## Summary
- Mark `actor-cell-facet-structure` as completed in `.kiro/steering/roadmap.md`.
- Mark `actor-system-state-registry-split` as completed in `.kiro/steering/roadmap.md`.

## Why
These roadmap entries were still unchecked even though the corresponding work has been merged and the task/spec evidence shows completion.

## Impact
Documentation-only roadmap synchronization. No runtime behavior changes.

## Validation
- `git diff --check -- .kiro/steering/roadmap.md`
- `git diff --check HEAD~1 HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only roadmap checkbox updates with no runtime or API impact.
> 
> **Overview**
> Updates **`.kiro/steering/roadmap.md`** so two Phase 3 actor workstreams are checked off: **`actor-cell-facet-structure`** and **`actor-system-state-registry-split`**. They were still listed as open even though the corresponding implementation/spec work is already done.
> 
> No code, config, or runtime behavior changes—only roadmap status alignment for reviewers and planning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3892ac889144f22bf8ab3bc64cb152c09f50d97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->