### PR TITLE
docs(talks): correct the test line-count metric to include integration tests

### DIFF
--- a/talks/fp-matsuri-2026/fp-matsuri-2026-marp.md
+++ b/talks/fp-matsuri-2026/fp-matsuri-2026-marp.md
@@ -1025,14 +1025,14 @@ StreamはSource、Flow、Sinkとして処理グラフを宣言し、需要量と
   <div class="metric"><strong>236</strong><span>3 crate の public 型宣言</span></div>
   <div class="metric"><strong>94%</strong><span>Pekko 主要50概念中 47 実装</span></div>
   <div class="metric"><strong>約4.6万</strong><span>3 crate の実装コード行数</span></div>
-  <div class="metric"><strong>約4.4万</strong><span>3 crate のテストコード行数</span></div>
+  <div class="metric"><strong>約4.7万</strong><span>3 crate のテストコード行数</span></div>
 </div>
 
 <!--
 [目安 1分30秒]
 ここまでのactor、mailbox、dispatcherが、本題に必要な前提知識です。次に、その本題であるstreamが、fraktor-rs全体のどこに位置するかを確認します。
 fraktor-rs全体は六つの領域を持ち、それぞれをno_stdのcoreとstd環境向けadaptorに分けています。coreはさらに、中心ロジックのkernelと、型安全な公開APIを提供するtypedに分かれている領域があります。本トークで掘り下げるのは右端のstreamです。
-数値は今月コードを走査した値です。236は三つのstream crateにあるpublicなstruct、enum、trait、type aliasの合計です。94パーセントは、リポジトリのギャップ分析文書で定義した、Pekkoの主要50概念のうち47を実装している割合です。実装コードは三つのstream crateの合計で約4万6千行、テストコードは約4万4千行で、実装とほぼ同量のテストを備えています。計測コマンドもリポジトリで公開しているので、手元で再計測できます。
+数値は今月コードを走査した値です。236は三つのstream crateにあるpublicなstruct、enum、trait、type aliasの合計です。94パーセントは、リポジトリのギャップ分析文書で定義した、Pekkoの主要50概念のうち47を実装している割合です。実装コードは三つのstream crateの合計で約4万6千行、テストコードは単体テストと統合テストを合わせて約4万7千行で、実装と同量以上のテストを備えています。計測コマンドもリポジトリで公開しているので、手元で再計測できます。
 規模を誇るためではなく、ここから示す設計が試作に留まらず、相応の実装面積で使われていることを示すための数値です。
 -->
 


### PR DESCRIPTION
## 概要

P7 のテストコード行数メトリクスが sibling `_test.rs`（単体テスト）のみの集計で、クレート直下の `tests/`（統合テスト 3,042 行）が漏れていたため修正する。

## 変更内容

- テストコード行数: 約4.4万 → **約4.7万**（単体 43,666 行 + 統合 3,042 行 = 46,708 行）
- スピーカーノートを「単体テストと統合テストを合わせて約4万7千行で、実装と同量以上」に更新
- 実装コード側（約4.6万 = 46,469 行）は2手法・内訳で再検証し、正確であることを確認済み
- PDF 同梱

## 注意

PR #2063 と同じ PDF を変更するため、どちらかのマージ後にもう一方は rebase + PDF 再生成が必要。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> 発表資料の数値・注釈のみの修正で、ランタイムやビルド挙動には影響しません。
> 
> **Overview**
> **fp-matsuri-2026** スライドの stream 規模メトリクスで、テストコード行数が単体テスト（sibling `_test.rs`）のみの集計になっていた誤りを直しています。
> 
> スライド上の値を **約4.4万 → 約4.7万** に更新し、スピーカーノートも「単体テストと統合テストを合わせて約4万7千行」「実装と同量以上」と明記するよう変更しています。実装コード（約4.6万）は PR 説明どおり再検証済みで、この diff では触れていません。
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc531bdebb9aa6578c58e6ddbfc8836c2b9d05fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->