### PR TITLE
chore(codex): hooks.json に Rust チェック hook を移設

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -26,14 +26,5 @@ description = "Ultra-fast worker for bounded mechanical edits with easy-to-revie
 config_file = "agents/spec-reviewer.toml"
 description = "Cross-spec consistency reviewer for detecting contradictions, boundary mismatches, and dependency-order problems."
 
-[[hooks.PostToolUse]]
-matcher = "^(apply_patch|Edit|Write)$"
-
-[[hooks.PostToolUse.hooks]]
-type = "command"
-command = '/usr/bin/python3 "$(git rev-parse --show-toplevel)/.agents/hooks/run_rust_checks_after_edit.py" --agent codex'
-timeout = 1800
-statusMessage = "Rust 変更後の fmt / dylint / clippy を確認中"
-
 [projects."/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs"]
 trust_level = "trusted"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'/Users/j5ik2o/.agents/skills/agmsg/scripts/session-start.sh' 'codex' '/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'",
-            "commandWindows": "$b=$env:GIT_BASH; if (-not $b) { $b=$env:AGMSG_BASH }; if (-not $b) { $b='C:\\Program Files\\Git\\bin\\bash.exe' }; & $b -lc '''/Users/j5ik2o/.agents/skills/agmsg/scripts/session-start.sh'' ''codex'' ''/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'''"
+            "command": "\"$HOME/.agents/skills/agmsg/scripts/session-start.sh\" codex \"$(git rev-parse --show-toplevel)\"",
+            "commandWindows": "$b=$env:GIT_BASH; if (-not $b) { $b=$env:AGMSG_BASH }; if (-not $b) { $b='bash.exe' }; & $b -lc '\"$HOME/.agents/skills/agmsg/scripts/session-start.sh\" codex \"$(git rev-parse --show-toplevel)\"'"
           }
         ]
       }
@@ -18,8 +18,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "'/Users/j5ik2o/.agents/skills/agmsg/scripts/session-end.sh'   'codex' '/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'",
-            "commandWindows": "$b=$env:GIT_BASH; if (-not $b) { $b=$env:AGMSG_BASH }; if (-not $b) { $b='C:\\Program Files\\Git\\bin\\bash.exe' }; & $b -lc '''/Users/j5ik2o/.agents/skills/agmsg/scripts/session-end.sh''   ''codex'' ''/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'''"
+            "command": "\"$HOME/.agents/skills/agmsg/scripts/session-end.sh\" codex \"$(git rev-parse --show-toplevel)\"",
+            "commandWindows": "$b=$env:GIT_BASH; if (-not $b) { $b=$env:AGMSG_BASH }; if (-not $b) { $b='bash.exe' }; & $b -lc '\"$HOME/.agents/skills/agmsg/scripts/session-end.sh\" codex \"$(git rev-parse --show-toplevel)\"'"
           }
         ]
       }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.agents/hooks/run_rust_checks_after_edit.py\" --agent codex",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.agents/hooks/run_rust_checks_after_edit.py\" --agent codex",
             "timeout": 1800,
             "statusMessage": "Rust 変更後の fmt / dylint / clippy を確認中"
           }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,41 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/Users/j5ik2o/.agents/skills/agmsg/scripts/session-start.sh' 'codex' '/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'",
+            "commandWindows": "$b=$env:GIT_BASH; if (-not $b) { $b=$env:AGMSG_BASH }; if (-not $b) { $b='C:\\Program Files\\Git\\bin\\bash.exe' }; & $b -lc '''/Users/j5ik2o/.agents/skills/agmsg/scripts/session-start.sh'' ''codex'' ''/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'''"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/Users/j5ik2o/.agents/skills/agmsg/scripts/session-end.sh'   'codex' '/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'",
+            "commandWindows": "$b=$env:GIT_BASH; if (-not $b) { $b=$env:AGMSG_BASH }; if (-not $b) { $b='C:\\Program Files\\Git\\bin\\bash.exe' }; & $b -lc '''/Users/j5ik2o/.agents/skills/agmsg/scripts/session-end.sh''   ''codex'' ''/Users/j5ik2o/Sources/j5ik2o.github.com/j5ik2o/fraktor-rs'''"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(apply_patch|Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 \"$(git rev-parse --show-toplevel)/.agents/hooks/run_rust_checks_after_edit.py\" --agent codex",
+            "timeout": 1800,
+            "statusMessage": "Rust 変更後の fmt / dylint / clippy を確認中"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/run-claude-corporate.sh
+++ b/scripts/run-claude-corporate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+export CLAUDE_IDENTITY="corporate"
 export CLAUDE_CONFIG_DIR="${HOME}/.claude"
 unset CLAUDE_CODE_OAUTH_TOKEN
 

--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+export PATH="${HOME}/.agents/bin:$PATH"
 export CODEX_HOME="${HOME}/.codex"
-mkdir -p "${CODEX_HOME}"
-exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"
+
+exec mise exec -- ${HOME}/.agents/bin/codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/scripts/run-codex-corporate.sh
+++ b/scripts/run-codex-corporate.sh
@@ -3,4 +3,5 @@
 export PATH="${HOME}/.agents/bin:$PATH"
 export CODEX_HOME="${HOME}/.codex"
 
-exec mise exec -- ${HOME}/.agents/bin/codex --dangerously-bypass-approvals-and-sandbox "$@"
+exec mise exec -- "${HOME}/.agents/bin/codex" --dangerously-bypass-approvals-and-sandbox "$@"
+

--- a/scripts/run-codex-personal.sh
+++ b/scripts/run-codex-personal.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+export PATH="${HOME}/.agents/bin:$PATH"
 export CODEX_HOME="${HOME}/.codex-personal"
-mkdir -p "${CODEX_HOME}"
-exec mise exec -- codex --dangerously-bypass-approvals-and-sandbox "$@"
+
+exec mise exec -- ${HOME}/.agents/bin/codex --dangerously-bypass-approvals-and-sandbox "$@"

--- a/scripts/run-codex-personal.sh
+++ b/scripts/run-codex-personal.sh
@@ -3,4 +3,5 @@
 export PATH="${HOME}/.agents/bin:$PATH"
 export CODEX_HOME="${HOME}/.codex-personal"
 
-exec mise exec -- ${HOME}/.agents/bin/codex --dangerously-bypass-approvals-and-sandbox "$@"
+exec mise exec -- "${HOME}/.agents/bin/codex" --dangerously-bypass-approvals-and-sandbox "$@"
+


### PR DESCRIPTION
## 概要

- Codex の Rust 変更後チェック hook を `.codex/config.toml` から `.codex/hooks.json` に移設
- SessionStart / SessionEnd hook と PostToolUse hook を `hooks.json` に集約
- Claude / Codex 起動スクリプトの PATH と実行バイナリ参照を更新

## 確認

- `python3 -m json.tool .codex/hooks.json`
- `python3` の `tomllib` で `.codex/config.toml` を読み込み
- `git push -u origin feature/actor-typed-receptionist-setup`（Everything up-to-date）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local agent tooling and launcher scripts only; no application runtime, auth, or data paths change.
> 
> **Overview**
> Codex lifecycle and edit hooks move out of **`.codex/config.toml`** into a new **`.codex/hooks.json`**: **SessionStart** / **SessionEnd** run agmsg scripts, and **PostToolUse** (on `apply_patch` / `Edit` / `Write`) still runs the Rust fmt / dylint / clippy check via `run_rust_checks_after_edit.py`.
> 
> **`scripts/run-codex-corporate.sh`** and **`run-codex-personal.sh`** prepend **`~/.agents/bin`** to `PATH`, drop `mkdir` for `CODEX_HOME`, and exec **`~/.agents/bin/codex`** instead of the mise `codex` on PATH. **`run-claude-corporate.sh`** sets **`CLAUDE_IDENTITY=corporate`** before launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27b048bc057a3c955b5601e7b7b44d0ac3c0802f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 実行用スクリプトから起動する際に、環境設定が自動で切り替わるようになりました。
  * すべての起動スクリプトで、必要な実行パスが事前に追加され、コマンドをより確実に起動できるようになりました。
* **改善**
  * 起動前の不要なディレクトリ作成をなくし、実行手順を簡素化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->