### PR TITLE
build(slides): switch slide:preview to marp server mode so the URL is printed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "slide:preview": "marp --preview --watch talks/fp-matsuri-2026/fp-matsuri-2026-marp.md --output talks/fp-matsuri-2026/fp-matsuri-2026-marp.html",
+    "slide:preview": "marp --server talks/fp-matsuri-2026",
     "slide:pdf": "marp --pdf --allow-local-files talks/fp-matsuri-2026/fp-matsuri-2026-marp.md --output talks/fp-matsuri-2026/fp-matsuri-2026-marp.pdf",
     "takt": "./scripts/run-takt.sh",
     "takt:personal": "./scripts/run-takt.sh personal",


### PR DESCRIPTION
## 概要

`npm run slide:preview` が `marp --preview` のワンショットプレビューウィンドウを開くだけで URL を表示せず、ブラウザを閉じると開き直せないため、marp のサーバーモードに切り替えた。

## 変更内容

- `slide:preview` を `marp --server talks/fp-matsuri-2026` に変更
  - 起動時に `http://localhost:8080/` が表示される
  - ブラウザを閉じても URL を開き直せる
  - ファイル変更時の再レンダリングはサーバーモードに内蔵（旧 `--watch` 相当は不要）

## 動作確認

- サーバー起動時に `[Server mode] Start server listened at http://localhost:8080/` が表示されることを確認
- `http://localhost:8080/fp-matsuri-2026-marp.md` が 200 を返すことを確認

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only npm script change for local slide preview; no runtime or production impact.
> 
> **Overview**
> **`slide:preview`** no longer runs `marp --preview` with `--watch` on a single markdown file and a one-off HTML output. It now starts **`marp --server`** against the `talks/fp-matsuri-2026` directory.
> 
> That prints a localhost URL (e.g. `http://localhost:8080/`) so you can reopen the deck after closing the browser, and file changes still reload via the server’s built-in behavior instead of explicit `--watch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfa02fad2d4301e334cea945593b35aafc133a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->